### PR TITLE
release: v0.2.4 — Context Portal, artifact versioning, sync enrollment, mm tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,82 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.2.4] — 2026-06-04
+
+Patch release on top of 0.2.3: a multi-project **Context Portal**,
+Langfuse-style **artifact version snapshots + label pointers** for agents and
+commands (ADR-0022), per-project **sync enrollment**, a new `mm tags` CLI, CLI
+session tracing on Langfuse v4, and broad Web UI / i18n / accessibility
+hardening — alongside a session-trace secret-redaction fix and retry/webhook
+reliability fixes.
+
+- **Secrets are now redacted in session-trace metadata sinks.** Session command
+  tracing wrote span/trace metadata to its observability sinks without running
+  the redaction pass, so a secret-shaped value captured in command context could
+  reach the trace backend in clear text. The metadata now goes through the same
+  redaction funnel as the rest of the trace payload.
+
+- **Context Portal — multi-project state board (ADR-0021).** The Context Gateway
+  gains a read-only runtime/client registration registry, a multi-project board
+  section, per-CLI runtime chips with a provider filter, project health + label
+  rename + lazy artifact counts, and a "Sync All" flow with per-phase progress, a
+  result summary, and (project, tier) pinning so each phase re-resolves against
+  the intended scope. The gateway now lands on the Projects Portal by default
+  (#1191–#1193, #1195–#1197, #1200–#1202).
+
+- **Artifact version snapshots + label pointers for agents and commands
+  (ADR-0022).** Canonical agents/commands can keep Langfuse-style
+  `versions/vN.md` snapshots with movable label pointers (e.g. `production`,
+  `staging`) instead of a single flat file. New MCP tools `mem_context_version`
+  and `mem_context_promote`, plus label-aware `mem_context_sync`, expose this
+  over MCP; the Web UI adds a detail-panel version/label manager, list-card label
+  chips (`GET /context/{type}?include=versions`), a versioned create layout, and
+  an opt-in "enable versioning" migration that adopts existing flat web-created
+  artifacts into the versioned layout (#1206, #1212–#1216, #1218).
+
+- **Per-project sync enrollment.** Project discovery is split from sync: matching
+  projects are auto-displayed, but artifacts only fan out once a project is
+  explicitly enrolled. Adds enroll / pause / resume UI, sync-eligibility gating
+  on the matrix and Sync-All, and a write-guard that returns a structured `409`
+  (with localized detail) on runtime-writing routes for paused or not-enrolled
+  projects (#1203, #1205, #1208, #1210, #1211).
+
+- **`mm tags` — list / rename / delete / merge tags (#688).** New CLI verb with a
+  matching Tags tab in the Web UI for the same rename / merge / delete actions.
+  Dry-run sampling is now global so the preview sample matches the count and the
+  applied set (#1175–#1177).
+
+- **CLI session command tracing + Langfuse v4 (#1199).** CLI command runs can
+  emit session traces through a new `observability/session_tracing.py`, updated
+  to the Langfuse v4 client surface.
+
+- **Kimi Code install detected via the `~/.kimi-code` home dir (#1204).** The
+  install probe also checks `~/.kimi-code` (the CLI data home set by
+  `KIMI_CODE_HOME`), fixing an ADR-0021 false-negative where a present Kimi
+  install was reported as absent.
+
+- **Retry and webhook reliability fixes.** `with_retry` now honors string
+  `retry_after` attributes instead of ignoring them (#1178), and
+  `_validate_webhook_url` URL-safety behavior is pinned by tests (#1179).
+
+- **Web UI accessibility + UX consolidation.** Context Gateway roster
+  consolidation (Overview matrix removed, Sync routed through the Projects
+  Portal), active-project + tier controls hoisted into one gateway header bar, a
+  single capability-mapped source for artifact-section toolbars, artifact lists
+  scoped to the active project with a "Show all projects" toggle, Sync/Import
+  dry-run confirm previews with count/destination threading, and a11y fixes
+  (settings-nav `<nav>` landmark + `aria-current`, un-nested project-remove `×`,
+  labeled Hooks controls) (#1217, #1219–#1223).
+
+- **Localization (EN/KO).** Command palette labels, the Context Gateway
+  create-form name placeholder, Search history and recent chips, settings
+  recovery messages, Decay scan status, Index streaming progress, and the
+  embedding-mismatch banner are now localized (#1184–#1190).
+
+- **Internal.** Unused `noqa` directives removed across src and tests; validated
+  `TargetScope` casts replace return-value `type: ignore`s; the gc orphan-project
+  report renderer is typed (#1180–#1183).
+
 ## [0.2.3] — 2026-06-01
 
 - **`mm memory doctor` — read-only hygiene report for memory stores.** A

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.2.3"
+version = "0.2.4"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -917,7 +917,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bumps `memtomem` **0.2.3 → 0.2.4**, dates the CHANGELOG `[0.2.4]` section, and syncs the `uv.lock` workspace pin. Standard 3-file release shape (CHANGELOG / pyproject / uv.lock) — no source changes.

Rolls up **60 commits** since `v0.2.3` (2026-06-01).

## Highlights
- **Secrets now redacted in session-trace metadata sinks** — session tracing previously wrote span/trace metadata without the redaction pass (security-relevant fix).
- **Context Portal — multi-project state board (ADR-0021)** — runtime/client registry, multi-project board, per-CLI runtime chips + provider filter, project health/labels/lazy counts, Sync-All with per-phase progress + (project, tier) pinning; gateway lands on Projects Portal by default.
- **Artifact version snapshots + label pointers for agents/commands (ADR-0022)** — Langfuse-style `versions/vN.md` + movable labels; new MCP `mem_context_version` / `mem_context_promote` + label-aware `mem_context_sync`; web version/label manager, list-card chips, versioned create layout, opt-in enable-versioning migration.
- **Per-project sync enrollment** — discovery split from sync; enroll/pause/resume UI; sync-eligibility gating; structured `409` write-guard on runtime-write routes for paused/not-enrolled projects.
- **`mm tags` CLI** (#688) — list/rename/delete/merge, with a matching Web UI Tags tab.
- **CLI session command tracing + Langfuse v4** (#1199).
- **Reliability** — `with_retry` honors string `retry_after` (#1178); `_validate_webhook_url` safety pinned (#1179); Kimi Code install detected via `~/.kimi-code` (#1204).
- **i18n (EN/KO)** batch + Web UI accessibility / UX consolidation.

See the `[0.2.4]` CHANGELOG section for the full grouped notes with PR references.

## Release gate (manual, not in this PR)
Per the release convention (#973), this PR only lands the version bump + notes. After merge, the **tag → PyPI publish** is a separate manual step gated by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)