### PR TITLE
fix(context): degrade malformed settings input to per-target error status (#1229)

### DIFF
--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -62,6 +62,19 @@ CANONICAL_SETTINGS_FILE = ".memtomem/settings.json"
 
 # Sentinel for malformed JSON detection (identity-compared via ``is``)
 _MALFORMED = object()
+
+
+class MalformedSettingsError(ValueError):
+    """A settings document carries a structurally unusable value (e.g.
+    ``hooks`` as a JSON array instead of a record keyed by event name).
+
+    Raised by the merge layer instead of silently coercing — coercion
+    destroyed the user's hook configuration and wrote it back with
+    ``status="ok"`` (#1229). Engine callers convert it to a per-target
+    ``status="error"`` so the file is never rewritten destructively.
+    """
+
+
 _KIMI_TOML_TEXT_KEY = "__memtomem_kimi_config_toml__"
 _KIMI_BEGIN = "# BEGIN memtomem managed hooks"
 _KIMI_END = "# END memtomem managed hooks"
@@ -327,14 +340,28 @@ def _merge_hooks_record(
     :func:`_ensure_gemini_handler_names`).
     """
     warnings: list[str] = []
+    if existing is not None and not isinstance(existing, dict):
+        raise MalformedSettingsError(
+            f"settings root must be a JSON object, found {type(existing).__name__}"
+        )
     merged = dict(existing) if existing else {}
 
     contrib_hooks: dict = contributions.get("hooks", {})
     if not isinstance(contrib_hooks, dict):
         contrib_hooks = {}
-    existing_hooks: dict = dict(merged.get("hooks", {}))
-    if not isinstance(existing_hooks, dict):
-        existing_hooks = {}
+    raw_hooks = merged.get("hooks", {})
+    if raw_hooks is None:
+        raw_hooks = {}
+    if not isinstance(raw_hooks, dict):
+        # Type-check BEFORE coercing: ``dict()`` over a list of rule dicts
+        # silently turns e.g. [{"matcher": ..., "hooks": [...]}] into the
+        # garbage {"matcher": "hooks"}, which then overwrites the user's
+        # entire hook configuration with status="ok" (#1229). Refuse loudly
+        # — the engine degrades this to a per-target error status.
+        raise MalformedSettingsError(
+            f"'hooks' must be a record keyed by event name, found {type(raw_hooks).__name__}"
+        )
+    existing_hooks: dict = dict(raw_hooks)
 
     for event, rules in contrib_hooks.items():
         if not isinstance(rules, list):
@@ -343,7 +370,16 @@ def _merge_hooks_record(
             existing_hooks[event] = list(rules)
             continue
 
-        existing_rules: list = list(existing_hooks[event])
+        # Same loud-refusal contract one level down: ``list()`` over a dict
+        # event value yields its key strings (written back as "rules"), and
+        # over a scalar raises TypeError past the MalformedSettingsError
+        # catch (Codex review on #1229).
+        raw_rules = existing_hooks[event]
+        if not isinstance(raw_rules, list):
+            raise MalformedSettingsError(
+                f"'hooks.{event}' must be a list of rules, found {type(raw_rules).__name__}"
+            )
+        existing_rules: list = list(raw_rules)
         contrib_rules: list[dict] = [r for r in rules if isinstance(r, dict)]
         # Contributions queued per matcher (FIFO, order preserved) so each
         # memtomem-owned slot consumes exactly one — never double-replacing or
@@ -1004,11 +1040,22 @@ def host_write_targets(project_root: Path, *, scope: str) -> list[Path]:
 
 
 def _safe_load_json(path: Path) -> dict | object:
-    """Load JSON from *path*, returning :data:`_MALFORMED` on parse error."""
+    """Load JSON from *path*, returning :data:`_MALFORMED` on parse error,
+    unreadable file, or a valid-JSON root that is not an object.
+
+    The non-dict root case matters: a settings file containing ``[]`` /
+    ``"text"`` / ``42`` used to flow into the merge layer and raise
+    ``AttributeError`` deep inside it, aborting EVERY runtime instead of
+    degrading to one target's ``status="error"`` (#1229).
+    ``settings_doctor._load_settings_dict`` and the web ``_compare_hooks``
+    already treat non-dict roots as malformed in-band — this brings the
+    sync/diff engine in line.
+    """
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return _MALFORMED
+    return raw if isinstance(raw, dict) else _MALFORMED
 
 
 def _read_with_mtime(path: Path) -> tuple[dict | None | object, int]:
@@ -1033,10 +1080,12 @@ def _read_settings_target(name: str, path: Path) -> tuple[dict | None | object, 
     if not path.is_file():
         return None, 0
     mtime_ns = path.stat().st_mtime_ns
-    text = path.read_text(encoding="utf-8")
     try:
+        text = path.read_text(encoding="utf-8")
         tomllib.loads(text)
-    except tomllib.TOMLDecodeError:
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError):
+        # Unreadable / undecodable / unparseable: degrade to the same
+        # per-target error status as malformed JSON targets (#1229).
         return _MALFORMED, mtime_ns
     return {_KIMI_TOML_TEXT_KEY: text}, mtime_ns
 
@@ -1124,7 +1173,8 @@ def generate_all_settings(
         if raw is _MALFORMED:
             results[name] = SettingsSyncResult(
                 status="error",
-                reason=f"{canonical_path} is not valid JSON. Fix the file manually.",
+                reason=f"{canonical_path} is not valid JSON (or not a JSON object). "
+                f"Fix the file manually.",
             )
             continue
         contributions: dict = raw  # type: ignore[assignment]
@@ -1171,15 +1221,25 @@ def generate_all_settings(
                     syntax_label = "TOML" if name == "kimi_settings" else "JSON"
                     results[name] = SettingsSyncResult(
                         status="error",
-                        reason=f"{target_path} is not valid {syntax_label}. "
-                        f"Fix the file manually, then re-run "
+                        reason=f"{target_path} is not valid {syntax_label} "
+                        f"(or not an object). Fix the file manually, then re-run "
                         f"`mm context sync --include=settings`.",
                     )
                     continue
                 existing: dict | None = existing_raw  # type: ignore[assignment]
 
-                # Step 2: merge in memory
-                merged, warnings = gen.merge(existing, contributions)
+                # Step 2: merge in memory. A structurally unusable target
+                # value (e.g. array-format hooks) degrades to this target's
+                # error status — the file is never rewritten (#1229).
+                try:
+                    merged, warnings = gen.merge(existing, contributions)
+                except MalformedSettingsError as exc:
+                    results[name] = SettingsSyncResult(
+                        status="error",
+                        reason=f"{target_path}: {exc}. Fix the file manually, "
+                        f"then re-run `mm context sync --include=settings`.",
+                    )
+                    continue
 
                 # Step 3: mtime check (concurrent-write guard)
                 if target_path.is_file() and target_path.stat().st_mtime_ns != existing_mtime_ns:
@@ -1246,7 +1306,7 @@ def diff_settings(
         if raw is _MALFORMED:
             results[name] = SettingsSyncResult(
                 status="error",
-                reason=f"{canonical_path} is not valid JSON",
+                reason=f"{canonical_path} is not valid JSON (or not a JSON object)",
             )
             continue
         contributions: dict = raw  # type: ignore[assignment]
@@ -1263,12 +1323,19 @@ def diff_settings(
             syntax_label = "TOML" if name == "kimi_settings" else "JSON"
             results[name] = SettingsSyncResult(
                 status="error",
-                reason=f"{target_path} is not valid {syntax_label}",
+                reason=f"{target_path} is not valid {syntax_label} (or not an object)",
             )
             continue
         existing: dict | None = existing_raw  # type: ignore[assignment]
 
-        merged, warnings = gen.merge(existing, contributions)
+        try:
+            merged, warnings = gen.merge(existing, contributions)
+        except MalformedSettingsError as exc:
+            results[name] = SettingsSyncResult(
+                status="error",
+                reason=f"{target_path}: {exc}",
+            )
+            continue
 
         if existing is not None:
             existing_norm = _normalize_settings_target(name, existing)
@@ -1299,6 +1366,7 @@ __all__ = [
     "CodexSettingsGenerator",
     "GeminiSettingsGenerator",
     "KimiSettingsGenerator",
+    "MalformedSettingsError",
     "SETTINGS_GENERATORS",
     "SettingsGenerator",
     "SettingsSyncResult",

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -529,6 +529,119 @@ class TestClaudeSettingsMergeMalformed:
         assert r.status == "error"
         assert "not valid JSON" in r.reason
 
+    def test_non_dict_json_canonical_returns_error(self, claude_home, tmp_path):
+        """Valid JSON whose root is not an object used to AttributeError deep
+        inside the merge layer, aborting every runtime (#1229)."""
+        _make_canonical_settings(tmp_path, "[]\n")
+        results = generate_all_settings(tmp_path, scope="user")
+        r = results["claude_settings"]
+        assert r.status == "error"
+        assert "not a JSON object" in r.reason
+
+    def test_non_dict_json_target_returns_error_and_preserves_file(self, claude_home, tmp_path):
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text('"just a string"\n', encoding="utf-8")
+
+        _make_canonical_settings(tmp_path, {"hooks": {}})
+        results = generate_all_settings(tmp_path, scope="user")
+        r = results["claude_settings"]
+        assert r.status == "error"
+        assert target.read_text(encoding="utf-8") == '"just a string"\n'
+
+    def test_list_shaped_hooks_target_returns_error_and_preserves_file(self, claude_home, tmp_path):
+        """Array-format hooks used to be silently destroyed: dict() over the
+        rule list coerced [{"matcher": ..., "hooks": [...]}] into the garbage
+        {"matcher": "hooks"} and wrote it back with status="ok" (#1229)."""
+        original = json.dumps(
+            {"hooks": [{"matcher": "Edit|Write", "hooks": [{"type": "command"}]}]}
+        )
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(original, encoding="utf-8")
+
+        _make_canonical_settings(tmp_path, {"hooks": {"PreToolUse": [_rule("Bash")]}})
+        results = generate_all_settings(tmp_path, scope="user")
+        r = results["claude_settings"]
+        assert r.status == "error"
+        assert "record keyed by event name" in r.reason
+        # The user's hook configuration must survive untouched.
+        assert target.read_text(encoding="utf-8") == original
+
+    def test_list_shaped_hooks_with_three_key_rules_returns_error(self, claude_home, tmp_path):
+        """Rules with != 2 keys made the same dict() coercion raise ValueError,
+        crashing the whole fan-out instead of erroring one target (#1229)."""
+        original = json.dumps(
+            {"hooks": [{"matcher": "Bash", "hooks": [], "comment": "three keys"}]}
+        )
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(original, encoding="utf-8")
+
+        _make_canonical_settings(tmp_path, {"hooks": {}})
+        results = generate_all_settings(tmp_path, scope="user")
+        r = results["claude_settings"]
+        assert r.status == "error"
+        assert target.read_text(encoding="utf-8") == original
+
+    def test_dict_shaped_event_value_returns_error_and_preserves_file(self, claude_home, tmp_path):
+        """A record-format hooks whose EVENT value is a dict (not a list)
+        used to be coerced by list() into its key strings and written back as
+        "rules" with status="ok" (Codex review on #1229)."""
+        original = json.dumps(
+            {"hooks": {"PreToolUse": {"matcher": "Bash", "hooks": [{"type": "command"}]}}}
+        )
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(original, encoding="utf-8")
+
+        _make_canonical_settings(tmp_path, {"hooks": {"PreToolUse": [_rule("Bash")]}})
+        results = generate_all_settings(tmp_path, scope="user")
+        r = results["claude_settings"]
+        assert r.status == "error"
+        assert "'hooks.PreToolUse' must be a list" in r.reason
+        assert target.read_text(encoding="utf-8") == original
+
+    def test_scalar_event_value_returns_error_not_crash(self, claude_home, tmp_path):
+        """A scalar event value made list() raise TypeError past the
+        MalformedSettingsError catch, crashing the whole fan-out (Codex
+        review on #1229)."""
+        original = json.dumps({"hooks": {"PreToolUse": 5}})
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(original, encoding="utf-8")
+
+        _make_canonical_settings(tmp_path, {"hooks": {"PreToolUse": [_rule("Bash")]}})
+        results = generate_all_settings(tmp_path, scope="user")
+        r = results["claude_settings"]
+        assert r.status == "error"
+        assert target.read_text(encoding="utf-8") == original
+
+    def test_diff_settings_dict_shaped_event_value_returns_error(self, claude_home, tmp_path):
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(
+            json.dumps({"hooks": {"PreToolUse": {"matcher": "", "hooks": []}}}),
+            encoding="utf-8",
+        )
+
+        _make_canonical_settings(tmp_path, {"hooks": {"PreToolUse": [_rule("Bash")]}})
+        results = diff_settings(tmp_path, scope="user")
+        r = results["claude_settings"]
+        assert r.status == "error"
+        assert "'hooks.PreToolUse' must be a list" in r.reason
+
+    def test_diff_settings_non_dict_canonical_returns_error(self, claude_home, tmp_path):
+        _make_canonical_settings(tmp_path, "42\n")
+        results = diff_settings(tmp_path, scope="user")
+        r = results["claude_settings"]
+        assert r.status == "error"
+        assert "not a JSON object" in r.reason
+
+    def test_diff_settings_list_shaped_hooks_target_returns_error(self, claude_home, tmp_path):
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(json.dumps({"hooks": [{"matcher": "", "hooks": []}]}), encoding="utf-8")
+
+        _make_canonical_settings(tmp_path, {"hooks": {}})
+        results = diff_settings(tmp_path, scope="user")
+        r = results["claude_settings"]
+        assert r.status == "error"
+        assert "record keyed by event name" in r.reason
+
 
 class TestKimiSettingsMerge:
     def test_writes_managed_toml_block_and_preserves_existing_config(self, kimi_home, tmp_path):


### PR DESCRIPTION
## Summary

Fixes two #1229 verified findings (backend-settings, both **major**) where a malformed canonical or target settings file either silently destroyed user configuration or aborted every runtime at once.

**1. Dead isinstance guards — array-format hooks silently destroyed.** In `_merge_hooks_record`, `dict(merged.get("hooks", {}))` ran **before** the `isinstance` guard on the next line, making the guard dead code (`dict()` either returns a dict or raises). A target `settings.json` carrying `hooks` as a JSON array — the legacy/foreign shape the module docstring explicitly warns about — was silently coerced: `dict()` over a list of 2-key rule dicts yields the garbage `{"matcher": "hooks"}`, which then **overwrote the user's entire hook configuration** on sync with `status="ok"`. Rules with 1 or 3+ keys instead raised `ValueError`, crashing the whole fan-out. Same dead pattern guarded the root.

**2. `_safe_load_json` only caught `JSONDecodeError`.** A valid-JSON non-object root (`[]`, `"text"`, `42`) flowed into the merge layer and raised `AttributeError`; an unreadable file raised `OSError` out of `read_text`. Neither was caught per-target, so ALL runtimes failed — HTTP 500 on the web settings-sync route, traceback on the CLI. `settings_doctor._load_settings_dict` and the web `_compare_hooks` already handle non-dict roots in-band; the engine was the acknowledged-elsewhere gap.

## Change

- `_merge_hooks_record` type-checks raw values **before** coercion and raises the new `MalformedSettingsError` for a non-record `hooks` value (or non-object root); `generate_all_settings` and `diff_settings` catch it per target and report `status="error"` with fix-it-manually guidance — the file is never rewritten. JSON `null` hooks is explicitly tolerated as an empty record. The error propagates through all three record-format merge wrappers (Claude direct, Codex filtered, Gemini remapped). Per Codex review, the same contract applies one level down: a record-format `hooks` whose **event value** is a dict (previously coerced by `list()` into its key strings and written back as "rules") or a scalar (previously `TypeError` past the catch) now raises too.
- `_safe_load_json` returns `_MALFORMED` for `OSError` / `UnicodeDecodeError` / non-dict roots; the Kimi TOML target read gets the same guard. The existing per-target error path handles the rest. Error messages gain "(or not a JSON object)" / "(or not an object)" so the guidance stays accurate (existing `"not valid JSON"` test pins unaffected).

## Tests

All 9 new regression tests fail pre-fix (silent destruction with `status="ok"`, `ValueError`, or `AttributeError`) and pass post-fix:

- `test_list_shaped_hooks_target_returns_error_and_preserves_file` — the silent-destruction case; asserts byte-identical file afterwards.
- `test_list_shaped_hooks_with_three_key_rules_returns_error` — the crash case.
- `test_non_dict_json_canonical_returns_error`, `test_non_dict_json_target_returns_error_and_preserves_file` — non-object roots on both sides.
- `test_dict_shaped_event_value_returns_error_and_preserves_file`, `test_scalar_event_value_returns_error_not_crash` — the event-value shapes from the Codex review.
- `test_diff_settings_non_dict_canonical_returns_error`, `test_diff_settings_list_shaped_hooks_target_returns_error`, `test_diff_settings_dict_shaped_event_value_returns_error` — same holes in the diff path.

`test_context_settings.py`: 95 passed; settings web suites + settings_doctor + context routes all green. `ruff` + `mypy` clean.

Part of #1229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
