### PR TITLE
fix(web): a11y — settings-nav→nav list, un-nest project-remove ×, label Hooks controls (rank 14/15/22)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1462,14 +1462,19 @@ function switchSettingsSection(sectionName) {
   try { localStorage.setItem(LAST_SECTION_KEY, sectionName); } catch {}
   document.querySelectorAll('.settings-nav-btn').forEach(b => {
     b.classList.remove('active');
-    b.setAttribute('aria-selected', 'false');
+    // ``.settings-nav`` is a navigation list (role-less <nav>), not a tablist
+    // (rank 14): the group headers are interactive collapse toggles, which a
+    // strict ARIA tablist may not contain. Mark the active entry with
+    // ``aria-current="page"`` — the standard nav-selection cue — instead of
+    // ``aria-selected``, which only belongs on a role=tab.
+    b.removeAttribute('aria-current');
   });
   document.querySelectorAll('.settings-section').forEach(s => s.classList.remove('active'));
   const btn = document.querySelector(`.settings-nav-btn[data-section="${sectionName}"]`);
   const section = document.getElementById(`settings-${sectionName}`);
   if (btn) {
     btn.classList.add('active');
-    btn.setAttribute('aria-selected', 'true');
+    btn.setAttribute('aria-current', 'page');
   }
   if (section) section.classList.add('active');
   ensureActiveGroupExpanded(sectionName);

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -2543,15 +2543,27 @@ async function loadCtxList(type) {
       // disambiguate same-name scopes (``Edu/inflearn`` vs ``Work/inflearn``)
       // on hover without inflating the visible label.
       const rootTitle = scope.root ? `title="${escapeHtml(scope.root)}"` : '';
-      html += `<details class="ctx-scope-group" data-scope-id="${escapeHtml(scope.scope_id)}" data-tier="${escapeHtml(scope.tier)}"${isActive ? ' open' : ''}>
-        <summary class="ctx-scope-summary" ${rootTitle}>
-          <span class="ctx-scope-summary-label">${escapeHtml(scope.label)}</span>
-          <span class="ctx-scope-summary-count">${count}</span>
-          ${_ctxScopeBadges(scope)}
-          ${removeBtn}
-        </summary>
-        <div class="ctx-scope-items" id="${groupId}" data-loaded="false"></div>
-      </details>`;
+      // The remove (×) button is a SIBLING of <details>, not a child of
+      // <summary> (rank 15). A real <button> nested inside the <summary>
+      // activation control is the banned nested-interactive antipattern
+      // (#1003) and made keyboard activation of × ambiguous against the
+      // disclosure's native toggle. It can't be a plain child of <details>
+      // either — native <details> hides every non-<summary> child while
+      // collapsed, which would make × disappear on closed groups. So wrap
+      // both and pin × over the summary's right edge via CSS
+      // (``.ctx-scope-group-wrap``), keeping × always visible and a
+      // standalone button with unambiguous keyboard activation.
+      html += `<div class="ctx-scope-group-wrap">
+        <details class="ctx-scope-group" data-scope-id="${escapeHtml(scope.scope_id)}" data-tier="${escapeHtml(scope.tier)}"${isActive ? ' open' : ''}>
+          <summary class="ctx-scope-summary" ${rootTitle}>
+            <span class="ctx-scope-summary-label">${escapeHtml(scope.label)}</span>
+            <span class="ctx-scope-summary-count">${count}</span>
+            ${_ctxScopeBadges(scope)}
+          </summary>
+          <div class="ctx-scope-items" id="${groupId}" data-loaded="false"></div>
+        </details>
+        ${removeBtn}
+      </div>`;
     }
     listEl.innerHTML = html;
     _ctxWireProjectControls();
@@ -2598,7 +2610,9 @@ async function loadCtxList(type) {
       if (groupEl.open) fetchOnce();
       groupEl.addEventListener('toggle', () => { if (groupEl.open) fetchOnce(); });
 
-      const removeBtn = groupEl.querySelector('.ctx-scope-remove');
+      // × is a sibling of <details> inside ``.ctx-scope-group-wrap`` (rank
+      // 15), so reach it through the wrapper rather than ``groupEl`` itself.
+      const removeBtn = groupEl.parentElement?.querySelector(':scope > .ctx-scope-remove');
       if (removeBtn) {
         removeBtn.addEventListener('click', async (ev) => {
           ev.preventDefault();

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=96" />
+  <link rel="stylesheet" href="/style.css?v=97" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -490,61 +490,61 @@
        ``switchSettingsSection('ctx-*'/'hooks-sync')`` auto-redirects here. -->
   <div id="tab-context-gateway" class="tab-panel" role="tabpanel" aria-labelledby="tabbtn-context-gateway" hidden>
     <div class="settings-layout">
-      <div class="settings-nav" role="tablist">
+      <nav class="settings-nav" data-i18n-aria-label="settings.nav.gateway_sections_aria" aria-label="Context Gateway sections">
         <button class="settings-nav-group" type="button" data-group="integrations" aria-expanded="true">
           <span class="nav-group-caret" aria-hidden="true">▾</span>
           <span data-i18n="settings.nav.integrations">Agent Integrations</span>
         </button>
-        <button class="settings-nav-btn settings-nav-btn--landing" data-ui-tier="prod" data-section="ctx-overview" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn settings-nav-btn--landing" data-ui-tier="prod" data-section="ctx-overview" data-group="integrations">
           <span class="nav-icon" aria-hidden="true">🔄</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_overview">Context Gateway</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_overview_sub">Sync overview</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-projects" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-projects" data-group="integrations">
           <span class="nav-icon" aria-hidden="true">📁</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_projects">Projects</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_projects_sub">Multi-project portal</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-skills" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-skills" data-group="integrations">
           <span class="nav-icon" aria-hidden="true">🧩</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_skills">Skills</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_skills_sub">Reusable workflows</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-commands" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-commands" data-group="integrations">
           <span class="nav-icon" aria-hidden="true">⌘</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_commands">Custom Commands</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_commands_sub">Slash commands</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-agents" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-agents" data-group="integrations">
           <span class="nav-icon" aria-hidden="true">🤖</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_agents">Subagents</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_agents_sub">Specialized agents</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-mcp-servers" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-mcp-servers" data-group="integrations">
           <span class="nav-icon" aria-hidden="true">🔌</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_mcp_servers">MCP Servers</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_mcp_servers_sub">Project tool servers</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="hooks-sync" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="hooks-sync" data-group="integrations">
           <span class="nav-icon" aria-hidden="true">📎</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.hooks_sync">Hooks</span>
             <span class="nav-sub" data-i18n="settings.nav.hooks_sync_sub">Lifecycle hooks</span>
           </span>
         </button>
-      </div>
+      </nav>
       <div class="settings-content">
 
         <!-- Context Gateway: Overview -->
@@ -832,19 +832,19 @@
   <!-- ===== SETTINGS HUB ===== -->
   <div id="tab-settings" class="tab-panel" role="tabpanel" aria-labelledby="tabbtn-settings" hidden>
     <div class="settings-layout">
-      <div class="settings-nav" role="tablist">
+      <nav class="settings-nav" data-i18n-aria-label="settings.nav.settings_sections_aria" aria-label="Settings sections">
         <button class="settings-nav-group" type="button" data-group="general" aria-expanded="true">
           <span class="nav-group-caret" aria-hidden="true">▾</span>
           <span data-i18n="settings.nav.general">General</span>
         </button>
-        <button class="settings-nav-btn active" data-ui-tier="prod" data-section="config" data-group="general" role="tab" aria-selected="true">
+        <button class="settings-nav-btn active" data-ui-tier="prod" data-section="config" data-group="general" aria-current="page">
           <span class="nav-icon" aria-hidden="true">⚙</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.config">Config</span>
             <span class="nav-sub" data-i18n="settings.nav.config_sub">Embedding &amp; DB</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="namespaces" data-group="general" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="namespaces" data-group="general">
           <span class="nav-icon" aria-hidden="true">🗂</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.namespaces">Namespaces</span>
@@ -856,28 +856,28 @@
           <span class="nav-group-caret" aria-hidden="true">▸</span>
           <span data-i18n="settings.nav.runtime">Runtime</span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="dev" data-section="harness-sessions" data-group="runtime" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="dev" data-section="harness-sessions" data-group="runtime">
           <span class="nav-icon" aria-hidden="true">▷</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.sessions">Sessions</span>
             <span class="nav-sub" data-i18n="settings.nav.sessions_sub">Episodic history</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="dev" data-section="harness-scratch" data-group="runtime" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="dev" data-section="harness-scratch" data-group="runtime">
           <span class="nav-icon" aria-hidden="true">✎</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.working_memory">Working Memory</span>
             <span class="nav-sub" data-i18n="settings.nav.working_memory_sub">Scratch KV</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="dev" data-section="harness-procedures" data-group="runtime" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="dev" data-section="harness-procedures" data-group="runtime">
           <span class="nav-icon" aria-hidden="true">📜</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.procedures">Procedures</span>
             <span class="nav-sub" data-i18n="settings.nav.procedures_sub">Saved recipes</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="dev" data-section="harness-health" data-group="runtime" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="dev" data-section="harness-health" data-group="runtime">
           <span class="nav-icon" aria-hidden="true">💓</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.health">Health Report</span>
@@ -889,21 +889,21 @@
           <span class="nav-group-caret" aria-hidden="true">▸</span>
           <span data-i18n="settings.nav.data">Data</span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="dedup" data-group="data" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="dedup" data-group="data">
           <span class="nav-icon" aria-hidden="true">🧹</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.dedup">Deduplicate</span>
             <span class="nav-sub" data-i18n="settings.nav.dedup_sub">Remove near-duplicates</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="decay" data-group="data" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="decay" data-group="data">
           <span class="nav-icon" aria-hidden="true">⏲</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.decay">Age-out</span>
             <span class="nav-sub" data-i18n="settings.nav.decay_sub">Expire old memories</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="export" data-group="data" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="export" data-group="data">
           <span class="nav-icon" aria-hidden="true">⇅</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.export_import">Export / Import</span>
@@ -915,14 +915,14 @@
           <span class="nav-group-caret" aria-hidden="true">⚠</span>
           <span data-i18n="settings.nav.danger_zone">Danger Zone</span>
         </div>
-        <button class="settings-nav-btn settings-nav-btn--danger" data-ui-tier="prod" data-section="reset" data-group="danger" role="tab" aria-selected="false">
+        <button class="settings-nav-btn settings-nav-btn--danger" data-ui-tier="prod" data-section="reset" data-group="danger">
           <span class="nav-icon" aria-hidden="true">⚠</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.reset">Reset Database</span>
             <span class="nav-sub" data-i18n="settings.nav.reset_sub">Delete all data</span>
           </span>
         </button>
-      </div>
+      </nav>
       <div class="settings-content">
 
         <!-- Config section -->
@@ -1507,16 +1507,16 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=123"></script>
+  <script src="/app.js?v=124"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=10"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>
   <script src="/settings-maintenance.js?v=3"></script>
   <script src="/settings-namespaces.js?v=9"></script>
   <script src="/settings-harness.js?v=2"></script>
-  <script src="/settings-hooks-watchdog.js?v=14"></script>
+  <script src="/settings-hooks-watchdog.js?v=15"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=55"></script>
+  <script src="/context-gateway.js?v=56"></script>
   <script src="/context-portal.js?v=2"></script>
   <script src="/path-picker.js?v=3"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -316,6 +316,8 @@
 
   "settings.nav.general": "General",
   "settings.nav.integrations": "Agent Integrations",
+  "settings.nav.gateway_sections_aria": "Context Gateway sections",
+  "settings.nav.settings_sections_aria": "Settings sections",
   "settings.nav.runtime": "Runtime",
   "settings.nav.data": "Data",
   "settings.nav.danger_zone": "Danger Zone",
@@ -670,6 +672,7 @@
   "settings.hooks.no_hooks_defined": "No hooks defined in .memtomem/settings.json.",
   "settings.hooks.no_hooks_hint": "Add hook rules to .memtomem/settings.json to make them appear as pending or synced.",
   "settings.hooks.load_failed": "Failed to load sync status",
+  "settings.hooks.controls_caption": "Tier and project select which settings.json is read and synced.",
   "settings.hooks.target_label": "Target:",
   "settings.hooks.target_label_user": "User-scope target:",
   "settings.hooks.target_label_project_shared": "Project (shared) target:",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -316,6 +316,8 @@
 
   "settings.nav.general": "일반",
   "settings.nav.integrations": "에이전트 연동",
+  "settings.nav.gateway_sections_aria": "컨텍스트 게이트웨이 섹션",
+  "settings.nav.settings_sections_aria": "설정 섹션",
   "settings.nav.runtime": "런타임",
   "settings.nav.data": "데이터",
   "settings.nav.danger_zone": "위험 구역",
@@ -670,6 +672,7 @@
   "settings.hooks.no_hooks_defined": ".memtomem/settings.json 에 정의된 훅이 없습니다.",
   "settings.hooks.no_hooks_hint": ".memtomem/settings.json 에 훅 규칙을 추가하면 대기 중 또는 동기화됨 상태로 표시됩니다.",
   "settings.hooks.load_failed": "동기화 상태를 불러오지 못했습니다",
+  "settings.hooks.controls_caption": "어느 settings.json을 읽고 동기화할지는 티어·프로젝트 선택으로 결정됩니다.",
   "settings.hooks.target_label": "대상:",
   "settings.hooks.target_label_user": "User 스코프 대상:",
   "settings.hooks.target_label_project_shared": "프로젝트(공유) 대상:",

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -85,6 +85,23 @@ function _hooksWireTierControls() {
   }
 }
 
+// rank 22: the Hooks section inherits the same project switcher + tier toggle
+// the artifact sections use, but renders them bare above a single "Sync Now"
+// button — so the control row read as accidental chrome rather than a
+// deliberate control. Both controls ARE functional here (they pick which
+// canonical settings.json is read/synced), so we keep them but wrap them in a
+// labeled row with an explicit caption naming that effect, matching the
+// intentional look of the artifact-section control rows.
+function _hooksControlsHtml() {
+  const proj = _hooksProjectControlsHtml();
+  const tier = _hooksTierControlsHtml();
+  if (!proj && !tier) return '';
+  const caption = typeof t === 'function' ? t('settings.hooks.controls_caption') : '';
+  return `<div class="hooks-controls">${proj}${tier}`
+    + `<p class="hooks-controls-caption" data-i18n="settings.hooks.controls_caption">`
+    + `${escapeHtml(caption)}</p></div>`;
+}
+
 function _renderHookRuleDetail(key, contentEl) {
   const idx = Number(key);
   const entry = Number.isInteger(idx) ? _hooksRuleRegistry[idx] : undefined;
@@ -403,7 +420,7 @@ async function loadHooksSync() {
     }
   }
   requestedProjectScope = _hooksCurrentProjectScope();
-  statusEl.innerHTML = _hooksProjectControlsHtml() + _hooksTierControlsHtml();
+  statusEl.innerHTML = _hooksControlsHtml();
   _hooksWireProjectControls();
   _hooksWireTierControls();
 
@@ -452,8 +469,7 @@ async function loadHooksSync() {
     // target path is often what the user needs to inspect.
     const showTarget = !!data.target_path && data.status !== 'no_source';
     statusEl.innerHTML =
-      _hooksProjectControlsHtml()
-      + _hooksTierControlsHtml()
+      _hooksControlsHtml()
       + `<span class="badge ${badge.cls}">${escapeHtml(badge.text)}</span>`
       + (showTarget
         ? `<div class="hooks-status-target" data-target-scope="${escapeHtml(scope || '')}">${escapeHtml(targetLabel)} <code>${escapeHtml(data.target_path)}</code></div>`

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -2516,6 +2516,25 @@ select:focus-visible {
   margin-bottom: 1rem;
 }
 #hooks-sync-status { display: flex; flex-direction: column; align-items: flex-start; gap: 4px; }
+/* rank 22: a deliberate control row for the Hooks project switcher + tier
+   toggle, with a full-width caption naming what they scope so the row reads
+   as intentional rather than chrome inherited from the artifact sections. */
+.hooks-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+  width: 100%;
+  margin-bottom: 4px;
+}
+.hooks-controls .ctx-project-switcher,
+.hooks-controls .ctx-tier-filter { margin-bottom: 0; }
+.hooks-controls-caption {
+  flex-basis: 100%;
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
 .hooks-status-target { font-size: 0.78rem; color: var(--muted); max-width: 100%; }
 /* ``overflow-wrap: anywhere`` lets long absolute paths break at any
  * character so the target span never pushes the Sync Now button or
@@ -3848,11 +3867,17 @@ body.help-hidden #help-toggle { opacity: 0.5; }
 .ctx-card-label-tag { font-family: var(--mono); }
 
 /* PR2 multi-project: collapsible scope groups, mirroring memory-dirs-group. */
-.ctx-scope-group { border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); margin-bottom: 8px; }
-.ctx-scope-group + .ctx-scope-group { margin-top: 0; }
+/* rank 15: wraps <details> + its sibling × so the remove button can be
+   pinned over the summary row while staying OUT of the <summary> activation
+   control (nested-interactive antipattern) and visible while collapsed. */
+.ctx-scope-group-wrap { position: relative; margin-bottom: 8px; }
+.ctx-scope-group-wrap + .ctx-scope-group-wrap { margin-top: 0; }
+.ctx-scope-group { border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); }
 .ctx-scope-summary {
   display: flex; align-items: center; gap: 10px;
-  padding: 10px 14px;
+  /* right padding reserves room for the absolutely-positioned × so badges
+     never slide under it. */
+  padding: 10px 40px 10px 14px;
   cursor: pointer;
   font-size: 0.86rem;
   user-select: none;
@@ -3977,7 +4002,12 @@ body.help-hidden #help-toggle { opacity: 0.5; }
   font-weight: 600;
 }
 .ctx-scope-remove {
-  margin-left: auto;
+  /* Pinned over the summary's right edge (rank 15) — a sibling of <details>,
+     not a flex child of <summary>, so it stays visible when the group is
+     collapsed and is a standalone keyboard-focusable button. */
+  position: absolute;
+  top: 8px;
+  right: 12px;
   background: transparent;
   border: 1px solid transparent;
   color: var(--muted);

--- a/packages/memtomem/tests/test_web_a11y.py
+++ b/packages/memtomem/tests/test_web_a11y.py
@@ -674,3 +674,148 @@ class TestIssue1073CtxKeyboardSemantics:
             "ctx-detail-tabs must wire keydown → _arrowNavIndex so Left/Right/"
             "Home/End move focus between tabs (#1073)"
         )
+
+
+_HOOKS_JS = _STATIC_DIR / "settings-hooks-watchdog.js"
+_STYLE_CSS = _STATIC_DIR / "style.css"
+
+
+@pytest.fixture(scope="module")
+def hooks_js() -> str:
+    assert _HOOKS_JS.exists(), f"settings-hooks-watchdog.js missing: {_HOOKS_JS}"
+    return _HOOKS_JS.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def style_css() -> str:
+    assert _STYLE_CSS.exists(), f"style.css missing: {_STYLE_CSS}"
+    return _STYLE_CSS.read_text(encoding="utf-8")
+
+
+class TestSettingsNavIsNavigationNotTablist:
+    """rank 14: the Gateway + Settings sidebars (``.settings-nav``, shared)
+    carry interactive collapsible group-header buttons, which a strict ARIA
+    tablist must not contain. They were demoted to navigation lists (``<nav>``
+    + ``aria-current=page``). Pin that so a future edit can't silently restore
+    the broken ``role=tablist`` / ``role=tab`` contract that announced
+    "tab, N of M" with no associated panel and no arrow-key movement.
+    """
+
+    def test_settings_nav_is_nav_landmark_not_tablist(self, index_html: str) -> None:
+        navs = re.findall(r"<nav class=\"settings-nav\"[^>]*>", index_html)
+        assert len(navs) == 2, (
+            f"expected 2 <nav class=settings-nav> (Gateway + Settings), got {len(navs)}"
+        )
+        for tag in navs:
+            assert "role=" not in tag, (
+                "settings-nav must not declare a role — it was demoted from "
+                f"role=tablist to a plain <nav> landmark (rank 14): {tag}"
+            )
+            assert "aria-label=" in tag, f"each settings-nav landmark needs an aria-label: {tag}"
+        assert 'class="settings-nav" role="tablist"' not in index_html, (
+            "settings-nav must no longer be a role=tablist (rank 14)"
+        )
+
+    def test_settings_nav_buttons_drop_tab_role(self, index_html: str) -> None:
+        btns = re.findall(r"<button class=\"settings-nav-btn[^>]*>", index_html)
+        assert btns, "no settings-nav-btn found — selector drift?"
+        for tag in btns:
+            assert 'role="tab"' not in tag, (
+                f"settings-nav-btn must not be role=tab (rank 14): {tag}"
+            )
+            assert "aria-selected" not in tag, (
+                "settings-nav-btn must not carry aria-selected — the active "
+                f"item uses aria-current=page instead (rank 14): {tag}"
+            )
+        config_btn = next((t for t in btns if 'data-section="config"' in t), None)
+        assert config_btn and 'aria-current="page"' in config_btn, (
+            "the statically-active 'config' nav item must mark itself with "
+            "aria-current=page (rank 14)"
+        )
+
+    def test_switch_settings_section_marks_aria_current(self, app_js: str) -> None:
+        body = _extract_function(app_js, "switchSettingsSection")
+        assert "setAttribute('aria-current', 'page')" in body, (
+            "switchSettingsSection must set aria-current=page on the active nav item (rank 14)"
+        )
+        assert "removeAttribute('aria-current')" in body, (
+            "switchSettingsSection must clear aria-current from inactive nav items (rank 14)"
+        )
+        assert "setAttribute('aria-selected'" not in body, (
+            "switchSettingsSection must not set aria-selected on the settings "
+            "nav — it is a navigation list, not a tablist (rank 14)"
+        )
+
+
+class TestScopeRemoveButtonNotNestedInSummary:
+    """rank 15: the destructive project-remove × must not be interpolated
+    inside the ``<summary>`` disclosure trigger (nested-interactive
+    antipattern, #1003). It now renders as a sibling of ``<details>`` inside
+    ``.ctx-scope-group-wrap``, pinned over the summary row by CSS so it stays
+    visible while the group is collapsed.
+    """
+
+    def test_remove_button_is_sibling_not_inside_summary(self, ctx_js: str) -> None:
+        assert '<div class="ctx-scope-group-wrap">' in ctx_js, (
+            "scope groups must be wrapped in .ctx-scope-group-wrap so × can be "
+            "a sibling of <details> (rank 15)"
+        )
+        i_summary = ctx_js.index('<summary class="ctx-scope-summary"')
+        i_summary_close = ctx_js.index("</summary>", i_summary)
+        i_details_close = ctx_js.index("</details>", i_summary_close)
+        i_remove = ctx_js.index("${removeBtn}", i_summary)
+        assert i_remove > i_details_close, (
+            "${removeBtn} must be interpolated after </details> (a sibling of "
+            "the disclosure), not within it — rank 15"
+        )
+        summary_block = ctx_js[i_summary:i_summary_close]
+        assert "${removeBtn}" not in summary_block, (
+            "the remove × must not live inside <summary> — that is the banned "
+            "nested-interactive antipattern (#1003 / rank 15)"
+        )
+
+    def test_remove_button_keeps_accessible_name(self, ctx_js: str) -> None:
+        m = re.search(r'<button class="ctx-scope-remove"[^>]*>', ctx_js)
+        assert m, "ctx-scope-remove button template not found"
+        tag = m.group(0)
+        assert "aria-label=" in tag and "title=" in tag, (
+            "ctx-scope-remove must keep aria-label + title (the × glyph alone "
+            "is not an accessible name)"
+        )
+
+    def test_remove_button_css_keeps_it_visible_when_collapsed(self, style_css: str) -> None:
+        assert ".ctx-scope-group-wrap { position: relative;" in style_css, (
+            ".ctx-scope-group-wrap must establish a positioning context (rank 15)"
+        )
+        m = re.search(r"\.ctx-scope-remove\s*\{[^}]*\}", style_css, re.DOTALL)
+        assert m and "position: absolute" in m.group(0), (
+            ".ctx-scope-remove must be position:absolute so it shows on a "
+            "collapsed group, where native <details> hides non-summary "
+            "children (rank 15)"
+        )
+
+
+class TestHooksControlsPresentation:
+    """rank 22: the Hooks section's inherited project switcher + tier toggle
+    are wrapped in a labeled ``.hooks-controls`` row with an explicit caption,
+    so the functional-but-bare control row reads as intentional rather than
+    chrome accidentally inherited from the artifact sections.
+    """
+
+    def test_hooks_controls_helper_wraps_with_caption(self, hooks_js: str) -> None:
+        body = _extract_function(hooks_js, "_hooksControlsHtml")
+        assert 'class="hooks-controls"' in body, (
+            "_hooksControlsHtml must wrap the controls in .hooks-controls (rank 22)"
+        )
+        assert "settings.hooks.controls_caption" in body, (
+            "_hooksControlsHtml must render the controls_caption (rank 22)"
+        )
+
+    def test_hooks_render_paths_use_wrapped_controls(self, hooks_js: str) -> None:
+        load = _extract_function(hooks_js, "loadHooksSync")
+        assert "_hooksControlsHtml()" in load, (
+            "loadHooksSync must render controls via the wrapped helper (rank 22)"
+        )
+        assert "_hooksProjectControlsHtml() + _hooksTierControlsHtml()" not in load, (
+            "loadHooksSync must not emit the bare unwrapped controls (rank 22)"
+        )


### PR DESCRIPTION
## What

Context Gateway UX-audit follow-up — three **P2 frontend-only** a11y/correctness ranks. No backend or route changes.

### rank 14 — sidebar ARIA contract → navigation list
The Gateway + Settings/More sidebars (`.settings-nav`, shared) declared `role=tablist` with `role=tab` buttons but **no `aria-controls`, no `tabpanel` roles, and no arrow-key nav** — a broken tab contract that announced *"tab, N of M"* with no associated panel. The sidebars also interleave **interactive collapsible group-header buttons**, which a strict tablist must not contain, so "completing" the tab pattern wasn't achievable cleanly.

**Fix (chosen direction):** demote to a navigation list — `<nav aria-label>`, drop `role=tab`/`aria-selected` from the 17 nav buttons, mark the active item with `aria-current="page"` (managed by `switchSettingsSection`). The four **real** tablists (top tab-nav, sources vendor, index-mode, detail sub-tabs) are untouched.

### rank 15 — un-nest the destructive project-remove ×
The × was interpolated **inside** the `<summary>` activation control (nested-interactive antipattern, #1003) with only a mouse-path `stopPropagation` guard. It's now a **sibling of `<details>`**, wrapped in `.ctx-scope-group-wrap` and pinned over the summary's right edge by CSS. It can't be a plain `<details>` child — native `<details>` hides non-`<summary>` children when collapsed (× would vanish) — so the wrapper keeps it always visible and a standalone keyboard-focusable button.

| collapsed | open |
|---|---|
| × stays visible (native `<details>` would otherwise hide it) | × pinned top-right, no badge overlap |

### rank 22 — label the Hooks control row
Hooks inherited the artifact-section project switcher + tier toggle but rendered them bare above a single "Sync Now" button, reading as accidental chrome. Both controls are functional (they pick which canonical `settings.json` is read/synced), so they're kept but wrapped in a labeled `.hooks-controls` row with a caption naming that effect.

## Tests
- New source-pin contracts in `test_web_a11y.py` (8) — lock each rank's contract so a future edit can't silently restore the broken patterns.
- `vitest` **128/128**, browser suite **165/165** (gateway · portal · ui_smoke · hooks · a11y · i18n), i18n parity (en/ko, 3 new keys), `ruff` clean.
- rank 15 × geometry visually verified against the real `style.css` (collapsed / open / non-removable Server-CWD; no badge overlap).
- Cache-bust bumped for the 4 edited static assets (style 97 / app 124 / hooks 15 / gateway 56).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
