### PR TITLE
fix(web): enforce sync-eligibility on runtime-writing API routes (#1203 §1i)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -28,7 +28,11 @@ from memtomem.context.agents import (
 )
 from memtomem.context.detector import AGENT_DIRS
 from memtomem.context.privacy_scan import PrivacyScanError
-from memtomem.web.routes.context_projects import resolve_scope_root
+from memtomem.web.routes.context_projects import (
+    resolve_scope_root,
+    resolve_scope_root_cascade_gated,
+    resolve_writable_scope_root,
+)
 from memtomem.web.routes._locks import _gateway_lock
 
 # Flat list of project-relative runtime scan paths reported on list / import
@@ -366,7 +370,7 @@ def _safe_rel(p: Path, project_root: Path) -> str:
 async def delete_agent(
     name: str,
     cascade: bool = Query(False),
-    project_root: Path = Depends(resolve_scope_root),
+    project_root: Path = Depends(resolve_scope_root_cascade_gated),
     target_scope: TargetScope = Query(
         "project_shared",
         description="Canonical-residency tier to delete from. Non-shared tiers rejected (ADR-0011).",
@@ -470,7 +474,7 @@ class SyncRequest(BaseModel):
 @router.post("/context/agents/sync")
 async def sync_agents(
     body: SyncRequest | None = None,
-    project_root: Path = Depends(resolve_scope_root),
+    project_root: Path = Depends(resolve_writable_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
         description="Canonical-residency tier to fan out. Non-shared tiers rejected (ADR-0011).",

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -27,7 +27,11 @@ from memtomem.context.commands import (
 )
 from memtomem.context.detector import COMMAND_DIRS
 from memtomem.context.privacy_scan import PrivacyScanError
-from memtomem.web.routes.context_projects import resolve_scope_root
+from memtomem.web.routes.context_projects import (
+    resolve_scope_root,
+    resolve_scope_root_cascade_gated,
+    resolve_writable_scope_root,
+)
 from memtomem.web.routes._locks import _gateway_lock
 
 # Flat list of project-relative runtime scan paths reported on list / import
@@ -356,7 +360,7 @@ async def update_command(
 async def delete_command(
     name: str,
     cascade: bool = Query(False),
-    project_root: Path = Depends(resolve_scope_root),
+    project_root: Path = Depends(resolve_scope_root_cascade_gated),
     target_scope: TargetScope = Query(
         "project_shared",
         description="Canonical-residency tier to delete from. Non-shared tiers rejected (ADR-0011).",
@@ -462,7 +466,7 @@ class SyncRequest(BaseModel):
 @router.post("/context/commands/sync")
 async def sync_commands(
     body: SyncRequest | None = None,
-    project_root: Path = Depends(resolve_scope_root),
+    project_root: Path = Depends(resolve_writable_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
         description="Canonical-residency tier to fan out. Non-shared tiers rejected (ADR-0011).",

--- a/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
@@ -27,7 +27,10 @@ from memtomem.context.mcp_servers import (
     scan_mcp_server_text,
 )
 from memtomem.web.routes._locks import _gateway_lock
-from memtomem.web.routes.context_projects import resolve_scope_root
+from memtomem.web.routes.context_projects import (
+    resolve_scope_root,
+    resolve_writable_scope_root,
+)
 
 router = APIRouter(tags=["context-mcp-servers"])
 
@@ -362,7 +365,7 @@ async def diff_mcp_server(
 
 @router.post("/context/mcp-servers/sync")
 async def sync_mcp_servers(
-    project_root: Path = Depends(resolve_scope_root),
+    project_root: Path = Depends(resolve_writable_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
         description="Canonical-residency tier to fan out. Only project_shared is supported in v1.",

--- a/packages/memtomem/src/memtomem/web/routes/context_projects.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_projects.py
@@ -94,6 +94,40 @@ def _default_project_root(request: Request) -> Path:
     return Path.cwd()
 
 
+def _resolve_selected_scope(
+    request: Request,
+    project_scope_id: str | None,
+    scope_id: str | None,
+) -> ProjectScope | None:
+    """Resolve an optional project selector to its discovered ``ProjectScope``.
+
+    Returns ``None`` when no selector is given (the caller falls back to the
+    server cwd). Raises 400 on a contradictory selector pair, and 404 on an
+    unknown or stale (registered but missing-root) selector. Shared by
+    :func:`resolve_scope_root` and :func:`resolve_writable_scope_root` so the
+    selector contract has exactly one implementation.
+    """
+    if project_scope_id is not None and scope_id is not None and project_scope_id != scope_id:
+        raise HTTPException(
+            status_code=400,
+            detail="project_scope_id and scope_id must match when both are provided",
+        )
+    selected_scope_id = project_scope_id or scope_id
+    if selected_scope_id is None:
+        return None
+
+    for scope in _discover_for(request):
+        if scope.scope_id != selected_scope_id:
+            continue
+        if scope.root is None or scope.missing:
+            raise HTTPException(
+                status_code=404,
+                detail=f"scope {selected_scope_id!r} is registered but its root is missing",
+            )
+        return scope
+    raise HTTPException(status_code=404, detail=f"unknown project_scope_id: {selected_scope_id!r}")
+
+
 def resolve_scope_root(
     request: Request,
     project_scope_id: str | None = Query(default=None),
@@ -107,25 +141,98 @@ def resolve_scope_root(
     Unknown selectors → 404. Stale selectors (registered but root no longer
     exists) → 404 too — read endpoints can't usefully serve from a missing dir.
     """
-    if project_scope_id is not None and scope_id is not None and project_scope_id != scope_id:
-        raise HTTPException(
-            status_code=400,
-            detail="project_scope_id and scope_id must match when both are provided",
-        )
-    selected_scope_id = project_scope_id or scope_id
-    if selected_scope_id is None:
+    scope = _resolve_selected_scope(request, project_scope_id, scope_id)
+    if scope is None:
         return _default_project_root(request)
+    assert scope.root is not None  # _resolve_selected_scope 404s on a missing root
+    return scope.root
 
-    for scope in _discover_for(request):
-        if scope.scope_id != selected_scope_id:
-            continue
-        if scope.root is None or scope.missing:
-            raise HTTPException(
-                status_code=404,
-                detail=f"scope {selected_scope_id!r} is registered but its root is missing",
-            )
-        return scope.root
-    raise HTTPException(status_code=404, detail=f"unknown project_scope_id: {selected_scope_id!r}")
+
+def resolve_writable_scope_root(
+    request: Request,
+    project_scope_id: str | None = Query(default=None),
+    scope_id: str | None = Query(default=None),
+    target_scope: TargetScope = Query(default="project_shared"),
+) -> Path:
+    """Like :func:`resolve_scope_root`, but refuses a sync-ineligible scope.
+
+    Defense-in-depth backend gate for sync-enrollment (#1203 §1i). The Web UI
+    and ``mm context update --all`` already skip ineligible projects, but a
+    direct API call to a runtime-writing endpoint
+    (``/context/{agents,commands,skills,mcp-servers}/sync``, ``/settings-sync``
+    and its conflict mutators) would otherwise push into a *paused* (enrolled then
+    disabled) or *never-enrolled* (discovery-only scan row) project's runtime.
+    Such a scope has ``sync_eligible=False``; we reject it with 409. Cascade
+    artifact deletes (``DELETE /context/{agents,commands,skills}/{name}?cascade=true``)
+    also unlink the generated runtime copies, so they route through the sibling
+    :func:`resolve_scope_root_cascade_gated`, which reuses this guard only when
+    ``cascade=true`` (a plain canonical delete stays ungated).
+
+    Both project-runtime tiers are gated — ``project_shared``
+    (``<root>/.claude/settings.json``) and ``project_local``
+    (``<root>/.claude/settings.local.json``) write *into the project*, so a
+    paused project must be refused for either. Only the ``user`` tier (global
+    ``~/.claude/``, not the project's runtime) stays exempt. The eligibility
+    check can't lean on the artifact routes' ``_reject_non_shared_write`` as a
+    ``project_local`` backstop: the settings-sync routes legitimately accept
+    ``project_local`` and never call it, so the gate must be enforced here for
+    every project-tier write.
+
+    server-cwd is always eligible (you can't pause the running directory), so
+    the no-selector default path is never blocked.
+    """
+    scope = _resolve_selected_scope(request, project_scope_id, scope_id)
+    if scope is None:
+        return _default_project_root(request)
+    if target_scope != "user" and not scope.sync_eligible:
+        # ``sync_eligible`` is False in two shapes: an enrolled known-project
+        # whose ``enabled`` flag is off (paused), or a discovery-only scope
+        # that was never enrolled. Surface a machine-readable ``reason_code``
+        # (mirrors the Web UI's paused/not-enrolled tooltip split) inside a
+        # structured ``detail`` so clients can tell this 409 apart from the
+        # plain-string "already exists" / mtime-conflict 409s on the same
+        # endpoints.
+        paused = "known-projects" in scope.sources
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "reason_code": "sync_paused" if paused else "sync_not_enrolled",
+                "message": (
+                    f"Project {scope.scope_id!r} is not enrolled for sync "
+                    + (
+                        "(enrollment paused). Resume sync"
+                        if paused
+                        else "(discovery-only; never enrolled). Enroll the project"
+                    )
+                    + " from the Projects portal before writing to its runtime."
+                ),
+                "project_scope_id": scope.scope_id,
+            },
+        )
+    assert scope.root is not None  # _resolve_selected_scope 404s on a missing root
+    return scope.root
+
+
+def resolve_scope_root_cascade_gated(
+    request: Request,
+    project_scope_id: str | None = Query(default=None),
+    scope_id: str | None = Query(default=None),
+    target_scope: TargetScope = Query(default="project_shared"),
+    cascade: bool = Query(default=False),
+) -> Path:
+    """Scope resolver for the cascade-capable ``DELETE`` artifact routes.
+
+    A plain delete (``cascade=False``) removes only the canonical source and
+    stays ungated — pausing sync must not block managing a project's artifacts.
+    A ``cascade=True`` delete ALSO unlinks the generated runtime copies
+    (``gen.target_file(...)`` / the runtime skill dir under the project's
+    ``.claude`` etc.), so it writes the project runtime and is gated for
+    sync-eligibility exactly like a sync push (#1203 §1i). Mirrors the
+    ``cascade`` query the delete handlers already declare.
+    """
+    if cascade:
+        return resolve_writable_scope_root(request, project_scope_id, scope_id, target_scope)
+    return resolve_scope_root(request, project_scope_id, scope_id)
 
 
 # ── GET /context/projects ────────────────────────────────────────────────

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -28,7 +28,11 @@ from memtomem.context.skills import (
 )
 from memtomem.config import TargetScope
 from memtomem.web.routes._locks import _gateway_lock
-from memtomem.web.routes.context_projects import resolve_scope_root
+from memtomem.web.routes.context_projects import (
+    resolve_scope_root,
+    resolve_scope_root_cascade_gated,
+    resolve_writable_scope_root,
+)
 
 # Flat list of project-relative runtime scan paths reported on list / import
 # responses so the web UI's empty-state hint can name the exact directories
@@ -342,7 +346,7 @@ async def update_skill(
 async def delete_skill(
     name: str,
     cascade: bool = Query(False),
-    project_root: Path = Depends(resolve_scope_root),
+    project_root: Path = Depends(resolve_scope_root_cascade_gated),
     target_scope: TargetScope = Query(
         "project_shared",
         description="Canonical-residency tier to delete from. Non-shared tiers rejected (ADR-0011).",
@@ -453,7 +457,7 @@ async def diff_skill(
 
 @router.post("/context/skills/sync")
 async def sync_skills(
-    project_root: Path = Depends(resolve_scope_root),
+    project_root: Path = Depends(resolve_writable_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
         description=(

--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -28,7 +28,10 @@ from memtomem.context.settings_doctor import (
     detect_duplicate_tiers,
 )
 from memtomem.web.routes._locks import _gateway_lock
-from memtomem.web.routes.context_projects import resolve_scope_root
+from memtomem.web.routes.context_projects import (
+    resolve_scope_root,
+    resolve_writable_scope_root,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -390,7 +393,7 @@ class ApplySettingsSyncRequest(BaseModel):
 @router.post("/context/settings/sync")
 async def apply_settings_sync(
     body: ApplySettingsSyncRequest | None = None,
-    project_root: Path = Depends(resolve_scope_root),
+    project_root: Path = Depends(resolve_writable_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
         description="Claude Code settings tier to write.",
@@ -470,7 +473,7 @@ class ResolveRequest(BaseModel):
 @router.post("/context/settings/resolve")
 async def resolve_conflict(
     body: ResolveRequest,
-    project_root: Path = Depends(resolve_scope_root),
+    project_root: Path = Depends(resolve_writable_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
         description="Claude Code settings tier to update.",
@@ -730,7 +733,7 @@ def _check_rule_action_freshness(
 @router.post("/context/settings/rules/delete")
 async def delete_target_rule(
     body: RuleActionRequest,
-    project_root: Path = Depends(resolve_scope_root),
+    project_root: Path = Depends(resolve_writable_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
         description="Claude Code settings tier to update.",

--- a/packages/memtomem/tests/test_web_sync_write_guard.py
+++ b/packages/memtomem/tests/test_web_sync_write_guard.py
@@ -1,0 +1,441 @@
+"""Backend sync-eligibility write-guard tests (#1203 §1i).
+
+``resolve_writable_scope_root`` refuses the runtime-writing endpoints
+(``/context/{agents,commands,skills,mcp-servers}/sync``, ``/settings-sync`` and
+its conflict mutators ``resolve`` / ``rules/delete``) for a project scope that is
+not sync-eligible — an enrolled-then-paused known project, or a discovery-only
+``claude-projects`` scan row that was never enrolled. The Web UI and
+``mm context update --all`` already skip these projects; this is the
+defense-in-depth backend gate so that a *direct* API call cannot push into a
+paused project's runtime.
+
+Canonical-management endpoints (create / update / delete / import, and rule
+``promote``) write the canonical source — not the project's runtime — so they
+stay ungated: pausing sync must not block preparing a project's artifacts.
+
+server-cwd is always eligible (the running directory can't be paused), even
+when it has also been enrolled and then paused (the trusted ``server-cwd``
+source coalesces and keeps ``sync_eligible`` true).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from memtomem.config import ContextGatewayConfig, Mem2MemConfig
+from memtomem.context import projects as proj_mod
+from memtomem.web.app import create_app
+
+from .helpers import set_home
+
+
+# ── Fixtures (mirror test_web_routes_context_projects.py) ────────────────
+
+
+@pytest.fixture
+def cwd_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Sandbox HOME; return the cwd project root with a .claude marker."""
+    set_home(monkeypatch, tmp_path)
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    (cwd / ".claude").mkdir()
+    return cwd
+
+
+@pytest.fixture
+def known_projects_path(tmp_path: Path) -> Path:
+    return tmp_path / "kp.json"
+
+
+@pytest.fixture
+def app(cwd_root: Path, known_projects_path: Path):
+    application = create_app(lifespan=None, mode="dev")
+    application.state.project_root = cwd_root
+    application.state.storage = AsyncMock()
+    config = Mem2MemConfig()
+    config.context_gateway = ContextGatewayConfig(
+        known_projects_path=known_projects_path,
+        experimental_claude_projects_scan=False,
+    )
+    application.state.config = config
+    application.state.search_pipeline = None
+    application.state.index_engine = None
+    application.state.embedder = None
+    application.state.dedup_scanner = None
+    application.state.last_reload_error = None
+    return application
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+async def _enroll(client, root: Path) -> str:
+    """Register *root* as a known project; return its scope_id."""
+    resp = await client.post("/api/context/known-projects", json={"root": str(root)})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["project_scope_id"]
+
+
+async def _pause(client, scope_id: str) -> None:
+    """Pause sync enrollment for *scope_id* (PATCH enabled=False)."""
+    resp = await client.patch(f"/api/context/known-projects/{scope_id}", json={"enabled": False})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["enabled"] is False
+
+
+async def _post(client, path: str, *, params: dict, body: dict | None = None):
+    kwargs = {"json": body} if body is not None else {}
+    return await client.post(path, params=params, **kwargs)
+
+
+def _guard_reason(resp) -> str | None:
+    """Return the write-guard ``reason_code`` if *resp* is our 409, else None.
+
+    Distinguishes the sync-eligibility 409 (structured ``detail`` dict) from
+    the plain-string 409s the same endpoints raise for other reasons
+    (``create`` "already exists", ``update`` mtime conflict).
+    """
+    if resp.status_code != 409:
+        return None
+    detail = resp.json().get("detail")
+    if isinstance(detail, dict):
+        return detail.get("reason_code")
+    return None
+
+
+# The seven runtime-writing mutators the guard protects: (label, path, body).
+# ``None`` body → endpoint with an optional request body (sent with no JSON).
+GATED_ENDPOINTS = [
+    ("agents_sync", "/api/context/agents/sync", None),
+    ("commands_sync", "/api/context/commands/sync", None),
+    ("skills_sync", "/api/context/skills/sync", None),
+    ("mcp_servers_sync", "/api/context/mcp-servers/sync", None),
+    ("settings_apply", "/api/settings-sync", None),
+    ("settings_resolve", "/api/settings-sync/resolve", {"event": "PreToolUse", "matcher": ""}),
+    (
+        "settings_delete",
+        "/api/settings-sync/rules/delete",
+        {"event": "PreToolUse", "rule_index": 0, "rule_hash": "deadbeef"},
+    ),
+]
+_GATED_IDS = [e[0] for e in GATED_ENDPOINTS]
+
+# The artifact sync endpoints that return 200 on a clean enrolled project.
+SYNC_ENDPOINTS = [e for e in GATED_ENDPOINTS if e[0].endswith("_sync")]
+_SYNC_IDS = [e[0] for e in SYNC_ENDPOINTS]
+
+
+# ── Paused → 409 across every gated mutator ──────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("label,path,body", GATED_ENDPOINTS, ids=_GATED_IDS)
+async def test_gated_mutator_rejects_paused_project(
+    client, tmp_path: Path, label: str, path: str, body: dict | None
+) -> None:
+    proj = tmp_path / "proj"
+    (proj / ".claude").mkdir(parents=True)
+    sid = await _enroll(client, proj)
+    await _pause(client, sid)
+
+    resp = await _post(client, path, params={"project_scope_id": sid}, body=body)
+
+    assert resp.status_code == 409, resp.text
+    detail = resp.json()["detail"]
+    assert detail["reason_code"] == "sync_paused"
+    assert detail["project_scope_id"] == sid
+
+
+# ── Eligible scopes pass the guard ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("label,path,body", SYNC_ENDPOINTS, ids=_SYNC_IDS)
+async def test_gated_sync_allows_enrolled_enabled(
+    client, tmp_path: Path, label: str, path: str, body: dict | None
+) -> None:
+    """An enrolled, enabled project is sync-eligible — the guard lets it through."""
+    proj = tmp_path / "proj"
+    (proj / ".claude").mkdir(parents=True)
+    sid = await _enroll(client, proj)  # enabled defaults True
+
+    resp = await _post(client, path, params={"project_scope_id": sid}, body=body)
+
+    assert resp.status_code == 200, resp.text
+    assert _guard_reason(resp) is None
+
+
+@pytest.mark.asyncio
+async def test_no_selector_server_cwd_passes(client) -> None:
+    """No selector → server cwd, which is always sync-eligible."""
+    resp = await client.post("/api/context/agents/sync")
+    assert resp.status_code == 200, resp.text
+    assert _guard_reason(resp) is None
+
+
+@pytest.mark.asyncio
+async def test_paused_cwd_still_eligible_via_server_cwd(client, cwd_root: Path) -> None:
+    """Enrolling + pausing the *running* directory must not lock it out.
+
+    The trusted ``server-cwd`` source coalesces with the paused known-projects
+    entry, so ``sync_eligible`` stays true — you can't pause the dir you're in.
+    """
+    sid = await _enroll(client, cwd_root)
+    await _pause(client, sid)
+
+    resp = await client.post("/api/context/agents/sync", params={"project_scope_id": sid})
+
+    assert resp.status_code == 200, resp.text
+    assert _guard_reason(resp) is None
+
+
+@pytest.mark.asyncio
+async def test_scan_only_never_enrolled_rejected(
+    client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A discovery-only claude-projects scan row was never enrolled → 409.
+
+    Distinct ``reason_code`` from the paused case so the client can render
+    "enroll first" vs "resume" (mirrors the Web UI tooltip split).
+    """
+    cp = tmp_path / "fake_home" / ".claude" / "projects"
+    cp.mkdir(parents=True)
+    # Overrides the suite-wide ``_isolate_claude_projects_scan`` autouse pin.
+    monkeypatch.setattr(proj_mod, "_CLAUDE_PROJECTS_DIR", cp)
+    scan_root = tmp_path / "scanned_proj"
+    (scan_root / ".claude").mkdir(parents=True)
+    (cp / proj_mod._encode_claude_project_path(scan_root)).mkdir()
+
+    listing = await client.get("/api/context/projects")
+    scopes = listing.json()["scopes"]
+    scan = next(
+        s for s in scopes if "claude-projects" in s["sources"] and "server-cwd" not in s["sources"]
+    )
+    assert scan["sync_eligible"] is False
+
+    resp = await client.post(
+        "/api/context/agents/sync", params={"project_scope_id": scan["project_scope_id"]}
+    )
+
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["detail"]["reason_code"] == "sync_not_enrolled"
+
+
+# ── Both project-runtime tiers gated; user tier exempt ───────────────────
+
+# The settings-sync routes legitimately accept ``project_local`` (they have NO
+# ``_reject_non_shared_write`` tier backstop), so the guard — not the route —
+# is the only thing standing between a paused project and a ``project_local``
+# runtime write.
+_SETTINGS_RUNTIME_WRITES = [e for e in GATED_ENDPOINTS if e[0].startswith("settings_")]
+_SETTINGS_IDS = [e[0] for e in _SETTINGS_RUNTIME_WRITES]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("label,path,body", _SETTINGS_RUNTIME_WRITES, ids=_SETTINGS_IDS)
+async def test_settings_project_local_on_paused_rejected(
+    client, tmp_path: Path, label: str, path: str, body: dict | None
+) -> None:
+    """Regression (review blocker): ``project_local`` is a project-runtime write
+    (``<root>/.claude/settings.local.json``). The settings routes have no
+    ``_reject_non_shared_write`` backstop, so the guard must 409 ``project_local``
+    on a paused project — and nothing may be written under ``proj/.claude/``.
+    """
+    proj = tmp_path / "proj"
+    (proj / ".claude").mkdir(parents=True)
+    sid = await _enroll(client, proj)
+    await _pause(client, sid)
+
+    resp = await _post(
+        client, path, params={"project_scope_id": sid, "target_scope": "project_local"}, body=body
+    )
+
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["detail"]["reason_code"] == "sync_paused"
+    assert not (proj / ".claude" / "settings.local.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_artifact_sync_project_local_on_paused_rejected_by_guard(
+    client, tmp_path: Path
+) -> None:
+    """For artifact sync, ``project_local`` + paused now 409s via the eligibility
+    guard (gated for every project tier). The guard runs before the route's
+    ``project_shared``-only tier gate, so the response is the structured 409,
+    not a plain 400.
+    """
+    proj = tmp_path / "proj"
+    (proj / ".claude").mkdir(parents=True)
+    sid = await _enroll(client, proj)
+    await _pause(client, sid)
+
+    resp = await client.post(
+        "/api/context/agents/sync",
+        params={"project_scope_id": sid, "target_scope": "project_local"},
+    )
+
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["detail"]["reason_code"] == "sync_paused"
+
+
+@pytest.mark.asyncio
+async def test_user_tier_exempt_on_paused(client, tmp_path: Path) -> None:
+    """``user`` targets global ``~/.claude``, not the project runtime, so a
+    paused project does not block it — the guard exempts user-tier writes.
+    """
+    proj = tmp_path / "proj"
+    (proj / ".claude").mkdir(parents=True)
+    sid = await _enroll(client, proj)
+    await _pause(client, sid)
+
+    resp = await _post(
+        client, "/api/settings-sync", params={"project_scope_id": sid, "target_scope": "user"}
+    )
+
+    assert _guard_reason(resp) is None
+
+
+@pytest.mark.asyncio
+async def test_settings_project_local_on_enabled_allowed(client, tmp_path: Path) -> None:
+    """A legitimate ``project_local`` settings sync to an enrolled+enabled project
+    must NOT be blocked — the guard only refuses sync-ineligible scopes.
+    """
+    proj = tmp_path / "proj"
+    (proj / ".claude").mkdir(parents=True)
+    sid = await _enroll(client, proj)  # enabled defaults True
+
+    resp = await _post(
+        client,
+        "/api/settings-sync",
+        params={"project_scope_id": sid, "target_scope": "project_local"},
+    )
+
+    assert _guard_reason(resp) is None
+
+
+# ── Canonical-management endpoints stay ungated on a paused project ───────
+
+
+@pytest.mark.asyncio
+async def test_canonical_create_not_gated_on_paused(client, tmp_path: Path) -> None:
+    """Creating a canonical agent writes the source, not the runtime → allowed."""
+    proj = tmp_path / "proj"
+    (proj / ".claude").mkdir(parents=True)
+    sid = await _enroll(client, proj)
+    await _pause(client, sid)
+
+    resp = await client.post(
+        "/api/context/agents",
+        params={"project_scope_id": sid},
+        json={"name": "helper", "content": "# helper\n"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert _guard_reason(resp) is None
+
+
+@pytest.mark.asyncio
+async def test_import_not_gated_on_paused(client, tmp_path: Path) -> None:
+    """Import pulls runtime → canonical (a canonical write) → not pause-gated."""
+    proj = tmp_path / "proj"
+    (proj / ".claude").mkdir(parents=True)
+    sid = await _enroll(client, proj)
+    await _pause(client, sid)
+
+    resp = await client.post("/api/context/agents/import", params={"project_scope_id": sid})
+
+    assert resp.status_code == 200, resp.text
+    assert _guard_reason(resp) is None
+
+
+@pytest.mark.asyncio
+async def test_promote_rule_not_gated_on_paused(client, tmp_path: Path) -> None:
+    """``rules/promote`` writes the canonical settings file → not pause-gated.
+
+    With no target rule present it fails downstream (not our 409); the point is
+    the write-guard never fires for this canonical-direction endpoint.
+    """
+    proj = tmp_path / "proj"
+    (proj / ".claude").mkdir(parents=True)
+    sid = await _enroll(client, proj)
+    await _pause(client, sid)
+
+    resp = await client.post(
+        "/api/settings-sync/rules/promote",
+        params={"project_scope_id": sid},
+        json={"event": "PreToolUse", "rule_index": 0, "rule_hash": "deadbeef"},
+    )
+
+    assert _guard_reason(resp) is None
+
+
+# ── Cascade delete: canonical ungated, runtime-cascade gated ──────────────
+#
+# DELETE /context/{type}/{name} removes the canonical source (ungated), but
+# ``?cascade=true`` ALSO unlinks the generated runtime copies — a runtime
+# write — so only the cascade variant is sync-eligibility-gated, via
+# ``resolve_scope_root_cascade_gated``. (Codex review catch.)
+
+_CASCADE_KINDS = ["agents", "commands", "skills"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", _CASCADE_KINDS)
+async def test_cascade_delete_on_paused_rejected(client, tmp_path: Path, kind: str) -> None:
+    """``cascade=true`` delete unlinks runtime copies → gated 409 on a paused project."""
+    proj = tmp_path / "proj"
+    (proj / ".claude").mkdir(parents=True)
+    sid = await _enroll(client, proj)
+    await _pause(client, sid)
+
+    resp = await client.delete(
+        f"/api/context/{kind}/anyname",
+        params={"project_scope_id": sid, "cascade": "true"},
+    )
+
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["detail"]["reason_code"] == "sync_paused"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", _CASCADE_KINDS)
+async def test_plain_delete_on_paused_not_gated(client, tmp_path: Path, kind: str) -> None:
+    """A plain (non-cascade) delete touches only the canonical source → ungated."""
+    proj = tmp_path / "proj"
+    (proj / ".claude").mkdir(parents=True)
+    sid = await _enroll(client, proj)
+    await _pause(client, sid)
+
+    # cascade defaults False → no runtime write → the guard must not fire.
+    resp = await client.delete(f"/api/context/{kind}/nonexistent", params={"project_scope_id": sid})
+
+    assert _guard_reason(resp) is None
+
+
+@pytest.mark.asyncio
+async def test_mcp_cascade_delete_on_paused_not_gated(client, tmp_path: Path) -> None:
+    """MCP cascade delete is a documented v1 no-op (no runtime unlink), so it is
+    intentionally NOT gated — gating a no-op would 409 a harmless request.
+    """
+    proj = tmp_path / "proj"
+    (proj / ".claude").mkdir(parents=True)
+    sid = await _enroll(client, proj)
+    await _pause(client, sid)
+
+    resp = await client.delete(
+        "/api/context/mcp-servers/nonexistent",
+        params={"project_scope_id": sid, "cascade": "true"},
+    )
+
+    assert _guard_reason(resp) is None


### PR DESCRIPTION
## What & why

Closes the last deferred item of #1203 (**§1i**): a **defense-in-depth backend gate** so a direct API call can't write into a **paused** (enrolled→disabled) or **never-enrolled** (discovery-only scan row) project's runtime. Until now, pause was enforced only at the **Web UI** and `mm context update --all` — both bypassable by hitting the HTTP API directly.

## How

- New FastAPI dependency **`resolve_writable_scope_root`** (sibling of `resolve_scope_root`, sharing the extracted `_resolve_selected_scope` resolver — no behavior change to the read path). Raises **409** with a structured `detail` carrying a machine-readable `reason_code` (`sync_paused` / `sync_not_enrolled`) when the resolved scope has `sync_eligible=False`. Reuses the existing `ProjectScope.sync_eligible` derivation — no duplicated logic. `server-cwd` is always eligible (you can't pause the running dir; it coalesces with a paused entry).
- Applied to the **seven always-runtime-writing mutators**:
  - `POST /context/{agents,commands,skills,mcp-servers}/sync`
  - `POST /settings-sync` (apply), `POST /settings-sync/resolve`, `POST /settings-sync/rules/delete`
- **Cascade deletes** are conditionally gated via **`resolve_scope_root_cascade_gated`**: `DELETE /context/{agents,commands,skills}/{name}` removes only the canonical source when plain (**ungated**), but `?cascade=true` ALSO unlinks the generated **runtime** copies — a runtime write — so the cascade variant is gated. (MCP cascade is a documented v1 no-op, so it stays ungated.)
- **Not gated** (canonical-direction writes — pause must not block preparing a project's artifacts): `create/update` agent·command·skill·mcp, `import_*`, `rules/promote`, and plain (non-cascade) `delete`.

### Tier handling
The guard gates **both project-runtime tiers** — `project_shared` (`.claude/settings.json`) and `project_local` (`.claude/settings.local.json`). The `user` tier targets global `~/.claude` and stays **exempt**.

## Adversarial review — two blockers caught & fixed

1. **`project_local` bypass** (multi-agent review): gating only `project_shared` left the three **settings** routes open — unlike the artifact routes they have no `_reject_non_shared_write` backstop and legitimately accept `project_local`, so `?target_scope=project_local` slipped a runtime write into a paused project (live-reproduced). Fixed by gating every project-runtime tier (`target_scope != "user"`).
2. **Cascade-delete bypass** (Codex review): `DELETE …?cascade=true` unlinks runtime copies through a route still on the ungated resolver. Fixed with the cascade-aware resolver above.

Both are regression-tested.

## Tests

`packages/memtomem/tests/test_web_sync_write_guard.py`: paused / not-enrolled **409 across all gated routes**; `server-cwd` + coalesced cwd-paused **pass**; the `project_local` hole closed (409 + no-write); `user`-tier exempt; **cascade delete gated while plain delete + MCP-cascade stay ungated**; canonical routes ungated on a paused project; `not_enrolled` reason_code via a real `claude-projects` scan row.

- Full `pytest -m "not ollama"`: **5884 passed**. The one unrelated failure, `test_calibrate_portfolio::test_collect_tagged_chunks_counts_match_corpus`, is a live-`corpus_v2`-fixture env/ordering check byte-identical to `main` (fails the same way before this change) — not caused by this PR.
- `ruff check` + `ruff format --check`: clean. `mypy`: advisory; the 2 pre-existing `_scope_to_dict` notes are untouched.

## Out of scope
CLI (`mm context update --all` already skips disabled) and MCP-tool sync parity — this PR is the **web-API** backstop.
