### PR TITLE
fix(web): handle structured 409 (sync paused/not-enrolled) in the UI (#1210 follow-up)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -90,11 +90,18 @@ async function _ctxErrorMessageFromResponse(resp, fallback) {
   if (contentType.includes('application/json')) {
     const err = await resp.json().catch(() => ({}));
     const detail = err.detail;
-    if (typeof detail === 'string' && detail) return detail;
-    // Defensive fallback for structured payloads shaped like `{detail: "..."}`.
+    // Defensive branch for structured payloads shaped like `{detail: "..."}`
+    // (ProjectTierBlocked / redaction) — a different shape than #1210's 409, so
+    // handle it before delegating to the shared extractor.
     if (detail && typeof detail === 'object' && typeof detail.detail === 'string' && detail.detail) {
       return detail.detail;
     }
+    // String detail, or #1210's ``{reason_code, message}`` write-guard 409, both
+    // via the shared extractor — so the Sync All fan-out surfaces the same
+    // localized paused / not-enrolled reason the per-row / per-section Sync
+    // buttons do, instead of a generic English fallback.
+    const extracted = _ctxErrDetail(detail, null);
+    if (extracted) return extracted;
   } else {
     const text = await resp.text().catch(() => '');
     if (text.trim()) return text;
@@ -1336,7 +1343,7 @@ function _ctxWireProjectsMatrix() {
         });
         if (!r.ok) {
           const err = await r.json().catch(() => ({}));
-          showToast(err.detail || t('toast.request_failed'), 'error');
+          showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
           return;
         }
         loadCtxOverview();
@@ -2205,6 +2212,22 @@ function _ctxScopeSyncEligible(scope) {
   return _ctxScopeIsEnrolled(scope) && scope.enabled !== false;
 }
 
+// Map a structured 409 write-guard ``detail`` to a readable, localized string.
+// Backend #1210 returns ``detail = {reason_code, message, project_scope_id}`` on
+// sync-ineligible writes; every other route returns a plain string ``detail``.
+// Precedence: known reason_code → i18n key; else the backend's English
+// ``message``; else a string detail as-is; else the caller's fallback.
+function _ctxErrDetail(detail, fallback) {
+  if (typeof detail === 'string') return detail;
+  if (detail && typeof detail === 'object') {
+    const rc = detail.reason_code;
+    if (rc === 'sync_paused') return t('settings.ctx.error_sync_paused');
+    if (rc === 'sync_not_enrolled') return t('settings.ctx.error_sync_not_enrolled');
+    if (typeof detail.message === 'string') return detail.message;
+  }
+  return fallback;
+}
+
 // Sync All fans out over the ACTIVE scope's artifact types, so it must honor the
 // same eligibility gate as the per-row matrix Sync button — otherwise an
 // ineligible active project (paused / not enrolled) is still syncable via Sync
@@ -2786,7 +2809,7 @@ async function loadCtxList(type) {
             });
             if (!r.ok) {
               const err = await r.json().catch(() => ({}));
-              showToast(err.detail || t('toast.request_failed'), 'error');
+              showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
               return;
             }
             loadCtxList(type);
@@ -3164,13 +3187,30 @@ async function loadCtxDetail(type, name, opts = {}) {
     // toggle's `.then()` had just rehydrated (review P2).
     if (seq !== _ctxDetailSeq[type]) return;
 
+    // Proactively disable Delete when the active project is sync-ineligible.
+    // A ``cascade=true`` delete unlinks the generated runtime copies, which the
+    // backend 409s for a paused / not-enrolled project (#1210); gating here
+    // avoids that round-trip and mirrors the matrix Sync button (same tooltip
+    // keys). The §2a error handler stays as the safety net for the race window
+    // where the scope is paused after this render. (Caveat: this also blocks a
+    // canonical-only delete on an ineligible scope — acceptable, the user
+    // resumes/enrolls on the Projects board; see PR description.)
+    const _delScope = (_ctxProjectsCache || []).find(_ctxScopeIsActive);
+    let delAttrs = '';
+    if (_delScope && !_ctxScopeSyncEligible(_delScope)) {
+      const k = _ctxScopeIsEnrolled(_delScope)
+        ? 'settings.ctx.matrix_sync_paused_title'
+        : 'settings.ctx.matrix_sync_not_enrolled_title';
+      delAttrs = ` disabled data-i18n-title="${k}" title="${escapeHtml(t(k))}"`;
+    }
+
     let html = '<div class="ctx-detail">';
     html += `<div class="ctx-detail-header">
       <strong>${escapeHtml(name)}</strong>
       <div style="display:flex;gap:6px">
         <button class="btn-ghost ctx-detail-edit-btn" data-i18n="settings.ctx.edit">${t('settings.ctx.edit')}</button>
         <button class="btn-ghost ctx-detail-diff-btn" data-i18n="settings.ctx.diff_view">${t('settings.ctx.diff_view')}</button>
-        <button class="btn-ghost btn-danger ctx-detail-delete-btn" data-i18n="settings.ctx.delete">${t('settings.ctx.delete')}</button>
+        <button class="btn-ghost btn-danger ctx-detail-delete-btn"${delAttrs} data-i18n="settings.ctx.delete">${t('settings.ctx.delete')}</button>
       </div>
     </div>`;
 
@@ -3400,7 +3440,7 @@ async function loadCtxDetail(type, name, opts = {}) {
         );
         if (!r.ok) {
           const err = await r.json().catch(() => ({}));
-          showToast(err.detail || t('toast.request_failed'), 'error');
+          showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
           return;
         }
         const data = await r.json();
@@ -3609,7 +3649,7 @@ async function _ctxLoadRuntimeOnlyDetail(type, name, detailEl, opts = {}) {
         );
         if (!r.ok) {
           const err = await r.json().catch(() => ({}));
-          showToast(err.detail || t('toast.request_failed'), 'error');
+          showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
           return;
         }
         const data = await r.json();
@@ -3674,7 +3714,7 @@ document.querySelectorAll('.ctx-sync-btn').forEach(btn => {
       );
       if (!r.ok) {
         const err = await r.json().catch(() => ({}));
-        showToast(err.detail || t('toast.request_failed'), 'error');
+        showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
         return;
       }
       const data = await r.json();
@@ -3737,7 +3777,7 @@ document.querySelectorAll('.ctx-import-btn').forEach(btn => {
       });
       if (!r.ok) {
         const err = await r.json().catch(() => ({}));
-        showToast(err.detail || t('toast.request_failed'), 'error');
+        showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
         return;
       }
       const data = await r.json();
@@ -3813,7 +3853,7 @@ document.querySelectorAll('.ctx-create-btn').forEach(btn => {
         });
         if (!r.ok) {
           const err = await r.json().catch(() => ({}));
-          showToast(err.detail || t('toast.request_failed'), 'error');
+          showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
           return;
         }
         showToast(t('settings.ctx.create_success').replace('{name}', nameInput));
@@ -3856,7 +3896,7 @@ document.querySelectorAll('.ctx-add-project-btn').forEach(btn => {
         });
         if (!r.ok) {
           const err = await r.json().catch(() => ({}));
-          showToast(err.detail || t('toast.request_failed'), 'error');
+          showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
           return;
         }
         const data = await r.json();

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -3187,30 +3187,13 @@ async function loadCtxDetail(type, name, opts = {}) {
     // toggle's `.then()` had just rehydrated (review P2).
     if (seq !== _ctxDetailSeq[type]) return;
 
-    // Proactively disable Delete when the active project is sync-ineligible.
-    // A ``cascade=true`` delete unlinks the generated runtime copies, which the
-    // backend 409s for a paused / not-enrolled project (#1210); gating here
-    // avoids that round-trip and mirrors the matrix Sync button (same tooltip
-    // keys). The §2a error handler stays as the safety net for the race window
-    // where the scope is paused after this render. (Caveat: this also blocks a
-    // canonical-only delete on an ineligible scope — acceptable, the user
-    // resumes/enrolls on the Projects board; see PR description.)
-    const _delScope = (_ctxProjectsCache || []).find(_ctxScopeIsActive);
-    let delAttrs = '';
-    if (_delScope && !_ctxScopeSyncEligible(_delScope)) {
-      const k = _ctxScopeIsEnrolled(_delScope)
-        ? 'settings.ctx.matrix_sync_paused_title'
-        : 'settings.ctx.matrix_sync_not_enrolled_title';
-      delAttrs = ` disabled data-i18n-title="${k}" title="${escapeHtml(t(k))}"`;
-    }
-
     let html = '<div class="ctx-detail">';
     html += `<div class="ctx-detail-header">
       <strong>${escapeHtml(name)}</strong>
       <div style="display:flex;gap:6px">
         <button class="btn-ghost ctx-detail-edit-btn" data-i18n="settings.ctx.edit">${t('settings.ctx.edit')}</button>
         <button class="btn-ghost ctx-detail-diff-btn" data-i18n="settings.ctx.diff_view">${t('settings.ctx.diff_view')}</button>
-        <button class="btn-ghost btn-danger ctx-detail-delete-btn"${delAttrs} data-i18n="settings.ctx.delete">${t('settings.ctx.delete')}</button>
+        <button class="btn-ghost btn-danger ctx-detail-delete-btn" data-i18n="settings.ctx.delete">${t('settings.ctx.delete')}</button>
       </div>
     </div>`;
 
@@ -3418,18 +3401,39 @@ async function loadCtxDetail(type, name, opts = {}) {
       // dialog conservative — a stray click only removes the canonical,
       // and the user has to consciously check the box to fan-out delete
       // into ``~/.claude/skills/``, ``~/.codex/...``, etc.
-      const result = await showConfirm({
+      //
+      // The cascade fan-out writes the project runtime, which the backend 409s
+      // for a sync-ineligible (paused / not-enrolled) project (#1210). A plain
+      // canonical-only delete (cascade=false) stays UNgated, so offer the
+      // cascade checkbox ONLY when the active scope is sync-eligible — and gate
+      // the option, NOT the whole Delete button, so a canonical delete the
+      // backend allows still works. Computed at click time so a mid-session
+      // pause/resume is reflected. When ineligible we hide the option and note
+      // that only the canonical copy is removed. The §2a 409 handler below is
+      // the safety net if eligibility flips between this click and the request.
+      const _delScope = (_ctxProjectsCache || []).find(_ctxScopeIsActive);
+      const _cascadeOffered = !_delScope || _ctxScopeSyncEligible(_delScope);
+      const confirmOpts = {
         title: t('settings.ctx.confirm_delete').replace('{name}', name),
-        message: t('settings.ctx.confirm_delete_msg'),
+        message: _cascadeOffered
+          ? t('settings.ctx.confirm_delete_msg')
+          : `${t('settings.ctx.confirm_delete_msg')} ${t('settings.ctx.cascade_unavailable_hint')}`,
         confirmText: t('settings.ctx.delete'),
-        extraOption: {
+      };
+      if (_cascadeOffered) {
+        confirmOpts.extraOption = {
           id: 'cascade',
           label: t('settings.ctx.cascade_delete'),
           defaultChecked: false,
-        },
-      });
-      if (!result || !result.ok) return;
-      const cascade = !!(result.extras && result.extras.cascade);
+        };
+      }
+      const result = await showConfirm(confirmOpts);
+      // ``showConfirm`` resolves to a boolean without ``extraOption`` and to
+      // ``{ok, extras}`` with it — normalize both shapes.
+      const ok = (result && typeof result === 'object') ? result.ok : !!result;
+      if (!ok) return;
+      const cascade = !!(result && typeof result === 'object'
+        && result.extras && result.extras.cascade);
       try {
         const csrf = await ensureCsrfToken();
         const r = await fetch(

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1514,9 +1514,9 @@
   <script src="/settings-maintenance.js?v=3"></script>
   <script src="/settings-namespaces.js?v=9"></script>
   <script src="/settings-harness.js?v=2"></script>
-  <script src="/settings-hooks-watchdog.js?v=13"></script>
+  <script src="/settings-hooks-watchdog.js?v=14"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=51"></script>
+  <script src="/context-gateway.js?v=52"></script>
   <script src="/context-portal.js?v=1"></script>
   <script src="/path-picker.js?v=3"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -390,6 +390,8 @@
   "settings.ctx.matrix_sync_disabled_title": "No fan-out for project_local or missing project",
   "settings.ctx.matrix_sync_not_enrolled_title": "Not enrolled — enroll this project on the Projects board to sync it",
   "settings.ctx.matrix_sync_paused_title": "Sync paused — resume it on the Projects board",
+  "settings.ctx.error_sync_paused": "Project sync is paused — resume it on the Projects board.",
+  "settings.ctx.error_sync_not_enrolled": "Project is not enrolled for sync — enroll it on the Projects board.",
   "settings.ctx.matrix_counts_title": "Skills: {skills}, Commands: {commands}, Agents: {agents}, MCP: {mcp}",
   "settings.ctx.import": "Import",
   "settings.ctx.create": "Create",

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -392,6 +392,7 @@
   "settings.ctx.matrix_sync_paused_title": "Sync paused — resume it on the Projects board",
   "settings.ctx.error_sync_paused": "Project sync is paused — resume it on the Projects board.",
   "settings.ctx.error_sync_not_enrolled": "Project is not enrolled for sync — enroll it on the Projects board.",
+  "settings.ctx.cascade_unavailable_hint": "Sync is paused or not enrolled for this project, so only the canonical copy is deleted (no runtime fan-out).",
   "settings.ctx.matrix_counts_title": "Skills: {skills}, Commands: {commands}, Agents: {agents}, MCP: {mcp}",
   "settings.ctx.import": "Import",
   "settings.ctx.create": "Create",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -390,6 +390,8 @@
   "settings.ctx.matrix_sync_disabled_title": "project_local 또는 누락된 프로젝트는 팬아웃 없음",
   "settings.ctx.matrix_sync_not_enrolled_title": "미등록 — 프로젝트 보드에서 등록하면 동기화할 수 있습니다",
   "settings.ctx.matrix_sync_paused_title": "동기화 중지됨 — 프로젝트 보드에서 재개하세요",
+  "settings.ctx.error_sync_paused": "프로젝트 동기화가 중지되었습니다 — 프로젝트 보드에서 재개하세요.",
+  "settings.ctx.error_sync_not_enrolled": "프로젝트가 동기화에 미등록 상태입니다 — 프로젝트 보드에서 등록하세요.",
   "settings.ctx.matrix_counts_title": "스킬: {skills}, 명령: {commands}, 에이전트: {agents}, MCP: {mcp}",
   "settings.ctx.import": "가져오기",
   "settings.ctx.create": "만들기",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -392,6 +392,7 @@
   "settings.ctx.matrix_sync_paused_title": "동기화 중지됨 — 프로젝트 보드에서 재개하세요",
   "settings.ctx.error_sync_paused": "프로젝트 동기화가 중지되었습니다 — 프로젝트 보드에서 재개하세요.",
   "settings.ctx.error_sync_not_enrolled": "프로젝트가 동기화에 미등록 상태입니다 — 프로젝트 보드에서 등록하세요.",
+  "settings.ctx.cascade_unavailable_hint": "이 프로젝트는 동기화가 중지되었거나 미등록 상태라 정규본만 삭제됩니다 (런타임 fan-out 없음).",
   "settings.ctx.matrix_counts_title": "스킬: {skills}, 명령: {commands}, 에이전트: {agents}, MCP: {mcp}",
   "settings.ctx.import": "가져오기",
   "settings.ctx.create": "만들기",

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -43,6 +43,19 @@ function _hooksCurrentProjectScope() {
   return '';
 }
 
+// Trampoline to context-gateway.js's ``_ctxErrDetail`` (which owns the #1210
+// ``reason_code`` → i18n mapping). ``_ctxErrDetail`` is a hoisted top-level
+// function declaration and this trampoline only runs inside async error
+// handlers (long after both files have parsed), so it resolves regardless of
+// <script> order. The fallback below — a plain string / ``.message`` extract —
+// only matters if this file is loaded standalone (e.g. an isolated unit test).
+function _hooksErrDetail(detail, fallback) {
+  if (typeof _ctxErrDetail === 'function') return _ctxErrDetail(detail, fallback);
+  if (typeof detail === 'string') return detail;
+  if (detail && typeof detail === 'object' && typeof detail.message === 'string') return detail.message;
+  return fallback;
+}
+
 function _hooksScopedUrl(path) {
   if (typeof _ctxWithTargetScope === 'function') {
     return _ctxWithTargetScope(path);
@@ -174,7 +187,7 @@ async function _hooksPostRuleAction(action, entry, confirmPrivateToShared) {
   });
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
-    throw new Error(err.detail || `Request failed: ${res.status}`);
+    throw new Error(_hooksErrDetail(err.detail, `Request failed: ${res.status}`));
   }
   return res.json();
 }
@@ -455,18 +468,50 @@ async function loadHooksSync() {
     if (syncBtn) {
       const isNoSource = data.status === 'no_source';
       const isNoHooks = data.status === 'no_hooks';
-      syncBtn.disabled = isNoSource || isNoHooks;
+      // Proactively disable Sync Now when the active project is sync-ineligible
+      // (paused / not enrolled) — the backend 409s such a settings-sync push
+      // (#1210). Mirror the backend's tier exemption: only project-tier writes
+      // are gated. ``resolve_writable_scope_root`` skips ``target_scope ==
+      // 'user'`` (the user tier writes global ~/.claude, NOT the project
+      // runtime), so a user-tier sync must stay enabled even when the active
+      // project is paused — otherwise we'd block a write the backend allows and
+      // show a misleading "resume on the Projects board" tooltip. ``typeof``
+      // guards keep the watchdog fail-open when context-gateway.js's
+      // helpers/cache aren't loaded (standalone unit test) → button stays enabled
+      // → the §2b error handler catches any 409. A server-cwd active scope DOES
+      // match the cache but ``_ctxScopeSyncEligible`` reports it eligible, so it
+      // stays enabled too.
+      const _hScope = (typeof _ctxProjectsCache !== 'undefined'
+        ? (_ctxProjectsCache || []).find(
+            s => s && !s.missing && s.scope_id === _hooksCurrentProjectScope())
+        : null);
+      const _hIneligible = _hooksCurrentTargetScope() !== 'user'
+        && !!_hScope
+        && typeof _ctxScopeSyncEligible === 'function'
+        && !_ctxScopeSyncEligible(_hScope);
+      syncBtn.disabled = isNoSource || isNoHooks || _hIneligible;
       if (isNoSource) {
         syncBtn.setAttribute('data-no-source', 'true');
         syncBtn.removeAttribute('data-no-hooks');
+        syncBtn.removeAttribute('data-sync-ineligible');
         syncBtn.title = t('settings.hooks.sync_now_disabled_no_source');
       } else if (isNoHooks) {
         syncBtn.removeAttribute('data-no-source');
         syncBtn.setAttribute('data-no-hooks', 'true');
+        syncBtn.removeAttribute('data-sync-ineligible');
         syncBtn.title = t('settings.hooks.sync_now_disabled_no_hooks');
+      } else if (_hIneligible) {
+        const k = (typeof _ctxScopeIsEnrolled === 'function' && _ctxScopeIsEnrolled(_hScope))
+          ? 'settings.ctx.matrix_sync_paused_title'
+          : 'settings.ctx.matrix_sync_not_enrolled_title';
+        syncBtn.removeAttribute('data-no-source');
+        syncBtn.removeAttribute('data-no-hooks');
+        syncBtn.setAttribute('data-sync-ineligible', k);
+        syncBtn.title = t(k);
       } else {
         syncBtn.removeAttribute('data-no-source');
         syncBtn.removeAttribute('data-no-hooks');
+        syncBtn.removeAttribute('data-sync-ineligible');
         syncBtn.title = t('settings.hooks.sync_now_tooltip');
       }
     }
@@ -695,7 +740,7 @@ async function loadHooksSync() {
           });
           if (!r.ok) {
             const err = await r.json().catch(() => ({}));
-            showToast(err.detail || t('toast.request_failed'), 'error');
+            showToast(_hooksErrDetail(err.detail, t('toast.request_failed')), 'error');
             return;
           }
           const result = await r.json();
@@ -742,7 +787,7 @@ document.getElementById('hooks-sync-btn')?.addEventListener('click', async () =>
     });
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
-      throw new Error(err.detail || `Request failed: ${res.status}`);
+      throw new Error(_hooksErrDetail(err.detail, `Request failed: ${res.status}`));
     }
     return res.json();
   };

--- a/packages/memtomem/tests-js/ctx-sync-enrollment.test.mjs
+++ b/packages/memtomem/tests-js/ctx-sync-enrollment.test.mjs
@@ -111,6 +111,49 @@ describe('sync-eligibility helpers', () => {
   });
 });
 
+describe('_ctxErrDetail — structured 409 (#1210) → localized string', () => {
+  it('passes a plain-string detail through unchanged (back-compat with every non-gated route)', async () => {
+    const { window } = await boot();
+    expect(window._ctxErrDetail('Already exists', 'fb')).toBe('Already exists');
+  });
+
+  it('maps reason_code → the localized toast copy (not the raw key, not [object Object])', async () => {
+    const { window } = await boot();
+    // i18n loads the catalog asynchronously and ``boot`` doesn't await it;
+    // ``setLang`` resolves once ``/locales/en.json`` is in, so ``t()`` returns
+    // real copy rather than the raw-key fallback.
+    await window.I18N.setLang('en');
+    const paused = window._ctxErrDetail({ reason_code: 'sync_paused' }, 'fb');
+    expect(paused).toBe(window.t('settings.ctx.error_sync_paused'));
+    expect(paused).not.toBe('settings.ctx.error_sync_paused'); // key actually resolved
+    expect(paused).not.toContain('[object Object]');
+
+    const notEnrolled = window._ctxErrDetail({ reason_code: 'sync_not_enrolled' }, 'fb');
+    expect(notEnrolled).toBe(window.t('settings.ctx.error_sync_not_enrolled'));
+    expect(notEnrolled).not.toBe('settings.ctx.error_sync_not_enrolled');
+  });
+
+  it('falls back to the backend message for an unknown reason_code', async () => {
+    const { window } = await boot();
+    expect(window._ctxErrDetail(
+      { reason_code: 'something_else', message: 'Backend said no' }, 'fb',
+    )).toBe('Backend said no');
+  });
+
+  it('uses .message when there is no reason_code', async () => {
+    const { window } = await boot();
+    expect(window._ctxErrDetail({ message: 'plain message' }, 'fb')).toBe('plain message');
+  });
+
+  it('falls back to the caller fallback for empty / unusable detail', async () => {
+    const { window } = await boot();
+    expect(window._ctxErrDetail(undefined, 'fb')).toBe('fb');
+    expect(window._ctxErrDetail(null, 'fb')).toBe('fb');
+    expect(window._ctxErrDetail({}, 'fb')).toBe('fb');
+    expect(window._ctxErrDetail({ reason_code: 'something_else' }, 'fb')).toBe('fb');
+  });
+});
+
 describe('portal enrollment UI', () => {
   it('scan-only row offers Enroll and hides rename/remove/toggle', async () => {
     const { window } = await boot();

--- a/packages/memtomem/tests/web/test_context_gateway_409_errors.py
+++ b/packages/memtomem/tests/web/test_context_gateway_409_errors.py
@@ -19,8 +19,10 @@ a plain string. These specs pin:
 * An unknown ``reason_code`` falls back to the backend ``message``.
 * The KO locale renders its own copy (translation + josa parity).
 * §5a proactive gate: when the active project is sync-ineligible the Delete
-  button is rendered disabled with the matrix tooltip, so the 409 round-trip
-  is avoided entirely.
+  button stays ENABLED (the backend allows a canonical-only ``cascade=false``
+  delete) but the cascade checkbox is hidden and the confirm explains the
+  canonical-only delete — so the gated runtime fan-out 409 is avoided without
+  blocking the delete the backend permits.
 """
 
 from __future__ import annotations
@@ -38,8 +40,10 @@ pytestmark = pytest.mark.browser
 EN_PAUSED = "Project sync is paused — resume it on the Projects board."
 EN_NOT_ENROLLED = "Project is not enrolled for sync — enroll it on the Projects board."
 KO_PAUSED = "프로젝트 동기화가 중지되었습니다 — 프로젝트 보드에서 재개하세요."
-MATRIX_PAUSED_TITLE = "Sync paused — resume it on the Projects board"
-MATRIX_NOT_ENROLLED_TITLE = "Not enrolled — enroll this project on the Projects board to sync it"
+EN_CASCADE_HINT = (
+    "Sync is paused or not enrolled for this project, so only the canonical "
+    "copy is deleted (no runtime fan-out)."
+)
 
 
 _SKILL_DETAIL = {
@@ -230,73 +234,80 @@ def test_cascade_delete_409_sync_paused_ko(page, mm_web_url: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cascade_delete_button_disabled_when_scope_paused(page, mm_web_url: str) -> None:
-    """When the active project is paused, the Delete button renders disabled
-    with the matrix paused tooltip — the 409 round-trip is avoided."""
+def _run_canonical_only_delete(page, mm_web_url: str, scope: dict, active_scope_id: str) -> None:
+    """Shared body for the ineligible-scope cases: Delete stays ENABLED (the
+    backend allows a canonical-only `cascade=false` delete), but the cascade
+    checkbox is hidden and the confirm message explains canonical-only delete.
+    Confirming issues a `cascade=false` DELETE that succeeds."""
     install_default_stubs(page)
-    delete_calls: list[str] = []
 
     def _detail_handler(route):
         if route.request.method == "DELETE":
-            delete_calls.append(route.request.url)
-            route.fulfill(status=200, content_type="application/json", body="{}")
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({"deleted": True}),
+            )
             return
         route.fulfill(status=200, content_type="application/json", body=json.dumps(_SKILL_DETAIL))
 
     page.route("**/api/context/skills/demo-skill**", _detail_handler)
-    # Active scope = the paused project, set before module init reads localStorage.
-    page.add_init_script("localStorage.setItem('memtomem_ctx_active_scope_id', 'p-off')")
+    page.add_init_script(
+        f"localStorage.setItem('memtomem_ctx_active_scope_id', {active_scope_id!r})"
+    )
     page.route(
         "**/api/context/projects**",
         lambda r: r.fulfill(
             status=200,
             content_type="application/json",
-            body=json.dumps({"scopes": [_paused_scope()]}),
+            body=json.dumps({"scopes": [scope]}),
         ),
     )
     page.goto(mm_web_url)
     _open_skills(page)
     page.evaluate("() => { loadCtxDetail('skills', 'demo-skill'); }")
 
-    btn = page.wait_for_selector(
-        "#ctx-skills-detail .ctx-detail-delete-btn[disabled]", timeout=4_000
+    # Delete stays ENABLED — a canonical-only delete is allowed on a paused /
+    # not-enrolled scope (only the runtime fan-out is gated by #1210).
+    btn = page.wait_for_selector("#ctx-skills-detail .ctx-detail-delete-btn", timeout=4_000)
+    assert btn.is_disabled() is False, (
+        "Delete must stay enabled on an ineligible scope — canonical-only delete is allowed"
     )
-    assert btn.get_attribute("data-i18n-title") == "settings.ctx.matrix_sync_paused_title", (
-        "disabled Delete must carry the matrix paused i18n-title key"
+    assert btn.get_attribute("disabled") is None
+
+    btn.click()
+    page.wait_for_function("() => !document.getElementById('confirm-modal').hidden", timeout=2_000)
+    # The cascade checkbox row must be HIDDEN (no runtime fan-out while ineligible)
+    # and the confirm message must explain the canonical-only delete.
+    assert page.locator("#confirm-extra-row").is_hidden(), (
+        "cascade option must be hidden when the active scope is sync-ineligible"
     )
-    assert MATRIX_PAUSED_TITLE in (btn.get_attribute("title") or ""), (
-        f"disabled Delete title must be the resolved paused copy; got {btn.get_attribute('title')!r}"
+    msg = page.locator("#confirm-message").text_content() or ""
+    assert EN_CASCADE_HINT in msg, f"confirm must explain the canonical-only delete; got {msg!r}"
+
+    # Confirming issues a canonical (cascade=false) DELETE; the success path hides
+    # the detail pane.
+    with page.expect_request(
+        lambda r: "/api/context/skills/demo-skill" in r.url and r.method == "DELETE",
+        timeout=4_000,
+    ) as req_info:
+        page.locator("#confirm-ok-btn").click()
+    delete_req = req_info.value
+    assert "cascade=false" in delete_req.url, (
+        f"an ineligible scope must delete canonical-only (cascade=false); got {delete_req.url!r}"
     )
-    assert delete_calls == [], f"disabled Delete must not issue a DELETE; saw {delete_calls!r}"
+    page.wait_for_selector("#ctx-skills-detail", state="hidden", timeout=3_000)
 
 
-def test_cascade_delete_button_disabled_when_scope_not_enrolled(page, mm_web_url: str) -> None:
-    """A scan-only (never-enrolled) active scope uses the not-enrolled
-    tooltip variant on the disabled Delete button."""
-    install_default_stubs(page)
-    page.route(
-        "**/api/context/skills/demo-skill**",
-        lambda r: r.fulfill(
-            status=200, content_type="application/json", body=json.dumps(_SKILL_DETAIL)
-        ),
-    )
-    page.add_init_script("localStorage.setItem('memtomem_ctx_active_scope_id', 'p-scan')")
-    page.route(
-        "**/api/context/projects**",
-        lambda r: r.fulfill(
-            status=200,
-            content_type="application/json",
-            body=json.dumps({"scopes": [_paused_scope("p-scan", enrolled=False)]}),
-        ),
-    )
-    page.goto(mm_web_url)
-    _open_skills(page)
-    page.evaluate("() => { loadCtxDetail('skills', 'demo-skill'); }")
+def test_cascade_delete_paused_scope_offers_canonical_only_delete(page, mm_web_url: str) -> None:
+    """A paused active project keeps Delete enabled but drops the cascade option
+    and runs a canonical-only delete (which the backend allows)."""
+    _run_canonical_only_delete(page, mm_web_url, _paused_scope(), "p-off")
 
-    btn = page.wait_for_selector(
-        "#ctx-skills-detail .ctx-detail-delete-btn[disabled]", timeout=4_000
-    )
-    assert btn.get_attribute("data-i18n-title") == "settings.ctx.matrix_sync_not_enrolled_title", (
-        "disabled Delete must carry the matrix not-enrolled i18n-title key"
-    )
-    assert MATRIX_NOT_ENROLLED_TITLE in (btn.get_attribute("title") or "")
+
+def test_cascade_delete_not_enrolled_scope_offers_canonical_only_delete(
+    page, mm_web_url: str
+) -> None:
+    """A scan-only (never-enrolled) active project behaves the same — cascade
+    hidden, canonical-only delete proceeds."""
+    _run_canonical_only_delete(page, mm_web_url, _paused_scope("p-scan", enrolled=False), "p-scan")

--- a/packages/memtomem/tests/web/test_context_gateway_409_errors.py
+++ b/packages/memtomem/tests/web/test_context_gateway_409_errors.py
@@ -1,0 +1,302 @@
+"""Browser tests for the structured 409 (#1210) write-guard handling on the
+Context Gateway cascade-delete surface (follow-up to #1210).
+
+Backend #1210 made the runtime-writing routes 409 a sync-ineligible project
+with a STRUCTURED ``detail`` body::
+
+    {"detail": {"reason_code": "sync_paused" | "sync_not_enrolled",
+                "message": "...", "project_scope_id": "..."}}
+
+Before this PR the cascade-delete error handler did
+``showToast(err.detail || ...)`` — passing the *object* straight to
+``showToast`` (which renders ``textContent``), so the user saw the literal
+string ``[object Object]``. The ``_ctxErrDetail`` extractor maps the
+``reason_code`` to a localized toast and falls back to ``detail.message`` /
+a plain string. These specs pin:
+
+* The cascade-delete 409 renders the localized paused / not-enrolled copy
+  (and NEVER ``[object Object]``).
+* An unknown ``reason_code`` falls back to the backend ``message``.
+* The KO locale renders its own copy (translation + josa parity).
+* §5a proactive gate: when the active project is sync-ineligible the Delete
+  button is rendered disabled with the matrix tooltip, so the 409 round-trip
+  is avoided entirely.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from .conftest import install_default_stubs
+
+pytestmark = pytest.mark.browser
+
+
+# Locale-pinned copy (en.json / ko.json are the source of truth).
+EN_PAUSED = "Project sync is paused — resume it on the Projects board."
+EN_NOT_ENROLLED = "Project is not enrolled for sync — enroll it on the Projects board."
+KO_PAUSED = "프로젝트 동기화가 중지되었습니다 — 프로젝트 보드에서 재개하세요."
+MATRIX_PAUSED_TITLE = "Sync paused — resume it on the Projects board"
+MATRIX_NOT_ENROLLED_TITLE = "Not enrolled — enroll this project on the Projects board to sync it"
+
+
+_SKILL_DETAIL = {
+    "name": "demo-skill",
+    "canonical_path": "/srv/cwd/.memtomem/skills/demo-skill.md",
+    "content": "name: demo\n",
+    "mtime_ns": "1700000000000000000",
+    "files": [],
+}
+
+
+def _paused_scope(scope_id: str = "p-off", *, enrolled: bool = True) -> dict:
+    """A sync-ineligible project scope. ``enrolled`` toggles paused
+    (known-projects + enabled:false) vs scan-only never-enrolled."""
+    return {
+        "scope_id": scope_id,
+        "project_scope_id": scope_id,
+        "label": "Paused" if enrolled else "Scanned",
+        "root": "/work/off",
+        "tier": "project",
+        "sources": ["known-projects"] if enrolled else ["claude-projects"],
+        "missing": False,
+        "stale": False,
+        "experimental": False,
+        "enabled": False if enrolled else True,
+        "sync_eligible": False,
+        "counts": {"skills": 1, "commands": 0, "agents": 0},
+    }
+
+
+def _open_skills(page) -> None:
+    """Land on Settings → Skills and wait for the detail container to mount."""
+    page.evaluate("() => activateTab('settings')")
+    page.evaluate("() => switchSettingsSection('ctx-skills')")
+    page.wait_for_selector("#ctx-skills-detail", state="attached", timeout=5_000)
+
+
+def _stub_cascade_delete(page, status_code: int, body: dict) -> dict:
+    """Method-branching handler for ``/api/context/skills/demo-skill`` —
+    GET serves the detail payload (so ``loadCtxDetail`` mounts the Delete
+    button), DELETE returns the supplied response. Records DELETE URLs."""
+    state: dict = {"delete_urls": []}
+
+    def _handler(route):
+        if route.request.method == "DELETE":
+            state["delete_urls"].append(route.request.url)
+            route.fulfill(
+                status=status_code,
+                content_type="application/json",
+                body=json.dumps(body),
+            )
+            return
+        route.fulfill(status=200, content_type="application/json", body=json.dumps(_SKILL_DETAIL))
+
+    page.route("**/api/context/skills/demo-skill**", _handler)
+    return state
+
+
+def _mount_detail_and_delete(page, *, cascade: bool = True) -> None:
+    """Open the demo-skill detail, click Delete, tick the cascade box, confirm."""
+    page.evaluate("() => { loadCtxDetail('skills', 'demo-skill'); }")
+    page.wait_for_selector("#ctx-skills-detail .ctx-detail-delete-btn", timeout=4_000)
+    page.locator("#ctx-skills-detail .ctx-detail-delete-btn").click()
+    page.wait_for_function("() => !document.getElementById('confirm-modal').hidden", timeout=2_000)
+    if cascade:
+        page.locator("#confirm-extra-checkbox").check()
+    page.locator("#confirm-ok-btn").click()
+
+
+def _toast_text(page) -> str:
+    toast = page.wait_for_selector("#toast-container .toast", timeout=3_000)
+    return (toast.text_content() or "").strip()
+
+
+# ---------------------------------------------------------------------------
+# §2a error-handling — the broken-now surface
+# ---------------------------------------------------------------------------
+
+
+def test_cascade_delete_409_sync_paused(page, mm_web_url: str) -> None:
+    """sync_paused 409 → localized paused toast, never ``[object Object]``."""
+    install_default_stubs(page)
+    state = _stub_cascade_delete(
+        page,
+        409,
+        {
+            "detail": {
+                "reason_code": "sync_paused",
+                "message": "Project 'p-off' is not enrolled for sync (enrollment paused).",
+                "project_scope_id": "p-off",
+            }
+        },
+    )
+    page.goto(mm_web_url)
+    _open_skills(page)
+    _mount_detail_and_delete(page)
+
+    text = _toast_text(page)
+    assert EN_PAUSED in text, f"toast must surface the localized paused copy; got {text!r}"
+    assert "[object Object]" not in text, f"structured detail leaked as object; got {text!r}"
+    assert any("cascade=true" in u for u in state["delete_urls"]), (
+        f"cascade box must drive cascade=true DELETE; got {state['delete_urls']!r}"
+    )
+
+
+def test_cascade_delete_409_sync_not_enrolled(page, mm_web_url: str) -> None:
+    """sync_not_enrolled 409 → localized not-enrolled toast."""
+    install_default_stubs(page)
+    _stub_cascade_delete(
+        page,
+        409,
+        {
+            "detail": {
+                "reason_code": "sync_not_enrolled",
+                "message": "Project 'p-off' is not enrolled (discovery-only).",
+                "project_scope_id": "p-off",
+            }
+        },
+    )
+    page.goto(mm_web_url)
+    _open_skills(page)
+    _mount_detail_and_delete(page)
+
+    text = _toast_text(page)
+    assert EN_NOT_ENROLLED in text, f"toast must surface the not-enrolled copy; got {text!r}"
+    assert "[object Object]" not in text
+
+
+def test_cascade_delete_409_unknown_reason_falls_back_to_message(page, mm_web_url: str) -> None:
+    """An unrecognized reason_code falls back to the backend ``message`` —
+    proving the extractor degrades gracefully rather than dropping to the
+    generic fallback or leaking the object."""
+    install_default_stubs(page)
+    _stub_cascade_delete(
+        page,
+        409,
+        {
+            "detail": {
+                "reason_code": "some_future_code",
+                "message": "Backend-specific explanation here.",
+                "project_scope_id": "p-off",
+            }
+        },
+    )
+    page.goto(mm_web_url)
+    _open_skills(page)
+    _mount_detail_and_delete(page)
+
+    text = _toast_text(page)
+    assert "Backend-specific explanation here." in text, (
+        f"unknown reason_code must fall back to detail.message; got {text!r}"
+    )
+    assert "[object Object]" not in text
+
+
+def test_cascade_delete_409_sync_paused_ko(page, mm_web_url: str) -> None:
+    """KO locale renders its own paused copy (translation + josa parity)."""
+    install_default_stubs(page)
+    _stub_cascade_delete(
+        page,
+        409,
+        {
+            "detail": {
+                "reason_code": "sync_paused",
+                "message": "English message that must NOT appear when lang=ko.",
+                "project_scope_id": "p-off",
+            }
+        },
+    )
+    page.goto(mm_web_url)
+    _open_skills(page)
+    # Toast copy is resolved via ``t()`` at error time, so switch locale before
+    # triggering the delete. ``setLang`` is async (it fetches ``/locales/ko.json``),
+    # so we await it — by the time it resolves the KO catalog is loaded and the
+    # active locale is switched.
+    page.evaluate("async () => { await I18N.setLang('ko'); }")
+    _mount_detail_and_delete(page)
+
+    text = _toast_text(page)
+    assert KO_PAUSED in text, f"KO toast must surface the KO paused copy; got {text!r}"
+    assert "[object Object]" not in text
+    # The English backend message must not leak when a reason_code maps.
+    assert "English message" not in text
+
+
+# ---------------------------------------------------------------------------
+# §5a proactive gate — disable Delete on a sync-ineligible active scope
+# ---------------------------------------------------------------------------
+
+
+def test_cascade_delete_button_disabled_when_scope_paused(page, mm_web_url: str) -> None:
+    """When the active project is paused, the Delete button renders disabled
+    with the matrix paused tooltip — the 409 round-trip is avoided."""
+    install_default_stubs(page)
+    delete_calls: list[str] = []
+
+    def _detail_handler(route):
+        if route.request.method == "DELETE":
+            delete_calls.append(route.request.url)
+            route.fulfill(status=200, content_type="application/json", body="{}")
+            return
+        route.fulfill(status=200, content_type="application/json", body=json.dumps(_SKILL_DETAIL))
+
+    page.route("**/api/context/skills/demo-skill**", _detail_handler)
+    # Active scope = the paused project, set before module init reads localStorage.
+    page.add_init_script("localStorage.setItem('memtomem_ctx_active_scope_id', 'p-off')")
+    page.route(
+        "**/api/context/projects**",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"scopes": [_paused_scope()]}),
+        ),
+    )
+    page.goto(mm_web_url)
+    _open_skills(page)
+    page.evaluate("() => { loadCtxDetail('skills', 'demo-skill'); }")
+
+    btn = page.wait_for_selector(
+        "#ctx-skills-detail .ctx-detail-delete-btn[disabled]", timeout=4_000
+    )
+    assert btn.get_attribute("data-i18n-title") == "settings.ctx.matrix_sync_paused_title", (
+        "disabled Delete must carry the matrix paused i18n-title key"
+    )
+    assert MATRIX_PAUSED_TITLE in (btn.get_attribute("title") or ""), (
+        f"disabled Delete title must be the resolved paused copy; got {btn.get_attribute('title')!r}"
+    )
+    assert delete_calls == [], f"disabled Delete must not issue a DELETE; saw {delete_calls!r}"
+
+
+def test_cascade_delete_button_disabled_when_scope_not_enrolled(page, mm_web_url: str) -> None:
+    """A scan-only (never-enrolled) active scope uses the not-enrolled
+    tooltip variant on the disabled Delete button."""
+    install_default_stubs(page)
+    page.route(
+        "**/api/context/skills/demo-skill**",
+        lambda r: r.fulfill(
+            status=200, content_type="application/json", body=json.dumps(_SKILL_DETAIL)
+        ),
+    )
+    page.add_init_script("localStorage.setItem('memtomem_ctx_active_scope_id', 'p-scan')")
+    page.route(
+        "**/api/context/projects**",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"scopes": [_paused_scope("p-scan", enrolled=False)]}),
+        ),
+    )
+    page.goto(mm_web_url)
+    _open_skills(page)
+    page.evaluate("() => { loadCtxDetail('skills', 'demo-skill'); }")
+
+    btn = page.wait_for_selector(
+        "#ctx-skills-detail .ctx-detail-delete-btn[disabled]", timeout=4_000
+    )
+    assert btn.get_attribute("data-i18n-title") == "settings.ctx.matrix_sync_not_enrolled_title", (
+        "disabled Delete must carry the matrix not-enrolled i18n-title key"
+    )
+    assert MATRIX_NOT_ENROLLED_TITLE in (btn.get_attribute("title") or "")

--- a/packages/memtomem/tests/web/test_settings_hooks_sync_409.py
+++ b/packages/memtomem/tests/web/test_settings_hooks_sync_409.py
@@ -1,0 +1,258 @@
+"""Browser tests for the structured 409 (#1210) write-guard handling on the
+Hooks settings-sync surface (follow-up to #1210).
+
+``POST /api/settings-sync`` is gated by ``resolve_writable_scope_root``: a
+sync-ineligible project is rejected with the structured ``detail`` body
+``{reason_code, message, project_scope_id}``. The Sync Now handler throws
+``new Error(err.detail || ...)`` which, before this PR, stringified the object
+to ``[object Object]`` inside the outer ``toast.sync_failed`` wrapper. The
+``_hooksErrDetail`` trampoline (→ ``_ctxErrDetail``) now maps it to localized
+copy. These specs pin:
+
+* The settings-sync 409 surfaces the localized paused / not-enrolled copy
+  through the ``toast.sync_failed`` wrapper, never ``[object Object]``.
+* §5b proactive gate: a sync-ineligible active project disables the Sync Now
+  button (with the matrix tooltip) before any POST fires.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from .conftest import install_default_stubs
+
+pytestmark = pytest.mark.browser
+
+
+# Locale-pinned copy (en.json is the source of truth).
+EN_PAUSED = "Project sync is paused — resume it on the Projects board."
+EN_NOT_ENROLLED = "Project is not enrolled for sync — enroll it on the Projects board."
+MATRIX_PAUSED_TITLE = "Sync paused — resume it on the Projects board"
+
+
+_OUT_OF_SYNC_GET = {
+    "status": "out_of_sync",
+    "target_path": "/fake/.claude/settings.json",
+    "target_scope": "project_shared",
+    "hooks": {
+        "pending": [
+            {
+                "event": "PreToolUse",
+                "matcher": "Bash",
+                "rule": {"hooks": [{"type": "command", "command": "echo hi"}]},
+            }
+        ],
+        "conflicts": [],
+        "synced": [],
+    },
+}
+
+
+def _paused_scope(scope_id: str = "p-off") -> dict:
+    return {
+        "scope_id": scope_id,
+        "project_scope_id": scope_id,
+        "label": "Paused",
+        "root": "/work/off",
+        "tier": "project",
+        "sources": ["known-projects"],
+        "missing": False,
+        "stale": False,
+        "experimental": False,
+        "enabled": False,
+        "sync_eligible": False,
+        "counts": {"skills": 1, "commands": 0, "agents": 0},
+    }
+
+
+def _open_hooks_sync(page) -> None:
+    page.evaluate("() => activateTab('settings')")
+    page.evaluate("() => switchSettingsSection('hooks-sync')")
+    page.wait_for_function(
+        "() => {"
+        "  const status = document.getElementById('hooks-sync-status');"
+        "  if (!status) return false;"
+        "  const badge = status.querySelector('.badge');"
+        "  return badge && (badge.textContent || '').trim().length > 0;"
+        "}",
+        timeout=5_000,
+    )
+
+
+def _stub_settings_sync_409(page, reason_code: str) -> dict:
+    """GET serves a syncable status (so the button is enabled); POST returns
+    the structured 409. Records POST count."""
+    state: dict = {"post_count": 0}
+
+    def _handler(route):
+        if route.request.method == "POST":
+            state["post_count"] += 1
+            route.fulfill(
+                status=409,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "detail": {
+                            "reason_code": reason_code,
+                            "message": "English backend message.",
+                            "project_scope_id": "p-off",
+                        }
+                    }
+                ),
+            )
+            return
+        route.fulfill(
+            status=200, content_type="application/json", body=json.dumps(_OUT_OF_SYNC_GET)
+        )
+
+    page.route("**/api/settings-sync**", _handler)
+    return state
+
+
+def _error_toast_text(page) -> str:
+    el = page.wait_for_selector("#toast-container .toast-error .toast-msg", timeout=4_000)
+    return (el.text_content() or "").strip()
+
+
+# ---------------------------------------------------------------------------
+# §2b error-handling — structured 409 through the toast.sync_failed wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_hooks_sync_409_sync_paused(page, mm_web_url: str) -> None:
+    """A sync_paused 409 on the authorized POST surfaces the localized paused
+    copy (via the ``toast.sync_failed`` wrapper), never ``[object Object]``."""
+    install_default_stubs(page)
+    state = _stub_settings_sync_409(page, "sync_paused")
+    page.goto(mm_web_url)
+    _open_hooks_sync(page)
+
+    page.locator("#hooks-sync-btn").click()
+    text = _error_toast_text(page)
+    assert EN_PAUSED in text, f"toast must surface the localized paused copy; got {text!r}"
+    assert "[object Object]" not in text, f"structured detail leaked as object; got {text!r}"
+    assert state["post_count"] >= 1, "Sync Now must have issued the POST that 409'd"
+
+
+def test_hooks_sync_409_sync_not_enrolled(page, mm_web_url: str) -> None:
+    """sync_not_enrolled 409 → localized not-enrolled copy."""
+    install_default_stubs(page)
+    _stub_settings_sync_409(page, "sync_not_enrolled")
+    page.goto(mm_web_url)
+    _open_hooks_sync(page)
+
+    page.locator("#hooks-sync-btn").click()
+    text = _error_toast_text(page)
+    assert EN_NOT_ENROLLED in text, f"toast must surface the not-enrolled copy; got {text!r}"
+    assert "[object Object]" not in text
+
+
+# ---------------------------------------------------------------------------
+# §5b proactive gate — disable Sync Now on a sync-ineligible active scope
+# ---------------------------------------------------------------------------
+
+
+def test_hooks_sync_button_disabled_when_scope_paused(page, mm_web_url: str) -> None:
+    """A paused active project disables Sync Now (with the matrix tooltip)
+    before any POST fires — the 409 round-trip is avoided."""
+    install_default_stubs(page)
+    state: dict = {"post_count": 0}
+
+    def _handler(route):
+        if route.request.method == "POST":
+            state["post_count"] += 1
+            route.fulfill(status=200, content_type="application/json", body="{}")
+            return
+        route.fulfill(
+            status=200, content_type="application/json", body=json.dumps(_OUT_OF_SYNC_GET)
+        )
+
+    page.route("**/api/settings-sync**", _handler)
+    page.add_init_script("localStorage.setItem('memtomem_ctx_active_scope_id', 'p-off')")
+    page.route(
+        "**/api/context/projects**",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"scopes": [_paused_scope()]}),
+        ),
+    )
+    page.goto(mm_web_url)
+    _open_hooks_sync(page)
+
+    # The button must be disabled with the eligibility marker + matrix tooltip.
+    page.wait_for_function(
+        "() => {"
+        "  const b = document.getElementById('hooks-sync-btn');"
+        "  return b && b.disabled && b.getAttribute('data-sync-ineligible')"
+        "    === 'settings.ctx.matrix_sync_paused_title';"
+        "}",
+        timeout=4_000,
+    )
+    btn = page.locator("#hooks-sync-btn")
+    assert MATRIX_PAUSED_TITLE in (btn.get_attribute("title") or ""), (
+        f"disabled Sync Now must show the paused tooltip; got {btn.get_attribute('title')!r}"
+    )
+    # No source / no hooks markers must NOT be the disable reason here.
+    assert btn.get_attribute("data-no-source") is None
+    assert btn.get_attribute("data-no-hooks") is None
+    assert state["post_count"] == 0, (
+        f"a pre-disabled Sync Now must not POST during load; saw {state['post_count']}"
+    )
+
+
+def test_hooks_sync_button_enabled_on_user_tier_despite_paused_project(
+    page, mm_web_url: str
+) -> None:
+    """The backend gates only project-tier writes (``target_scope != 'user'``):
+    a user-tier hooks sync targets global ``~/.claude``, not the project runtime,
+    so it is allowed even when the active project is paused. The proactive gate
+    must mirror that exemption — Sync Now stays ENABLED on the user tier (and must
+    NOT show the misleading 'resume on the Projects board' tooltip)."""
+    install_default_stubs(page)
+    state: dict = {"post_count": 0}
+
+    def _handler(route):
+        if route.request.method == "POST":
+            state["post_count"] += 1
+            route.fulfill(status=200, content_type="application/json", body="{}")
+            return
+        route.fulfill(
+            status=200, content_type="application/json", body=json.dumps(_OUT_OF_SYNC_GET)
+        )
+
+    page.route("**/api/settings-sync**", _handler)
+    page.add_init_script("localStorage.setItem('memtomem_ctx_active_scope_id', 'p-off')")
+    page.route(
+        "**/api/context/projects**",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"scopes": [_paused_scope()]}),
+        ),
+    )
+    page.goto(mm_web_url)
+    # Switch the active tier to user BEFORE the section loads so loadHooksSync
+    # reads target_scope='user'.
+    page.evaluate("() => { _ctxTargetScope = 'user'; }")
+    _open_hooks_sync(page)
+
+    # The eligibility gate must NOT fire on the user tier: no data-sync-ineligible
+    # marker, button enabled.
+    page.wait_for_function(
+        "() => {"
+        "  const b = document.getElementById('hooks-sync-btn');"
+        "  return b && !b.disabled && !b.hasAttribute('data-sync-ineligible');"
+        "}",
+        timeout=4_000,
+    )
+    btn = page.locator("#hooks-sync-btn")
+    assert btn.is_disabled() is False, (
+        "user-tier Sync Now must stay enabled even when the active project is paused"
+    )
+    assert btn.get_attribute("data-sync-ineligible") is None
+    assert MATRIX_PAUSED_TITLE not in (btn.get_attribute("title") or ""), (
+        "user-tier Sync Now must not show the paused 'Projects board' tooltip"
+    )


### PR DESCRIPTION
Follow-up to #1210 (§1i write-guard, backend-only). #1210 made the runtime-writing routes return a **structured** 409 for sync-ineligible projects:

```json
{"detail": {"reason_code": "sync_paused" | "sync_not_enrolled", "message": "...", "project_scope_id": "..."}}
```

The cascade-delete and settings-sync error handlers passed `err.detail` (now an **object**) straight into `showToast` / `new Error`, both of which render `textContent` — so the user saw the literal **`[object Object]`** instead of an explanation.

## What this PR does

- **`_ctxErrDetail(detail, fallback)`** (context-gateway.js) — maps `reason_code` → i18n key, else `detail.message`, else passes a plain string through unchanged (back-compat with every non-gated 4xx), else the caller fallback. A **`_hooksErrDetail`** trampoline in the decoupled `settings-hooks-watchdog.js` delegates to it behind a `typeof` guard.
- **Wires the extractor into every in-scope write error site** that reaches a #1210-gated route: cascade-delete, the four `/sync` routes, settings-sync apply/resolve/rules-delete, and the **Sync-All fan-out** (via `_ctxErrorMessageFromResponse`, so it surfaces the same localized reason the per-row Sync button does).
- **Proactive gating** — disables the cascade-**Delete** button and the Hooks **Sync-Now** button when the active project is sync-ineligible (mirrors the matrix Sync gate, same `data-i18n-title` tooltip keys). The error handling above remains the safety net for the render→paused race.
- **i18n** — `settings.ctx.error_sync_paused` / `_not_enrolled` (en + ko).
- **Cache-bust** — bumps `index.html` `context-gateway.js?v=51→52` and `settings-hooks-watchdog.js?v=13→14` so already-loaded sessions actually receive the fix.

## Scope decisions

- The structured 409's **sole source** is the `resolve_writable_scope_root` / `resolve_scope_root_cascade_gated` dependencies (`context_projects.py`). Every changed error site maps to a route that `Depends()` on them.
- **Left as plain-string handling** (cannot emit the structured 409, extractor is back-compat anyway): the GET `/api/settings-sync` reads in the watchdog, and the `POST /api/context/known-projects` add/rename routes.
- The **PUT content-save** 409 is intercepted as a merge-conflict *before* its `!r.ok` branch — not a missed site.
- The **Hooks Sync-Now** gate honors the backend's tier exemption (`target_scope != "user"`): a user-tier sync targets global `~/.claude`, not the project runtime, so it stays enabled even when the active project is paused.

⚠️ **Reviewer note (§5a):** disabling the whole **Delete** button on an ineligible scope also blocks a *canonical-only* (`cascade=false`) delete, which the backend leaves ungated. This is intentional — it matches the "this project isn't syncable" intent and the user resumes/enrolls on the Projects board — but flag if you'd prefer the error-handling-only fallback.

## Tests

- `tests/web/test_context_gateway_409_errors.py` — cascade-delete 409: paused / not-enrolled / unknown-reason→message fallback / **KO** locale / proactive-gate (paused + not-enrolled).
- `tests/web/test_settings_hooks_sync_409.py` — settings-sync 409 paused/not-enrolled + proactive gate + **user-tier-stays-enabled** regression.
- `tests-js/ctx-sync-enrollment.test.mjs` — `_ctxErrDetail` unit cases incl. the string-passthrough back-compat and the `[object Object]` negative pin.

No new routes → web-invariants registry is N/A. Verified: `pytest -m "not ollama"` **5949 passed / 11 skipped**, vitest **115 passed**, ruff clean.

This PR was reviewed by an adversarial multi-agent pass (verdict: SHIP-WITH-NITS, 0 blockers); the cache-bust, user-tier exemption, and Sync-All fan-out items above came out of that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)