### PR TITLE
fix(web): stop skills sync from blocking the event loop on cross-process locks

### DIFF
--- a/packages/memtomem/src/memtomem/context/_skip_reasons.py
+++ b/packages/memtomem/src/memtomem/context/_skip_reasons.py
@@ -24,6 +24,12 @@ PARSE_ERROR: Final = "parse_error"
 # user-only). Loud emit, not silent — feedback_defensive_noise.md.
 NO_PROJECT_FANOUT_FOR_RUNTIME: Final = "no_project_fanout_for_runtime"
 
+# Another process held a destination sidecar lock past the engine's whole-call
+# acquisition budget (``skills._SKILLS_LOCK_BUDGET_S``). Emitted instead of
+# blocking indefinitely so an async web caller offloading to a thread can never
+# orphan a worker that writes after its request already timed out (#1145 shape).
+LOCK_TIMEOUT: Final = "lock_timeout"
+
 # Import (runtime → canonical) skip codes.
 INVALID_NAME: Final = "invalid_name"
 ALREADY_IMPORTED: Final = "already_imported"
@@ -58,6 +64,7 @@ SkipCode = Literal[
     "unknown_runtime",
     "parse_error",
     "no_project_fanout_for_runtime",
+    "lock_timeout",
     "invalid_name",
     "already_imported",
     "canonical_exists",

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -23,6 +23,7 @@ import logging
 import os
 import secrets
 import shutil
+import time
 from contextlib import ExitStack
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -51,6 +52,16 @@ logger = logging.getLogger(__name__)
 
 CANONICAL_SKILL_ROOT = ".memtomem/skills"
 SKILL_MANIFEST = "SKILL.md"
+# Whole-call budget for destination sidecar-lock acquisition in
+# :func:`generate_all_skills` — one shared deadline across every lock, not a
+# fresh bound per destination (N dsts × per-lock bound could overrun the web
+# handler's 60s ``asyncio.timeout`` and re-open the orphaned-worker window —
+# the #1145 settings review shape; see ``settings._SETTINGS_LOCK_BUDGET_S``).
+# The budget applies to EVERY caller (web, CLI, MCP) — matching the settings
+# precedent: a CLI run that would otherwise block forever now aborts with a
+# typed ``lock_timeout`` skip and a retry hint, and an ``asyncio.to_thread``
+# web caller can never be wedged by a stuck cross-process lock holder.
+_SKILLS_LOCK_BUDGET_S = 30.0
 # Canonical-side subdirectory that holds per-vendor SKILL.md overrides
 # (``<canonical>/<name>/overrides/<vendor>.<ext>`` — see
 # :mod:`memtomem.context.override`). It is the SOURCE of overrides, never part
@@ -382,6 +393,17 @@ def generate_all_skills(
 
     targets = runtimes if runtimes is not None else list(SKILL_GENERATORS.keys())
 
+    # One shared deadline for ALL destination sidecar-lock waits — the whole
+    # call, not each destination, is bounded by ``_SKILLS_LOCK_BUDGET_S``.
+    # A timed-out acquisition becomes a typed ``lock_timeout`` skip instead
+    # of blocking forever, so a thread-offloaded web caller can never be
+    # wedged (or orphaned past its own timeout) by a stuck cross-process
+    # holder (#1145 shape).
+    lock_deadline = time.monotonic() + _SKILLS_LOCK_BUDGET_S
+
+    def _lock_timeout() -> float:
+        return max(0.0, lock_deadline - time.monotonic())
+
     # ``project_shared`` is a hard-refusal surface: if any skill or
     # runtime override fails Gate A, no runtime fan-out should be
     # promoted. Hold all destination locks, stage+scan every final tree,
@@ -409,8 +431,26 @@ def generate_all_skills(
         staged: list[tuple[str, Path, Path]] = []
         try:
             with ExitStack() as stack:
-                for lock_path in sorted({_lock_path_for(dst) for _, _, _, dst in work}, key=str):
-                    stack.enter_context(_file_lock(lock_path))
+                # Locks are acquired before any staging work, so a budget
+                # overrun here aborts the batch with nothing to roll back —
+                # all-or-nothing is preserved (this scope is the hard-refusal
+                # surface; promoting a partial batch is never acceptable).
+                try:
+                    for lock_path in sorted(
+                        {_lock_path_for(dst) for _, _, _, dst in work}, key=str
+                    ):
+                        stack.enter_context(_file_lock(lock_path, timeout=_lock_timeout()))
+                except TimeoutError:
+                    skipped.append(
+                        (
+                            "<all>",
+                            "another process held a destination lock past the "
+                            f"{_SKILLS_LOCK_BUDGET_S:g}s acquisition budget — "
+                            "re-run sync to retry",
+                            skip_codes.LOCK_TIMEOUT,
+                        )
+                    )
+                    return SkillSyncResult(generated=generated, skipped=skipped)
                 for target, _gen, skill_dir, dst in work:
                     # Unreadable canonical: typed PARSE_ERROR skip rather than
                     # an exception bubbling up — symmetric with agents.py /
@@ -520,7 +560,25 @@ def generate_all_skills(
             # swaps. Without the lock, a second invocation could
             # recreate ``dst`` between the move-aside and the rename-in,
             # leaving the rollback path with no clean dst to restore.
-            with _file_lock(_lock_path_for(dst)):
+            # Acquisition is bounded by the shared call budget; a timed-out
+            # destination becomes a typed per-item skip (the other
+            # destinations still proceed — non-shared scopes have no
+            # all-or-nothing batch contract).
+            dst_lock = ExitStack()
+            try:
+                dst_lock.enter_context(_file_lock(_lock_path_for(dst), timeout=_lock_timeout()))
+            except TimeoutError:
+                skipped.append(
+                    (
+                        skill_dir.name,
+                        "another process held the destination lock past the "
+                        f"{_SKILLS_LOCK_BUDGET_S:g}s acquisition budget — "
+                        "re-run sync to retry",
+                        skip_codes.LOCK_TIMEOUT,
+                    )
+                )
+                continue
+            with dst_lock:
                 # Unreadable canonical: typed PARSE_ERROR skip rather than
                 # an exception bubbling up — symmetric with agents.py /
                 # commands.py read_bytes failure handling.

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -472,7 +472,18 @@ async def sync_skills(
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
-                result = generate_all_skills(project_root)
+                # Offload to a worker thread — the engine acquires
+                # cross-process destination sidecar locks (skills hold them
+                # across the whole staging swap, _locks.py), which would
+                # otherwise block this synchronous call ON the event loop
+                # thread, stalling every request AND preventing the enclosing
+                # ``asyncio.timeout(60)`` from firing (its expiry callback
+                # runs on the very loop that is blocked) — the exact shape
+                # #1145 fixed for settings. The engine's own
+                # ``_SKILLS_LOCK_BUDGET_S`` (30s < 60s) bounds the lock
+                # waits, so a timed-out request cannot orphan a worker
+                # thread that writes after the 503 already went out.
+                result = await asyncio.to_thread(generate_all_skills, project_root)
     except TimeoutError:
         raise HTTPException(503, "Skills sync timed out — another sync may be in progress")
     except PrivacyScanError as exc:

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -4143,12 +4143,19 @@ document.querySelectorAll('.ctx-sync-btn').forEach(btn => {
       const skipped = data.skipped || [];
       const emptyCanonical = generated.length === 0
         && skipped.some(s => s && s.reason_code === 'no_canonical_root');
+      const lockTimeout = skipped.some(s => s && s.reason_code === 'lock_timeout');
       if (emptyCanonical) {
         // ``{canonical}`` is a real path — keep the raw slug there.
         const msg = t('settings.ctx.sync_empty_canonical')
           .replace('{type}', _ctxTypeName(type))
           .replace('{canonical}', data.canonical_root || `.memtomem/${type}`);
         showToast(msg, 'info');
+      } else if (lockTimeout) {
+        // A foreign process held a destination lock past the engine's
+        // acquisition budget — none (batch tier) or only part (per-dst
+        // tiers) of the fan-out happened. Falling through to
+        // ``sync_success`` would report a sync that didn't run.
+        showToast(t('settings.ctx.sync_lock_timeout'), 'warning');
       } else if (dropped.length) {
         // commands/agents render dropped per-field omissions — keep the
         // existing warning so the user can investigate field-level loss.

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1467,7 +1467,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=16"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=62"></script>
+  <script src="/context-gateway.js?v=63"></script>
   <script src="/context-portal.js?v=2"></script>
   <script src="/path-picker.js?v=3"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -409,6 +409,7 @@
   "settings.ctx.confirm_import_overwrite_hint": "Enable Overwrite to replace the existing ones.",
   "settings.ctx.confirm_import_overwrite_label": "Overwrite existing stored files",
   "settings.ctx.sync_success": "Sync completed",
+  "settings.ctx.sync_lock_timeout": "Sync didn't run — another process is holding a destination lock. Try again in a moment.",
   "settings.ctx.sync_dropped": "{count} field(s) dropped during sync",
   "settings.ctx.import_priority": "When the same name exists in more than one runtime, the Claude copy is imported (then Antigravity). Codex is pushed to but never read back.",
   "settings.ctx.import_result": "{imported} imported, {skipped} skipped",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -409,6 +409,7 @@
   "settings.ctx.confirm_import_overwrite_hint": "덮어쓰기를 켜면 기존 항목이 교체됩니다.",
   "settings.ctx.confirm_import_overwrite_label": "기존 저장 파일 덮어쓰기",
   "settings.ctx.sync_success": "동기화 완료",
+  "settings.ctx.sync_lock_timeout": "동기화가 실행되지 않았습니다 — 다른 프로세스가 대상 잠금을 잡고 있습니다. 잠시 후 다시 시도하세요.",
   "settings.ctx.sync_dropped": "동기화 중 {count}개 필드가 제거됨",
   "settings.ctx.import_priority": "같은 이름이 여러 런타임에 있으면 Claude 사본을 가져오고 그다음 Antigravity 순입니다. Codex 로는 내보내기만 하고 읽어오지 않습니다.",
   "settings.ctx.import_result": "{imported}개 가져옴, {skipped}개 건너뜀",

--- a/packages/memtomem/tests/test_context_skills_staging.py
+++ b/packages/memtomem/tests/test_context_skills_staging.py
@@ -402,3 +402,80 @@ class TestOverridePreservation:
         assert len(privacy_skips) == 1, result.skipped
         # Negative: dst not created.
         assert not dst.exists()
+
+
+class TestLockBudget:
+    """#1229 (review 2026-06-10): destination sidecar-lock acquisition in
+    ``generate_all_skills`` is bounded by a whole-call budget so the engine can
+    be offloaded to a worker thread by the web route without an unbounded
+    cross-process lock wait blocking forever (the #1145 settings shape —
+    ``asyncio.timeout`` on the caller's loop cannot fire while the loop thread
+    itself is blocked, and ``asyncio.to_thread`` cannot cancel a wedged
+    thread).
+    """
+
+    def test_held_lock_aborts_batch_within_bound_not_hangs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """project_shared batch path: a foreign holder on ANY destination lock
+        aborts the WHOLE batch (all-or-nothing is preserved — locks are taken
+        before any staging) with a typed ``lock_timeout`` skip, instead of
+        blocking indefinitely."""
+        import time as _time
+
+        import memtomem.context.skills as skills_mod
+        from memtomem.context._atomic import _file_lock, _lock_path_for
+
+        _seed_canonical_skill(tmp_path, name="foo")
+        dst = SKILL_GENERATORS["claude_skills"].target_dir(tmp_path, "foo", scope="project_shared")
+        assert dst is not None
+
+        monkeypatch.setattr(skills_mod, "_SKILLS_LOCK_BUDGET_S", 0.2)
+        start = _time.monotonic()
+        # Foreign holder: separate open-file-description — portalocker
+        # contends per-OFD even within one process.
+        with _file_lock(_lock_path_for(dst)):
+            result = generate_all_skills(tmp_path)
+        elapsed = _time.monotonic() - start
+
+        assert result.generated == []
+        assert [s for s in result.skipped if s[2] == skip_codes.LOCK_TIMEOUT], result.skipped
+        skip = next(s for s in result.skipped if s[2] == skip_codes.LOCK_TIMEOUT)
+        assert skip[0] == "<all>"
+        assert "acquisition budget" in skip[1]
+        # Bounded: ~one budget + overhead, never an indefinite block. Loose
+        # bound — CI runners are slow; the point is "seconds, not forever".
+        assert elapsed < 10, f"abort took {elapsed:.1f}s — budget not applied?"
+        # Nothing promoted while the lock was held.
+        assert not dst.exists()
+
+    def test_held_lock_skips_only_contended_destination_on_user_scope(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """user-scope per-destination path: only the contended destination is
+        skipped (typed ``lock_timeout``); the remaining runtimes still fan
+        out — non-shared scopes carry no all-or-nothing batch contract."""
+        import memtomem.context.skills as skills_mod
+        from memtomem.context._atomic import _file_lock, _lock_path_for
+
+        home = tmp_path / "home"
+        home.mkdir()
+        set_home(monkeypatch, home)
+        _seed_canonical_skill(tmp_path, name="foo", scope="user")
+
+        held_dst = SKILL_GENERATORS["claude_skills"].target_dir(tmp_path, "foo", scope="user")
+        assert held_dst is not None
+
+        monkeypatch.setattr(skills_mod, "_SKILLS_LOCK_BUDGET_S", 0.2)
+        with _file_lock(_lock_path_for(held_dst)):
+            result = generate_all_skills(tmp_path, scope="user")
+
+        lock_skips = [s for s in result.skipped if s[2] == skip_codes.LOCK_TIMEOUT]
+        assert len(lock_skips) == 1, result.skipped
+        assert lock_skips[0][0] == "foo"
+        # The contended claude destination was not written...
+        assert not held_dst.exists()
+        # ...but at least one other runtime destination was.
+        other_runtimes = {rt for rt, _p in result.generated}
+        assert other_runtimes, result.skipped
+        assert "claude_skills" not in other_runtimes

--- a/packages/memtomem/tests/web/test_context_gateway_rank10_confirm.py
+++ b/packages/memtomem/tests/web/test_context_gateway_rank10_confirm.py
@@ -258,3 +258,50 @@ def test_portal_sync_confirm_names_project(page, mm_web_url: str) -> None:
     message = page.locator("#confirm-message").text_content() or ""
     assert "Alpha" in message, f"portal sync confirm should name the project, got {message!r}"
     page.locator("#confirm-cancel-btn").click()
+
+
+def test_section_sync_lock_timeout_skip_toasts_warning_not_success(page, mm_web_url: str) -> None:
+    """#1229: when the engine aborts on a held destination lock, the response
+    is HTTP 200 with ``skipped=[{reason_code: 'lock_timeout'}]`` and zero
+    ``generated``. The handler previously special-cased only
+    ``no_canonical_root`` and ``dropped``, so a lock-timeout run fell through
+    to the "Sync completed" success toast — reporting a sync that never ran.
+    """
+    install_default_stubs(page)
+    _stub_skills_list(page)
+    page.route(
+        "**/api/context/skills/sync**",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "generated": [],
+                    "skipped": [
+                        {
+                            "runtime": "<all>",
+                            "reason": (
+                                "another process held a destination lock past "
+                                "the 30s acquisition budget — re-run sync to retry"
+                            ),
+                            "reason_code": "lock_timeout",
+                        }
+                    ],
+                    "canonical_root": ".memtomem/skills",
+                }
+            ),
+        ),
+    )
+    page.goto(mm_web_url)
+    _open_skills_list(page)
+
+    page.locator("#settings-ctx-skills .ctx-sync-btn[data-type='skills']").click()
+    page.wait_for_selector("#confirm-modal:not([hidden])", timeout=2_000)
+    page.locator("#confirm-ok-btn").click()
+
+    toast = page.wait_for_selector("#toast-container .toast.toast-warning", timeout=4_000)
+    text = toast.text_content() or ""
+    assert "lock" in text.lower(), f"warning toast should explain the lock, got {text!r}"
+    assert page.locator("#toast-container .toast.toast-success").count() == 0, (
+        "a lock_timeout run must not toast 'Sync completed'"
+    )


### PR DESCRIPTION
## Why

Top major from the Context Gateway review catalog (#1229), verified 2/2 with the freeze mechanism re-derived by both verifiers.

`POST /context/skills/sync` ran `generate_all_skills()` **synchronously on the event loop**, and the skills engine acquires cross-process portalocker sidecar locks with `timeout=None` (indefinite `LOCK_EX`). Consequences when a foreign process (CLI `mm context sync`, MCP tool, or a wedged holder) has the lock:

- the **entire uvicorn event loop blocks** — every web request stalls, not just this one;
- the surrounding `asyncio.timeout(60)` is **inert**: its expiry callback is scheduled on the very loop that is blocked, so the advertised 503 "Skills sync timed out" is unreachable for exactly the contention case it exists for.

`_locks.py` documents skills as the one engine that holds its file lock across the whole staging swap; settings fixed this identical shape in #1145 (`asyncio.to_thread` + lock budget) but skills never got the treatment.

## What changed

Mirror of #1145:

- **Route**: `result = await asyncio.to_thread(generate_all_skills, project_root)` inside the gateway lock. `PrivacyScanError` still propagates → 422.
- **Engine**: one shared whole-call deadline `_SKILLS_LOCK_BUDGET_S = 30s` (< the handler's 60s, so a timed-out request can never orphan a worker thread that writes after the 503) threaded into both lock sites:
  - *batch path* (`project_shared`): locks are acquired **before any staging**, so a budget overrun aborts the whole batch with a typed `("<all>", …, lock_timeout)` skip — the all-or-nothing hard-refusal contract is preserved with nothing to roll back;
  - *per-destination path* (`user`/`project_local`): the contended destination becomes a per-item `lock_timeout` skip; the remaining runtimes still fan out (no batch contract on these tiers).
- **New typed skip code** `lock_timeout` (`_skip_reasons.py`), and the web sync handler surfaces it as a **warning toast** instead of falling through to "Sync completed" (Codex review catch), with en+ko copy.

The budget now applies to every caller (web, CLI, MCP) — matching the settings precedent: a CLI run that would previously hang forever aborts at 30s with a retry hint.

## Verification

- New engine tests (`TestLockBudget`): held-lock abort on the batch path (all-or-nothing, `<all>` skip, bounded wall-clock, dst untouched) and partial-skip on the user-scope path (contended destination skipped, others still generated). Mutation-checked: both fail against the unfixed module.
- New browser regression: a `lock_timeout` response toasts warning, never `Sync completed`.
- `extract`/import path verified to take no `_file_lock` — not offloaded (bounded by actual work).
- Suites: skills engine + staging + privacy-block + web-route + locks + full browser suite green standalone; `ruff check`/`format` clean. (Note: running `tests/web` and `test_web_routes_context_locks.py` in one pytest session fails on the **clean tree** too — pre-existing cross-suite isolation artifact; CI runs them in separate jobs.)
- Codex review: NEEDS-FIX → both findings addressed (success-toast misreport fixed + misleading comment corrected); lock handling itself assessed sound (batch all-or-nothing, no lock-leak paths, `to_thread` interaction).

Conflicts note: touches the same `context-gateway.js` sync handler region as #1227/#1228 (and bumps `?v=`) — whichever merges later takes a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
