### PR TITLE
fix(context): guard settings-migrate apply with a tier pair lock + mtime recheck (#1229)

### DIFF
--- a/packages/memtomem/src/memtomem/context/settings_migrate.py
+++ b/packages/memtomem/src/memtomem/context/settings_migrate.py
@@ -23,12 +23,17 @@ from __future__ import annotations
 
 import json
 import logging
+import time
+from contextlib import ExitStack
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
-from memtomem.context._atomic import atomic_write_text
+from memtomem.context._atomic import _file_lock, _lock_path_for, atomic_write_text
 from memtomem.context.settings import (
     CANONICAL_SETTINGS_FILE,
+    _MALFORMED,
+    _SETTINGS_LOCK_BUDGET_S,
+    _read_with_mtime,
     _rule_content_equal,
     _stamp_status_markers,
     resolve_scope_path,
@@ -513,60 +518,161 @@ def apply_migration(plan: MigratePlan) -> MigrateResult:
     refused per-move: the target is not appended to and the source entry is
     not cleaned, and a human-readable note is added to
     :attr:`MigrateResult.warnings` for the CLI to surface.
+
+    Concurrency: the whole classify → target-write → source-clean transaction
+    runs while holding BOTH tiers' sidecar ``_file_lock``\\ s — the same locks
+    :func:`~memtomem.context.settings.generate_all_settings` takes for these
+    exact files (issue #1123 B3-3) — acquired in sorted ``str(lock_path)``
+    order (the pair-lock discipline of ``migrate._acquire_pair_lock``).
+    Holding the pair, not one lock at a time, is load-bearing: the source
+    clean-up is only valid while "the target carries the entry" stays true,
+    and with sequential per-tier locking two opposite-direction applies
+    starting from a duplicate state (both tiers carrying the entry, e.g.
+    after a crash between the two writes) could each classify their target
+    as ``exact`` and then each clean its own source — deleting the entry
+    from BOTH tiers. Sorted-pair acquisition cannot deadlock: every
+    pair-holder takes the same global order, and ``generate_all_settings``
+    is a strict single-lock holder (it never waits while holding), so no
+    wait cycle can form. Acquisition shares one ``_SETTINGS_LOCK_BUDGET_S``
+    budget across both locks (#1145 shape); on expiry the apply is refused
+    with a warning instead of blocking forever. The ``st_mtime_ns`` recheck
+    before each write is the same second layer ``generate_all_settings``
+    keeps: it catches a non-gateway direct disk edit that bypasses the
+    sidecar lock entirely. A tier that exists but is not readable as a JSON
+    object is refused loudly rather than treated as empty — rewriting it
+    would destroy the user's file (the apply-side analogue of the sync
+    engine's ``MalformedSettingsError`` contract).
     """
     result = MigrateResult(plan=plan)
     if plan.is_noop:
         return result
 
-    # Re-read + re-classify the target against its current on-disk state,
-    # deriving the write-set and the source-clean-set from the LIVE target
-    # rather than the plan-time snapshot.
-    target_existing = _safe_load_json_dict(plan.target_path) or {}
-    target_index = _target_rule_lookup(target_existing.get("hooks", {}))
+    retry_hint = "Re-run `mm context settings-migrate --apply` to retry."
+    heal_hint = (
+        "Re-run `mm context settings-migrate --apply` to finish the "
+        "clean-up (the target already carries the entries)."
+    )
+    # One shared deadline for BOTH sidecar-lock acquisitions, so the whole
+    # apply — not each tier — is bounded by ``_SETTINGS_LOCK_BUDGET_S``
+    # (mirrors generate_all_settings; #1145 review shape).
+    lock_deadline = time.monotonic() + _SETTINGS_LOCK_BUDGET_S
 
-    moves_to_write: list[MigrateMove] = []
+    def _lock_timeout() -> float:
+        return max(0.0, lock_deadline - time.monotonic())
+
+    # Both tier locks are held for the whole transaction, in sorted order
+    # (see the docstring). The set() dedupes the degenerate same-sidecar
+    # spelling (plan_migration rejects same-path upstream, but a symlinked
+    # alias could still collapse here — _file_lock does not nest).
+    lock_paths = sorted(
+        {_lock_path_for(plan.target_path), _lock_path_for(plan.source_path)}, key=str
+    )
     sigs_to_drop: set[HookSignature] = set()
-    for move in plan.applicable_moves:
-        status, reason = _classify_target(target_index, move.signature, _canonical_inner_of(move))
-        if status == "conflict":
-            # Drift introduced after planning: refuse this move. Appending
-            # would duplicate the matcher; cleaning source would leave the
-            # target permanently drifted from the canonical contract.
-            result.warnings.append(reason)
-            continue
-        if status == "missing":
-            # No rule under (event, matcher) at target → append it.
-            moves_to_write.append(move)
-        # status == "exact": target already carries the canonical inner —
-        # skip the append, but still drop the now-redundant source entry.
-        sigs_to_drop.add(move.signature)
+    try:
+        with ExitStack() as stack:
+            for lock_path in lock_paths:
+                stack.enter_context(_file_lock(lock_path, timeout=_lock_timeout()))
 
-    # --- Target write ---------------------------------------------------
-    if moves_to_write:
-        # ``already_at_target`` is forced False so _add_target_rules appends
-        # every move we decided to write — including a plan-time "already"
-        # move that re-classified to "missing" because the target lost the
-        # entry between plan and apply.
-        target_merged = _add_target_rules(
-            target_existing,
-            [replace(m, already_at_target=False) for m in moves_to_write],
+            # --- Target read-modify-write -------------------------------
+            # Re-read + re-classify the target against its current on-disk
+            # state, deriving the write-set and the source-clean-set from the
+            # LIVE target rather than the plan-time snapshot.
+            target_raw, target_mtime_ns = _read_with_mtime(plan.target_path)
+            if target_raw is _MALFORMED:
+                result.warnings.append(
+                    f"{plan.target_path} is not valid JSON (or not a JSON "
+                    f"object); refusing to rewrite it. Fix the file manually, "
+                    f"then re-run `mm context settings-migrate --apply`."
+                )
+                return result
+            target_existing: dict = target_raw if isinstance(target_raw, dict) else {}
+            target_index = _target_rule_lookup(target_existing.get("hooks", {}))
+
+            moves_to_write: list[MigrateMove] = []
+            for move in plan.applicable_moves:
+                status, reason = _classify_target(
+                    target_index, move.signature, _canonical_inner_of(move)
+                )
+                if status == "conflict":
+                    # Drift introduced after planning: refuse this move.
+                    # Appending would duplicate the matcher; cleaning source
+                    # would leave the target permanently drifted from the
+                    # canonical contract.
+                    result.warnings.append(reason)
+                    continue
+                if status == "missing":
+                    # No rule under (event, matcher) at target → append it.
+                    moves_to_write.append(move)
+                # status == "exact": target already carries the canonical
+                # inner — skip the append, but still drop the now-redundant
+                # source entry.
+                sigs_to_drop.add(move.signature)
+
+            if moves_to_write:
+                # mtime recheck (second layer, like generate_all_settings
+                # Step 3): catches a direct disk edit that bypassed the
+                # sidecar lock during classification. Abort the whole apply —
+                # the target was not written, so the source must not be
+                # cleaned either.
+                if (
+                    plan.target_path.is_file()
+                    and plan.target_path.stat().st_mtime_ns != target_mtime_ns
+                ):
+                    result.warnings.append(
+                        f"{plan.target_path} was modified by another process "
+                        f"during apply; nothing was written. {retry_hint}"
+                    )
+                    return result
+                # ``already_at_target`` is forced False so _add_target_rules
+                # appends every move we decided to write — including a
+                # plan-time "already" move that re-classified to "missing"
+                # because the target lost the entry between plan and apply.
+                target_merged = _add_target_rules(
+                    target_existing,
+                    [replace(m, already_at_target=False) for m in moves_to_write],
+                )
+                _write_json(plan.target_path, target_merged)
+                result.target_written = True
+
+            # --- Source clean-up (target state still pinned by our locks) -
+            if not sigs_to_drop:
+                return result
+            source_raw, source_mtime_ns = _read_with_mtime(plan.source_path)
+            if source_raw is None:
+                # Source vanished between plan and apply (rare). Source is
+                # already clean from this command's POV; leave as-is.
+                return result
+            if source_raw is _MALFORMED:
+                result.warnings.append(
+                    f"{plan.source_path} is not valid JSON (or not a JSON "
+                    f"object); the migrated entries were not cleaned from it. "
+                    f"Fix the file manually, then re-run "
+                    f"`mm context settings-migrate --apply`."
+                )
+                return result
+            source_existing: dict = source_raw  # type: ignore[assignment]
+
+            source_new = _strip_source_inner_entries(source_existing, sigs_to_drop)
+            if source_new != source_existing:
+                # Same second-layer mtime recheck as the target write above.
+                if (
+                    plan.source_path.is_file()
+                    and plan.source_path.stat().st_mtime_ns != source_mtime_ns
+                ):
+                    result.warnings.append(
+                        f"{plan.source_path} was modified by another process "
+                        f"during apply; the source was not cleaned. {heal_hint}"
+                    )
+                    return result
+                _write_json(plan.source_path, source_new)
+                result.source_written = True
+    except TimeoutError:
+        result.warnings.append(
+            f"another process held a settings tier lock past the "
+            f"{_SETTINGS_LOCK_BUDGET_S:g}s acquisition budget "
+            f"({plan.target_path} / {plan.source_path}); nothing was written. "
+            f"{retry_hint}"
         )
-        _write_json(plan.target_path, target_merged)
-        result.target_written = True
-
-    # --- Source write ---------------------------------------------------
-    if not sigs_to_drop:
-        return result
-    source_existing = _safe_load_json_dict(plan.source_path)
-    if source_existing is None:
-        # Source vanished between plan and apply (rare). Source is already
-        # clean from this command's POV; leave as-is.
-        return result
-
-    source_new = _strip_source_inner_entries(source_existing, sigs_to_drop)
-    if source_new != source_existing:
-        _write_json(plan.source_path, source_new)
-        result.source_written = True
 
     return result
 

--- a/packages/memtomem/tests/test_settings_migrate.py
+++ b/packages/memtomem/tests/test_settings_migrate.py
@@ -749,3 +749,289 @@ class TestApplyTimeDrift:
 
         assert result.exit_code == 1
         assert "PostToolUse:Edit|Write" in result.output
+
+
+class TestApplyConcurrencyGuards:
+    """apply_migration's classify → write → clean transaction runs while
+    holding BOTH tiers' sidecar ``_file_lock``\\ s — the same locks
+    ``generate_all_settings`` takes for these files (#1123 B3-3; #1229
+    catalog) — acquired in sorted order (pair-lock discipline), with the
+    ``st_mtime_ns`` recheck kept as a second layer against direct disk
+    edits, a shared acquisition budget so a held lock aborts instead of
+    blocking forever (#1145 shape), and a loud refusal to rewrite a
+    malformed tier."""
+
+    def _plan(self, project_root, fake_home) -> MigratePlan:
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        assert plan.applicable_moves
+        return plan
+
+    def test_apply_holds_both_tier_locks_across_transaction(
+        self, project_root, fake_home, monkeypatch
+    ):
+        """BOTH sidecar locks are acquired (sorted order, nested) before any
+        write and released only after all writes — holding the pair is what
+        makes the source clean-up decision safe (see the opposite-direction
+        regression below)."""
+        import contextlib
+
+        from memtomem.context import settings_migrate as migrate_mod
+        from memtomem.context._atomic import _lock_path_for
+
+        plan = self._plan(project_root, fake_home)
+        events: list[str] = []
+        orig_file_lock = migrate_mod._file_lock
+        orig_write_json = migrate_mod._write_json
+
+        @contextlib.contextmanager
+        def spy_file_lock(lock_path, *, timeout=None):
+            events.append(f"enter:{lock_path.name}")
+            with orig_file_lock(lock_path, timeout=timeout):
+                yield
+            events.append(f"exit:{lock_path.name}")
+
+        def spy_write_json(path, data):
+            events.append(f"write:{path.name}")
+            return orig_write_json(path, data)
+
+        monkeypatch.setattr(migrate_mod, "_file_lock", spy_file_lock)
+        monkeypatch.setattr(migrate_mod, "_write_json", spy_write_json)
+
+        result = apply_migration(plan)
+        assert result.target_written is True
+        assert result.source_written is True
+
+        first_lock, second_lock = [
+            p.name
+            for p in sorted(
+                [_lock_path_for(plan.target_path), _lock_path_for(plan.source_path)],
+                key=str,
+            )
+        ]
+        writes = [i for i, e in enumerate(events) if e.startswith("write:")]
+        assert writes  # both tier writes happened
+        # Sorted acquisition, nested release (ExitStack unwinds in reverse).
+        assert events.index(f"enter:{first_lock}") < events.index(f"enter:{second_lock}")
+        assert events.index(f"exit:{second_lock}") < events.index(f"exit:{first_lock}")
+        # Every write happens while BOTH locks are held.
+        assert events.index(f"enter:{second_lock}") < min(writes)
+        assert max(writes) < events.index(f"exit:{second_lock}")
+
+    def test_held_target_lock_aborts_within_budget(self, project_root, fake_home, monkeypatch):
+        """A foreign holder of the target sidecar (e.g. a concurrent
+        ``mm context sync --include=settings``) makes apply abort cleanly
+        within the budget — nothing written, warning surfaced (exit 1 via
+        the existing CLI warnings plumbing)."""
+        from memtomem.context import settings_migrate as migrate_mod
+        from memtomem.context._atomic import _file_lock, _lock_path_for
+
+        plan = self._plan(project_root, fake_home)
+        source_before = _read_settings(plan.source_path)
+        monkeypatch.setattr(migrate_mod, "_SETTINGS_LOCK_BUDGET_S", 0.2)
+        # Separate fd in the same process contends (portalocker locks are
+        # per open-file-description).
+        with _file_lock(_lock_path_for(plan.target_path)):
+            result = apply_migration(plan)
+
+        assert result.target_written is False
+        assert result.source_written is False
+        assert any("held a settings tier lock" in w for w in result.warnings)
+        assert not plan.target_path.exists()
+        assert _read_settings(plan.source_path) == source_before
+
+    def test_held_source_lock_aborts_whole_apply(self, project_root, fake_home, monkeypatch):
+        """A held SOURCE lock aborts the whole apply — both locks are needed
+        before anything is written, so nothing moves and nothing is cleaned
+        (no half-applied state to heal)."""
+        from memtomem.context import settings_migrate as migrate_mod
+        from memtomem.context._atomic import _file_lock, _lock_path_for
+
+        plan = self._plan(project_root, fake_home)
+        source_before = _read_settings(plan.source_path)
+        monkeypatch.setattr(migrate_mod, "_SETTINGS_LOCK_BUDGET_S", 0.2)
+        with _file_lock(_lock_path_for(plan.source_path)):
+            result = apply_migration(plan)
+
+        assert result.target_written is False
+        assert result.source_written is False
+        assert any("held a settings tier lock" in w for w in result.warnings)
+        assert not plan.target_path.exists()
+        assert _read_settings(plan.source_path) == source_before
+
+    def test_aborts_on_target_mtime_change(self, project_root, fake_home):
+        """A direct disk edit landing on the target between migrate's read and
+        write (bypassing the sidecar lock) trips the ``st_mtime_ns`` recheck:
+        nothing is written, the concurrent edit survives intact."""
+        import os
+        import unittest.mock
+
+        from memtomem.context import settings_migrate as migrate_mod
+
+        plan = self._plan(project_root, fake_home)
+        source_before = _read_settings(plan.source_path)
+        concurrent = {"hooks": {}, "_concurrent": True}
+        orig_read = migrate_mod._read_with_mtime
+
+        def patched_read(path):
+            result = orig_read(path)
+            if path == plan.target_path:
+                _write_settings(plan.target_path, concurrent)
+                # Bump explicitly so the simulated concurrent write is
+                # distinguishable regardless of OS timer granularity (same
+                # discipline as the generate_all_settings mtime-abort test).
+                st = plan.target_path.stat()
+                os.utime(plan.target_path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+            return result
+
+        with unittest.mock.patch.object(migrate_mod, "_read_with_mtime", patched_read):
+            result = apply_migration(plan)
+
+        assert result.target_written is False
+        assert result.source_written is False
+        assert any("modified by another process" in w for w in result.warnings)
+        # The concurrent edit was NOT clobbered, the source NOT cleaned.
+        assert _read_settings(plan.target_path) == concurrent
+        assert _read_settings(plan.source_path) == source_before
+
+    def test_aborts_on_source_mtime_change_after_target_write(self, project_root, fake_home):
+        """Same second layer on the source clean-up: a direct edit during the
+        strip computation survives; only the clean-up is refused (the target
+        write already landed and stays)."""
+        import os
+        import unittest.mock
+
+        from memtomem.context import settings_migrate as migrate_mod
+
+        plan = self._plan(project_root, fake_home)
+        concurrent = _settings_doc(_bundled_hook())
+        concurrent["_concurrent"] = True
+        orig_read = migrate_mod._read_with_mtime
+
+        def patched_read(path):
+            result = orig_read(path)
+            if path == plan.source_path:
+                _write_settings(plan.source_path, concurrent)
+                st = plan.source_path.stat()
+                os.utime(plan.source_path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+            return result
+
+        with unittest.mock.patch.object(migrate_mod, "_read_with_mtime", patched_read):
+            result = apply_migration(plan)
+
+        assert result.target_written is True
+        assert result.source_written is False
+        assert any("modified by another process" in w for w in result.warnings)
+        assert _read_settings(plan.source_path) == concurrent
+
+    def test_malformed_target_refused_nothing_written(self, project_root, fake_home):
+        """A target tier that exists but is not a JSON object is never
+        rewritten — treating it as empty would replace the user's file with
+        just the migrated rules (the apply-side analogue of the sync engine's
+        ``MalformedSettingsError`` refusal)."""
+        plan = self._plan(project_root, fake_home)
+        source_before = _read_settings(plan.source_path)
+        plan.target_path.parent.mkdir(parents=True, exist_ok=True)
+        # VALID JSON whose root is not an object — the sneakier flavor
+        # (the source-side test below covers the decode-error flavor).
+        plan.target_path.write_text("[1, 2]", encoding="utf-8")
+
+        result = apply_migration(plan)
+
+        assert result.target_written is False
+        assert result.source_written is False
+        assert any("not valid JSON" in w for w in result.warnings)
+        assert plan.target_path.read_text(encoding="utf-8") == "[1, 2]"
+        assert _read_settings(plan.source_path) == source_before
+
+    def test_malformed_source_warns_and_is_left_alone(self, project_root, fake_home):
+        """A source tier corrupted after planning blocks only the clean-up:
+        the target write proceeds, the corrupt source is left byte-identical,
+        and the warning says the entries were not cleaned (previously this
+        case was silent)."""
+        plan = self._plan(project_root, fake_home)
+        plan.source_path.write_text("[1, 2", encoding="utf-8")
+
+        result = apply_migration(plan)
+
+        assert result.target_written is True
+        assert result.source_written is False
+        assert any("not cleaned" in w for w in result.warnings)
+        assert plan.source_path.read_text(encoding="utf-8") == "[1, 2"
+
+    def test_opposite_direction_applies_cannot_clean_both_tiers(self, project_root, fake_home):
+        """Codex review blocker on the first cut of this fix: with sequential
+        per-tier locking, two opposite-direction applies starting from a
+        duplicate state (both tiers carry the entry, e.g. after a crash
+        between migrate's two writes) could BOTH classify their target as
+        ``exact`` and then each clean its own source — deleting the entry
+        from both tiers. The pair lock forces the whole classify→clean
+        transaction to serialize, so the second apply re-classifies against
+        the first one's outcome and exactly one tier keeps the entry.
+
+        The barrier rendezvous in ``_target_rule_lookup`` (called once per
+        apply, right after the locked target read) deterministically forces
+        the broken interleaving when it is possible: under sequential locks
+        both threads classify together, then both clean. Under the pair lock
+        the second thread cannot even reach classification until the first
+        releases, so the barrier times out (broken) and both proceed
+        serialized."""
+        import threading
+        import unittest.mock
+
+        from memtomem.context import settings_migrate as migrate_mod
+
+        _write_canonical(project_root, _bundled_hook())
+        user_path = fake_home / ".claude" / "settings.json"
+        local_path = project_root / ".claude" / "settings.local.json"
+        # Duplicate state: BOTH tiers carry the canonical entry.
+        _write_settings(user_path, _settings_doc(_bundled_hook()))
+        _write_settings(local_path, _settings_doc(_bundled_hook()))
+
+        plan_ab = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        plan_ba = plan_migration(project_root, source_scope="project_local", target_scope="user")
+        assert plan_ab.applicable_moves and plan_ba.applicable_moves
+
+        barrier = threading.Barrier(2)
+        orig_lookup = migrate_mod._target_rule_lookup
+
+        def rendezvous_lookup(target_hooks):
+            try:
+                barrier.wait(timeout=1.5)
+            except threading.BrokenBarrierError:
+                pass
+            return orig_lookup(target_hooks)
+
+        results: dict[str, MigrateResult] = {}
+        errors: list[BaseException] = []
+
+        def run(name: str, plan: MigratePlan) -> None:
+            try:
+                results[name] = apply_migration(plan)
+            except BaseException as exc:  # surfaced via the errors list
+                errors.append(exc)
+
+        with unittest.mock.patch.object(migrate_mod, "_target_rule_lookup", rendezvous_lookup):
+            t1 = threading.Thread(target=run, args=("ab", plan_ab))
+            t2 = threading.Thread(target=run, args=("ba", plan_ba))
+            t1.start()
+            t2.start()
+            t1.join(timeout=30)
+            t2.join(timeout=30)
+
+        assert not t1.is_alive() and not t2.is_alive()
+        assert not errors
+        assert set(results) == {"ab", "ba"}
+
+        def _has_entry(path) -> bool:
+            doc = _read_settings(path)
+            return any(
+                i.get("command") == "mm session start"
+                for r in doc.get("hooks", {}).get("PostToolUse", [])
+                for i in r.get("hooks", [])
+                if isinstance(i, dict)
+            )
+
+        # Exactly ONE tier still carries the canonical entry — never zero.
+        assert [_has_entry(user_path), _has_entry(local_path)].count(True) == 1


### PR DESCRIPTION
## Summary

Fixes the #1229 catalog **major** finding (idx 63): `apply_migration` did a plain load → mutate → atomic-write on both settings tiers with no lock and no staleness check, while `mm context sync --include=settings` (CLI/MCP/Web) writes the same files under the per-target sidecar lock (#1123 B3-3). A sync landing inside migrate's window was silently clobbered — lost update of freshly synced hook rules or of a user edit — and `settings_doctor` explicitly steers users to run migrate alongside sync, so the overlap is realistic.

## What changed

- The whole classify → target-write → source-clean transaction now runs while holding **both** tiers' sidecar locks, acquired in sorted `str(lock_path)` order (the `migrate._acquire_pair_lock` discipline), bounded by one shared `_SETTINGS_LOCK_BUDGET_S` acquisition budget (#1145 shape — abort with a warning instead of blocking forever).
- Holding the pair — not one lock at a time — is load-bearing: with sequential per-tier locking, two opposite-direction applies starting from a duplicate state (both tiers carrying the entry, e.g. after a crash between migrate's two writes) could each classify their target as `exact` and then each clean its own source, deleting the entry from **both** tiers. Caught by Codex review on the first cut of this fix; regression-pinned with a barrier-forced interleaving test that fails `[False, False]` deterministically on the sequential shape.
- The `st_mtime_ns` recheck before each write is kept as the same second layer `generate_all_settings` uses against direct disk edits that bypass the lock.
- Incidental hardening on the same two windows (call path: `apply_migration` only): a tier that exists but is not readable as a JSON object (decode error or valid-JSON non-object) is refused loudly instead of treated as empty — previously a corrupt target was clobbered with just the migrated rules, and a corrupt source skipped its clean-up silently.
- All aborts ride the existing `MigrateResult.warnings` plumbing (CLI: ⚠ lines + exit 1); no caller changes. Migrate's only user-facing surface is the CLI — no web route or MCP tool calls `plan/apply_migration`.

Deadlock analysis: every pair-holder takes the same sorted global order, and `generate_all_settings` is a strict single-lock holder that never waits while holding — no wait cycle can form. Skills/artifact/memory sidecars are disjoint files.

## Tests

`TestApplyConcurrencyGuards` (8 tests), each validated to fail on the unfixed code first:

- both-locks-held-across-the-whole-transaction spy (sorted + nested order)
- held target / held source lock → bounded abort, nothing written
- target / source `st_mtime_ns` drift → abort, the concurrent edit survives byte-identical
- malformed target (valid-JSON non-object flavor) refused; malformed source clean-up refused loudly
- opposite-direction duplicate-state interleave → the entry survives in exactly one tier

`test_settings_migrate.py` 43 passed · adjacent `test_context_settings.py` / `test_context_atomic.py` / `test_locking_contention.py` 112 passed · ruff check/format clean · mypy clean.

Part of #1229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
