### PR TITLE
fix(web): per-name diff routes resolve runtime targets at the requested tier (#1229)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -480,7 +480,9 @@ async def diff_agent(
 
     runtimes = []
     for gen_name, gen in AGENT_GENERATORS.items():
-        target = gen.target_file(project_root, name)
+        # Match the canonical side's tier — see context_skills.py diff_skill
+        # for the rationale (#1229). NO_FANOUT tiers return None → skipped.
+        target = gen.target_file(project_root, name, scope=target_scope)
         if target is None:
             continue
         if canonical_content is None and not target.is_file():

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -473,7 +473,9 @@ async def diff_command(
 
     runtimes = []
     for gen_name, gen in COMMAND_GENERATORS.items():
-        target = gen.target_file(project_root, name)
+        # Match the canonical side's tier — see context_skills.py diff_skill
+        # for the rationale (#1229). NO_FANOUT tiers return None → skipped.
+        target = gen.target_file(project_root, name, scope=target_scope)
         if target is None:
             continue
         if canonical_content is None and not target.is_file():

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -416,7 +416,12 @@ async def diff_skill(
 
     runtimes = []
     for gen_name, gen in SKILL_GENERATORS.items():
-        target = gen.target_dir(project_root, name)
+        # Resolve the runtime side at the same tier as the canonical side —
+        # the engine diff (diff_skills) already does; without scope= this
+        # always probed project_shared paths and the detail panel
+        # contradicted the list view on user/project_local tiers (#1229).
+        # NO_FANOUT tiers (e.g. project_local) return None and are skipped.
+        target = gen.target_dir(project_root, name, scope=target_scope)
         if target is None:
             continue
         target_manifest = target / SKILL_MANIFEST

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -12,6 +12,8 @@ from httpx import ASGITransport, AsyncClient
 from memtomem.context.skills import SKILL_MANIFEST
 from memtomem.web.app import create_app
 
+from .helpers import set_home
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -860,6 +862,47 @@ class TestDiffSkill:
         assert claude_rt["status"] == "out of sync"
         assert claude_rt["runtime_content"] == "# V2\n"
 
+    @pytest.mark.anyio
+    async def test_diff_user_tier_resolves_user_runtime(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """``target_scope=user`` must probe the user-tier fan-out roots
+        (``~/.claude/skills``), not the project's project_shared paths, so the
+        detail panel agrees with the scope-aware list diff (#1229)."""
+        home = tmp_path / "home"
+        set_home(monkeypatch, home)
+        content = "# User skill\n"
+        skill_dir = home / ".memtomem" / "skills" / "scoped"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / SKILL_MANIFEST).write_text(content, encoding="utf-8")
+        rt_dir = home / ".claude" / "skills" / "scoped"
+        rt_dir.mkdir(parents=True)
+        (rt_dir / SKILL_MANIFEST).write_text(content, encoding="utf-8")
+
+        r = await client.get("/api/context/skills/scoped/diff", params={"target_scope": "user"})
+        assert r.status_code == 200
+        data = r.json()
+        claude_rt = [rt for rt in data["runtimes"] if rt["runtime"] == "claude_skills"][0]
+        assert claude_rt["status"] == "in sync"
+
+    @pytest.mark.anyio
+    async def test_diff_project_local_has_no_runtime_rows(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """project_local has no runtime fan-out (ADR-0011 §3): the detail diff
+        must not fabricate runtime rows against project_shared paths (#1229)."""
+        local_dir = tmp_path / ".memtomem" / "skills.local" / "draft"
+        local_dir.mkdir(parents=True)
+        (local_dir / SKILL_MANIFEST).write_text("# Draft\n", encoding="utf-8")
+
+        r = await client.get(
+            "/api/context/skills/draft/diff", params={"target_scope": "project_local"}
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["canonical_content"] == "# Draft\n"
+        assert data["runtimes"] == []
+
 
 # ---------------------------------------------------------------------------
 # Skills — Sync
@@ -1202,6 +1245,47 @@ class TestCommandCRUD:
         assert cmd_file.read_text(encoding="utf-8") == _CMD_CONTENT
 
 
+class TestDiffCommand:
+    @pytest.mark.anyio
+    async def test_diff_user_tier_resolves_user_runtime(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """``target_scope=user`` must probe ``~/.claude/commands``, not the
+        project's project_shared paths (#1229)."""
+        home = tmp_path / "home"
+        set_home(monkeypatch, home)
+        cmd_dir = home / ".memtomem" / "commands"
+        cmd_dir.mkdir(parents=True)
+        (cmd_dir / "scoped.md").write_text(_CMD_CONTENT, encoding="utf-8")
+        rt_dir = home / ".claude" / "commands"
+        rt_dir.mkdir(parents=True)
+        (rt_dir / "scoped.md").write_text(_CMD_CONTENT, encoding="utf-8")
+
+        r = await client.get("/api/context/commands/scoped/diff", params={"target_scope": "user"})
+        assert r.status_code == 200
+        data = r.json()
+        claude_rt = [rt for rt in data["runtimes"] if rt["runtime"] == "claude_commands"][0]
+        assert claude_rt["status"] == "in sync"
+
+    @pytest.mark.anyio
+    async def test_diff_project_local_has_no_runtime_rows(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """project_local has no runtime fan-out (ADR-0011 §3) — no fabricated
+        rows against project_shared paths (#1229)."""
+        local_dir = tmp_path / ".memtomem" / "commands.local"
+        local_dir.mkdir(parents=True)
+        (local_dir / "draft.md").write_text(_CMD_CONTENT, encoding="utf-8")
+
+        r = await client.get(
+            "/api/context/commands/draft/diff", params={"target_scope": "project_local"}
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["canonical_content"] == _CMD_CONTENT
+        assert data["runtimes"] == []
+
+
 class TestSyncCommands:
     @pytest.mark.anyio
     async def test_sync_with_dropped(self, client: AsyncClient, tmp_path: Path):
@@ -1448,6 +1532,47 @@ class TestAgentCRUD:
         assert data["status"] == "aborted"
         assert data["mtime_ns"] == str(agent_path.stat().st_mtime_ns)
         assert "overwritten" not in agent_path.read_text(encoding="utf-8")
+
+
+class TestDiffAgent:
+    @pytest.mark.anyio
+    async def test_diff_user_tier_resolves_user_runtime(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """``target_scope=user`` must probe ``~/.claude/agents``, not the
+        project's project_shared paths (#1229)."""
+        home = tmp_path / "home"
+        set_home(monkeypatch, home)
+        agent_dir = home / ".memtomem" / "agents"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "scoped.md").write_text(_AGENT_CONTENT, encoding="utf-8")
+        rt_dir = home / ".claude" / "agents"
+        rt_dir.mkdir(parents=True)
+        (rt_dir / "scoped.md").write_text(_AGENT_CONTENT, encoding="utf-8")
+
+        r = await client.get("/api/context/agents/scoped/diff", params={"target_scope": "user"})
+        assert r.status_code == 200
+        data = r.json()
+        claude_rt = [rt for rt in data["runtimes"] if rt["runtime"] == "claude_agents"][0]
+        assert claude_rt["status"] == "in sync"
+
+    @pytest.mark.anyio
+    async def test_diff_project_local_has_no_runtime_rows(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """project_local has no runtime fan-out (ADR-0011 §3) — no fabricated
+        rows against project_shared paths (#1229)."""
+        local_dir = tmp_path / ".memtomem" / "agents.local"
+        local_dir.mkdir(parents=True)
+        (local_dir / "draft.md").write_text(_AGENT_CONTENT, encoding="utf-8")
+
+        r = await client.get(
+            "/api/context/agents/draft/diff", params={"target_scope": "project_local"}
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["canonical_content"] == _AGENT_CONTENT
+        assert data["runtimes"] == []
 
 
 class TestSyncAgents:


### PR DESCRIPTION
## Summary

Fixes the #1229 verified finding (routes-api, **major**): *Per-name /diff endpoints ignore `target_scope` when resolving runtime targets — detail diff contradicts the list view on user/project_local tiers.*

The per-name `GET /api/context/{skills,commands,agents}/{name}/diff` routes resolved the **canonical** side scope-aware (`_canonical_skill_dir(..., scope=target_scope)` etc.) but probed every **runtime** target via `gen.target_dir(project_root, name)` / `gen.target_file(project_root, name)`, which default to `scope="project_shared"`:

- On the **user** tier the detail panel compared user-tier canonical content against the project's `.claude/...` files and reported phantom `missing target` / `out of sync` / `missing canonical` rows that contradict the scope-aware list diff.
- On **project_local** (a NO_FANOUT tier per ADR-0011 §3) it fabricated runtime comparisons that cannot exist.

## Change

Pass `scope=target_scope` through to the generator target resolution in the three per-name diff handlers. NO_FANOUT tiers then return `None` and are skipped by the existing guard — matching the engine diff (`diff_skills` / `diff_commands` / `diff_agents`) that the list endpoints use.

Same-shape audit: the remaining scope-less `gen.target_*` calls in these route files are the cascade-delete paths, which are gated by `_reject_non_shared_write`, so `project_shared` (the default) is the only tier that can reach them — left unchanged deliberately.

## Tests

- 6 new regression tests; all fail pre-fix with phantom `missing target` rows and pass post-fix:
  - `test_diff_user_tier_resolves_user_runtime` (skills / commands / agents): user-tier canonical + identical `~/.claude/...` runtime copy → claude row reports `in sync`.
  - `test_diff_project_local_has_no_runtime_rows` (skills / commands / agents): project_local canonical → `runtimes == []`.
- `test_web_routes_context.py`: 101 passed. `ruff check` + `ruff format --check`: clean.

Part of #1229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
