### PR TITLE
refactor(web): hoist active-project + tier controls to one gateway header bar (rank 11)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1478,6 +1478,16 @@ function switchSettingsSection(sectionName) {
   }
   if (section) section.classList.add('active');
   ensureActiveGroupExpanded(sectionName);
+  // rank 11: repaint the persistent gateway control bar synchronously on every
+  // gateway section switch. Its visibility (hidden on the Projects portal) and
+  // selection must update the instant the section flips — the async loader below
+  // also repaints it post-fetch, but this synchronous call avoids a stale or
+  // wrong-section bar in the interim (and hides it immediately on ctx-projects,
+  // which has no loader that touches the bar). Guarded for non-gateway sections
+  // and for script load order (context-gateway.js defines _ctxRenderControlBar).
+  if (GATEWAY_SECTIONS.has(sectionName) && typeof _ctxRenderControlBar === 'function') {
+    _ctxRenderControlBar();
+  }
   // Section-specific loads (reuse existing functions)
   if (sectionName === 'config') loadConfig();
   if (sectionName === 'namespaces') loadNamespacesTab();

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -167,6 +167,12 @@ let _ctxTargetScope = 'project_shared';
 const _CTX_ACTIVE_SCOPE_KEY = 'memtomem_ctx_active_scope_id';
 let _ctxActiveScopeId = '';
 let _ctxProjectsCache = [];
+// rank 11: a Sync All run disables the shared header bar's controls for its
+// duration. The lock lives here, not only in the DOM, because the bar is a
+// single shared host that ``_ctxRenderControlBar`` repaints on section switches
+// / loader resolves / langchange — re-applying the flag after each repaint keeps
+// the controls disabled until the run's ``finally`` clears it (Codex review).
+let _ctxSyncControlsLocked = false;
 
 // De-dup memo for the `/api/context/projects` failure toast (#1101).
 // ``_ctxFetchProjects`` runs from three independent panel-load paths
@@ -429,6 +435,69 @@ async function _ctxFetchProjects() {
   const result = await _ctxFetchProjectsData();
   _ctxCommitProjects(result);
   return result.data;
+}
+
+// -- Hoisted gateway control bar (rank 11) ------------------------------------
+//
+// The active-project ``<select>`` and the canonical-tier filter used to be
+// re-emitted into EVERY gateway section's content (Overview, Skills, Commands,
+// Agents, MCP, Hooks) — the same picker painted 6× for one piece of state,
+// since ``_ctxActiveScopeId`` / ``_ctxTargetScope`` are module globals. They now
+// render ONCE into the persistent ``#ctx-control-bar`` host that sits above the
+// section panels. ``_ctxRenderControlBar`` repaints that single host for the
+// active section; the unchanged ``_ctxWireProjectControls`` / ``_ctxWireTier
+// Controls`` helpers route a change to the active section's loader via the
+// control's ``data-type`` (overview→loadCtxOverview, hooks-sync→loadHooksSync,
+// else→loadCtxList). The Projects portal owns its own roster and never carried
+// these controls, so the bar is hidden there.
+const _CTX_SECTION_BAR_TYPE = {
+  'ctx-overview': 'overview',
+  'ctx-skills': 'skills',
+  'ctx-commands': 'commands',
+  'ctx-agents': 'agents',
+  'ctx-mcp-servers': 'mcp-servers',
+  'hooks-sync': 'hooks-sync',
+  // ``ctx-projects`` is intentionally absent → the bar hides on the portal.
+};
+
+// The control "type" of the active gateway section, or '' when none applies
+// (Projects portal, or no gateway section active). The active section id is
+// ``settings-<section>`` (e.g. ``settings-ctx-skills`` / ``settings-hooks-sync``);
+// strip the prefix, then map to the loader-routing type.
+function _ctxActiveGatewayType() {
+  const active = document.querySelector('#tab-context-gateway .settings-section.active');
+  if (!active || !active.id) return '';
+  const section = active.id.replace(/^settings-/, '');
+  return _CTX_SECTION_BAR_TYPE[section] || '';
+}
+
+// Repaint the persistent control bar for whatever gateway section is currently
+// active — ALWAYS sourced from the live ``.settings-section.active`` (never a
+// caller-supplied type). This is deliberate: the bar is one shared, visible
+// host, and the loaders that trigger a repaint are async. If a stale
+// ``loadCtxOverview`` / ``loadCtxList`` resolves AFTER the user has navigated to
+// a different section, sourcing the type from the active section makes the late
+// render paint the bar for the section the user is actually on (or hide it on
+// the Projects portal) instead of hijacking it back to the loader's section and
+// mis-routing the next tier/project change. Re-rendering replaces the host's
+// markup, so the (idempotent, global) wire helpers re-bind the single live
+// instance and the detached prior nodes drop their listeners with them.
+function _ctxRenderControlBar() {
+  const host = document.getElementById('ctx-control-bar');
+  if (!host) return;
+  const type = _ctxActiveGatewayType();
+  if (!type) {
+    host.hidden = true;
+    host.innerHTML = '';
+    return;
+  }
+  host.hidden = false;
+  host.innerHTML = _ctxProjectControls(type) + _ctxTierControls(type);
+  _ctxWireProjectControls();
+  _ctxWireTierControls();
+  // Re-apply a Sync All lock to the freshly-rendered controls so a repaint
+  // mid-run (navigation / loader / langchange) can't silently re-enable them.
+  _ctxApplySyncControlsLock();
 }
 
 function _ctxProjectControls(type, scopes = _ctxProjectsCache) {
@@ -868,8 +937,6 @@ function _renderCtxOverview(data) {
       </div>
       ${lastSyncHtml}
     </div>`;
-  html += _ctxProjectControls('overview');
-  html += _ctxTierControls('overview');
   html += '<div class="ctx-overview-grid">';
   for (const typ of types) {
       const d = data[typ.key] || {};
@@ -1029,8 +1096,12 @@ function _renderCtxOverview(data) {
     }
     html += '</div>';
     el.innerHTML = html;
-    _ctxWireProjectControls();
-    _ctxWireTierControls();
+    // rank 11: the active-project + tier controls live in the persistent gateway
+    // header bar, not inside this section's content. Repaint the (shared) bar —
+    // it self-sources the type from the active section, so a stale overview
+    // render that resolves after the user navigated away repaints the bar for
+    // their CURRENT section rather than hijacking it back to Overview.
+    _ctxRenderControlBar();
 
   // Gate the Sync All button: when every artifact type's items are
   // entirely runtime-only (no canonicals to fan out), Sync All resolves
@@ -1454,6 +1525,17 @@ window.addEventListener('langchange', () => {
     || (settingsTab && settingsTab.classList.contains('active'));
   if (!hostActive) return;
 
+  // rank 11: the hoisted control bar's labels are inline ``t()`` (active-project
+  // label, tier options, tier-filter aria), so ``I18N.applyDOM`` can't reach
+  // them — repaint the bar for the active gateway section on a locale flip. The
+  // per-section re-issue below also repaints it for the overview/list sections
+  // (an idempotent same-tick double-render, no visible flicker); this standalone
+  // call additionally covers hooks-sync, whose section has no re-issue branch
+  // here. Gated on the Gateway tab being the visible host so we never repaint
+  // into a hidden panel (the Settings-tab fallback above keeps ``hostActive``
+  // true while the gateway sections are off-screen).
+  if (gatewayTab && gatewayTab.classList.contains('active')) _ctxRenderControlBar();
+
   const overviewSection = document.getElementById('settings-ctx-overview');
   if (overviewSection && overviewSection.classList.contains('active')) {
     if (_ctxOverviewCache) {
@@ -1680,16 +1762,27 @@ function _renderCtxSyncStatus(states) {
 // a Sync All run. The tier/project values are already pinned into the phase
 // URLs (see ``_ctxWithTargetScope`` opts), so this is a clarity affordance —
 // it prevents the user from flipping a control whose change won't take effect
-// until the next run. Scoped to the overview section so per-list-page controls
-// are untouched. ``loadCtxOverview`` re-renders fresh (enabled) controls in the
-// handler's ``finally``, so this only governs the in-flight window.
+// until the next run. rank 11: the controls now live in the shared
+// ``#ctx-control-bar`` header, not inside the overview section — target the bar
+// directly (the old ``#settings-ctx-overview`` scope would match nothing and
+// the lock would silently no-op). ``loadCtxOverview`` re-renders fresh
+// (enabled) controls in the handler's ``finally``, so this only governs the
+// in-flight window.
+// Apply the current ``_ctxSyncControlsLocked`` flag to the shared bar's live
+// controls. Called both when the lock toggles and after every bar repaint, so
+// the disabled state survives the shared host being re-rendered mid-run.
+function _ctxApplySyncControlsLock() {
+  document
+    .querySelectorAll('#ctx-control-bar .ctx-tier-filter button')
+    .forEach((btn) => { btn.disabled = _ctxSyncControlsLocked; });
+  document
+    .querySelectorAll('#ctx-control-bar .ctx-project-select')
+    .forEach((sel) => { sel.disabled = _ctxSyncControlsLocked; });
+}
+
 function _ctxSetSyncControlsDisabled(disabled) {
-  document
-    .querySelectorAll('#settings-ctx-overview .ctx-tier-filter button')
-    .forEach((btn) => { btn.disabled = disabled; });
-  document
-    .querySelectorAll('#settings-ctx-overview .ctx-project-select')
-    .forEach((sel) => { sel.disabled = disabled; });
+  _ctxSyncControlsLocked = disabled;
+  _ctxApplySyncControlsLock();
 }
 
 // Sync All button
@@ -2532,17 +2625,17 @@ function _ctxRenderDeepLinkBanner(type, link, matchCount) {
   });
   banner.appendChild(labelEl);
   banner.appendChild(resetBtn);
-  // Insert above the per-scope groups but below any tier-filter row so
-  // the banner reads as a list-level state, not a per-scope label.
-  // ``.ctx-runtime-only-banner`` is a sibling concern (no canonicals);
-  // both banners can co-exist when a project has runtime-only items
-  // *and* the user deep-linked into the type.
-  const tierRow = listEl.querySelector('.ctx-tier-filter');
-  if (tierRow && tierRow.nextSibling) {
-    listEl.insertBefore(banner, tierRow.nextSibling);
-  } else {
-    listEl.insertBefore(banner, listEl.firstChild);
-  }
+  // rank 11: the tier filter moved to the persistent header bar, so the list no
+  // longer holds a tier-filter row to sit below. Keep the tier-aware
+  // write-blocked banner (#943) at the very top — its copy explains why the
+  // write buttons are dimmed, so the deep-link banner must not land above it —
+  // and place this banner immediately AFTER it when present (mirroring the
+  // runtime-only remediation banner's anchoring in _ctxRefreshSectionState),
+  // otherwise at the list's first row. ``.ctx-runtime-only-banner`` is a sibling
+  // concern; both can co-exist with a deep link.
+  const writeBlocked = listEl.querySelector('.ctx-write-blocked-banner');
+  const anchor = writeBlocked ? writeBlocked.nextSibling : listEl.firstChild;
+  listEl.insertBefore(banner, anchor);
 }
 
 async function loadCtxList(type) {
@@ -2588,9 +2681,11 @@ async function loadCtxList(type) {
     const activeScopes = scopes.filter(_ctxScopeIsActive);
     const visibleScopes = (_ctxListShowAllScopes || !activeScopes.length) ? scopes : activeScopes;
 
-    let html = _ctxProjectControls(type, scopes);
-    html += _ctxTierControls(type);
-    html += _ctxShowAllScopesControl(type, scopes);
+    // rank 11: the active-project + tier controls are no longer emitted into each
+    // section's list — they render once into the persistent header bar
+    // (``_ctxRenderControlBar`` below). The list keeps only the rank-2c "Show all
+    // projects" toggle + the per-scope groups for the visible scope(s).
+    let html = _ctxShowAllScopesControl(type, scopes);
     for (const scope of visibleScopes) {
       const isActive = _ctxScopeIsActive(scope);
       const count = _ctxScopeCount(scope, type);
@@ -2634,8 +2729,10 @@ async function loadCtxList(type) {
       </div>`;
     }
     listEl.innerHTML = html;
-    _ctxWireProjectControls();
-    _ctxWireTierControls();
+    // rank 11: repaint the shared header bar (self-sources from the active
+    // section so a stale list render can't hijack it). rank 2c: wire the
+    // "Show all projects" toggle that still lives in the list.
+    _ctxRenderControlBar();
     _ctxWireShowAllScopes(type, listEl);
 
     // Tier-aware read-only banner (issue #943): inserted at the top of

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=98" />
+  <link rel="stylesheet" href="/style.css?v=99" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -546,6 +546,14 @@
         </button>
       </nav>
       <div class="settings-content">
+
+        <!-- rank 11: persistent active-project + canonical-tier control bar,
+             hoisted out of the per-section content so one shared picker drives
+             every section's loader. Populated/toggled by _ctxRenderControlBar
+             (context-gateway.js); hidden on the Projects portal, which owns its
+             own roster. The inner controls carry their own labels/aria, so the
+             host stays a plain styling container. -->
+        <div id="ctx-control-bar" class="ctx-control-bar" hidden></div>
 
         <!-- Context Gateway: Overview -->
         <div class="settings-section active" id="settings-ctx-overview">
@@ -1507,16 +1515,16 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=124"></script>
+  <script src="/app.js?v=125"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=10"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>
   <script src="/settings-maintenance.js?v=3"></script>
   <script src="/settings-namespaces.js?v=9"></script>
   <script src="/settings-harness.js?v=2"></script>
-  <script src="/settings-hooks-watchdog.js?v=15"></script>
+  <script src="/settings-hooks-watchdog.js?v=16"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=59"></script>
+  <script src="/context-gateway.js?v=60"></script>
   <script src="/context-portal.js?v=2"></script>
   <script src="/path-picker.js?v=3"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -678,7 +678,6 @@
   "settings.hooks.no_hooks_defined": "No hooks defined in .memtomem/settings.json.",
   "settings.hooks.no_hooks_hint": "Add hook rules to .memtomem/settings.json to make them appear as pending or synced.",
   "settings.hooks.load_failed": "Failed to load sync status",
-  "settings.hooks.controls_caption": "Tier and project select which settings.json is read and synced.",
   "settings.hooks.target_label": "Target:",
   "settings.hooks.target_label_user": "User-scope target:",
   "settings.hooks.target_label_project_shared": "Project (shared) target:",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -678,7 +678,6 @@
   "settings.hooks.no_hooks_defined": ".memtomem/settings.json 에 정의된 훅이 없습니다.",
   "settings.hooks.no_hooks_hint": ".memtomem/settings.json 에 훅 규칙을 추가하면 대기 중 또는 동기화됨 상태로 표시됩니다.",
   "settings.hooks.load_failed": "동기화 상태를 불러오지 못했습니다",
-  "settings.hooks.controls_caption": "어느 settings.json을 읽고 동기화할지는 티어·프로젝트 선택으로 결정됩니다.",
   "settings.hooks.target_label": "대상:",
   "settings.hooks.target_label_user": "User 스코프 대상:",
   "settings.hooks.target_label_project_shared": "프로젝트(공유) 대상:",

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -63,44 +63,15 @@ function _hooksScopedUrl(path) {
   return path;
 }
 
-function _hooksProjectControlsHtml() {
-  if (typeof _ctxProjectControls !== 'function') return '';
-  return _ctxProjectControls('hooks-sync');
-}
-
-function _hooksWireProjectControls() {
-  if (typeof _ctxWireProjectControls === 'function') {
-    _ctxWireProjectControls();
-  }
-}
-
-function _hooksTierControlsHtml() {
-  if (typeof _ctxTierControls !== 'function') return '';
-  return _ctxTierControls('hooks-sync');
-}
-
-function _hooksWireTierControls() {
-  if (typeof _ctxWireTierControls === 'function') {
-    _ctxWireTierControls();
-  }
-}
-
-// rank 22: the Hooks section inherits the same project switcher + tier toggle
-// the artifact sections use, but renders them bare above a single "Sync Now"
-// button — so the control row read as accidental chrome rather than a
-// deliberate control. Both controls ARE functional here (they pick which
-// canonical settings.json is read/synced), so we keep them but wrap them in a
-// labeled row with an explicit caption naming that effect, matching the
-// intentional look of the artifact-section control rows.
-function _hooksControlsHtml() {
-  const proj = _hooksProjectControlsHtml();
-  const tier = _hooksTierControlsHtml();
-  if (!proj && !tier) return '';
-  const caption = typeof t === 'function' ? t('settings.hooks.controls_caption') : '';
-  return `<div class="hooks-controls">${proj}${tier}`
-    + `<p class="hooks-controls-caption" data-i18n="settings.hooks.controls_caption">`
-    + `${escapeHtml(caption)}</p></div>`;
-}
+// rank 11: the active-project + tier controls for the Hooks section moved to the
+// shared gateway header bar (``_ctxRenderControlBar()`` in loadHooksSync), which
+// supersedes rank 22 (#1220). That PR had kept the controls in-section, wrapped
+// in a labeled caption row; once they are hoisted out there is nothing left in
+// the section to wrap, so the in-section wrapper helper, its CSS, its i18n
+// caption key, and its a11y pins are removed (see test_web_a11y.py). The tier
+// still scopes which canonical settings.json is read/synced — that function is
+// preserved, just driven from the shared bar. The former per-section project /
+// tier control emitters are gone with the move.
 
 function _renderHookRuleDetail(key, contentEl) {
   const idx = Number(key);
@@ -420,9 +391,14 @@ async function loadHooksSync() {
     }
   }
   requestedProjectScope = _hooksCurrentProjectScope();
-  statusEl.innerHTML = _hooksControlsHtml();
-  _hooksWireProjectControls();
-  _hooksWireTierControls();
+  // rank 11: the active-project + tier controls live in the shared gateway
+  // header bar (``#ctx-control-bar``), not in this section's status row. Projects
+  // are already committed above, so paint the bar for hooks-sync now and leave
+  // the status row for the badge + target line painted post-fetch.
+  statusEl.innerHTML = '';
+  // Paint the shared header bar (self-sources from the active section, so a
+  // stale hooks load that lands after a section switch won't hijack it).
+  if (typeof _ctxRenderControlBar === 'function') _ctxRenderControlBar();
 
   try {
     const res = await fetch(_hooksScopedUrl('/api/settings-sync'));
@@ -468,14 +444,14 @@ async function loadHooksSync() {
     // (PR D follow-up). ``error`` state still shows it because the
     // target path is often what the user needs to inspect.
     const showTarget = !!data.target_path && data.status !== 'no_source';
+    // rank 11: controls are in the shared header bar (already painted pre-fetch
+    // and unaffected by this settings-sync fetch), so the status row now holds
+    // only the badge + target line.
     statusEl.innerHTML =
-      _hooksControlsHtml()
-      + `<span class="badge ${badge.cls}">${escapeHtml(badge.text)}</span>`
+      `<span class="badge ${badge.cls}">${escapeHtml(badge.text)}</span>`
       + (showTarget
         ? `<div class="hooks-status-target" data-target-scope="${escapeHtml(scope || '')}">${escapeHtml(targetLabel)} <code>${escapeHtml(data.target_path)}</code></div>`
         : '');
-    _hooksWireTierControls();
-    _hooksWireProjectControls();
 
     // Sync Now is only meaningful when a canonical source exists and has
     // at least one hook rule. Disable the button for empty sources so a

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -2516,25 +2516,9 @@ select:focus-visible {
   margin-bottom: 1rem;
 }
 #hooks-sync-status { display: flex; flex-direction: column; align-items: flex-start; gap: 4px; }
-/* rank 22: a deliberate control row for the Hooks project switcher + tier
-   toggle, with a full-width caption naming what they scope so the row reads
-   as intentional rather than chrome inherited from the artifact sections. */
-.hooks-controls {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px 12px;
-  width: 100%;
-  margin-bottom: 4px;
-}
-.hooks-controls .ctx-project-switcher,
-.hooks-controls .ctx-tier-filter { margin-bottom: 0; }
-.hooks-controls-caption {
-  flex-basis: 100%;
-  margin: 0;
-  font-size: 0.75rem;
-  color: var(--muted);
-}
+/* rank 11 superseded rank 22's in-section ``.hooks-controls`` row: the Hooks
+   active-project + tier controls now live in the shared gateway header bar
+   (#ctx-control-bar), so the section status row holds only the badge + target. */
 .hooks-status-target { font-size: 0.78rem; color: var(--muted); max-width: 100%; }
 /* ``overflow-wrap: anywhere`` lets long absolute paths break at any
  * character so the target span never pushes the Sync Now button or
@@ -3762,6 +3746,31 @@ body.help-hidden #help-toggle { opacity: 0.5; }
 .ctx-tier-filter button.active {
   background: var(--accent);
   color: white;
+}
+
+/* rank 11: persistent gateway header control bar. Hosts the active-project
+   switcher + canonical-tier filter once, above the section panels, instead of
+   re-emitting them into every section. Sticky so it stays put while the section
+   content scrolls under it (.settings-content is the overflow-y:auto ancestor);
+   opaque --bg (the inherited panel background) covers the scrolled rows. The
+   descendant margin reset drops the controls' stacking margin-bottom — in this
+   horizontal row the bar's gap owns the spacing. */
+.ctx-control-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 10px 0;
+  margin-bottom: 4px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+.ctx-control-bar .ctx-project-switcher,
+.ctx-control-bar .ctx-tier-filter {
+  margin: 0;
 }
 
 /* Sync All per-phase progress + result summary (ADR-0021 §C). */

--- a/packages/memtomem/tests-js/ctx-control-bar-hoist.test.mjs
+++ b/packages/memtomem/tests-js/ctx-control-bar-hoist.test.mjs
@@ -1,0 +1,285 @@
+/* rank 11 — the active-project switcher + canonical-tier filter are hoisted out
+ * of every gateway section's content into ONE persistent header bar
+ * (``#ctx-control-bar``). These guards pin the new contract:
+ *   (1) the controls render once, in the bar — never inside the per-section
+ *       list/content — for every bar-eligible section;
+ *   (2) the bar is hidden on the Projects portal (which owns its own roster)
+ *       and restored when switching back to a bar-eligible section;
+ *   (3) exactly one instance exists no matter how many sections are visited
+ *       (no duplicate/stacked pickers);
+ *   (4) a change on the single control fires the ACTIVE section's loader.
+ *
+ * The static modules ship un-built, so bootApp loads the production index.html
+ * (now carrying ``#ctx-control-bar``) and injects context-gateway.js verbatim.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+const SCOPES = [
+  {
+    scope_id: '', label: 'Server CWD', root: '/srv', tier: 'project',
+    sources: ['server-cwd'], missing: false, stale: false, experimental: false,
+    counts: { skills: 1, commands: 0, agents: 0, 'mcp-servers': 0 },
+  },
+  {
+    scope_id: 'p1', label: 'Alpha', root: '/work/Alpha', tier: 'project',
+    sources: ['known-projects'], missing: false, stale: false, experimental: false,
+    counts: { skills: 0, commands: 0, agents: 0, 'mcp-servers': 0 },
+  },
+];
+
+const OVERVIEW = {
+  skills: { total: 0, in_sync: 0 },
+  commands: { total: 0, in_sync: 0 },
+  agents: { total: 0, in_sync: 0 },
+  settings: { total: 0, in_sync: 0, status: 'in_sync' },
+  detected_runtimes: [],
+  project_root: '/srv',
+  target_scope: 'project_shared',
+};
+
+function jsonOk(body) {
+  return { ok: true, status: 200, headers: { get: () => 'application/json' }, json: async () => body, text: async () => JSON.stringify(body) };
+}
+
+function installFetch(window) {
+  const upstream = window.fetch;
+  window.fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : input?.url || '';
+    const p = url.split('?')[0];
+    if (p.includes('/api/context/projects')) return jsonOk({ scopes: SCOPES, target_scope: 'project_shared' });
+    if (p.endsWith('/api/context/overview')) return jsonOk(OVERVIEW);
+    if (p.endsWith('/api/context/runtimes')) return jsonOk({ runtimes: [] });
+    // Per-scope list items (lazy-loaded on the open group) — empty is fine.
+    if (p.match(/\/api\/context\/(skills|commands|agents|mcp-servers)$/)) return jsonOk({ items: [] });
+    return upstream(input, init);
+  };
+}
+
+async function flush(window, ticks = 30) {
+  for (let i = 0; i < ticks; i++) await new Promise((r) => window.setTimeout(r, 0));
+}
+
+// Mimic switchSettingsSection's class bookkeeping for the gateway sections so
+// _ctxActiveGatewayType()'s ``.settings-section.active`` lookup resolves the
+// intended section without driving the full activateTab/tab-hop machinery.
+function setActiveSection(window, sectionId) {
+  window.document
+    .querySelectorAll('#tab-context-gateway .settings-section')
+    .forEach((s) => s.classList.remove('active'));
+  const sec = window.document.getElementById(`settings-${sectionId}`);
+  if (sec) sec.classList.add('active');
+}
+
+async function boot() {
+  const dom = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+  const { window } = dom;
+  installFetch(window);
+  await window.I18N.init();
+  return window;
+}
+
+describe('rank 11 — hoisted gateway control bar', () => {
+  it('renders the controls once in the header bar, never inside the section list', async () => {
+    const window = await boot();
+    setActiveSection(window, 'ctx-skills');
+    await window.loadCtxList('skills');
+    await flush(window);
+
+    const bar = window.document.getElementById('ctx-control-bar');
+    expect(bar).not.toBeNull();
+    expect(bar.hidden).toBe(false);
+    expect(bar.querySelectorAll('.ctx-project-switcher').length).toBe(1);
+    expect(bar.querySelectorAll('.ctx-tier-filter').length).toBe(1);
+    // The select carries the active-section type so the wire handler routes a
+    // change to the right loader.
+    expect(bar.querySelector('.ctx-project-switcher').dataset.type).toBe('skills');
+
+    // The section's own list must no longer carry a copy of either control.
+    const list = window.document.getElementById('ctx-skills-list');
+    expect(list.querySelectorAll('.ctx-project-switcher').length).toBe(0);
+    expect(list.querySelectorAll('.ctx-tier-filter').length).toBe(0);
+  });
+
+  it('keeps a single bar instance (no stacking) across section visits', async () => {
+    const window = await boot();
+    setActiveSection(window, 'ctx-skills');
+    await window.loadCtxList('skills');
+    await flush(window);
+    setActiveSection(window, 'ctx-commands');
+    await window.loadCtxList('commands');
+    await flush(window);
+    setActiveSection(window, 'ctx-overview');
+    await window.loadCtxOverview();
+    await flush(window);
+
+    // One bar, one switcher, one tier filter in the entire document.
+    expect(window.document.querySelectorAll('.ctx-project-switcher').length).toBe(1);
+    expect(window.document.querySelectorAll('.ctx-tier-filter').length).toBe(1);
+    const bar = window.document.getElementById('ctx-control-bar');
+    expect(bar.querySelector('.ctx-project-switcher').dataset.type).toBe('overview');
+  });
+
+  it('hides the bar on the Projects portal and restores it elsewhere', async () => {
+    const window = await boot();
+    // Prime the projects cache so the switcher (not just the tier filter)
+    // renders, then exercise no-arg _ctxRenderControlBar's active-section
+    // detection across switches.
+    setActiveSection(window, 'ctx-skills');
+    await window.loadCtxList('skills');
+    await flush(window);
+    const bar = window.document.getElementById('ctx-control-bar');
+    expect(bar.hidden).toBe(false);
+    expect(bar.querySelectorAll('.ctx-tier-filter').length).toBe(1);
+
+    // Projects → bar hidden + emptied (portal owns its own roster).
+    setActiveSection(window, 'ctx-projects');
+    window._ctxRenderControlBar();
+    expect(bar.hidden).toBe(true);
+    expect(bar.innerHTML).toBe('');
+
+    // Back to Commands → bar visible again, now driving the commands loader.
+    setActiveSection(window, 'ctx-commands');
+    window._ctxRenderControlBar();
+    expect(bar.hidden).toBe(false);
+    expect(bar.querySelector('.ctx-project-switcher').dataset.type).toBe('commands');
+  });
+
+  it('routes a project-switch on the shared bar to the active section loader', async () => {
+    const window = await boot();
+    setActiveSection(window, 'ctx-skills');
+    await window.loadCtxList('skills');
+    await flush(window);
+
+    // Spy after the real render wired the controls; the wire handlers call the
+    // global loaders by name, so a window reassignment intercepts them.
+    const calls = { list: [], overview: 0, hooks: 0 };
+    window.loadCtxList = (t) => { calls.list.push(t); };
+    window.loadCtxOverview = () => { calls.overview += 1; };
+    window.loadHooksSync = () => { calls.hooks += 1; };
+
+    const select = window.document.querySelector('#ctx-control-bar .ctx-project-select');
+    expect(select).not.toBeNull();
+    select.value = 'p1';
+    select.dispatchEvent(new window.Event('change'));
+
+    expect(calls.list).toEqual(['skills']);
+    expect(calls.overview).toBe(0);
+    expect(calls.hooks).toBe(0);
+  });
+
+  it('routes a tier-filter change on the shared bar to the active section loader', async () => {
+    const window = await boot();
+    setActiveSection(window, 'ctx-agents');
+    await window.loadCtxList('agents');
+    await flush(window);
+
+    const calls = { list: [], overview: 0, hooks: 0 };
+    window.loadCtxList = (t) => { calls.list.push(t); };
+    window.loadCtxOverview = () => { calls.overview += 1; };
+    window.loadHooksSync = () => { calls.hooks += 1; };
+
+    const userBtn = window.document.querySelector(
+      '#ctx-control-bar .ctx-tier-filter button[data-scope="user"]',
+    );
+    expect(userBtn).not.toBeNull();
+    userBtn.click();
+
+    expect(calls.list).toEqual(['agents']);
+    expect(calls.overview).toBe(0);
+    expect(calls.hooks).toBe(0);
+  });
+
+  it('a stale overview render does NOT hijack the shared bar for the active section', async () => {
+    // Regression for the review blocker: the bar is one shared, VISIBLE host, and
+    // loaders are async. If a late loadCtxOverview (Sync All finally / Refresh /
+    // slow fetch) resolves after the user navigated to Skills, it must repaint
+    // the bar for Skills — NOT hijack it back to 'overview' and mis-route the
+    // next tier/project change. ``_ctxRenderControlBar`` self-sources the type
+    // from the active section, so this holds.
+    const window = await boot();
+    setActiveSection(window, 'ctx-skills');
+    await window.loadCtxList('skills');
+    await flush(window);
+    const bar = window.document.getElementById('ctx-control-bar');
+    expect(bar.querySelector('.ctx-tier-filter').dataset.type).toBe('skills');
+
+    // A late overview render lands while Skills is still the active section.
+    await window.loadCtxOverview();
+    await flush(window);
+    expect(bar.querySelector('.ctx-tier-filter').dataset.type).toBe('skills');
+    expect(bar.querySelector('.ctx-project-switcher').dataset.type).toBe('skills');
+
+    // And the next tier-filter change still routes to the Skills loader.
+    const calls = { list: [], overview: 0, hooks: 0 };
+    window.loadCtxList = (t) => { calls.list.push(t); };
+    window.loadCtxOverview = () => { calls.overview += 1; };
+    window.loadHooksSync = () => { calls.hooks += 1; };
+    bar.querySelector('.ctx-tier-filter button[data-scope="user"]').click();
+    expect(calls.list).toEqual(['skills']);
+    expect(calls.overview).toBe(0);
+  });
+
+  it('re-renders the bar for hooks-sync on a locale flip (langchange)', async () => {
+    // hooks-sync has no per-section re-issue branch in the langchange listener,
+    // so the bar's inline-t() labels are re-translated only by the standalone
+    // _ctxRenderControlBar() the listener fires when the Gateway tab is the
+    // visible host. Pin that path: clear the bar, dispatch langchange, expect it
+    // repainted for the active hooks-sync section.
+    const window = await boot();
+    // Prime the projects cache (any loader) so the switcher renders too.
+    setActiveSection(window, 'ctx-skills');
+    await window.loadCtxList('skills');
+    await flush(window);
+    // Now sit on hooks-sync with the Gateway tab visible (the langchange gate).
+    window.document.getElementById('tab-context-gateway').classList.add('active');
+    setActiveSection(window, 'hooks-sync');
+    window._ctxRenderControlBar();
+    const bar = window.document.getElementById('ctx-control-bar');
+    expect(bar.querySelector('.ctx-tier-filter').dataset.type).toBe('hooks-sync');
+
+    bar.innerHTML = '';
+    window.dispatchEvent(new window.Event('langchange'));
+    await flush(window);
+    expect(bar.hidden).toBe(false);
+    expect(bar.querySelector('.ctx-tier-filter')).not.toBeNull();
+    expect(bar.querySelector('.ctx-tier-filter').dataset.type).toBe('hooks-sync');
+    expect(bar.querySelector('.ctx-project-switcher')).not.toBeNull();
+  });
+
+  it('keeps the shared bar controls disabled across repaints during a Sync All run', async () => {
+    // Codex review: the bar is one shared host that repaints on section switch /
+    // loader / langchange. A Sync All lock must survive those repaints — else the
+    // user flips project/tier mid-run, whose handler clears the run's status
+    // summary. The lock lives in a module flag re-applied after every repaint.
+    const window = await boot();
+    setActiveSection(window, 'ctx-skills');
+    await window.loadCtxList('skills');
+    await flush(window);
+    const bar = window.document.getElementById('ctx-control-bar');
+    const allDisabled = () =>
+      [...bar.querySelectorAll('.ctx-tier-filter button')].every((b) => b.disabled)
+      && bar.querySelector('.ctx-project-select').disabled === true;
+    const noneDisabled = () =>
+      [...bar.querySelectorAll('.ctx-tier-filter button')].every((b) => !b.disabled)
+      && bar.querySelector('.ctx-project-select').disabled === false;
+
+    // Lock (Sync All start).
+    window._ctxSetSyncControlsDisabled(true);
+    expect(allDisabled()).toBe(true);
+
+    // A repaint from navigating to another section must NOT re-enable them.
+    setActiveSection(window, 'ctx-commands');
+    await window.loadCtxList('commands');
+    await flush(window);
+    expect(allDisabled()).toBe(true);
+
+    // Unlock (Sync All finally + its overview reload) restores them.
+    window._ctxSetSyncControlsDisabled(false);
+    setActiveSection(window, 'ctx-overview');
+    await window.loadCtxOverview();
+    await flush(window);
+    expect(noneDisabled()).toBe(true);
+  });
+});

--- a/packages/memtomem/tests/test_web_a11y.py
+++ b/packages/memtomem/tests/test_web_a11y.py
@@ -795,27 +795,28 @@ class TestScopeRemoveButtonNotNestedInSummary:
         )
 
 
-class TestHooksControlsPresentation:
-    """rank 22: the Hooks section's inherited project switcher + tier toggle
-    are wrapped in a labeled ``.hooks-controls`` row with an explicit caption,
-    so the functional-but-bare control row reads as intentional rather than
-    chrome accidentally inherited from the artifact sections.
+class TestHooksControlsHoisted:
+    """rank 11 superseded rank 22: the Hooks section's project switcher + tier
+    toggle were hoisted out of the section into the shared gateway header bar
+    (#ctx-control-bar), so the section no longer emits, wraps, or captions its
+    own controls — it paints the shared bar and keeps only the badge + target.
     """
 
-    def test_hooks_controls_helper_wraps_with_caption(self, hooks_js: str) -> None:
-        body = _extract_function(hooks_js, "_hooksControlsHtml")
-        assert 'class="hooks-controls"' in body, (
-            "_hooksControlsHtml must wrap the controls in .hooks-controls (rank 22)"
-        )
-        assert "settings.hooks.controls_caption" in body, (
-            "_hooksControlsHtml must render the controls_caption (rank 22)"
+    def test_hooks_render_uses_shared_control_bar(self, hooks_js: str) -> None:
+        load = _extract_function(hooks_js, "loadHooksSync")
+        assert "_ctxRenderControlBar()" in load, (
+            "loadHooksSync must paint the shared header bar via _ctxRenderControlBar() (rank 11)"
         )
 
-    def test_hooks_render_paths_use_wrapped_controls(self, hooks_js: str) -> None:
-        load = _extract_function(hooks_js, "loadHooksSync")
-        assert "_hooksControlsHtml()" in load, (
-            "loadHooksSync must render controls via the wrapped helper (rank 22)"
+    def test_hooks_drops_in_section_control_helpers(self, hooks_js: str) -> None:
+        # The rank-22 wrapper and the per-section control emitters/caption are
+        # gone — the controls live in the shared bar now.
+        assert "_hooksControlsHtml" not in hooks_js, (
+            "rank 11 removed the in-section _hooksControlsHtml wrapper"
         )
-        assert "_hooksProjectControlsHtml() + _hooksTierControlsHtml()" not in load, (
-            "loadHooksSync must not emit the bare unwrapped controls (rank 22)"
+        assert "_hooksProjectControlsHtml" not in hooks_js, (
+            "rank 11 removed the per-section project-control emitter"
+        )
+        assert "controls_caption" not in hooks_js, (
+            "rank 11 removed the hooks controls_caption (no in-section row)"
         )

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -624,9 +624,14 @@ def test_app_js_pins_ui_mode_default_and_toast_copy() -> None:
     assert "ctx-overview-runtimes" in cg_js, (
         "Context Gateway runtime tags disappeared from the prod overview header."
     )
+    # rank 11 hoisted the active-project + tier controls out of the overview
+    # body into the shared ``#ctx-control-bar`` header, so the old
+    # ``html += _ctxTierControls('overview')`` marker is gone — bound the
+    # runtime-chips region on the grid open instead (the next thing emitted
+    # after the header block).
     runtime_block = cg_js[
         cg_js.find("const runtimes = Array.isArray(data.detected_runtimes)") : cg_js.find(
-            "html += _ctxTierControls('overview')"
+            "html += '<div class=\"ctx-overview-grid\">'"
         )
     ]
     assert "STATE.uiMode" not in runtime_block, (
@@ -636,7 +641,10 @@ def test_app_js_pins_ui_mode_default_and_toast_copy() -> None:
     hooks_js = _read_static("settings-hooks-watchdog.js")
     assert "_hooksScopedUrl('/api/settings-sync')" in hooks_js
     assert "_hooksScopedUrl('/api/context/settings/resolve')" in hooks_js
-    assert "_ctxTierControls('hooks-sync')" in hooks_js
+    # rank 11: the Hooks tier control moved to the shared gateway header bar;
+    # loadHooksSync now paints it via _ctxRenderControlBar() (which self-sources
+    # the active section) instead of emitting _ctxTierControls inline.
+    assert "_ctxRenderControlBar()" in hooks_js
     assert "let _hooksSyncSeq = 0;" in hooks_js
     assert "const requestedScope = _hooksCurrentTargetScope();" in hooks_js
     assert "seq !== _hooksSyncSeq" in hooks_js

--- a/packages/memtomem/tests/web/test_context_gateway_lists.py
+++ b/packages/memtomem/tests/web/test_context_gateway_lists.py
@@ -575,11 +575,11 @@ def test_context_list_non_shared_tier_click_threads_target_scope(page, mm_web_ur
     page.goto(mm_web_url)
     _open_skills_list(page)
 
-    page.locator("#ctx-skills-list .ctx-tier-filter button[data-scope='project_local']").click()
+    page.locator("#ctx-control-bar .ctx-tier-filter button[data-scope='project_local']").click()
     page.wait_for_function(
         "() => {"
         "  const b = document.querySelector("
-        "    '#ctx-skills-list .ctx-tier-filter button[data-scope=\"project_local\"]');"
+        "    '#ctx-control-bar .ctx-tier-filter button[data-scope=\"project_local\"]');"
         "  return b && b.classList.contains('active');"
         "}",
         timeout=3_000,
@@ -1558,11 +1558,11 @@ def test_q956_empty_hint_user_tier_paths_to_user_canonical(page, mm_web_url: str
     page.goto(mm_web_url)
     _open_skills_list(page)
 
-    page.locator("#ctx-skills-list .ctx-tier-filter button[data-scope='user']").click()
+    page.locator("#ctx-control-bar .ctx-tier-filter button[data-scope='user']").click()
     page.wait_for_function(
         "() => {"
         "  const b = document.querySelector("
-        "    '#ctx-skills-list .ctx-tier-filter button[data-scope=\"user\"]');"
+        "    '#ctx-control-bar .ctx-tier-filter button[data-scope=\"user\"]');"
         "  return b && b.classList.contains('active');"
         "}",
         timeout=3_000,
@@ -1611,11 +1611,11 @@ def test_q956_empty_hint_user_tier_ko_locale(page, mm_web_url: str) -> None:
     page.goto(mm_web_url)
     _open_skills_list(page)
 
-    page.locator("#ctx-skills-list .ctx-tier-filter button[data-scope='user']").click()
+    page.locator("#ctx-control-bar .ctx-tier-filter button[data-scope='user']").click()
     page.wait_for_function(
         "() => {"
         "  const b = document.querySelector("
-        "    '#ctx-skills-list .ctx-tier-filter button[data-scope=\"user\"]');"
+        "    '#ctx-control-bar .ctx-tier-filter button[data-scope=\"user\"]');"
         "  return b && b.classList.contains('active');"
         "}",
         timeout=3_000,

--- a/packages/memtomem/tests/web/test_context_gateway_write_blocked.py
+++ b/packages/memtomem/tests/web/test_context_gateway_write_blocked.py
@@ -103,13 +103,14 @@ def _open_skills(page):
 
 
 def _switch_tier(page, scope: str) -> None:
-    """Click the tier-filter button for ``scope`` inside the Skills section
-    and wait for the active class to flip — proxy for "the SPA has
-    observed the click and started the re-render."""
-    page.locator(f"#ctx-skills-list .ctx-tier-filter button[data-scope='{scope}']").click()
+    """Click the tier-filter button for ``scope`` in the shared gateway control
+    bar (rank 11: hoisted out of the per-section content) and wait for the
+    active class to flip — proxy for "the SPA has observed the click and started
+    the re-render."""
+    page.locator(f"#ctx-control-bar .ctx-tier-filter button[data-scope='{scope}']").click()
     page.wait_for_function(
         f"() => {{ const b = document.querySelector("
-        f"'#ctx-skills-list .ctx-tier-filter button[data-scope=\"{scope}\"]'); "
+        f"'#ctx-control-bar .ctx-tier-filter button[data-scope=\"{scope}\"]'); "
         f"return b && b.classList.contains('active'); }}",
         timeout=3_000,
     )


### PR DESCRIPTION
## Context Gateway UX audit — rank 11

The active-project `<select>` and the canonical-tier filter were re-emitted into **6 of the 7** gateway sections (Overview, Skills, Commands, Agents, MCP, Hooks) — the same picker painted six times for one piece of module-global state (`_ctxActiveScopeId` / `_ctxTargetScope`). This hoists them into **one persistent host `#ctx-control-bar`** above the section panels.

### How it works
- **`_ctxRenderControlBar()` always self-sources the type** from the active gateway section (`.settings-section.active`), never a caller-supplied value. The bar is a single shared, *visible* host and the loaders that repaint it are async, so a stale `loadCtxOverview`/`loadCtxList` that resolves after the user navigated away paints the bar for the section they're **actually** on (or hides it on the Projects portal) instead of hijacking it back and mis-routing the next tier/project change.
- `switchSettingsSection` repaints it synchronously on every gateway switch; each loader + the `langchange` listener repaint it too (the latter covers `hooks-sync`, which has no per-section re-issue branch).
- A **Sync All lock** now lives in a module flag (`_ctxSyncControlsLocked`) re-applied after every repaint, so navigating / a loader / a locale flip can't silently re-enable the shared controls mid-run.
- The deep-link banner keeps the tier-aware write-blocked banner (#943) at the very top, mirroring the runtime-only remediation banner's anchoring.

### Supersedes rank 22 (#1220)
#1220 kept the Hooks controls in-section, wrapped in a labeled `.hooks-controls` row + caption. Hoisting them out leaves nothing there to wrap, so this removes the now-dead `_hooksControlsHtml` helper, the `.hooks-controls` / `.hooks-controls-caption` CSS, the `settings.hooks.controls_caption` i18n key (en/ko), and re-points the two rank-22 a11y source pins to assert the hoist. The tier still scopes which canonical `settings.json` is read/synced — that function is preserved, just driven from the shared bar. **rank 14** (nav landmark) and **rank 15** (project-remove × un-nest) from #1220, and **rank 6** (#1218) version manager, are untouched (rebased onto both).

### Review
Two adversarial review passes (multi-agent in-house workflow + Codex):
- **BLOCKER** (in-house): a stale async overview render could hijack the shared bar's section → fixed by making `_ctxRenderControlBar()` self-source the active section.
- **Major** (Codex): Sync All lock lost on repaint → fixed with the module-flag lock re-applied per repaint.
- **Minor** (Codex): deep-link banner could land above the write-blocked banner → fixed with the established anchor pattern.

### Tests (all green)
- vitest **136** (new `ctx-control-bar-hoist.test.mjs`, 8 cases: render-once, hide-on-projects, loader-routing, stale-render-no-hijack, hooks-sync langchange, sync-lock persistence)
- browser gateway/portal/hooks **129**; retargeted 8 Playwright tier-filter selectors `#ctx-skills-list` → `#ctx-control-bar`
- full non-browser pytest **5850 passed** (the only failures are 12 `test_web_cli.py` — a local flake from a live `mm web` server holding the pidfile, not this change)
- `test_web_mode` / `test_web_a11y` / `test_i18n` source pins updated; ruff clean; `?v` cache-busts bumped above main (style 98 / app 125 / hooks 16 / gateway 58)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
