### PR TITLE
fix(context): stop re.sub template processing corrupting Kimi config.toml on re-sync

### DIFF
--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -695,7 +695,13 @@ def _replace_kimi_managed_block(existing: str, body: str) -> str:
         r"(?ms)^# BEGIN memtomem managed hooks\n.*?^# END memtomem managed hooks\n?"
     )
     if pattern.search(existing):
-        updated = pattern.sub(block, existing)
+        # Callable replacement — a plain-string replacement is processed as a
+        # template, so the ``\\`` sequences ``_toml_string`` emits for
+        # backslash-bearing hook commands (regex ``\b``, Windows paths) get
+        # halved and literal ``\n`` becomes a raw newline, corrupting the
+        # TOML on the second and every later sync (the first sync takes the
+        # concat branch below and was unaffected).
+        updated = pattern.sub(lambda _m: block, existing)
     else:
         updated = existing.rstrip()
         if updated and block:

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -583,6 +583,42 @@ class TestKimiSettingsMerge:
         assert 'matcher = "WriteFile"' in text
         assert tomllib.loads(text)["hooks"][0]["command"] == "mm index ~/memories"
 
+    def test_resync_preserves_backslashes_and_newlines_in_command(self, kimi_home, tmp_path):
+        """Regression: ``_replace_kimi_managed_block`` used the rendered block
+        as a plain-string ``re.sub`` replacement, so template processing halved
+        the doubled-backslash escapes ``_toml_string`` emits (regex ``\\b``,
+        Windows paths) and turned a literal backslash-n into a raw newline
+        inside the TOML string. The FIRST sync takes the no-block concat branch
+        and was always correct; the SECOND sync (block present →
+        ``pattern.sub``) corrupted ``config.toml`` into unparseable TOML.
+        Sync twice and require an exact command round-trip both times.
+        """
+        target = kimi_home / ".kimi" / "config.toml"
+        target.write_text('theme = "dark"\n', encoding="utf-8")
+        nasty = 'grep "\\bfoo" C:\\tools\\hook.exe && printf "a\\nb"'
+        _make_canonical_settings(
+            tmp_path,
+            {"hooks": {"PreToolUse": [_rule("Bash", nasty)]}},
+        )
+
+        first = generate_all_settings(tmp_path, scope="user")["kimi_settings"]
+        assert first.status == "ok"
+        parsed_first = tomllib.loads(target.read_text(encoding="utf-8"))
+        assert parsed_first["hooks"][0]["command"] == nasty
+
+        # Second sync: the managed block now exists, so this run exercises
+        # the ``pattern.sub`` replacement path that did the corrupting.
+        second = generate_all_settings(tmp_path, scope="user")["kimi_settings"]
+        assert second.status == "ok"
+        text = target.read_text(encoding="utf-8")
+        parsed_second = tomllib.loads(text)  # corrupted output raises TOMLDecodeError
+        assert parsed_second["hooks"][0]["command"] == nasty
+        assert parsed_second["theme"] == "dark"
+        # Negative pin on the corruption signature: the doubled escape in the
+        # TOML source (backslash backslash before ``bfoo``) must survive the
+        # re-sync — template processing halved it to a single backslash.
+        assert "\\\\bfoo" in text
+
 
 class TestClaudeSettingsMergeConcurrent:
     """Mtime changed between read and write → abort."""


### PR DESCRIPTION
## Why

Critical #1 from the Context Gateway review catalog (#1229), verified 2/2 by adversarial verification with a live reproduction.

`_replace_kimi_managed_block` passed the rendered managed block to `pattern.sub()` as a plain replacement **string**, so Python's replacement-template escape processing ran over it:

- the doubled-backslash escapes `_toml_string` (`json.dumps`) emits for backslash-bearing hook commands (regex `\b`, awk/sed scripts, Windows paths) were **halved** to a single backslash;
- a literal `\n` sequence became a **raw newline** inside the TOML basic string.

The first sync was always correct (no existing block → plain concat branch). The **second and every later sync** took the `sub()` path and rewrote `~/.kimi/config.toml` into unparseable TOML (`Unescaped '\' in a string`), bricking the Kimi target into permanent error status — silent corruption of a user-owned config file on a routine re-sync.

## What changed

One line: replace via a callable (`pattern.sub(lambda _m: block, existing)`) so the block is inserted verbatim with no template processing, plus an explanatory comment.

## Verification

- New regression test `TestKimiSettingsMerge::test_resync_preserves_backslashes_and_newlines_in_command`: syncs twice with a command containing backslashes, quotes, and an escaped newline; requires `tomllib` round-trip + exact command equality both times; negative-pins the doubled-escape signature in the TOML source.
- Mutation-validated: with the fix stashed, the test fails with exactly the predicted `TOMLDecodeError`; with the fix, the full `test_context_settings.py` + `test_context_settings_multiruntime.py` suites pass (118 passed).
- `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
