### PR TITLE
feat(web): scope artifact lists to the active project + "Show all projects" toggle (rank 2c)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -527,6 +527,32 @@ function _ctxWireTierControls() {
   });
 }
 
+// rank 2c: the "Show all projects" toggle. Rendered only when there is more
+// than one scope (a single Server-CWD-only install has nothing to collapse,
+// so the toggle would be a dead checkbox). The count in the label is the
+// total scope count so the user knows how large the roster they're hiding
+// is — the same framing as the Projects portal's row count.
+function _ctxShowAllScopesControl(type, scopes) {
+  const list = Array.isArray(scopes) ? scopes : [];
+  if (list.length <= 1) return '';
+  const label = t('settings.ctx.show_all_projects').replace('{n}', String(list.length));
+  return `<label class="ctx-list-show-all" data-type="${escapeHtml(type)}">
+    <input type="checkbox" id="ctx-${escapeHtml(type)}-show-all"${_ctxListShowAllScopes ? ' checked' : ''}>
+    <span>${escapeHtml(label)}</span>
+  </label>`;
+}
+
+function _ctxWireShowAllScopes(type, listEl) {
+  const toggle = listEl.querySelector(`#ctx-${type}-show-all`);
+  if (!toggle) return;
+  toggle.addEventListener('change', () => {
+    _ctxListShowAllScopes = toggle.checked;
+    // Re-run the section so the scope loop re-filters; mirrors how the
+    // project switcher / tier filter re-issue ``loadCtxList`` on change.
+    loadCtxList(type);
+  });
+}
+
 // -- Tier-aware write-block gate (issue #943) ---------------------------------
 //
 // ADR-0011 / #940 wired ``target_scope`` through every artifact route, with
@@ -1943,6 +1969,15 @@ document.getElementById('ctx-refresh-btn')?.addEventListener('click', async () =
 // ``loadCtxList`` invocation that originated them.
 let _ctxListSeq = { skills: 0, commands: 0, agents: 0, 'mcp-servers': 0 };
 
+// rank 2c: artifact sections (Skills/Commands/Agents/MCP) scope to the
+// active project by default — the same ~30-project roster the Projects
+// portal already owns shouldn't be re-painted as a wall of collapsed
+// accordions in every section. A "Show all projects" toggle opts back
+// into the full roster. Shared across all four sections (a deliberate
+// reading: the toggle answers "do I want the roster or just my project",
+// which is the same intent regardless of which artifact I'm browsing).
+let _ctxListShowAllScopes = false;
+
 // Sibling guard for ``loadCtxDetail`` and ``_ctxLoadRuntimeOnlyDetail``
 // races. Both write to the same ``detailEl``, so they share one
 // per-type counter. Rapid langchange / card-click bursts can put
@@ -2543,9 +2578,20 @@ async function loadCtxList(type) {
       return;
     }
 
+    // rank 2c: default to the active project only — the Projects portal owns
+    // the full roster, so re-painting every scope as a collapsed accordion in
+    // each artifact section just buries the one project the user is acting on.
+    // The "Show all projects" toggle opts back into the full list. Fall back
+    // to all scopes if no active scope resolves (``_ctxCommitProjects``
+    // normalizes one, but never blank the panel) so a stale active-scope id
+    // can't strand the user on an empty section.
+    const activeScopes = scopes.filter(_ctxScopeIsActive);
+    const visibleScopes = (_ctxListShowAllScopes || !activeScopes.length) ? scopes : activeScopes;
+
     let html = _ctxProjectControls(type, scopes);
     html += _ctxTierControls(type);
-    for (const scope of scopes) {
+    html += _ctxShowAllScopesControl(type, scopes);
+    for (const scope of visibleScopes) {
       const isActive = _ctxScopeIsActive(scope);
       const count = _ctxScopeCount(scope, type);
       const groupId = `ctx-${type}-group-${escapeHtml(scope.scope_id)}`;
@@ -2590,6 +2636,7 @@ async function loadCtxList(type) {
     listEl.innerHTML = html;
     _ctxWireProjectControls();
     _ctxWireTierControls();
+    _ctxWireShowAllScopes(type, listEl);
 
     // Tier-aware read-only banner (issue #943): inserted at the top of
     // the list whenever the canonical-tier filter is set to a
@@ -2620,7 +2667,9 @@ async function loadCtxList(type) {
     // and the per-scope remove (×) button. ``seq`` is threaded into the
     // group fetch so a late group response from a stale ``loadCtxList``
     // can't paint into the new list's ``ctx-scope-items`` containers.
-    for (const scope of scopes) {
+    // Iterate the same ``visibleScopes`` the render loop used so we never
+    // try to wire a group that wasn't painted (rank 2c).
+    for (const scope of visibleScopes) {
       const groupEl = listEl.querySelector(`details[data-scope-id="${CSS.escape(scope.scope_id)}"]`);
       if (!groupEl) continue;
       const itemsEl = groupEl.querySelector('.ctx-scope-items');

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=97" />
+  <link rel="stylesheet" href="/style.css?v=98" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -1516,7 +1516,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=15"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=58"></script>
+  <script src="/context-gateway.js?v=59"></script>
   <script src="/context-portal.js?v=2"></script>
   <script src="/path-picker.js?v=3"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -442,6 +442,7 @@
   "settings.ctx.load_failed": "Failed to load {type}",
   "settings.ctx.load_detail_failed": "Failed to load detail",
   "settings.ctx.no_project_scopes": "No project scopes",
+  "settings.ctx.show_all_projects": "Show all projects ({n})",
   "settings.ctx.not_found": "\"{name}\" not found",
   "settings.ctx.diff_tab_hint": "Click the Diff tab to load...",
   "settings.ctx.diff_failed": "Diff failed",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -442,6 +442,7 @@
   "settings.ctx.load_failed": "{type} 목록을 불러오지 못했습니다",
   "settings.ctx.load_detail_failed": "세부 정보를 불러오지 못했습니다",
   "settings.ctx.no_project_scopes": "프로젝트 스코프가 없습니다",
+  "settings.ctx.show_all_projects": "모든 프로젝트 보기 ({n})",
   "settings.ctx.not_found": "\"{name}\"을(를) 찾을 수 없습니다",
   "settings.ctx.diff_tab_hint": "Diff 탭을 클릭하면 불러옵니다...",
   "settings.ctx.diff_failed": "Diff에 실패했습니다",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -3990,6 +3990,9 @@ body.help-hidden #help-toggle { opacity: 0.5; }
 /* "Initialized only" toggle sits beside Sort in the toolbar. */
 .ctx-portal-hide-uninit { display: flex; align-items: center; gap: 5px; color: var(--muted); font-size: 0.85rem; cursor: pointer; }
 .ctx-portal-hide-uninit input { cursor: pointer; }
+/* rank 2c: "Show all projects" toggle in the artifact-list controls row. */
+.ctx-list-show-all { display: flex; align-items: center; gap: 5px; color: var(--muted); font-size: 0.85rem; cursor: pointer; }
+.ctx-list-show-all input { cursor: pointer; }
 /* "N uninitialized hidden" hint above the rows. */
 .ctx-portal-hidden-hint { font-size: 0.8rem; margin: 0 0 8px; }
 .ctx-portal-row-actions { display: flex; align-items: center; gap: 6px; flex-shrink: 0; flex-wrap: wrap; justify-content: flex-end; }

--- a/packages/memtomem/tests/web/test_context_gateway_lists.py
+++ b/packages/memtomem/tests/web/test_context_gateway_lists.py
@@ -56,6 +56,24 @@ def _open_agents_list(page) -> None:
     )
 
 
+def _show_all_projects(page, type_: str = "skills") -> None:
+    """Enable the rank-2c "Show all projects" toggle so non-active scope
+    accordions render.
+
+    Artifact sections default to the active project only (the Projects portal
+    owns the full roster), so any assertion on a non-active scope's accordion
+    must first opt back into the full list. Mirrors the portal suite's
+    ``showUninitialized`` helper for the rank-3 hide-uninit toggle. Waits for
+    the re-render to paint more than one group so the caller's per-scope
+    locators don't race the ``loadCtxList`` refetch the toggle triggers.
+    """
+    page.locator(f"#ctx-{type_}-show-all").check()
+    page.wait_for_function(
+        f"() => document.querySelectorAll('#ctx-{type_}-list .ctx-scope-group').length > 1",
+        timeout=5_000,
+    )
+
+
 # Single-scope CWD payload with one out-of-sync canonical skill (so
 # ``renderRuntimeBadges`` has something to label) plus a non-cwd scope
 # carrying the ``missing`` flag (so ``_ctxScopeBadges`` renders).
@@ -80,6 +98,34 @@ _CWD_PROJECTS_WITH_NON_CWD_MISSING = {
             "experimental": False,
             "missing": True,
             "counts": {"skills": 0, "commands": 0, "agents": 0},
+        },
+    ]
+}
+
+
+# Active Server-CWD scope plus a second *live* project (not missing) so the
+# rank-2c active-only default has a real non-active accordion to hide.
+_CWD_PROJECTS_WITH_SECOND_LIVE = {
+    "scopes": [
+        {
+            "scope_id": "cwd-scope",
+            "label": "cwd",
+            "root": "/srv/cwd",
+            "tier": "user",
+            "sources": ["server-cwd"],
+            "experimental": False,
+            "missing": False,
+            "counts": {"skills": 1, "commands": 0, "agents": 0},
+        },
+        {
+            "scope_id": "other-proj",
+            "label": "other-project",
+            "root": "/srv/other",
+            "tier": "user",
+            "sources": ["history"],
+            "experimental": False,
+            "missing": False,
+            "counts": {"skills": 1, "commands": 0, "agents": 0},
         },
     ]
 }
@@ -178,6 +224,9 @@ def test_q_pr4_langchange_rerenders_scope_badge_inline_text(page, mm_web_url: st
     _stub_skills(page, _CWD_SKILLS_ITEMS)
     page.goto(mm_web_url)
     _open_skills_list(page)
+    # The missing scope is non-active, so it's hidden until "Show all
+    # projects" is enabled (rank 2c).
+    _show_all_projects(page, "skills")
 
     badge = page.locator(
         "#ctx-skills-list "
@@ -207,6 +256,85 @@ def test_q_pr4_langchange_rerenders_scope_badge_inline_text(page, mm_web_url: st
     assert post == "(없음)", f"KO scope_missing badge should be '(없음)', got {post!r}"
     # Symmetric negative: the English literal must not linger.
     assert "(missing)" not in post, f"EN literal must not survive KO toggle: {post!r}"
+
+
+def test_artifact_list_defaults_to_active_scope_only(page, mm_web_url: str) -> None:
+    """rank 2c: an artifact section paints ONLY the active project's accordion
+    by default — not the full roster the Projects portal already owns.
+
+    With two live scopes (active Server-CWD + a second project), the cold
+    list renders exactly one ``.ctx-scope-group`` (the active one), the
+    non-active scope's accordion is absent, and the "Show all projects"
+    toggle is present but unchecked.
+    """
+    install_default_stubs(page)
+    _stub_projects(page, _CWD_PROJECTS_WITH_SECOND_LIVE)
+    _stub_skills(page, _CWD_SKILLS_ITEMS)
+    page.goto(mm_web_url)
+    _open_skills_list(page)
+
+    groups = page.locator("#ctx-skills-list .ctx-scope-group")
+    assert groups.count() == 1, (
+        f"Default artifact list must render only the active scope, got {groups.count()} groups"
+    )
+    assert page.locator("#ctx-skills-list details[data-scope-id='cwd-scope']").count() == 1, (
+        "The active (Server-CWD) scope accordion must be the one rendered"
+    )
+    assert page.locator("#ctx-skills-list details[data-scope-id='other-proj']").count() == 0, (
+        "A non-active scope accordion must be hidden until 'Show all projects'"
+    )
+
+    toggle = page.locator("#ctx-skills-show-all")
+    assert toggle.count() == 1, "The 'Show all projects' toggle must render with >1 scope"
+    assert not toggle.is_checked(), "The toggle defaults to off (active project only)"
+    # The ``{n}`` count interpolates the total scope count (2 here) so a broken
+    # i18n key or replace would surface as a literal ``{n}`` / missing number.
+    label = page.locator(".ctx-list-show-all[data-type='skills'] span")
+    assert "(2)" in (label.text_content() or ""), (
+        f"Toggle label must interpolate the scope count, got {label.text_content()!r}"
+    )
+
+
+def test_show_all_projects_toggle_reveals_all_scopes(page, mm_web_url: str) -> None:
+    """rank 2c: enabling "Show all projects" re-renders the full roster — every
+    scope accordion, including non-active ones, becomes visible again.
+    """
+    install_default_stubs(page)
+    _stub_projects(page, _CWD_PROJECTS_WITH_SECOND_LIVE)
+    _stub_skills(page, _CWD_SKILLS_ITEMS)
+    page.goto(mm_web_url)
+    _open_skills_list(page)
+    assert page.locator("#ctx-skills-list .ctx-scope-group").count() == 1
+
+    # ``_show_all_projects`` checks the toggle and waits for >1 group to paint.
+    _show_all_projects(page, "skills")
+
+    assert page.locator("#ctx-skills-list .ctx-scope-group").count() == 2, (
+        "Show all projects must reveal every scope accordion"
+    )
+    assert page.locator("#ctx-skills-list details[data-scope-id='cwd-scope']").count() == 1, (
+        "Active scope still present after revealing all"
+    )
+    assert page.locator("#ctx-skills-list details[data-scope-id='other-proj']").count() == 1, (
+        "Previously hidden non-active scope is now visible"
+    )
+
+
+def test_single_scope_install_has_no_show_all_toggle(page, mm_web_url: str) -> None:
+    """rank 2c: a Server-CWD-only install (one scope) has nothing to collapse,
+    so the "Show all projects" toggle is suppressed — it would be a dead
+    checkbox. The default ``install_default_stubs`` payload is exactly this
+    single-scope shape.
+    """
+    install_default_stubs(page)
+    _stub_skills(page, _CWD_SKILLS_ITEMS)
+    page.goto(mm_web_url)
+    _open_skills_list(page)
+
+    assert page.locator("#ctx-skills-list .ctx-scope-group").count() == 1
+    assert page.locator("#ctx-skills-show-all").count() == 0, (
+        "Single-scope installs must not render the show-all toggle"
+    )
 
 
 def test_q_pr4_langchange_rerenders_runtime_badge_label(page, mm_web_url: str) -> None:


### PR DESCRIPTION
## What

Context Gateway artifact sections (**Skills / Commands / Agents / MCP**) now scope to the **active project only** by default, with a **"Show all projects ({n})"** toggle to opt back into the full roster.

## Why (rank 2c)

The gateway painted the same ~30-project roster **three** times — Projects portal cards, the Overview matrix, and a per-project accordion in every artifact section. #1217 (rank 2) removed the matrix and made the portal the single roster, but the **third** source remained: each artifact section still rendered a collapsed accordion for *every* scope, so acting on one project meant scrolling the whole roster in whichever of the four sections you were in.

This closes that last duplication: the portal owns the full roster; artifact sections show just the project you're working on.

## How

- `loadCtxList` computes `visibleScopes = showAll || !activeScopes.length ? scopes : activeScopes` and both the render and wire loops iterate it (a group is never wired without being painted).
- No-active-scope **fallback** to all scopes so a stale active-scope id can't blank the panel.
- `_ctxShowAllScopesControl` / `_ctxWireShowAllScopes` (module state `_ctxListShowAllScopes`, default off). The toggle is **suppressed for single-scope installs** (nothing to collapse). Re-runs `loadCtxList` on change, mirroring the project switcher / tier filter.
- en/ko `settings.ctx.show_all_projects`; `.ctx-list-show-all` CSS reusing the hide-uninit toggle style; cache-bust `context-gateway.js ?v=59` / `style.css ?v=98`.
- Frontend-only — no backend route added.

## Tests

New browser tests: active-only default, toggle reveals all scopes, single-scope suppresses the toggle (+ `{n}` label interpolation). The existing `missing-scope` langchange test opts into show-all to reach the non-active accordion (new `_show_all_projects` helper, mirroring the portal's `showUninitialized`).

Verified: browser **208 passed** · i18n parity **63** · web-invariants registry **4** · ruff check/format clean. Codex review: **SHIP, no findings**.

> vitest not run locally (worktree has no `node_modules`); no vitest test calls the changed code path (`ctx-projects-coverage-optin` asserts only fetch URLs, unaffected) — CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)