### PR TITLE
fix(context): key diff canonicals by frontmatter name and survive undecodable files (#1229)

### DIFF
--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -988,10 +988,26 @@ def diff_agents(
     pre-PR-E3 behavior.
     """
     results: list[tuple[str, str, str]] = []
-    canonical_index = {
-        path.parent.name if layout == "dir" else path.stem: (path, layout)
-        for path, layout in list_canonical_agents(project_root, scope=scope)
-    }
+    # Key canonicals by the parsed frontmatter ``name:`` — the identity sync
+    # targets (``_sync_atomic`` Phase 1: bytes → decode errors="replace" →
+    # parse → ``name_of``). Keying by file stem reported permanent phantom
+    # drift after a successful sync whenever stem and frontmatter name
+    # disagree: ('<stem>', 'missing target') + ('<name>', 'missing
+    # canonical') on every runtime, forever (#1229). The lenient decode also
+    # keeps a stray non-UTF-8 byte from aborting the whole diff with an
+    # uncaught UnicodeDecodeError while sync handles the same file fine.
+    # Unreadable / unparseable canonicals keep the stem / dir-name key
+    # (``None`` value) so their "parse error" row still names the file.
+    canonical_index: dict[str, SubAgent | None] = {}
+    for path, layout in list_canonical_agents(project_root, scope=scope):
+        fallback_name = path.parent.name if layout == "dir" else path.stem
+        try:
+            text = path.read_bytes().decode("utf-8", errors="replace")
+            parsed = _parse_canonical_agent_text(text, source=path, layout=layout)
+        except (OSError, AgentParseError):
+            canonical_index[fallback_name] = None
+        else:
+            canonical_index[parsed.name] = parsed
     canonical_names = set(canonical_index)
 
     for gen_name, gen in AGENT_GENERATORS.items():
@@ -1014,10 +1030,8 @@ def diff_agents(
                 results.append((gen_name, name, "missing canonical"))
                 continue
 
-            src, layout = canonical_index[name]
-            try:
-                agent = parse_canonical_agent(src, layout=layout)
-            except AgentParseError:
+            agent = canonical_index[name]
+            if agent is None:
                 results.append((gen_name, name, "parse error"))
                 continue
             # Cleanup item #2: the upstream ``runtime_fanout_root`` guard
@@ -1047,13 +1061,29 @@ def diff_agents(
                     # so we can't assert parity — report drift, never mask it.
                     results.append((gen_name, name, "out of sync"))
                     continue
-                actual_bytes = target.read_bytes() if target.is_file() else b""
+                try:
+                    actual_bytes = target.read_bytes() if target.is_file() else b""
+                except OSError:
+                    # Unreadable runtime file — same contract as above.
+                    results.append((gen_name, name, "out of sync"))
+                    continue
                 status = "in sync" if expected_bytes == actual_bytes else "out of sync"
                 results.append((gen_name, name, status))
                 continue
 
             expected, _ = gen.render(agent)
-            actual = target.read_text(encoding="utf-8") if target.is_file() else ""
+            # Lenient decode mirrors the canonical side (and sync): a stray
+            # non-UTF-8 byte means drift, not a diff-wide crash. An unreadable
+            # runtime file can't assert parity — report drift, never mask it.
+            try:
+                actual = (
+                    target.read_bytes().decode("utf-8", errors="replace")
+                    if target.is_file()
+                    else ""
+                )
+            except OSError:
+                results.append((gen_name, name, "out of sync"))
+                continue
             if expected.strip() == actual.strip():
                 results.append((gen_name, name, "in sync"))
             else:

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -762,10 +762,19 @@ def diff_commands(
     pre-PR-E3 behavior.
     """
     results: list[tuple[str, str, str]] = []
-    canonical_index = {
-        path.parent.name if layout == "dir" else path.stem: (path, layout)
-        for path, layout in list_canonical_commands(project_root, scope=scope)
-    }
+    # Key canonicals by the parsed frontmatter ``name:`` with a lenient
+    # decode — mirrors diff_agents; see the comment there for the phantom
+    # drift + UnicodeDecodeError rationale (#1229).
+    canonical_index: dict[str, SlashCommand | None] = {}
+    for path, layout in list_canonical_commands(project_root, scope=scope):
+        fallback_name = path.parent.name if layout == "dir" else path.stem
+        try:
+            text = path.read_bytes().decode("utf-8", errors="replace")
+            parsed = _parse_canonical_command_text(text, source=path, layout=layout)
+        except (OSError, CommandParseError):
+            canonical_index[fallback_name] = None
+        else:
+            canonical_index[parsed.name] = parsed
     canonical_names = set(canonical_index)
 
     for gen_name, gen in COMMAND_GENERATORS.items():
@@ -789,10 +798,8 @@ def diff_commands(
                 results.append((gen_name, name, "missing canonical"))
                 continue
 
-            src, layout = canonical_index[name]
-            try:
-                cmd = parse_canonical_command(src, layout=layout)
-            except CommandParseError:
+            cmd = canonical_index[name]
+            if cmd is None:
                 results.append((gen_name, name, "parse error"))
                 continue
             # Cleanup item #2: the upstream ``runtime_fanout_root`` guard
@@ -822,13 +829,29 @@ def diff_commands(
                     # so we can't assert parity — report drift, never mask it.
                     results.append((gen_name, name, "out of sync"))
                     continue
-                actual_bytes = target.read_bytes() if target.is_file() else b""
+                try:
+                    actual_bytes = target.read_bytes() if target.is_file() else b""
+                except OSError:
+                    # Unreadable runtime file — same contract as above.
+                    results.append((gen_name, name, "out of sync"))
+                    continue
                 status = "in sync" if expected_bytes == actual_bytes else "out of sync"
                 results.append((gen_name, name, status))
                 continue
 
             expected, _ = gen.render(cmd)
-            actual = target.read_text(encoding="utf-8") if target.is_file() else ""
+            # Lenient decode mirrors the canonical side (and sync): a stray
+            # non-UTF-8 byte means drift, not a diff-wide crash. An unreadable
+            # runtime file can't assert parity — report drift, never mask it.
+            try:
+                actual = (
+                    target.read_bytes().decode("utf-8", errors="replace")
+                    if target.is_file()
+                    else ""
+                )
+            except OSError:
+                results.append((gen_name, name, "out of sync"))
+                continue
             if expected.strip() == actual.strip():
                 results.append((gen_name, name, "in sync"))
             else:

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -937,7 +937,15 @@ def diff_skills(
                             # un-overridden canonical (which could mask it).
                             results.append((gen_name, name, "out of sync"))
                             continue
-                if _skill_effective_equal(src, dst, override_bytes):
+                # An unreadable file inside either tree (PermissionError etc.)
+                # must not abort the whole diff — we can't assert parity, so
+                # report drift, never mask it (same contract as the override
+                # read above; #1229).
+                try:
+                    equal = _skill_effective_equal(src, dst, override_bytes)
+                except OSError:
+                    equal = False
+                if equal:
                     results.append((gen_name, name, "in sync"))
                 else:
                     results.append((gen_name, name, "out of sync"))

--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -453,6 +453,43 @@ class TestDiffAgents:
         rows = diff_agents(tmp_path)
         assert any(status == "missing canonical" for _, _, status in rows)
 
+    def test_frontmatter_name_wins_over_stem_after_sync(self, tmp_path, codex_home):
+        """Sync targets the parsed frontmatter ``name:``; diff must key
+        canonicals the same way, or a stem/name mismatch reports two phantom
+        rows per runtime ('missing target' + 'missing canonical') that
+        re-syncing never clears (#1229)."""
+        body = SAMPLE_MINIMAL_AGENT.replace("helper", "code-reviewer")
+        _make_canonical_agent(tmp_path, "reviewer", body)  # stem != frontmatter name
+        generate_all_agents(tmp_path)
+        rows = diff_agents(tmp_path)
+        assert rows
+        assert {name for _, name, _ in rows} == {"code-reviewer"}
+        assert all(status == "in sync" for _, _, status in rows)
+
+    def test_non_utf8_canonical_byte_does_not_abort_diff(self, tmp_path, codex_home):
+        """A stray latin-1 byte must not abort the whole diff with an uncaught
+        UnicodeDecodeError — sync decodes the same file with errors='replace'
+        and succeeds, so diff must agree with what sync wrote (#1229)."""
+        root = tmp_path / CANONICAL_AGENT_ROOT
+        root.mkdir(parents=True, exist_ok=True)
+        (root / "cafe.md").write_bytes(b"---\nname: cafe\ndescription: caf\xe9\n---\n\nBody.\n")
+        generate_all_agents(tmp_path)
+        rows = diff_agents(tmp_path)
+        assert {status for _, name, status in rows if name == "cafe"} == {"in sync"}
+
+    def test_non_utf8_runtime_byte_reports_drift_not_crash(self, tmp_path, codex_home):
+        """A non-UTF-8 byte in a runtime copy is drift, not a diff-wide crash
+        (#1229)."""
+        _make_canonical_agent(tmp_path, "helper", SAMPLE_MINIMAL_AGENT)
+        generate_all_agents(tmp_path)
+        (tmp_path / ".claude/agents/helper.md").write_bytes(
+            b"---\nname: helper\ndescription: caf\xe9 drift\n---\n\nBody.\n"
+        )
+        rows = diff_agents(tmp_path)
+        status_by_runtime = {r: s for r, _, s in rows}
+        assert status_by_runtime["claude_agents"] == "out of sync"
+        assert status_by_runtime["gemini_agents"] == "in sync"
+
 
 class TestRuntimeAgentNames:
     """Pin the runtime-name lookup contract directly so a future revert of the

--- a/packages/memtomem/tests/test_context_commands.py
+++ b/packages/memtomem/tests/test_context_commands.py
@@ -401,6 +401,40 @@ class TestDiffCommands:
         rows = diff_commands(tmp_path)
         assert any(status == "missing canonical" for _, _, status in rows)
 
+    def test_frontmatter_name_wins_over_stem_after_sync(self, tmp_path):
+        """Sync targets the parsed frontmatter ``name:``; diff must key
+        canonicals the same way, or a stem/name mismatch reports two phantom
+        rows per runtime that re-syncing never clears (#1229)."""
+        body = "---\nname: run-review\ndescription: Simple prompt\n---\n\nSay hi.\n"
+        _make_canonical_command(tmp_path, "review", body)  # stem != frontmatter name
+        generate_all_commands(tmp_path)
+        rows = diff_commands(tmp_path)
+        assert rows
+        assert {name for _, name, _ in rows} == {"run-review"}
+        assert all(status == "in sync" for _, _, status in rows)
+
+    def test_non_utf8_canonical_byte_does_not_abort_diff(self, tmp_path):
+        """A stray latin-1 byte must not abort the whole diff with an uncaught
+        UnicodeDecodeError — sync decodes the same file with errors='replace'
+        and succeeds, so diff must agree with what sync wrote (#1229)."""
+        root = tmp_path / CANONICAL_COMMAND_ROOT
+        root.mkdir(parents=True, exist_ok=True)
+        (root / "cafe.md").write_bytes(b"---\ndescription: caf\xe9\n---\n\nSay hi.\n")
+        generate_all_commands(tmp_path)
+        rows = diff_commands(tmp_path)
+        assert {status for _, name, status in rows if name == "cafe"} == {"in sync"}
+
+    def test_non_utf8_runtime_byte_reports_drift_not_crash(self, tmp_path):
+        """A non-UTF-8 byte in a runtime copy is drift, not a diff-wide crash
+        (#1229)."""
+        _make_canonical_command(tmp_path, "hi", SAMPLE_MINIMAL_COMMAND)
+        generate_all_commands(tmp_path)
+        (tmp_path / ".claude/commands/hi.md").write_bytes(b"caf\xe9 drift\n")
+        rows = diff_commands(tmp_path)
+        status_by_runtime = {r: s for r, _, s in rows}
+        assert status_by_runtime["claude_commands"] == "out of sync"
+        assert status_by_runtime["gemini_commands"] == "in sync"
+
 
 class TestDetectCommandDirs:
     def test_empty(self, tmp_path):

--- a/packages/memtomem/tests/test_context_skills.py
+++ b/packages/memtomem/tests/test_context_skills.py
@@ -1,5 +1,6 @@
 """Tests for context/skills.py — canonical ⇄ runtime skill fan-out."""
 
+import os
 import shutil
 
 import pytest
@@ -441,6 +442,25 @@ class TestDiffSkills:
         (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
         rows = diff_skills(tmp_path)
         assert any(status == "missing canonical" for _, _, status in rows)
+
+    @pytest.mark.skipif(
+        os.name == "nt" or os.geteuid() == 0,
+        reason="needs POSIX permissions and a non-root user",
+    )
+    def test_unreadable_runtime_file_reports_drift_not_crash(self, tmp_path):
+        """A PermissionError inside either tree must not abort the whole diff
+        — parity can't be asserted, so report drift, never mask it (#1229)."""
+        _make_canonical_skill(tmp_path, "a")
+        generate_all_skills(tmp_path)
+        manifest = tmp_path / ".claude/skills/a/SKILL.md"
+        manifest.chmod(0)
+        try:
+            rows = diff_skills(tmp_path)
+        finally:
+            manifest.chmod(0o644)
+        status_by_runtime = {runtime: status for runtime, _, status in rows}
+        assert status_by_runtime["claude_skills"] == "out of sync"
+        assert status_by_runtime["gemini_skills"] == "in sync"
 
 
 class TestRoundtrip:


### PR DESCRIPTION
## Summary

Fixes two #1229 verified findings (backend-artifacts, both **major**) in the artifact diff engine, plus one same-family guard named in the finding's evidence.

**1. Stem-vs-frontmatter-name phantom drift.** The sync engine targets the parsed frontmatter `name:` (`_sync_atomic` Phase 1 → `name_of`), but `diff_agents` / `diff_commands` keyed their canonical index by file stem / dir name. A canonical whose stem differs from its frontmatter name (e.g. `.memtomem/agents/reviewer.md` containing `name: code-reviewer`) synced correctly, then reported two phantom rows per runtime — `('reviewer', 'missing target')` + `('code-reviewer', 'missing canonical')` — forever. Re-syncing never cleared them, and the bogus `missing canonical` row invited an import that would duplicate the artifact under a second name.

**2. One non-UTF-8 byte aborted the whole diff.** The same functions read canonical and runtime files with strict UTF-8; a single stray latin-1 byte raised an uncaught `UnicodeDecodeError` (only `AgentParseError` / `CommandParseError` were caught), turning the per-type list routes into 500s and `mm context diff` into a traceback — losing status for **all** artifacts — while sync decodes the same bytes with `errors="replace"` and succeeds.

## Change

- `diff_agents` / `diff_commands` now parse each canonical **once up front** (bytes → decode `errors="replace"` → `_parse_canonical_*_text`) and key the index by the parsed name — the same identity derivation sync uses. Unreadable/unparseable canonicals keep the stem / dir-name key so their `parse error` row still names the file (existing wire statuses unchanged).
- Runtime-side reads use the same lenient decode; an undecodable byte now degrades to a per-artifact `out of sync` (matching what sync actually wrote). `OSError` on a runtime read also reports `out of sync` — parity can't be asserted, so report drift, never mask it (the existing unreadable-override contract).
- Same-family guard (named in the finding's evidence): `diff_skills` no longer lets a `PermissionError` from `_skill_effective_equal`'s `read_bytes` abort the whole skills diff — the comparison is guarded per artifact with the same drift-not-crash contract.

Side benefit: each canonical is parsed once per diff call instead of once per generator.

## Tests

- 7 new regression tests; all fail pre-fix (phantom rows / `UnicodeDecodeError` / `PermissionError`) and pass post-fix:
  - `test_frontmatter_name_wins_over_stem_after_sync` (agents / commands): sync then diff → single name, all `in sync`.
  - `test_non_utf8_canonical_byte_does_not_abort_diff` (agents / commands): `0xe9` byte in canonical → diff agrees with what sync wrote.
  - `test_non_utf8_runtime_byte_reports_drift_not_crash` (agents / commands): corrupted runtime copy → `out of sync`, others untouched.
  - `test_unreadable_runtime_file_reports_drift_not_crash` (skills, POSIX non-root only): chmod-0 runtime manifest → `out of sync`, no crash.
- Full suite (`-m "not ollama"`): 6089 passed; the only failures are pre-existing `test_session_tracing` config-rollback cases that reproduce identically on a clean `origin/main` checkout (environment-dependent, unrelated to this change). `ruff` clean; `mypy` on the three changed files: clean.

Part of #1229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
