### PR TITLE
feat(context): MCP version/promote tools + label-aware sync (ADR-0022 PR2)

### DIFF
--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -132,6 +132,8 @@ from memtomem.server.tools.context import (
     mem_context_memory_migrate,
     mem_context_migrate,  # deprecated alias for mem_context_memory_migrate (#1147 B5-2)
     mem_context_artifact_migrate,
+    mem_context_version,  # ADR-0022 PR2 — version snapshots (list/create)
+    mem_context_promote,  # ADR-0022 PR2 — label pointers (promote/delete)
 )
 from memtomem.server.tools.ingest import (
     mem_ingest,  # no @mcp.tool; import triggers @register("ingest") for mem_do routing

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, cast
 import click
 
 from memtomem.config import TargetScope
+from memtomem.context import versioning
 from memtomem.context.scope_resolver import find_project_root
 from memtomem.server import mcp
 from memtomem.server.context import CtxType
@@ -16,8 +17,10 @@ from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
 if TYPE_CHECKING:
+    from memtomem.context._names import Layout
     from memtomem.context.migrate import MigrateRow, MigrateScopeResult
     from memtomem.context.scope_resolver import ArtifactKind
+    from memtomem.context.versioning import VersionsManifest
 
 # Known --include values (mirrors cli.context_cmd._KNOWN_INCLUDES).
 _KNOWN_INCLUDES: frozenset[str] = frozenset({"skills", "agents", "commands", "settings"})
@@ -82,6 +85,44 @@ def _parse_include(include: str) -> set[str]:
             )
         values.add(token)
     return values
+
+
+# Kinds whose fan-out honors a version label (ADR-0022 v1 scope: agents +
+# commands). Mirrors ``cli.context_cmd._LABEL_ELIGIBLE_KINDS``.
+_LABEL_ELIGIBLE_KINDS: frozenset[str] = frozenset({"agents", "commands"})
+
+
+def _normalize_label(label: str) -> str | None:
+    """MCP ``label`` arg (``str``, default ``""``) → ``generate_all_*``'s
+    ``str | None``. Empty/whitespace → ``None`` (== working file, today's
+    behavior); ``"latest"`` is passed through and also resolves to the working
+    file at the engine boundary (ADR-0022 invariant 2)."""
+    label = label.strip()
+    return label or None
+
+
+def _label_ineligible_notes(label: str | None, inc: set[str]) -> list[str]:
+    """MCP analog of cli ``_warn_label_ineligible_kinds`` (ADR-0022 invariant 10).
+
+    ``label`` governs only agents/commands; ineligible included kinds
+    (skills/settings/project-memory) run label-less, and a label with no
+    eligible kind in ``include`` is a warned no-op (never an error). Returns
+    note lines for the tool output instead of ``click.secho``-ing them.
+    """
+    if label is None or label == "latest":
+        return []
+    notes: list[str] = []
+    ineligible = sorted(inc - _LABEL_ELIGIBLE_KINDS)
+    if ineligible:
+        notes.append(
+            f"  note: label does not apply to {', '.join(ineligible)} "
+            "(only agents/commands are versioned); they sync from the working file."
+        )
+    if not (inc & _LABEL_ELIGIBLE_KINDS):
+        notes.append(
+            f"  note: label={label} had no effect — no versioned kind (agents/commands) in include."
+        )
+    return notes
 
 
 def _validate_on_drop(on_drop: str) -> str:
@@ -476,6 +517,7 @@ async def mem_context_generate(
     on_drop: str = "ignore",
     scope: str = "",
     allow_host_writes: bool = False,
+    label: str = "",
     ctx: CtxType = None,
 ) -> str:
     """Generate agent configuration files from .memtomem/context.md.
@@ -484,6 +526,14 @@ async def mem_context_generate(
         agent: Agent name (claude, cursor, gemini, codex, copilot) or "all".
         include: Comma-separated extra artifact kinds
             (``skills``, ``agents``, ``commands``, ``settings``).
+        label: ADR-0022 — fan out the frozen version at this label
+            (e.g. ``"production"``) or a bare version tag (``"v2"``) for the
+            versioned kinds (``agents`` / ``commands``) instead of the working
+            canonical. ``""`` (default) / ``"latest"`` means the working file
+            (today's behavior, unchanged). Ineligible included kinds run
+            label-less with a note (invariant 10); an unknown/dangling label is
+            isolated as a per-artifact skip, not a whole-run error. Mirrors the
+            CLI ``mm context generate --label``.
         strict: Legacy alias for ``on_drop="error"``. Promotes dropped-field
             warnings to errors when converting sub-agents or slash commands.
             When both are supplied, ``on_drop`` wins unless it is still the
@@ -516,11 +566,12 @@ async def mem_context_generate(
 
     inc = _parse_include(include)
     on_drop = _validate_on_drop(on_drop)
+    label_norm = _normalize_label(label)
     root = _find_project_root()
     artifact_scope = _resolve_artifact_mcp_scope(scope)
     ctx_path = root / CONTEXT_FILENAME
 
-    results: list[str] = []
+    results: list[str] = _label_ineligible_notes(label_norm, inc)
 
     if ctx_path.exists():
         sections = parse_context(ctx_path)
@@ -539,7 +590,9 @@ async def mem_context_generate(
         else:
             results.append(f"{CONTEXT_FILENAME} is empty.")
     elif not inc:
-        return f"{CONTEXT_FILENAME} not found. Create it with 'mm context init'."
+        # Carry any label note through this nothing-to-generate exit (CLI parity).
+        msg = f"{CONTEXT_FILENAME} not found. Create it with 'mm context init'."
+        return "\n".join([*results, msg]) if results else msg
     else:
         results.append(f"({CONTEXT_FILENAME} missing — skipping project memory)")
 
@@ -560,7 +613,7 @@ async def mem_context_generate(
     if "agents" in inc:
         try:
             agent_result = generate_all_agents(
-                root, strict=strict, on_drop=on_drop, scope=artifact_scope
+                root, strict=strict, on_drop=on_drop, scope=artifact_scope, label=label_norm
             )
         except StrictDropError as exc:
             return f"strict error: {exc}"
@@ -583,7 +636,7 @@ async def mem_context_generate(
     if "commands" in inc:
         try:
             command_result = generate_all_commands(
-                root, strict=strict, on_drop=on_drop, scope=artifact_scope
+                root, strict=strict, on_drop=on_drop, scope=artifact_scope, label=label_norm
             )
         except CommandStrictDropError as exc:
             return f"strict error: {exc}"
@@ -765,6 +818,7 @@ async def mem_context_sync(
     on_drop: str = "ignore",
     scope: str = "",
     allow_host_writes: bool = False,
+    label: str = "",
     ctx: CtxType = None,
 ) -> str:
     """Sync .memtomem/context.md to all detected agent files.
@@ -788,6 +842,16 @@ async def mem_context_sync(
     ``~/.claude/settings.json``), the tool returns a ``needs confirmation``
     line listing the host path instead of writing. Surface that to the
     user, then re-call with ``allow_host_writes=True`` to proceed.
+
+    ``label`` (ADR-0022) deploys a frozen version instead of the working
+    canonical for the versioned kinds (``agents`` / ``commands``): pass a label
+    (e.g. ``"production"``) or a bare version tag (``"v2"``) created via
+    ``mem_context_version`` / ``mem_context_promote``. ``""`` (default) /
+    ``"latest"`` fans out the working file (byte-for-byte today's behavior).
+    The label applies only to agents/commands — ineligible included kinds run
+    label-less with a note (invariant 10) — and an unknown/dangling label or a
+    flat-layout artifact is isolated as a per-artifact ``skipped`` row, never a
+    whole-run error. Mirrors the CLI ``mm context sync --label``.
     """
     from memtomem.context.agents import StrictDropError, generate_all_agents
     from memtomem.context.commands import (
@@ -802,11 +866,12 @@ async def mem_context_sync(
 
     inc = _parse_include(include)
     on_drop = _validate_on_drop(on_drop)
+    label_norm = _normalize_label(label)
     root = _find_project_root()
     artifact_scope = _resolve_artifact_mcp_scope(scope)
     ctx_path = root / CONTEXT_FILENAME
 
-    results: list[str] = []
+    results: list[str] = _label_ineligible_notes(label_norm, inc)
 
     if ctx_path.exists():
         sections = parse_context(ctx_path)
@@ -833,9 +898,14 @@ async def mem_context_sync(
                     results.append(f"{f.agent}: {gen.output_path}")
                     agents_synced.add(f.agent)
             elif not inc:
-                return "No agent files detected. Use mem_context_generate to create them."
+                # Carry any label note (e.g. "label had no effect") through this
+                # nothing-to-sync exit so a labeled call still warns, matching the
+                # CLI which prints the warning before this terminal message.
+                msg = "No agent files detected. Use mem_context_generate to create them."
+                return "\n".join([*results, msg]) if results else msg
     elif not inc:
-        return f"{CONTEXT_FILENAME} not found. Create it with 'mm context init'."
+        msg = f"{CONTEXT_FILENAME} not found. Create it with 'mm context init'."
+        return "\n".join([*results, msg]) if results else msg
     else:
         results.append(f"({CONTEXT_FILENAME} missing — skipping project memory)")
 
@@ -857,7 +927,7 @@ async def mem_context_sync(
     if "agents" in inc:
         try:
             agent_result = generate_all_agents(
-                root, strict=strict, on_drop=on_drop, scope=artifact_scope
+                root, strict=strict, on_drop=on_drop, scope=artifact_scope, label=label_norm
             )
         except StrictDropError as exc:
             return f"strict error: {exc}"
@@ -881,7 +951,7 @@ async def mem_context_sync(
     if "commands" in inc:
         try:
             command_result = generate_all_commands(
-                root, strict=strict, on_drop=on_drop, scope=artifact_scope
+                root, strict=strict, on_drop=on_drop, scope=artifact_scope, label=label_norm
             )
         except CommandStrictDropError as exc:
             return f"strict error: {exc}"
@@ -1407,3 +1477,337 @@ async def mem_context_artifact_migrate(
         return "Nothing to migrate."
 
     return await asyncio.to_thread(_run_artifact_flat_apply, project_root, rows, force=force)
+
+
+# ── Version snapshots + label pointers (ADR-0022) ───────────────────────────
+#
+# Headless-agent parity for the ``mm context version`` CLI group
+# (``cli/context_cmd.py``) and the web ``/context/{type}/{name}/versions`` +
+# ``/labels/{label}`` routes (``web/routes/context_versions.py``). A *version*
+# is an immutable snapshot of one artifact's working canonical; a *label*
+# (``production`` / ``staging`` / …) is a movable pointer over versions, where a
+# promote doubles as a rollback. Both tools reuse the SAME pure-filesystem
+# ``context/versioning.py`` store the CLI and web routes use — no logic is
+# re-implemented. agents + commands only (skills are tree-snapshot artifacts,
+# deferred per ADR-0022 invariant 7).
+
+
+def _resolve_version_artifact(
+    artifact_type: str,
+    project_root: Path,
+    raw_name: str,
+    scope: TargetScope,
+) -> tuple[str, Path, Layout]:
+    """Resolve ``(artifact_type, name, scope)`` → ``(name, working_file, layout)``.
+
+    Mirrors the web router's ``_resolve_versionable`` (agents + commands only;
+    skills / unknown types rejected — ADR-0022 invariant 7). Raises
+    ``ValueError`` with a clean, path-free message for an unsupported type, an
+    invalid name (``validate_name``'s ``InvalidNameError`` is a ``ValueError``),
+    or a missing artifact — the caller catches it and returns ``error: …``.
+    """
+    from memtomem.context._names import validate_name
+    from memtomem.context.agents import resolve_canonical_agent
+    from memtomem.context.commands import resolve_canonical_command
+
+    resolvers = {
+        "agents": (resolve_canonical_agent, "agent"),
+        "commands": (resolve_canonical_command, "command"),
+    }
+    entry = resolvers.get(artifact_type)
+    if entry is None:
+        raise ValueError(
+            f"Versioning is not supported for {artifact_type!r} "
+            f"(agents and commands only — skills are deferred, ADR-0022 invariant 7)."
+        )
+    resolver, kind = entry
+    name = validate_name(raw_name, kind=kind)
+    resolved = resolver(project_root, name, scope=scope)
+    if resolved is None:
+        raise ValueError(f"{kind} {name!r} not found")
+    working_file, layout = resolved
+    return name, working_file, layout
+
+
+def _flat_layout_hint(artifact_type: str, name: str) -> str:
+    """The shared "no version store on flat layout" remediation line (inv 3)."""
+    return (
+        f"{artifact_type}/{name} uses flat layout, which has no per-artifact version "
+        f"store. Run mem_context_artifact_migrate(asset_type='{artifact_type}', "
+        f"name='{name}') to convert it to directory layout first."
+    )
+
+
+def _format_version_list(
+    artifact_type: str, name: str, scope: str, manifest: VersionsManifest
+) -> str:
+    """Plain-text version listing (newest first), mirroring the web GET shape
+    and the CLI ``version list`` content."""
+    if not manifest.versions:
+        return f"{artifact_type}/{name} [{scope}]: no versions yet."
+    # Reverse the label map so each version line shows the pointers that land
+    # on it (tag → [labels]).
+    labels_by_tag: dict[str, list[str]] = {}
+    for label, tag in manifest.labels.items():
+        labels_by_tag.setdefault(tag, []).append(label)
+    lines = [f"{artifact_type}/{name} [{scope}] versions (newest first):"]
+    for tag in sorted(manifest.versions, key=lambda t: int(t[1:]), reverse=True):
+        rec = manifest.versions[tag]
+        pointers = labels_by_tag.get(tag, [])
+        suffix = f"  [{', '.join(sorted(pointers))}]" if pointers else ""
+        note = f"  — {rec.note}" if rec.note else ""
+        lines.append(f"  {tag:6s} {rec.created_at}{suffix}{note}")
+    return "\n".join(lines)
+
+
+def _format_label_result(headline: str, manifest: VersionsManifest) -> str:
+    """Append the post-mutation label map to *headline* so the caller sees the
+    full pointer state after a promote / delete (mirrors the web routes echoing
+    ``labels`` in their response)."""
+    if not manifest.labels:
+        return f"{headline}\n  (no labels)"
+    body = "\n".join(f"  {label} → {manifest.labels[label]}" for label in sorted(manifest.labels))
+    return f"{headline}\nLabels:\n{body}"
+
+
+@mcp.tool()
+@tool_handler
+@register("context")
+async def mem_context_version(
+    artifact_type: str,
+    name: str,
+    action: str = "list",
+    note: str = "",
+    scope: str = "",
+    confirm_project_shared: bool = False,
+    ctx: CtxType = None,
+) -> str:
+    """List or freeze per-artifact version snapshots (ADR-0022).
+
+    Headless-agent parity for the ``mm context version list|create`` CLI
+    commands and the web ``GET/POST /context/{type}/{name}/versions`` routes:
+    freeze a known-good working canonical into an immutable ``versions/vN.md``
+    snapshot, then point a label at it with ``mem_context_promote`` — so
+    editing the canonical and deploying it become two acts with instant
+    rollback. Covers ``agents`` and ``commands`` only (skills are directory-tree
+    artifacts, deferred per ADR-0022 invariant 7).
+
+    Args:
+        artifact_type: ``agents`` or ``commands``. Any other type (including
+            ``skills``) is rejected.
+        name: Canonical artifact name (the directory under
+            ``.memtomem/<type>/``).
+        action: ``list`` (default, read-only) to show versions + label
+            pointers, or ``create`` to freeze the current working canonical
+            into a new ``vN`` snapshot.
+        note: Optional annotation stored with a ``create`` snapshot; ignored
+            for ``list``.
+        scope: ADR-0011 canonical residency tier — ``project_shared``
+            (default), ``user``, or ``project_local``. The user-tier and
+            project_shared ``name`` have independent version histories and
+            label maps (ADR-0022 Decision b); there is no cross-tier lookup.
+        confirm_project_shared: Required for ``action="create"`` when
+            ``scope="project_shared"`` is passed explicitly — the snapshot
+            lands in the git-tracked tree and MCP cannot prompt, so a missing
+            confirmation returns a ``needs confirmation`` line. The implicit
+            default scope does not require it (mirrors ``mem_context_init``).
+
+    A flat-layout artifact has no per-artifact ``versions/`` store (ADR-0022
+    invariant 3): ``list`` returns a benign migrate-required hint and
+    ``create`` refuses with a "run mem_context_artifact_migrate first" error.
+
+    On ``create`` the snapshot bytes are privacy-scanned (Gate A, ADR-0011
+    trust boundary): for ``project_shared`` a secret hard-refuses with a
+    ``privacy block:`` line before ``versions/vN.md`` lands in git-tracked
+    storage; ``user`` / ``project_local`` are permissive (the working file
+    already holds the content locally). Mirrors the CLI ``version create``.
+    Refusals are prefixed (``error:`` / ``needs confirmation:`` /
+    ``privacy block:``) so callers can branch on the prefix.
+    """
+    action = (action or "").strip().lower()
+    if action not in ("list", "create"):
+        return f"error: unknown action {action!r}. Supported: list, create."
+
+    root = await asyncio.to_thread(_find_project_root)
+    scope_explicit = bool(scope.strip())
+    try:
+        artifact_scope = _resolve_artifact_mcp_scope(scope)
+        name, working_file, layout = await asyncio.to_thread(
+            _resolve_version_artifact, artifact_type, root, name, artifact_scope
+        )
+    except ValueError as exc:
+        return f"error: {exc}"
+
+    artifact_dir = working_file.parent
+
+    if action == "list":
+        if layout != "dir":
+            # Benign hint, not an error — parity with the web read route's
+            # ``migrate_required`` flag (the UI hints instead of erroring).
+            return f"{_flat_layout_hint(artifact_type, name)} (no versions yet — migrate to start.)"
+        try:
+            manifest = await asyncio.to_thread(versioning.load_manifest, artifact_dir)
+        except versioning.VersionError as exc:
+            return f"error: {exc}"
+        return _format_version_list(artifact_type, name, artifact_scope, manifest)
+
+    # ── action == "create" ──
+    # Gate B: an explicit project_shared write into the git-tracked tree needs
+    # confirmation MCP cannot prompt for (mirrors mem_context_init / migrate).
+    if scope_explicit and artifact_scope == "project_shared" and not confirm_project_shared:
+        return (
+            "needs confirmation: scope='project_shared' freezes a snapshot into the "
+            "git-tracked tree. Re-call with confirm_project_shared=True to proceed."
+        )
+    if layout != "dir":
+        return f"error: {_flat_layout_hint(artifact_type, name)}"
+
+    # Gate A on the snapshot bytes (mirror cli version_create_cmd): read the
+    # working canonical ONCE and snapshot the SAME bytes via ``source_bytes=`` so
+    # a concurrent edit between scan and write cannot slip unscanned bytes into
+    # versions/vN.md. ``raise_or_collect`` hard-refuses project_shared on a hit
+    # and returns a (ignored) skip tuple for user / project_local — permissive
+    # because the working file already holds the content locally.
+    from memtomem.context.privacy_scan import (
+        PrivacyScanError,
+        raise_or_collect,
+        scan_text_content,
+    )
+
+    try:
+        snapshot_bytes = await asyncio.to_thread(working_file.read_bytes)
+    except OSError as exc:
+        return f"error: cannot read working canonical {working_file}: {exc}"
+    file_scan = await asyncio.to_thread(
+        lambda: scan_text_content(
+            snapshot_bytes.decode("utf-8", errors="replace"),
+            source_path=working_file,
+            surface="mcp_context_version_create",
+            scope=artifact_scope,
+            project_root=root,
+        )
+    )
+    if file_scan.decision in ("blocked", "blocked_project_shared"):
+        try:
+            raise_or_collect(
+                file_scan, scope=artifact_scope, kind=artifact_type[:-1], artifact_name=name
+            )
+        except PrivacyScanError as exc:
+            return f"privacy block: {exc.message}"
+
+    try:
+        record = await asyncio.to_thread(
+            versioning.create_version,
+            artifact_dir,
+            working_file,
+            note=note,
+            source_bytes=snapshot_bytes,
+        )
+    except versioning.VersionError as exc:
+        return f"error: {exc}"
+
+    return (
+        f"Created {artifact_type}/{name} version {record.tag} "
+        f"[{artifact_scope}] at {record.created_at}" + (f" — {record.note}" if record.note else "")
+    )
+
+
+@mcp.tool()
+@tool_handler
+@register("context")
+async def mem_context_promote(
+    artifact_type: str,
+    name: str,
+    label: str,
+    version: str = "",
+    delete: bool = False,
+    scope: str = "",
+    confirm_project_shared: bool = False,
+    ctx: CtxType = None,
+) -> str:
+    """Move or drop a label pointer over an artifact's versions (ADR-0022).
+
+    Headless-agent parity for ``mm context version promote`` and the web
+    ``PUT/DELETE /context/{type}/{name}/labels/{label}`` routes. A *label*
+    (``production`` / ``staging`` / …) is a movable pointer over the immutable
+    versions created by ``mem_context_version``. Promote and rollback are the
+    same act — both just move the pointer; pass ``delete=True`` to drop a label
+    entirely. Covers ``agents`` and ``commands`` only.
+
+    Moving a pointer only updates the manifest — it does NOT fan out to the
+    runtimes by itself. Deploy the pointed-at version with
+    ``mem_context_sync(include="agents", label="<label>", scope=...)`` (or the
+    CLI ``mm context sync --label <label>``).
+
+    Args:
+        artifact_type: ``agents`` or ``commands``.
+        name: Canonical artifact name.
+        label: The label to move or drop (e.g. ``production``). The reserved
+            ``latest`` (always the working file) and version-shaped names
+            (``v1`` — reserved for direct version addressing) are rejected.
+        version: Version tag to point ``label`` at (e.g. ``v2``). Required
+            unless ``delete=True``.
+        delete: Drop ``label`` from the manifest instead of moving it. A
+            ``delete`` of an absent label is a no-op (still succeeds). Cannot
+            be combined with ``version``.
+        scope: ADR-0011 canonical residency tier — ``project_shared``
+            (default), ``user``, or ``project_local`` (independent label maps
+            per tier, ADR-0022 Decision b).
+        confirm_project_shared: Required when ``scope="project_shared"`` is
+            passed explicitly — the label map (``versions.json``) is
+            git-tracked and MCP cannot prompt. The implicit default scope does
+            not require it (mirrors ``mem_context_init``).
+
+    A flat-layout artifact has no version store (ADR-0022 invariant 3) and is
+    refused. Refusals are prefixed (``error:`` / ``needs confirmation:``) so
+    callers can branch on the prefix.
+    """
+    if delete and version.strip():
+        return "error: delete=True drops the label and takes no version."
+    if not delete and not version.strip():
+        return (
+            "error: version is required to promote (e.g. version='v2'), "
+            "or pass delete=True to drop the label."
+        )
+
+    root = await asyncio.to_thread(_find_project_root)
+    scope_explicit = bool(scope.strip())
+    # Resolve scope + artifact BEFORE the confirm gate (matches
+    # mem_context_version's order) — telling the caller the artifact is missing
+    # or flat is more useful than asking them to confirm a write that cannot
+    # land. Neither resolution step mutates disk.
+    try:
+        artifact_scope = _resolve_artifact_mcp_scope(scope)
+        name, working_file, layout = await asyncio.to_thread(
+            _resolve_version_artifact, artifact_type, root, name, artifact_scope
+        )
+    except ValueError as exc:
+        return f"error: {exc}"
+
+    # Gate B: explicit project_shared write into the git-tracked label map.
+    if scope_explicit and artifact_scope == "project_shared" and not confirm_project_shared:
+        return (
+            "needs confirmation: scope='project_shared' moves a pointer in the "
+            "git-tracked label map. Re-call with confirm_project_shared=True to proceed."
+        )
+
+    if layout != "dir":
+        return f"error: {_flat_layout_hint(artifact_type, name)}"
+    artifact_dir = working_file.parent
+
+    try:
+        if delete:
+            await asyncio.to_thread(versioning.delete_label, artifact_dir, label)
+            manifest = await asyncio.to_thread(versioning.load_manifest, artifact_dir)
+            return _format_label_result(
+                f"Dropped label {label!r} from {artifact_type}/{name} [{artifact_scope}]",
+                manifest,
+            )
+        await asyncio.to_thread(versioning.promote_label, artifact_dir, label, version)
+        manifest = await asyncio.to_thread(versioning.load_manifest, artifact_dir)
+        return _format_label_result(
+            f"Promoted {artifact_type}/{name} [{artifact_scope}]: {label} → {version}",
+            manifest,
+        )
+    except versioning.VersionError as exc:
+        return f"error: {exc}"

--- a/packages/memtomem/src/memtomem/server/tools/meta.py
+++ b/packages/memtomem/src/memtomem/server/tools/meta.py
@@ -26,6 +26,14 @@ _ALIASES: dict[str, str] = {
     "context_migrate": "context_memory_migrate",
     # Discoverability shortcut for the artifact-migration tool (#1147 B5-1).
     "artifact_migrate": "context_artifact_migrate",
+    # Discoverability shortcut for the ADR-0022 promote tool (PR2). There is
+    # deliberately NO "version" alias: the bare ``version`` action is already
+    # taken by ``mem_version`` (protocol negotiation for memtomem-stm), and
+    # aliases resolve BEFORE real actions in ``mem_do`` (see below), so a
+    # "version" alias would silently shadow it. Use the canonical
+    # ``context_version`` action instead. The alias-collision guard in
+    # test_meta_tool.py pins this invariant for every alias.
+    "promote": "context_promote",
 }
 
 

--- a/packages/memtomem/tests/test_meta_tool.py
+++ b/packages/memtomem/tests/test_meta_tool.py
@@ -3,7 +3,7 @@
 import json
 
 from memtomem.server.tool_registry import ACTIONS
-from memtomem.server.tools.meta import _help
+from memtomem.server.tools.meta import _ALIASES, _help, mem_do
 from memtomem.server.tools.status_config import mem_version
 
 
@@ -89,6 +89,42 @@ class TestMemDoRouting:
         """Verify fuzzy matching would find similar actions."""
         similar = [k for k in ACTIONS if "tag" in k]
         assert len(similar) >= 2  # tag_list, tag_rename, tag_delete, auto_tag
+
+
+class TestAliasInvariants:
+    """Guards for the ``_ALIASES`` map (ADR-0022 PR2 review)."""
+
+    def test_no_alias_shadows_a_registered_action(self):
+        """An alias key MUST NOT equal a real action name.
+
+        ``mem_do`` resolves aliases FIRST (``resolved = _ALIASES.get(action,
+        action)``) before the registry lookup, so an alias whose key matches a
+        registered action silently HIJACKS that action. A "version" alias for
+        ``context_version`` did exactly this to ``mem_version`` (the
+        memtomem-stm protocol-negotiation action) and was caught in review.
+        This fails loudly if any future alias re-introduces the collision.
+        """
+        collisions = sorted(set(_ALIASES) & set(ACTIONS))
+        assert not collisions, f"alias keys shadow real actions: {collisions}"
+
+    def test_every_alias_target_is_a_real_action(self):
+        """Each alias must resolve to an action that actually exists."""
+        dangling = sorted(t for t in _ALIASES.values() if t not in ACTIONS)
+        assert not dangling, f"aliases point at non-existent actions: {dangling}"
+
+
+class TestMemDoProtocolNegotiation:
+    """``mem_do('version')`` must reach ``mem_version``, not a context tool.
+
+    Pins the contract memtomem-stm depends on. The existing ``TestMemVersion``
+    only calls ``mem_version()`` directly, so it stayed green when a "version"
+    alias hijacked the ``mem_do`` route — this exercises the route end-to-end.
+    """
+
+    async def test_mem_do_version_returns_protocol_json(self):
+        result = await mem_do("version")
+        parsed = json.loads(result)
+        assert "version" in parsed and "capabilities" in parsed
 
 
 class TestScheduleActions:

--- a/packages/memtomem/tests/test_server_tools_context_version.py
+++ b/packages/memtomem/tests/test_server_tools_context_version.py
@@ -1,0 +1,463 @@
+"""Real-FS integration pins for the ``mem_context_version`` /
+``mem_context_promote`` MCP tools (ADR-0022 PR2 — headless-agent parity).
+
+The two tools surface the ADR-0022 edit/deploy split (immutable version
+snapshots + movable label pointers) over the SAME pure-filesystem
+``context/versioning.py`` store the CLI ``mm context version`` group and the web
+``context_versions`` routes use. These tests exercise them against real on-disk
+canonical layouts (not mocked) through the same ``.git`` + ``HOME`` fixture the
+sibling ``mem_context_artifact_migrate`` tests use, and pin:
+
+* list / create roundtrip across agents + commands, newest-first ordering;
+* flat-layout: ``list`` returns a benign migrate hint, ``create`` / ``promote``
+  refuse (ADR-0022 invariant 3);
+* unsupported type (``skills``) / unknown action / invalid name / missing
+  artifact;
+* the ``project_shared`` explicit-scope confirmation gate (the implicit default
+  scope stays frictionless — mirrors ``mem_context_init``);
+* Gate A privacy scan on ``create`` — ``project_shared`` hard-refuses and
+  nothing lands, ``user`` is permissive (mirrors the CLI ``version create``);
+* promote == rollback (pointer move), delete label, reserved + version-shaped
+  label rejection, promote-missing-version, delete+version contradiction;
+* ``mem_do`` routing via the canonical action name and the alias.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memtomem.server.tools.context import mem_context_promote, mem_context_version
+
+_DIR_FILE = {"agents": "agent.md", "commands": "command.md"}
+# A secret that trips Gate A: ``api_key=`` matches the api-key pattern and the
+# AKIA token matches the AWS access-key pattern (mirrors the CLI e2e fixture).
+_SECRET_BODY = "---\nname: leaky\ndescription: d\n---\n\napi_key=AKIA1234567890ABCDEF\n"
+
+
+@pytest.fixture
+def layout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    """A project root (with ``.git`` so ``_find_project_root`` terminates) plus a
+    fake ``HOME`` so the ``user`` tier resolves under ``tmp_path``."""
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    (project_root / ".git").mkdir()
+    user_home = tmp_path / "home"
+    user_home.mkdir()
+    monkeypatch.setenv("HOME", str(user_home))
+    monkeypatch.setenv("USERPROFILE", str(user_home))
+    monkeypatch.chdir(project_root)
+    return {"project_root": project_root, "user_home": user_home}
+
+
+def _canonical_root(layout: dict[str, Path], kind: str, scope: str) -> Path:
+    if scope == "user":
+        return layout["user_home"] / ".memtomem" / kind
+    if scope == "project_shared":
+        return layout["project_root"] / ".memtomem" / kind
+    if scope == "project_local":
+        return layout["project_root"] / ".memtomem" / f"{kind}.local"
+    raise ValueError(scope)
+
+
+def _seed_dir(
+    layout: dict[str, Path],
+    kind: str,
+    name: str,
+    *,
+    scope: str = "project_shared",
+    body: str = "a harmless body\n",
+) -> Path:
+    """Directory-layout canonical artifact; returns the artifact directory."""
+    d = _canonical_root(layout, kind, scope) / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / _DIR_FILE[kind]).write_text(body, encoding="utf-8")
+    return d
+
+
+def _seed_flat(layout: dict[str, Path], kind: str, name: str) -> Path:
+    """Flat-layout canonical (``<kind>/<name>.md``); returns the flat file."""
+    flat = _canonical_root(layout, kind, "project_shared") / f"{name}.md"
+    flat.parent.mkdir(parents=True, exist_ok=True)
+    flat.write_text("# flat\n", encoding="utf-8")
+    return flat
+
+
+# ── list ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_list_default_action_empty(layout):
+    _seed_dir(layout, "agents", "foo")
+    out = await mem_context_version(artifact_type="agents", name="foo")
+    assert "no versions yet" in out
+
+
+@pytest.mark.anyio
+async def test_list_missing_artifact_errors(layout):
+    out = await mem_context_version(artifact_type="agents", name="ghost")
+    assert out.startswith("error:") and "not found" in out
+
+
+@pytest.mark.anyio
+async def test_unsupported_type_skills(layout):
+    out = await mem_context_version(artifact_type="skills", name="foo", action="create")
+    assert out.startswith("error:") and "agents and commands only" in out
+
+
+@pytest.mark.anyio
+async def test_unknown_action(layout):
+    _seed_dir(layout, "agents", "foo")
+    out = await mem_context_version(artifact_type="agents", name="foo", action="freeze")
+    assert out.startswith("error: unknown action")
+
+
+@pytest.mark.anyio
+async def test_invalid_name(layout):
+    out = await mem_context_version(artifact_type="agents", name="../escape", action="list")
+    assert out.startswith("error:")
+
+
+# ── create + list roundtrip ───────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_create_then_list_roundtrip_agents(layout):
+    artifact_dir = _seed_dir(layout, "agents", "foo")
+
+    r1 = await mem_context_version("agents", "foo", action="create", note="first")
+    assert "version v1" in r1 and "first" in r1
+    assert (artifact_dir / "versions" / "v1.md").is_file()
+    assert (artifact_dir / "versions.json").is_file()
+
+    r2 = await mem_context_version("agents", "foo", action="create")
+    assert "version v2" in r2
+    assert (artifact_dir / "versions" / "v2.md").is_file()
+
+    listing = await mem_context_version("agents", "foo")
+    # Newest first: v2 line precedes v1 line.
+    assert listing.index("v2") < listing.index("v1")
+    assert "first" in listing  # v1's note is shown
+
+
+@pytest.mark.anyio
+async def test_create_roundtrip_commands(layout):
+    artifact_dir = _seed_dir(layout, "commands", "mycmd")
+    r = await mem_context_version("commands", "mycmd", action="create")
+    assert "commands/mycmd version v1" in r
+    assert (artifact_dir / "versions" / "v1.md").is_file()
+
+
+@pytest.mark.anyio
+async def test_create_implicit_project_shared_no_confirm(layout):
+    # The implicit default scope must stay frictionless (mirrors mem_context_init).
+    _seed_dir(layout, "agents", "foo")
+    out = await mem_context_version("agents", "foo", action="create")
+    assert out.startswith("Created")
+
+
+@pytest.mark.anyio
+async def test_create_explicit_project_shared_requires_confirm(layout):
+    artifact_dir = _seed_dir(layout, "agents", "foo")
+    out = await mem_context_version("agents", "foo", action="create", scope="project_shared")
+    assert out.startswith("needs confirmation")
+    assert not (artifact_dir / "versions.json").exists()
+
+
+@pytest.mark.anyio
+async def test_create_explicit_project_shared_with_confirm(layout):
+    _seed_dir(layout, "agents", "foo")
+    out = await mem_context_version(
+        "agents", "foo", action="create", scope="project_shared", confirm_project_shared=True
+    )
+    assert out.startswith("Created")
+
+
+@pytest.mark.anyio
+async def test_create_user_scope(layout):
+    artifact_dir = _seed_dir(layout, "agents", "uagent", scope="user")
+    out = await mem_context_version("agents", "uagent", action="create", scope="user")
+    assert "[user]" in out
+    assert (artifact_dir / "versions" / "v1.md").is_file()
+
+
+# ── flat-layout (invariant 3) ─────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_flat_layout_list_returns_hint(layout):
+    _seed_flat(layout, "agents", "flatone")
+    out = await mem_context_version("agents", "flatone", action="list")
+    # Benign hint (parity with the web read route's migrate_required flag),
+    # NOT an ``error:`` prefix.
+    assert not out.startswith("error:")
+    assert "flat layout" in out and "mem_context_artifact_migrate" in out
+
+
+@pytest.mark.anyio
+async def test_flat_layout_create_refuses(layout):
+    flat = _seed_flat(layout, "agents", "flatone")
+    out = await mem_context_version("agents", "flatone", action="create")
+    assert out.startswith("error:") and "flat layout" in out
+    # Nothing was written next to the flat file.
+    assert not (flat.parent / "flatone" / "versions.json").exists()
+
+
+# ── Gate A privacy scan on create ─────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_privacy_block_project_shared_nothing_lands(layout):
+    artifact_dir = _seed_dir(layout, "agents", "leaky", body=_SECRET_BODY)
+    out = await mem_context_version("agents", "leaky", action="create")
+    assert out.startswith("privacy block:")
+    # The version must NOT have been frozen — the scan precedes create_version.
+    assert not (artifact_dir / "versions.json").exists()
+    assert not (artifact_dir / "versions").exists()
+
+
+@pytest.mark.anyio
+async def test_privacy_permissive_user_tier(layout):
+    # user / project_local are permissive: the working file already holds the
+    # content locally, so a snapshot adds no exposure (mirrors the CLI).
+    artifact_dir = _seed_dir(layout, "agents", "uleaky", scope="user", body=_SECRET_BODY)
+    out = await mem_context_version("agents", "uleaky", action="create", scope="user")
+    assert out.startswith("Created")
+    assert (artifact_dir / "versions" / "v1.md").is_file()
+
+
+# ── promote / rollback / delete ───────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_promote_then_rollback(layout):
+    _seed_dir(layout, "agents", "foo")
+    await mem_context_version("agents", "foo", action="create")
+    await mem_context_version("agents", "foo", action="create")
+
+    up = await mem_context_promote("agents", "foo", label="production", version="v2")
+    assert "production → v2" in up
+
+    # Rollback is the same act — just move the pointer back.
+    down = await mem_context_promote("agents", "foo", label="production", version="v1")
+    assert "production → v1" in down
+
+    # Pin WHICH version the pointer lands on: production must render on v1's
+    # line (the rollback target) and NOT on v2's — `"[production]" in listing`
+    # alone would pass even if the rollback silently didn't move the pointer.
+    lines = (await mem_context_version("agents", "foo")).splitlines()
+    v1_line = next(ln for ln in lines if ln.strip().startswith("v1 "))
+    v2_line = next(ln for ln in lines if ln.strip().startswith("v2 "))
+    assert "[production]" in v1_line
+    assert "[production]" not in v2_line
+
+
+@pytest.mark.anyio
+async def test_delete_label(layout):
+    _seed_dir(layout, "agents", "foo")
+    await mem_context_version("agents", "foo", action="create")
+    await mem_context_promote("agents", "foo", label="staging", version="v1")
+
+    out = await mem_context_promote("agents", "foo", label="staging", delete=True)
+    assert "Dropped label 'staging'" in out and "(no labels)" in out
+
+
+@pytest.mark.anyio
+async def test_delete_absent_label_is_noop(layout):
+    _seed_dir(layout, "agents", "foo")
+    await mem_context_version("agents", "foo", action="create")
+    out = await mem_context_promote("agents", "foo", label="nope", delete=True)
+    assert "Dropped label 'nope'" in out  # no-op still succeeds
+
+
+@pytest.mark.anyio
+async def test_promote_missing_version_errors(layout):
+    _seed_dir(layout, "agents", "foo")
+    await mem_context_version("agents", "foo", action="create")
+    out = await mem_context_promote("agents", "foo", label="production", version="v9")
+    assert out.startswith("error:") and "v9" in out
+
+
+@pytest.mark.anyio
+async def test_promote_reserved_label_rejected(layout):
+    _seed_dir(layout, "agents", "foo")
+    await mem_context_version("agents", "foo", action="create")
+    out = await mem_context_promote("agents", "foo", label="latest", version="v1")
+    assert out.startswith("error:") and "reserved" in out
+
+
+@pytest.mark.anyio
+async def test_promote_version_shaped_label_rejected(layout):
+    _seed_dir(layout, "agents", "foo")
+    await mem_context_version("agents", "foo", action="create")
+    out = await mem_context_promote("agents", "foo", label="v1", version="v1")
+    assert out.startswith("error:") and "version tag" in out
+
+
+@pytest.mark.anyio
+async def test_promote_requires_version(layout):
+    _seed_dir(layout, "agents", "foo")
+    await mem_context_version("agents", "foo", action="create")
+    out = await mem_context_promote("agents", "foo", label="production")
+    assert out.startswith("error:") and "version is required" in out
+
+
+@pytest.mark.anyio
+async def test_delete_with_version_is_contradiction(layout):
+    _seed_dir(layout, "agents", "foo")
+    out = await mem_context_promote("agents", "foo", label="x", version="v1", delete=True)
+    assert out.startswith("error:") and "takes no version" in out
+
+
+@pytest.mark.anyio
+async def test_promote_flat_layout_refuses(layout):
+    _seed_flat(layout, "agents", "flatone")
+    out = await mem_context_promote("agents", "flatone", label="production", version="v1")
+    assert out.startswith("error:") and "flat layout" in out
+
+
+@pytest.mark.anyio
+async def test_promote_missing_artifact_errors(layout):
+    out = await mem_context_promote("agents", "ghost", label="production", version="v1")
+    assert out.startswith("error:") and "not found" in out
+
+
+@pytest.mark.anyio
+async def test_promote_explicit_project_shared_confirm_gate(layout):
+    _seed_dir(layout, "agents", "foo")
+    await mem_context_version("agents", "foo", action="create")
+    out = await mem_context_promote(
+        "agents", "foo", label="production", version="v1", scope="project_shared"
+    )
+    assert out.startswith("needs confirmation")
+
+
+# ── mem_do routing ────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_mem_do_routes_version_and_promote(layout):
+    from memtomem.server.tools.meta import mem_do
+
+    _seed_dir(layout, "agents", "foo")
+    # Canonical action name ``context_version`` (there is no "version" alias —
+    # that name belongs to mem_version, the protocol-negotiation action).
+    created = await mem_do(
+        "context_version", {"artifact_type": "agents", "name": "foo", "action": "create"}
+    )
+    assert created.startswith("Created")
+    # Surviving discoverability alias ``promote`` → ``context_promote``.
+    promoted = await mem_do(
+        "promote",
+        {"artifact_type": "agents", "name": "foo", "label": "production", "version": "v1"},
+    )
+    assert "production → v1" in promoted
+
+
+# ── label-aware deploy (mem_context_sync / mem_context_generate --label) ────
+
+
+def _agent_md(name: str, marker: str) -> str:
+    """A valid sub-agent canonical whose body carries a distinguishable marker."""
+    return f"---\nname: {name}\ndescription: example\n---\n{marker}\n"
+
+
+def _runtime_agent_text(layout: dict[str, Path], name: str) -> str:
+    """Read the user-tier Claude runtime fan-out for agent *name*."""
+    return (layout["user_home"] / ".claude" / "agents" / f"{name}.md").read_text(encoding="utf-8")
+
+
+@pytest.mark.anyio
+async def test_sync_label_deploys_frozen_version_not_working_file(layout):
+    from memtomem.server.tools.context import mem_context_sync
+
+    adir = _seed_dir(
+        layout, "agents", "deployer", scope="user", body=_agent_md("deployer", "FROZEN_V1")
+    )
+    assert "version v1" in await mem_context_version(
+        "agents", "deployer", action="create", scope="user"
+    )
+
+    # Edit the working canonical AFTER freezing — a labeled sync must ignore it.
+    (adir / "agent.md").write_text(_agent_md("deployer", "WORKING_V2"), encoding="utf-8")
+    await mem_context_promote("agents", "deployer", label="production", version="v1", scope="user")
+
+    out = await mem_context_sync(include="agents", scope="user", label="production")
+    assert "Sub-agent fan-out:" in out
+    text = _runtime_agent_text(layout, "deployer")
+    assert "FROZEN_V1" in text and "WORKING_V2" not in text
+
+
+@pytest.mark.anyio
+async def test_sync_label_latest_deploys_working_file(layout):
+    from memtomem.server.tools.context import mem_context_sync
+
+    adir = _seed_dir(layout, "agents", "d2", scope="user", body=_agent_md("d2", "FROZEN_V1"))
+    await mem_context_version("agents", "d2", action="create", scope="user")
+    (adir / "agent.md").write_text(_agent_md("d2", "WORKING_V2"), encoding="utf-8")
+
+    # "latest" is the reserved working-file label (invariant 2) — unchanged behavior.
+    await mem_context_sync(include="agents", scope="user", label="latest")
+    text = _runtime_agent_text(layout, "d2")
+    assert "WORKING_V2" in text and "FROZEN_V1" not in text
+
+
+@pytest.mark.anyio
+async def test_sync_unknown_label_isolates_as_skip(layout):
+    from memtomem.server.tools.context import mem_context_sync
+
+    _seed_dir(layout, "agents", "d3", scope="user", body=_agent_md("d3", "BODY"))
+    await mem_context_version("agents", "d3", action="create", scope="user")
+    # No label promoted → resolving "ghost" fails per-artifact, isolated as a
+    # skip (not a whole-run error), so nothing is deployed.
+    out = await mem_context_sync(include="agents", scope="user", label="ghost")
+    assert "skipped" in out
+    assert not (layout["user_home"] / ".claude" / "agents" / "d3.md").exists()
+
+
+@pytest.mark.anyio
+async def test_sync_label_notes_ineligible_kinds(layout):
+    from memtomem.server.tools.context import mem_context_sync
+
+    _seed_dir(layout, "agents", "d4", scope="user", body=_agent_md("d4", "BODY"))
+    await mem_context_version("agents", "d4", action="create", scope="user")
+    await mem_context_promote("agents", "d4", label="production", version="v1", scope="user")
+    # skills is ineligible for labels → a note, but agents still deploy labeled.
+    out = await mem_context_sync(include="agents,skills", scope="user", label="production")
+    assert "note: label does not apply to skills" in out
+    assert "FROZEN" not in out  # sanity: note text is about skills, not a leak
+
+
+@pytest.mark.anyio
+async def test_generate_label_deploys_frozen_version(layout):
+    from memtomem.server.tools.context import mem_context_generate
+
+    adir = _seed_dir(layout, "agents", "g1", scope="user", body=_agent_md("g1", "FROZEN_V1"))
+    await mem_context_version("agents", "g1", action="create", scope="user")
+    (adir / "agent.md").write_text(_agent_md("g1", "WORKING_V2"), encoding="utf-8")
+    await mem_context_promote("agents", "g1", label="production", version="v1", scope="user")
+
+    out = await mem_context_generate(include="agents", scope="user", label="v1")
+    assert "Sub-agent fan-out:" in out
+    text = _runtime_agent_text(layout, "g1")
+    assert "FROZEN_V1" in text and "WORKING_V2" not in text  # bare version tag resolves directly
+
+
+@pytest.mark.anyio
+async def test_sync_label_note_survives_nothing_to_sync_exit(layout):
+    from memtomem.server.tools.context import mem_context_sync
+
+    # No context.md + no eligible kind, but a label → the "had no effect" note
+    # must survive the nothing-to-sync early return (CLI parity; Codex review).
+    out = await mem_context_sync(include="", scope="user", label="production")
+    assert "had no effect" in out  # the label note is carried, not dropped
+    assert "not found" in out  # the terminal nothing-to-do message still present
+
+
+@pytest.mark.anyio
+async def test_generate_label_note_survives_nothing_to_do_exit(layout):
+    from memtomem.server.tools.context import mem_context_generate
+
+    out = await mem_context_generate(include="", scope="user", label="production")
+    assert "had no effect" in out and "not found" in out


### PR DESCRIPTION
## ADR-0022 PR2 — MCP version/promote tools + label-aware sync

Headless-agent parity for the **edit/deploy split**. Agents driving memtomem over MCP (no shell, no web UI) now get the same freeze → promote → deploy flow the CLI `mm context version` group + `--label` and the web `context_versions` routes (PR1 #1212 / PR3 #1213) already expose. Everything reuses the pure-filesystem `context/versioning.py` store and the existing `generate_all_{agents,commands}(label=)` engine path — **no logic re-implemented**. `agents` + `commands` only (skills deferred, ADR-0022 inv 7).

### New `@register("context")` tools
core-9 default mode unchanged; reachable via `mem_do` in core mode.

- **`mem_context_version(artifact_type, name, action="list"|"create", note, scope, confirm_project_shared)`** — list versions + label pointers (read-only default) or freeze the working canonical into an immutable `versions/vN.md`. **Gate A on create** mirrors the CLI `version_create_cmd`: read once + snapshot the **same** bytes (`source_bytes=`) so a concurrent edit can't slip unscanned bytes into git-tracked `versions/vN.md`; `project_shared` hard-refuses a privacy hit *before anything lands*, `user`/`project_local` permissive.
- **`mem_context_promote(artifact_type, name, label, version, delete, scope, confirm_project_shared)`** — move a label pointer (promote == rollback) or `delete=True` to drop it.

### Deploy half (folded in)
`mem_context_sync` / `mem_context_generate` gain a **`label`** param threaded to `generate_all_{agents,commands}(label=)`:
- `""` / `"latest"` → the working file (byte-for-byte today's behavior — no caller changes);
- a label or bare version tag → fans out the **frozen** bytes for agents/commands;
- ineligible included kinds run label-less with a note (inv 10); an unknown/dangling label or flat-layout artifact isolates as a per-artifact **skip**, never a whole-run error;
- `mem_context_diff` stays label-unaware (inv 8).

Full headless flow: **`mem_context_version`** (freeze) → **`mem_context_promote`** (label) → **`mem_context_sync(label=)`** (deploy).

### Boundaries
Flat layout — `list` hints, `create`/`promote` refuse (inv 3); reserved `latest` + version-shaped label names rejected by the shared store; explicit `project_shared` writes need `confirm_project_shared` (git-tracked tree, MCP can't prompt — mirrors `mem_context_init`); the implicit default scope stays frictionless.

### Review
An adversarial multi-lens review caught + fixed a **blocker**: the originally-added `mem_do` alias `"version"` shadowed the existing `mem_version` action (memtomem-stm protocol negotiation), because `mem_do` resolves aliases before real actions. Dropped that alias (kept the collision-free `"promote"`), added a guard test that no alias key may shadow a registered action, plus a regression pin that `mem_do("version")` still returns the protocol JSON.

### Tests
- `test_server_tools_context_version.py` — 32 real-FS pins: list/create/promote/delete, flat-layout, privacy block + user-tier permissive, confirm gate, `mem_do` routing, and label-aware deploy (frozen-not-working / latest / unknown-label skip / ineligible-kind note / generate-by-version-tag).
- `test_meta_tool.py` — alias-collision guard + protocol-negotiation pin.
- Full `pytest -m "not ollama"` green (6003 passed). The 12 `test_web_cli` failures are a pre-existing stale `web.pid` in the local env, reproduced on the base branch — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)