### PR TITLE
feat(web): list-card label chips + ?include=versions enrichment (ADR-0022 PR4)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -33,6 +33,7 @@ from memtomem.web.routes.context_projects import (
     resolve_scope_root_cascade_gated,
     resolve_writable_scope_root,
 )
+from memtomem.web.routes.context_versions import include_has, version_summary
 from memtomem.web.routes._locks import _gateway_lock
 
 # Flat list of project-relative runtime scan paths reported on list / import
@@ -120,8 +121,17 @@ async def list_agents(
             "when explicitly requested."
         ),
     ),
+    include: str | None = Query(
+        None,
+        description=(
+            "Comma-separated optional enrichments. ``versions`` adds a per-item "
+            "``versions`` summary (label pointers + count) to feed the list-card "
+            "chips (ADR-0022 PR4); omitted by default so the list stays I/O-free."
+        ),
+    ),
 ) -> dict:
     """List canonical agents. Accepts project selector aliases like list_skills."""
+    want_versions = include_has(include, "versions")
     canonicals = list_canonical_agents(project_root, scope=target_scope)
     diffs = diff_agents(project_root, scope=target_scope)
 
@@ -134,25 +144,34 @@ async def list_agents(
     for agent_path, layout in canonicals:
         name = canonical_agent_name(agent_path, layout)
         canonical_names.add(name)
-        agents.append(
-            {
-                "name": name,
-                "canonical_path": _safe_rel(agent_path, project_root),
-                "target_scope": target_scope,
-                "runtimes": by_name.get(name, []),
-            }
-        )
+        item: dict[str, object] = {
+            "name": name,
+            "canonical_path": _safe_rel(agent_path, project_root),
+            "target_scope": target_scope,
+            "runtimes": by_name.get(name, []),
+        }
+        if want_versions:
+            item["versions"] = version_summary(agent_path, layout)
+        agents.append(item)
 
     for agent_name, runtimes in by_name.items():
         if agent_name not in canonical_names:
-            agents.append(
-                {
-                    "name": agent_name,
-                    "canonical_path": None,
-                    "target_scope": target_scope,
-                    "runtimes": runtimes,
+            item = {
+                "name": agent_name,
+                "canonical_path": None,
+                "target_scope": target_scope,
+                "runtimes": runtimes,
+            }
+            if want_versions:
+                # Runtime-only: no canonical file → nothing to version and no
+                # store to migrate. Keep the four-key shape for the JS reader.
+                item["versions"] = {
+                    "labels": {},
+                    "count": 0,
+                    "versionable": False,
+                    "migrate_required": False,
                 }
-            )
+            agents.append(item)
 
     return {
         "agents": agents,

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -32,6 +32,7 @@ from memtomem.web.routes.context_projects import (
     resolve_scope_root_cascade_gated,
     resolve_writable_scope_root,
 )
+from memtomem.web.routes.context_versions import include_has, version_summary
 from memtomem.web.routes._locks import _gateway_lock
 
 # Flat list of project-relative runtime scan paths reported on list / import
@@ -107,8 +108,17 @@ async def list_commands(
             "when explicitly requested."
         ),
     ),
+    include: str | None = Query(
+        None,
+        description=(
+            "Comma-separated optional enrichments. ``versions`` adds a per-item "
+            "``versions`` summary (label pointers + count) to feed the list-card "
+            "chips (ADR-0022 PR4); omitted by default so the list stays I/O-free."
+        ),
+    ),
 ) -> dict:
     """List canonical commands. Accepts project selector aliases like list_skills."""
+    want_versions = include_has(include, "versions")
     canonicals = list_canonical_commands(project_root, scope=target_scope)
     diffs = diff_commands(project_root, scope=target_scope)
 
@@ -121,25 +131,34 @@ async def list_commands(
     for cmd_path, layout in canonicals:
         name = canonical_command_name(cmd_path, layout)
         canonical_names.add(name)
-        commands.append(
-            {
-                "name": name,
-                "canonical_path": _safe_rel(cmd_path, project_root),
-                "target_scope": target_scope,
-                "runtimes": by_name.get(name, []),
-            }
-        )
+        item: dict[str, object] = {
+            "name": name,
+            "canonical_path": _safe_rel(cmd_path, project_root),
+            "target_scope": target_scope,
+            "runtimes": by_name.get(name, []),
+        }
+        if want_versions:
+            item["versions"] = version_summary(cmd_path, layout)
+        commands.append(item)
 
     for cmd_name, runtimes in by_name.items():
         if cmd_name not in canonical_names:
-            commands.append(
-                {
-                    "name": cmd_name,
-                    "canonical_path": None,
-                    "target_scope": target_scope,
-                    "runtimes": runtimes,
+            item = {
+                "name": cmd_name,
+                "canonical_path": None,
+                "target_scope": target_scope,
+                "runtimes": runtimes,
+            }
+            if want_versions:
+                # Runtime-only: no canonical file → nothing to version and no
+                # store to migrate. Keep the four-key shape for the JS reader.
+                item["versions"] = {
+                    "labels": {},
+                    "count": 0,
+                    "versionable": False,
+                    "migrate_required": False,
                 }
-            )
+            commands.append(item)
 
     return {
         "commands": commands,

--- a/packages/memtomem/src/memtomem/web/routes/context_versions.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_versions.py
@@ -153,6 +153,73 @@ def _require_dir_layout(name: str, layout: Layout) -> None:
         )
 
 
+# ── List-card enrichment (?include=versions) ─────────────────────────────
+#
+# Imported by ``context_agents.list_agents`` / ``context_commands.list_commands``
+# so a single ``GET /context/{type}?include=versions`` can feed the per-card
+# label chips (ADR-0022 PR4) without an N+1 fan-out to the per-artifact
+# ``/versions`` route. Kept here next to ``versioning`` so the list routes stay
+# version-store-agnostic and the eligible-type / dir-layout rules live in one file.
+
+
+def include_has(include: str | None, token: str) -> bool:
+    """True iff *token* appears in a comma-separated ``?include=`` query value.
+
+    Tolerant of surrounding whitespace (``include=versions, foo``) and of the
+    param being absent/empty, so callers branch on a plain bool.
+    """
+    if not include:
+        return False
+    return token in {part.strip() for part in include.split(",")}
+
+
+def version_summary(canonical_path: Path, layout: Layout) -> dict:
+    """Compact per-artifact version summary for ``?include=versions`` enrichment.
+
+    Called once per canonical list item so the list cards can render label chips
+    (``production → v2``) without a round-trip per artifact. The shape always
+    carries the same four keys so the JS reader never has to branch on presence:
+
+    - ``labels`` — ``{label: tag}`` pointer map (empty unless dir-layout w/ labels)
+    - ``count`` — number of frozen versions
+    - ``versionable`` — ``True`` iff a version store can live here (dir layout)
+    - ``migrate_required`` — ``True`` iff a canonical exists but is flat-layout
+      (invariant 3: ``mm context migrate`` first before it can be versioned)
+
+    A flat-layout artifact has no per-artifact home for a ``versions/`` store
+    (invariant 3) → ``versionable=False, migrate_required=True``, no labels. A
+    corrupt ``versions.json`` is isolated per-artifact (``error=True``, empty
+    labels) rather than 500-ing the whole list — mirroring how the sync engine
+    isolates a per-item read/parse failure as a skip instead of aborting the
+    fan-out. The manifest read is unsynchronized (``load_manifest`` takes no
+    lock), matching every other read path against this sidecar.
+    """
+    if layout != "dir":
+        return {"labels": {}, "count": 0, "versionable": False, "migrate_required": True}
+    artifact_dir = canonical_path.parent
+    try:
+        manifest = versioning.load_manifest(artifact_dir)
+    except VersionError:
+        # Name only (not the full path) in the server log — keep the corrupt
+        # sidecar diagnosable without 500-ing the list or leaking the abs path.
+        logger.warning(
+            "versions manifest unreadable for %r; listing without chips", artifact_dir.name
+        )
+        return {
+            "labels": {},
+            "count": 0,
+            "versionable": True,
+            "migrate_required": False,
+            "error": True,
+        }
+    return {
+        "labels": dict(manifest.labels),
+        "count": len(manifest.versions),
+        "versionable": True,
+        "migrate_required": False,
+    }
+
+
 # ── Read ─────────────────────────────────────────────────────────────────
 
 

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -63,6 +63,31 @@ function renderDroppedChips(fields) {
   return fields.map(f => `<span class="ctx-dropped-chip">${escapeHtml(t('settings.ctx.dropped_fields'))}: ${escapeHtml(f)}</span>`).join('');
 }
 
+// ADR-0022 PR4: read-only ``production → v2`` label chips for a list card,
+// fed by the ``?include=versions`` enrichment (``item.versions.labels``). Chips
+// are informational only — freeze / promote / remove live in the detail panel
+// (PR3), so there is intentionally NO interactive element inside a card that is
+// itself ``role=button`` (avoids the nested-interactive trap). ``versionInfo``
+// is the per-item ``versions`` summary object; absent (no enrichment) or empty
+// labels render nothing. Server emits labels already alphabetically sorted, so
+// ``Object.keys`` insertion order is stable across reloads.
+function renderLabelChips(versionInfo) {
+  const labels = versionInfo && versionInfo.labels;
+  if (!labels) return '';
+  const names = Object.keys(labels);
+  if (!names.length) return '';
+  const chips = names.map((name) => {
+    const tag = labels[name];
+    const tip = t('settings.ctx.versions.list_chip_tooltip', { label: name, tag });
+    return `<span class="ctx-card-label-chip" data-label="${escapeHtml(name)}" title="${escapeHtml(tip)}">`
+      + `<span class="ctx-card-label-name">${escapeHtml(name)}</span>`
+      + `<span class="ctx-card-label-arrow" aria-hidden="true">→</span>`
+      + `<span class="ctx-card-label-tag">${escapeHtml(tag)}</span>`
+      + `</span>`;
+  }).join('');
+  return `<div class="ctx-card-labels">${chips}</div>`;
+}
+
 function renderImportResult(data) {
   let html = `<div class="ctx-import-result">`;
   html += `<div class="ctx-import-priority">${t('settings.ctx.import_priority')}</div>`;
@@ -2407,7 +2432,16 @@ function _ctxRenderItemsHtml(items, type, projectRoot, scannedDirs, { clickable 
         statusSet.add(_ctxStatusText('missing canonical'));
       }
       const statusParts = Array.from(statusSet);
-      const suffix = statusParts.length ? ` — ${statusParts.join(', ')}` : '';
+      // Append label pointers (``production at v2``) so the SR string matches the
+      // visible chips. A clickable card carries an ``aria-label``, which OVERRIDES
+      // the visible chip text for assistive tech — chips not echoed here would be
+      // invisible to SR (same reasoning as the status suffix above). The arrow
+      // glyph in the visible chip is ``aria-hidden``; this uses a word phrasing.
+      const ariaLabels = (item.versions && item.versions.labels) || {};
+      const labelParts = Object.keys(ariaLabels).map((l) =>
+        t('settings.ctx.versions.list_chip_aria', { label: l, tag: ariaLabels[l] }));
+      const parts = statusParts.concat(labelParts);
+      const suffix = parts.length ? ` — ${parts.join(', ')}` : '';
       cardAriaLabel = ` aria-label="${escapeHtml(item.name + suffix)}"`;
     }
     html += `<div class="${cardClass}"${a11yAttrs}${cardAriaLabel} data-name="${escapeHtml(item.name)}"${canonAttr} data-out-of-sync="${outOfSync}"${statusesAttr}>
@@ -2418,6 +2452,7 @@ function _ctxRenderItemsHtml(items, type, projectRoot, scannedDirs, { clickable 
         </div>
         ${renderRuntimeBadges(item.runtimes)}
       </div>
+      ${renderLabelChips(item.versions)}
     </div>`;
   }
   return html;
@@ -2431,6 +2466,11 @@ async function _loadScopeGroupItems(type, scope, container, seq) {
     if (scope && scope.scope_id && !_ctxScopeIsServerCwd(scope)) {
       params.set('scope_id', scope.scope_id);
     }
+    // ADR-0022 PR4: only agents + commands carry a version store (skills are
+    // out of v1, inv 7), so request the per-item ``versions`` enrichment for the
+    // label chips only there. The skills list route has no ``include`` param and
+    // would ignore it, but gating keeps the wire honest about what's versionable.
+    if (type === 'agents' || type === 'commands') params.set('include', 'versions');
     const query = params.toString();
     const res = await fetch(`/api/context/${type}${query ? `?${query}` : ''}`);
     if (!res.ok) throw new Error((await res.json().catch(() => ({}))).detail || `Failed to load ${type}`);

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=94" />
+  <link rel="stylesheet" href="/style.css?v=95" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -1516,7 +1516,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=14"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=53"></script>
+  <script src="/context-gateway.js?v=54"></script>
   <script src="/context-portal.js?v=1"></script>
   <script src="/path-picker.js?v=3"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -524,6 +524,8 @@
   "settings.ctx.versions.freeze_success": "Froze as {tag}: {name}",
   "settings.ctx.versions.promote_success": "Promoted {label} → {tag}",
   "settings.ctx.versions.remove_label_success": "Removed label: {label}",
+  "settings.ctx.versions.list_chip_tooltip": "Label {label} → version {tag}. Manage versions in the detail panel.",
+  "settings.ctx.versions.list_chip_aria": "label {label} at version {tag}",
   "settings.hooks.detail.event": "Event",
   "settings.hooks.detail.matcher": "Matcher",
   "settings.hooks.detail.command": "Command",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -524,6 +524,8 @@
   "settings.ctx.versions.freeze_success": "버전 고정 완료 ({tag}): {name}",
   "settings.ctx.versions.promote_success": "배포 완료: {label} → {tag}",
   "settings.ctx.versions.remove_label_success": "라벨 제거됨: {label}",
+  "settings.ctx.versions.list_chip_tooltip": "라벨 {label} → 버전 {tag}. 상세 패널에서 버전을 관리하세요.",
+  "settings.ctx.versions.list_chip_aria": "라벨 {label}, 버전 {tag}",
   "settings.hooks.detail.event": "이벤트",
   "settings.hooks.detail.matcher": "매처",
   "settings.hooks.detail.command": "명령",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -3830,6 +3830,16 @@ body.help-hidden #help-toggle { opacity: 0.5; }
 .ctx-card-header { display: flex; align-items: center; justify-content: space-between; }
 .ctx-card-name { font-weight: 600; font-size: 0.9rem; }
 .ctx-card-path { font-size: 0.72rem; color: var(--muted); margin-top: 2px; }
+/* ADR-0022 PR4: read-only label chips (production → v2) on a list card. Pill
+   shape is derived from the detail panel's ``.ctx-version-label-chip`` (same
+   accent pill), sized at 0.68rem to match the sibling ``.ctx-runtime-badge`` on
+   the same card — the denser list card runs a notch under the detail panel's
+   0.72rem chip. */
+.ctx-card-labels { display: flex; gap: 5px; flex-wrap: wrap; margin-top: 7px; }
+.ctx-card-label-chip { display: inline-flex; align-items: center; gap: 3px; padding: 1px 8px; border-radius: 12px; background: rgba(90, 160, 224, 0.14); color: var(--accent); font-size: 0.68rem; font-weight: 600; }
+.ctx-card-label-name { white-space: nowrap; }
+.ctx-card-label-arrow { opacity: 0.65; }
+.ctx-card-label-tag { font-family: var(--mono); }
 
 /* PR2 multi-project: collapsible scope groups, mirroring memory-dirs-group. */
 .ctx-scope-group { border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); margin-bottom: 8px; }

--- a/packages/memtomem/tests-js/ctx-list-label-chips.test.mjs
+++ b/packages/memtomem/tests-js/ctx-list-label-chips.test.mjs
@@ -1,0 +1,147 @@
+/* ADR-0022 PR4 — list-card label chips fed by the ?include=versions enrichment.
+ *
+ * Unit-drives the real ``_ctxRenderItemsHtml`` against item payloads carrying a
+ * ``versions`` summary and asserts: the read-only ``production → v2`` chips
+ * render (no interactive element inside the role=button card), an item with no
+ * labels renders no chip row, the chips are echoed into the card aria-label for
+ * SR parity, the inline ``t()`` tooltip follows a locale switch, and an item
+ * with no ``versions`` key (enrichment not requested) renders nothing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+const ITEM_WITH_LABELS = {
+  name: 'reviewer',
+  canonical_path: '.memtomem/agents/reviewer/agent.md',
+  target_scope: 'project_shared',
+  runtimes: [{ runtime: 'claude_agents', status: 'in sync' }],
+  versions: {
+    labels: { production: 'v2', staging: 'v1' },
+    count: 2,
+    versionable: true,
+    migrate_required: false,
+  },
+};
+
+const ITEM_NO_LABELS = {
+  name: 'planner',
+  canonical_path: '.memtomem/agents/planner/agent.md',
+  target_scope: 'project_shared',
+  runtimes: [{ runtime: 'claude_agents', status: 'in sync' }],
+  versions: { labels: {}, count: 0, versionable: true, migrate_required: false },
+};
+
+function render(window, items) {
+  // _ctxRenderItemsHtml(items, type, projectRoot, scannedDirs, { clickable })
+  return window._ctxRenderItemsHtml(items, 'agents', '/srv/cwd', [], { clickable: true });
+}
+
+function parse(window, html) {
+  const div = window.document.createElement('div');
+  div.innerHTML = html;
+  return div;
+}
+
+async function boot() {
+  const dom = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+  // bootApp resolves before the async locale fetch settles; force-load EN so the
+  // inline ``t()`` in the synchronous render below resolves keys (not their ids).
+  await dom.window.I18N.setLang('en');
+  return dom;
+}
+
+describe('ADR-0022 PR4 list-card label chips', () => {
+  it('renders a read-only production → v2 chip per label, no interactive child', async () => {
+    const { window } = await boot();
+    const root = parse(window, render(window, [ITEM_WITH_LABELS]));
+    const chips = root.querySelectorAll(
+      '.ctx-card[data-name="reviewer"] .ctx-card-label-chip',
+    );
+    expect(chips.length).toBe(2);
+    const prod = root.querySelector('.ctx-card-label-chip[data-label="production"]');
+    expect(prod).not.toBeNull();
+    expect(prod.textContent.replace(/\s+/g, ' ')).toContain('production');
+    expect(prod.querySelector('.ctx-card-label-tag').textContent).toBe('v2');
+    // The card is itself role=button — a button/anchor inside it would be a
+    // nested-interactive a11y violation. Chips are pure spans.
+    expect(root.querySelector('.ctx-card-label-chip button')).toBeNull();
+    expect(root.querySelector('.ctx-card-label-chip a')).toBeNull();
+  });
+
+  it('renders no chip row when the item has no labels', async () => {
+    const { window } = await boot();
+    const root = parse(window, render(window, [ITEM_NO_LABELS]));
+    expect(root.querySelector('.ctx-card-labels')).toBeNull();
+    expect(root.querySelector('.ctx-card-label-chip')).toBeNull();
+  });
+
+  it('echoes label pointers into the card aria-label for SR parity', async () => {
+    const { window } = await boot();
+    const root = parse(window, render(window, [ITEM_WITH_LABELS]));
+    const card = root.querySelector('.ctx-card[data-name="reviewer"]');
+    const aria = card.getAttribute('aria-label') || '';
+    // Visible chips would be invisible to SR otherwise — aria-label overrides
+    // child text on a role=button element.
+    expect(aria).toContain('production');
+    expect(aria).toContain('v2');
+    expect(aria).toContain('staging');
+    expect(aria).toContain('v1');
+  });
+
+  it('chip tooltip follows a locale switch (inline t())', async () => {
+    const { window } = await boot();
+    const enTip = parse(window, render(window, [ITEM_WITH_LABELS]))
+      .querySelector('.ctx-card-label-chip[data-label="production"]')
+      .getAttribute('title');
+    expect(enTip).toContain('detail panel');
+
+    await window.I18N.setLang('ko');
+    const koTip = parse(window, render(window, [ITEM_WITH_LABELS]))
+      .querySelector('.ctx-card-label-chip[data-label="production"]')
+      .getAttribute('title');
+    expect(koTip).toContain('상세 패널');
+    expect(koTip).not.toContain('detail panel');
+
+    await window.I18N.setLang('en');
+  });
+
+  it('HTML-escapes a malicious label name across every interpolation point', async () => {
+    // ``_validate_label_name`` (versioning.py) imposes NO charset restriction on
+    // label names — only ``latest`` and version-shaped names are rejected — so a
+    // hand-edited or future-write label can carry markup. The escaping in
+    // renderLabelChips (data-label, title, .ctx-card-label-name) and the card
+    // aria-label is therefore load-bearing, not defensive. Pin it so a future
+    // refactor that drops an escapeHtml call fails loudly.
+    const { window } = await boot();
+    const evil = 'prod"><img src=x onerror=alert(1)>';
+    const item = {
+      name: 'reviewer',
+      canonical_path: '.memtomem/agents/reviewer/agent.md',
+      target_scope: 'project_shared',
+      runtimes: [],
+      versions: { labels: { [evil]: 'v1' }, count: 1, versionable: true, migrate_required: false },
+    };
+    const html = render(window, [item]);
+    // A single oracle over the whole markup catches any unescaped point (the
+    // chip data-label/title/name AND the card aria-label all carry the label).
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;img');
+    // The card aria-label is built from the same label via t() + escapeHtml.
+    expect(html).toContain('aria-label=');
+    expect(html).not.toContain('"><img');
+  });
+
+  it('renders nothing when the item carries no versions key (enrichment off)', async () => {
+    const { window } = await boot();
+    const bare = {
+      name: 'legacy',
+      canonical_path: '.memtomem/agents/legacy/agent.md',
+      target_scope: 'project_shared',
+      runtimes: [],
+    };
+    const root = parse(window, render(window, [bare]));
+    expect(root.querySelector('.ctx-card-label-chip')).toBeNull();
+    expect(root.querySelector('.ctx-card-labels')).toBeNull();
+  });
+});

--- a/packages/memtomem/tests/test_web_routes_context_versions.py
+++ b/packages/memtomem/tests/test_web_routes_context_versions.py
@@ -16,6 +16,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from memtomem.context import versioning
+from memtomem.context.skills import SKILL_MANIFEST
 from memtomem.web.app import create_app
 
 
@@ -72,6 +73,27 @@ def _make_dir_command(tmp_path: Path, name: str) -> Path:
     return d
 
 
+def _make_dir_skill(tmp_path: Path, name: str) -> Path:
+    """Directory-layout skill: ``.memtomem/skills/<name>/<SKILL_MANIFEST>``.
+
+    Skills are out of versioning (ADR-0022 inv 7); used only to give the skills
+    LIST a non-empty payload for the ``?include=versions`` no-op assertion.
+    """
+    d = tmp_path / ".memtomem" / "skills" / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / SKILL_MANIFEST).write_text(
+        f"---\nname: {name}\ndescription: d\n---\nbody\n", encoding="utf-8"
+    )
+    return d
+
+
+def _by_name(items: list[dict], name: str) -> dict:
+    for it in items:
+        if it["name"] == name:
+            return it
+    raise AssertionError(f"{name!r} not in list: {[i['name'] for i in items]}")
+
+
 # ---------------------------------------------------------------------------
 # List
 # ---------------------------------------------------------------------------
@@ -115,6 +137,143 @@ class TestListVersions:
     async def test_missing_artifact_404(self, client, tmp_path):
         r = await client.get("/api/context/agents/ghost/versions")
         assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# include_has — comma-separated ?include= parsing (pure)
+# ---------------------------------------------------------------------------
+
+
+class TestIncludeHas:
+    @pytest.mark.parametrize(
+        "include,expected",
+        [
+            (None, False),
+            ("", False),
+            ("versions", True),
+            ("foo,versions", True),
+            ("foo, versions ", True),  # whitespace-tolerant
+            ("versions,bar", True),
+            ("versionsx", False),  # substring is not a member
+            ("ver", False),
+            ("foo,bar", False),
+        ],
+    )
+    def test_membership(self, include, expected):
+        from memtomem.web.routes.context_versions import include_has
+
+        assert include_has(include, "versions") is expected
+
+
+# ---------------------------------------------------------------------------
+# List-card enrichment (?include=versions) — ADR-0022 PR4
+# ---------------------------------------------------------------------------
+
+
+class TestListIncludeVersions:
+    @pytest.mark.anyio
+    async def test_no_include_omits_versions_key(self, client, tmp_path):
+        """Default list path is unchanged — no per-item ``versions`` key, so
+        existing callers and the wire shape stay byte-compatible."""
+        _make_dir_agent(tmp_path, "reviewer")
+        r = await client.get("/api/context/agents")
+        assert r.status_code == 200
+        items = r.json()["agents"]
+        assert items and all("versions" not in it for it in items)
+
+    @pytest.mark.anyio
+    async def test_include_versions_dir_agent_empty_store(self, client, tmp_path):
+        _make_dir_agent(tmp_path, "reviewer")
+        r = await client.get("/api/context/agents?include=versions")
+        assert r.status_code == 200
+        item = _by_name(r.json()["agents"], "reviewer")
+        assert item["versions"] == {
+            "labels": {},
+            "count": 0,
+            "versionable": True,
+            "migrate_required": False,
+        }
+
+    @pytest.mark.anyio
+    async def test_include_versions_reflects_labels_and_count(self, client, tmp_path):
+        _make_dir_agent(tmp_path, "reviewer")
+        await client.post("/api/context/agents/reviewer/versions", json={})  # v1
+        await client.post("/api/context/agents/reviewer/versions", json={})  # v2
+        await client.put("/api/context/agents/reviewer/labels/production", json={"version": "v2"})
+        await client.put("/api/context/agents/reviewer/labels/staging", json={"version": "v1"})
+        r = await client.get("/api/context/agents?include=versions")
+        item = _by_name(r.json()["agents"], "reviewer")
+        assert item["versions"]["labels"] == {"production": "v2", "staging": "v1"}
+        assert item["versions"]["count"] == 2
+        assert item["versions"]["versionable"] is True
+        assert item["versions"]["migrate_required"] is False
+
+    @pytest.mark.anyio
+    async def test_include_versions_flat_agent_migrate_required(self, client, tmp_path):
+        _make_flat_agent(tmp_path, "legacy")
+        r = await client.get("/api/context/agents?include=versions")
+        item = _by_name(r.json()["agents"], "legacy")
+        assert item["versions"]["versionable"] is False
+        assert item["versions"]["migrate_required"] is True
+        assert item["versions"]["labels"] == {}
+        assert item["versions"]["count"] == 0
+
+    @pytest.mark.anyio
+    async def test_corrupt_manifest_isolated_not_500(self, client, tmp_path):
+        """One unreadable ``versions.json`` must not 500 the list nor hide a
+        healthy sibling's labels (per-artifact isolation, like a sync skip)."""
+        _make_dir_agent(tmp_path, "good")
+        bad = _make_dir_agent(tmp_path, "bad")
+        await client.post("/api/context/agents/good/versions", json={})  # v1
+        await client.put("/api/context/agents/good/labels/production", json={"version": "v1"})
+        # Wrong JSON shape → VersionError on load_manifest.
+        (bad / "versions.json").write_text("[]", encoding="utf-8")
+
+        r = await client.get("/api/context/agents?include=versions")
+        assert r.status_code == 200
+        good_item = _by_name(r.json()["agents"], "good")
+        bad_item = _by_name(r.json()["agents"], "bad")
+        assert good_item["versions"]["labels"] == {"production": "v1"}
+        assert bad_item["versions"]["labels"] == {}
+        assert bad_item["versions"]["error"] is True
+        assert bad_item["versions"]["count"] == 0
+
+    @pytest.mark.anyio
+    async def test_include_versions_commands_too(self, client, tmp_path):
+        _make_dir_command(tmp_path, "deploy")
+        await client.post("/api/context/commands/deploy/versions", json={})  # v1
+        await client.put("/api/context/commands/deploy/labels/production", json={"version": "v1"})
+        r = await client.get("/api/context/commands?include=versions")
+        assert r.status_code == 200
+        item = _by_name(r.json()["commands"], "deploy")
+        assert item["versions"]["labels"] == {"production": "v1"}
+        assert item["versions"]["count"] == 1
+        assert item["versions"]["versionable"] is True
+
+    @pytest.mark.anyio
+    async def test_no_include_omits_versions_key_commands(self, client, tmp_path):
+        """Mirror of the agents default-path pin for commands — the byte-identical
+        per-route enrichment guard must keep the no-include wire shape (the two
+        routes write the guard independently, so the agents pin alone doesn't
+        protect a regression that drops the commands guard)."""
+        _make_dir_command(tmp_path, "deploy")
+        r = await client.get("/api/context/commands")
+        assert r.status_code == 200
+        items = r.json()["commands"]
+        assert items and all("versions" not in it for it in items)
+
+    @pytest.mark.anyio
+    async def test_skills_list_ignores_include_versions(self, client, tmp_path):
+        """The skills LIST route declares no ``include`` param (skills are out of
+        versioning, inv 7). FastAPI silently ignores an undeclared query param →
+        200, never 422, and no per-item ``versions`` key. Pins the frontend
+        gate's load-bearing assumption that sending the param to skills is a
+        harmless no-op."""
+        _make_dir_skill(tmp_path, "demo")
+        r = await client.get("/api/context/skills?include=versions")
+        assert r.status_code == 200
+        items = r.json()["skills"]
+        assert items and all("versions" not in it for it in items)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/memtomem/tests/web/test_context_gateway_lists.py
+++ b/packages/memtomem/tests/web/test_context_gateway_lists.py
@@ -45,6 +45,17 @@ def _open_skills_list(page) -> None:
     )
 
 
+def _open_agents_list(page) -> None:
+    """Navigate to the Agents sub-section of Context Gateway (ADR-0022 PR4 chips
+    live only on agents + commands, never skills)."""
+    page.evaluate("() => activateTab('settings')")
+    page.evaluate("() => switchSettingsSection('ctx-agents')")
+    page.wait_for_function(
+        "() => document.querySelectorAll('#ctx-agents-list .ctx-scope-group').length > 0",
+        timeout=5_000,
+    )
+
+
 # Single-scope CWD payload with one out-of-sync canonical skill (so
 # ``renderRuntimeBadges`` has something to label) plus a non-cwd scope
 # carrying the ``missing`` flag (so ``_ctxScopeBadges`` renders).
@@ -274,6 +285,105 @@ def test_context_list_card_renders_project_local_tier_badge_with_annotation(
     assert "project_local" in text
     assert "no runtime fan-out" in text
     assert card_name.locator(".badge-tier--project_local").count() == 1
+
+
+# ADR-0022 PR4: cwd scope carrying one versioned agent. ``counts.agents >= 1``
+# so the agents section's cwd group lazily fetches the list.
+_CWD_PROJECTS_AGENTS = {
+    "scopes": [
+        {
+            "scope_id": "cwd-scope",
+            "label": "cwd",
+            "root": "/srv/cwd",
+            "tier": "user",
+            "sources": ["server-cwd"],
+            "experimental": False,
+            "missing": False,
+            "counts": {"skills": 0, "commands": 0, "agents": 1},
+        },
+    ]
+}
+
+# Enriched agents list payload as ``?include=versions`` would return it: one
+# canonical agent with two label pointers landing on frozen versions.
+_CWD_AGENTS_WITH_LABELS = {
+    "agents": [
+        {
+            "name": "reviewer",
+            "canonical_path": "/srv/cwd/.memtomem/agents/reviewer/agent.md",
+            "target_scope": "user",
+            "runtimes": [{"runtime": "claude_agents", "status": "in sync"}],
+            "versions": {
+                "labels": {"production": "v2", "staging": "v1"},
+                "count": 2,
+                "versionable": True,
+                "migrate_required": False,
+            },
+        }
+    ],
+    "scanned_dirs": ["/srv/cwd/.claude/agents/"],
+}
+
+
+def test_pr4_list_card_renders_label_chips_and_requests_include_versions(
+    page, mm_web_url: str
+) -> None:
+    """End-to-end pin for ADR-0022 PR4: the agents list is fetched with
+    ``?include=versions`` and the per-item label map renders read-only
+    ``production → v2`` chips on the card (with SR parity via aria-label).
+    """
+    install_default_stubs(page)
+    _stub_projects(page, _CWD_PROJECTS_AGENTS)
+
+    agents_calls: list[str] = []
+
+    def _agents_handler(route):
+        agents_calls.append(route.request.url)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(_CWD_AGENTS_WITH_LABELS),
+        )
+
+    page.route("**/api/context/agents**", _agents_handler)
+    page.goto(mm_web_url)
+    _open_agents_list(page)
+
+    page.wait_for_selector(
+        "#ctx-agents-list details[data-scope-id='cwd-scope'] "
+        ".ctx-card[data-name='reviewer'] .ctx-card-label-chip",
+        timeout=5_000,
+    )
+    chips = page.locator(
+        "#ctx-agents-list details[data-scope-id='cwd-scope'] "
+        ".ctx-card[data-name='reviewer'] .ctx-card-label-chip"
+    )
+    assert chips.count() == 2, f"expected 2 label chips, got {chips.count()}"
+
+    prod = page.locator(
+        "#ctx-agents-list .ctx-card[data-name='reviewer'] "
+        ".ctx-card-label-chip[data-label='production']"
+    )
+    prod_text = (prod.text_content() or "").replace(" ", "")
+    assert "production" in prod_text and "v2" in prod_text, (
+        f"production chip should read 'production → v2', got {prod_text!r}"
+    )
+
+    # The enrichment must actually be requested for the agents list — the chips
+    # have no other data source.
+    assert any("include=versions" in u for u in agents_calls), (
+        f"agents list must be fetched with ?include=versions; got {agents_calls!r}"
+    )
+
+    # SR parity: the clickable card echoes the pointers into its aria-label
+    # (which overrides the visible chip text for assistive tech).
+    aria = (
+        page.locator("#ctx-agents-list .ctx-card[data-name='reviewer']").get_attribute("aria-label")
+        or ""
+    )
+    assert "production" in aria and "v2" in aria, (
+        f"card aria-label should echo the label pointers, got {aria!r}"
+    )
 
 
 def test_context_list_non_shared_tier_click_threads_target_scope(page, mm_web_url: str) -> None:


### PR DESCRIPTION
## ADR-0022 PR4 — list-card label chips + `GET /context/{type}?include=versions`

Stacked on the merged ADR-0022 work (PR1 version store + routes `#1212`, PR3 detail-panel version manager `#1213`). PR3's commit explicitly deferred this slice to keep itself focused.

Brings the edit/deploy split to the **list** view: each agents/commands card shows read-only `production → v2` label chips, so a user sees which frozen version a label points at without opening the detail panel.

### Backend — opt-in enrichment
- New `include_has()` + `version_summary()` in `context_versions.py`, imported by **both** `list_agents` / `list_commands` (one implementation, no copy-paste divergence; no circular import — `context_versions` imports the `context.*` package, never the web-route modules).
- Each canonical item gains a nested `versions: {labels, count, versionable, migrate_required}`. **Opt-in**: without `?include=versions` the list path is byte-identical with zero extra I/O.
- Flat-layout artifact → `versionable:false, migrate_required:true` (inv 3). A **corrupt `versions.json` is isolated per-artifact** (`error:true`, empty labels) — one bad sidecar can't 500 the whole list, mirroring how the sync engine isolates a per-item skip.

### Frontend — read-only chips
- `renderLabelChips()` renders escaped accent pills (visually derived from PR3's detail-panel chip). Label names are **charset-unrestricted server-side**, so every interpolation is `escapeHtml`'d (load-bearing, not defensive).
- The card is `role=button`, so there is **no interactive element inside a chip** (avoids the nested-interactive a11y trap); label pointers are echoed into the card `aria-label` for SR parity (the visible `→` glyph is `aria-hidden`).
- `include=versions` requested only for agents/commands (skills out of v1, inv 7). `langchange` re-renders the list, keeping inline `t()` tooltip/aria locale-correct.
- 2 new en/ko i18n keys (josa-safe on Latin `{label}`/`{tag}`). Cache-bust `style.css 94→95`, `context-gateway.js 53→54`.

Scope: agents + commands only; chips are **read-only** — freeze/promote/remove stay in the PR3 detail panel.

### Tests
- **Backend +17**: no-include unchanged (agents **and** commands), dir/flat, labels+count, corrupt-manifest isolation w/ healthy sibling, commands, `include_has` parametrized, skills-ignores-`include`.
- **vitest +6** (`ctx-list-label-chips`): render, no-labels, aria parity, locale switch, enrichment-off, malicious-label **XSS-escape** pin.
- **Playwright +1**: chips render + `?include=versions` requested + aria parity.

Full `pytest -m "not ollama"`, full vitest (128), `ruff check`/`format --check`, and `mypy` all green. Reviewed by a 5-dimension adversarial agent pass; 4 nits found and fixed (XSS-escape pin, CSS chip-size comment, skills-ignores-include test, commands default-path test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
