### PR TITLE
fix(context): convert skill target conflicts to typed skips instead of mid-batch crashes (#1229)

### DIFF
--- a/packages/memtomem/src/memtomem/context/_skip_reasons.py
+++ b/packages/memtomem/src/memtomem/context/_skip_reasons.py
@@ -30,6 +30,15 @@ NO_PROJECT_FANOUT_FOR_RUNTIME: Final = "no_project_fanout_for_runtime"
 # orphan a worker that writes after its request already timed out (#1145 shape).
 LOCK_TIMEOUT: Final = "lock_timeout"
 
+# The fan-out destination already holds non-skill content — a directory with
+# files but no SKILL.md manifest, or a plain file — that
+# ``skills._promote_staging`` refuses to overwrite. Emitted as a typed
+# per-destination skip instead of letting the IsADirectoryError /
+# NotADirectoryError crash the sync mid-batch (#1229, which also broke the
+# project_shared all-or-nothing promote). The human reason names the
+# conflicting path so the user can remove it (or add a SKILL.md) and re-run.
+TARGET_CONFLICT: Final = "target_conflict"
+
 # Import (runtime → canonical) skip codes.
 INVALID_NAME: Final = "invalid_name"
 ALREADY_IMPORTED: Final = "already_imported"
@@ -65,6 +74,7 @@ SkipCode = Literal[
     "parse_error",
     "no_project_fanout_for_runtime",
     "lock_timeout",
+    "target_conflict",
     "invalid_name",
     "already_imported",
     "canonical_exists",

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -280,21 +280,40 @@ def _stage_skill(src: Path, dst: Path, *, strip_overrides: bool = False) -> Path
     return staging
 
 
+def _target_conflict(dst: Path) -> OSError | None:
+    """Why :func:`_promote_staging` would refuse to replace ``dst``, or ``None``.
+
+    Single source of truth for the refusal predicate, shared by the promote
+    itself and the sync/import preflights that convert the refusal into a
+    typed ``TARGET_CONFLICT`` skip — so the preflights can never drift from
+    what the promote actually enforces (#1229). An existing but EMPTY
+    non-skill directory is not a conflict (the promote replaces it).
+    """
+    if not dst.exists():
+        return None
+    if not dst.is_dir():
+        return NotADirectoryError(f"target exists and is not a directory: {dst}")
+    if not (dst / SKILL_MANIFEST).is_file() and any(dst.iterdir()):
+        return IsADirectoryError(
+            f"refusing to overwrite non-skill directory: {dst} "
+            f"(add a SKILL.md or remove the directory first)"
+        )
+    return None
+
+
 def _promote_staging(staging: Path, dst: Path) -> None:
     """Atomic-replace ``dst`` with ``staging`` (same-fs precondition).
 
     Cross-platform via :func:`os.replace`. When ``dst`` already exists,
     moves it aside first then renames staging into place; rolls back on
     any failure during the swap window (``feedback_stage_before_mutation_revert.md``).
+    Raises the :func:`_target_conflict` refusal (``NotADirectoryError`` /
+    ``IsADirectoryError``) when ``dst`` holds non-skill content.
     """
+    conflict = _target_conflict(dst)
+    if conflict is not None:
+        raise conflict
     if dst.exists():
-        if not dst.is_dir():
-            raise NotADirectoryError(f"target exists and is not a directory: {dst}")
-        if not (dst / SKILL_MANIFEST).is_file() and any(dst.iterdir()):
-            raise IsADirectoryError(
-                f"refusing to overwrite non-skill directory: {dst} "
-                f"(add a SKILL.md or remove the directory first)"
-            )
         # Move-aside name uses the same {pid}-{rand} discipline as staging
         # so concurrent runs (different pids) cannot collide.
         suffix = f"{os.getpid()}-{secrets.token_hex(3)}"
@@ -452,6 +471,18 @@ def generate_all_skills(
                     )
                     return SkillSyncResult(generated=generated, skipped=skipped)
                 for target, _gen, skill_dir, dst in work:
+                    # Preflight the promote refusal predicate while the
+                    # destination locks are held, BEFORE anything stages: a
+                    # pre-existing non-skill dst would otherwise make the
+                    # promote loop below raise mid-batch AFTER earlier
+                    # destinations were already promoted — an uncaught crash
+                    # AND a broken all-or-nothing contract (#1229). Typed
+                    # per-destination skip; the rest of the batch proceeds
+                    # (same isolation as the PARSE_ERROR skips below).
+                    conflict = _target_conflict(dst)
+                    if conflict is not None:
+                        skipped.append((skill_dir.name, str(conflict), skip_codes.TARGET_CONFLICT))
+                        continue
                     # Unreadable canonical: typed PARSE_ERROR skip rather than
                     # an exception bubbling up — symmetric with agents.py /
                     # commands.py read_bytes failure handling. Privacy block
@@ -505,7 +536,18 @@ def generate_all_skills(
                         )
 
                 for target, staging, dst in staged:
-                    _promote_staging(staging, dst)
+                    try:
+                        _promote_staging(staging, dst)
+                    except (IsADirectoryError, NotADirectoryError) as exc:
+                        # Residual race: only a NON-gateway writer (manual
+                        # shell, editor) can recreate conflicting content at
+                        # dst after the preflight above — the sidecar lock
+                        # held since before staging serializes every gateway
+                        # writer. Loud typed skip; the remaining destinations
+                        # still promote (the finally below reaps the
+                        # unconsumed staging tree).
+                        skipped.append((dst.name, str(exc), skip_codes.TARGET_CONFLICT))
+                        continue
                     generated.append((target, dst))
         finally:
             for _target, staging, _dst in staged:
@@ -579,6 +621,14 @@ def generate_all_skills(
                 )
                 continue
             with dst_lock:
+                # Preflight the promote refusal predicate (same conversion to
+                # a typed skip as the project_shared batch above, #1229) —
+                # before staging so a conflicted destination wastes no
+                # stage+scan work.
+                conflict = _target_conflict(dst)
+                if conflict is not None:
+                    skipped.append((skill_dir.name, str(conflict), skip_codes.TARGET_CONFLICT))
+                    continue
                 # Unreadable canonical: typed PARSE_ERROR skip rather than
                 # an exception bubbling up — symmetric with agents.py /
                 # commands.py read_bytes failure handling.
@@ -631,10 +681,18 @@ def generate_all_skills(
                         )
                         skipped.append((skill_dir.name, reason, code))
                     else:
-                        # 4. Promote — atomic os.replace into dst.
-                        _promote_staging(staging, dst)
-                        promoted = True
-                        generated.append((target, dst))
+                        # 4. Promote — atomic os.replace into dst. The
+                        # conflict refusal can still fire here if a
+                        # NON-gateway writer recreated content at dst after
+                        # the preflight (the held sidecar lock serializes
+                        # gateway writers only) — same typed-skip conversion.
+                        try:
+                            _promote_staging(staging, dst)
+                        except (IsADirectoryError, NotADirectoryError) as exc:
+                            skipped.append((skill_dir.name, str(exc), skip_codes.TARGET_CONFLICT))
+                        else:
+                            promoted = True
+                            generated.append((target, dst))
                 finally:
                     # 5. Cleanup. Promote consumes staging via rename, so we
                     # only remove it when something else (block/exception)
@@ -746,6 +804,16 @@ def extract_skills_to_canonical(
                 logger.warning("skip %s from %s: %s", skill_name, runtime_label, reason)
                 seen[skill_name] = runtime_label
                 continue
+            # ``--overwrite`` onto a canonical dst holding non-skill content
+            # (or a plain file) would make copy_skill's promote raise
+            # mid-import — typed skip instead (#1229). Checked for dry-run
+            # too, so the preview's skip decisions match the real run.
+            conflict = _target_conflict(dst)
+            if conflict is not None:
+                skipped.append((skill_name, str(conflict), skip_codes.TARGET_CONFLICT))
+                logger.warning("skip %s from %s: %s", skill_name, runtime_label, conflict)
+                seen[skill_name] = runtime_label
+                continue
 
             # Gate A — walk every file in the skill tree before copying.
             # One blocked file aborts the whole skill (atomic — never
@@ -802,7 +870,17 @@ def extract_skills_to_canonical(
             # mkdir + copy so the preview never mutates disk (rank-10).
             if not dry_run:
                 dst.parent.mkdir(parents=True, exist_ok=True)
-                copy_skill(skill_dir, dst)
+                try:
+                    copy_skill(skill_dir, dst)
+                except (IsADirectoryError, NotADirectoryError) as exc:
+                    # Residual race: the import path holds no locks, so any
+                    # writer can land conflicting content at dst between the
+                    # preflight above and the promote — typed skip, the
+                    # remaining imports proceed.
+                    skipped.append((skill_name, str(exc), skip_codes.TARGET_CONFLICT))
+                    logger.warning("skip %s from %s: %s", skill_name, runtime_label, exc)
+                    seen[skill_name] = runtime_label
+                    continue
             imported.append(dst)
             seen[skill_name] = runtime_label
 

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -4250,6 +4250,7 @@ document.querySelectorAll('.ctx-sync-btn').forEach(btn => {
       const emptyCanonical = generated.length === 0
         && skipped.some(s => s && s.reason_code === 'no_canonical_root');
       const lockTimeout = skipped.some(s => s && s.reason_code === 'lock_timeout');
+      const targetConflict = skipped.find(s => s && s.reason_code === 'target_conflict');
       if (emptyCanonical) {
         // ``{canonical}`` is a real path — keep the raw slug there.
         const msg = t('settings.ctx.sync_empty_canonical')
@@ -4262,6 +4263,18 @@ document.querySelectorAll('.ctx-sync-btn').forEach(btn => {
         // tiers) of the fan-out happened. Falling through to
         // ``sync_success`` would report a sync that didn't run.
         showToast(t('settings.ctx.sync_lock_timeout'), 'warning');
+      } else if (targetConflict) {
+        // A fan-out destination holds non-skill content the engine refuses
+        // to overwrite — that destination was skipped (typed
+        // ``target_conflict``) while the rest fanned out. Falling through
+        // to ``sync_success`` would hide the skip; the backend reason names
+        // the conflicting path and how to resolve it (kept raw — it carries
+        // a real filesystem path).
+        showToast(
+          t('settings.ctx.sync_target_conflict')
+            .replace('{reason}', targetConflict.reason || ''),
+          'warning',
+        );
       } else if (dropped.length) {
         // commands/agents render dropped per-field omissions — keep the
         // existing warning so the user can investigate field-level loss.

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1467,7 +1467,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=16"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=64"></script>
+  <script src="/context-gateway.js?v=65"></script>
   <script src="/context-portal.js?v=2"></script>
   <script src="/path-picker.js?v=3"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -410,6 +410,7 @@
   "settings.ctx.confirm_import_overwrite_label": "Overwrite existing stored files",
   "settings.ctx.sync_success": "Sync completed",
   "settings.ctx.sync_lock_timeout": "Sync didn't run — another process is holding a destination lock. Try again in a moment.",
+  "settings.ctx.sync_target_conflict": "Sync skipped a conflicting destination — {reason}",
   "settings.ctx.sync_dropped": "{count} field(s) dropped during sync",
   "settings.ctx.import_priority": "When the same name exists in more than one runtime, the Claude copy is imported (then Antigravity). Codex is pushed to but never read back.",
   "settings.ctx.import_result": "{imported} imported, {skipped} skipped",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -410,6 +410,7 @@
   "settings.ctx.confirm_import_overwrite_label": "기존 저장 파일 덮어쓰기",
   "settings.ctx.sync_success": "동기화 완료",
   "settings.ctx.sync_lock_timeout": "동기화가 실행되지 않았습니다 — 다른 프로세스가 대상 잠금을 잡고 있습니다. 잠시 후 다시 시도하세요.",
+  "settings.ctx.sync_target_conflict": "충돌하는 대상을 건너뛰었습니다 — {reason}",
   "settings.ctx.sync_dropped": "동기화 중 {count}개 필드가 제거됨",
   "settings.ctx.import_priority": "같은 이름이 여러 런타임에 있으면 Claude 사본을 가져오고 그다음 Antigravity 순입니다. Codex 로는 내보내기만 하고 읽어오지 않습니다.",
   "settings.ctx.import_result": "{imported}개 가져옴, {skipped}개 건너뜀",

--- a/packages/memtomem/tests/test_context_skills.py
+++ b/packages/memtomem/tests/test_context_skills.py
@@ -479,3 +479,63 @@ class TestRoundtrip:
             encoding="utf-8"
         )
         assert script == SAMPLE_SCRIPT
+
+
+class TestExtractTargetConflict:
+    """#1229: ``--overwrite`` onto a canonical destination holding non-skill
+    content used to crash extract mid-batch with IsADirectoryError (the web
+    import routes surfaced it as HTTP 500). It is now a typed
+    ``target_conflict`` skip, and the dry-run preview reports the same skip
+    so the preview matches the real run."""
+
+    def _seed_runtime_skill(self, tmp_path, name="foo"):
+        d = tmp_path / ".claude" / "skills" / name
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
+        return d
+
+    def _seed_conflicted_canonical(self, tmp_path, name="foo"):
+        canonical = tmp_path / CANONICAL_SKILL_ROOT / name
+        canonical.mkdir(parents=True)
+        (canonical / "junk.txt").write_text("keep me", encoding="utf-8")
+        return canonical
+
+    def test_overwrite_onto_non_skill_canonical_is_typed_skip(self, tmp_path):
+        self._seed_runtime_skill(tmp_path)
+        canonical = self._seed_conflicted_canonical(tmp_path)
+
+        result = extract_skills_to_canonical(tmp_path, overwrite=True)  # must not raise
+
+        assert result.imported == []
+        conflicts = [s for s in result.skipped if s[2] == "target_conflict"]
+        assert len(conflicts) == 1, result.skipped
+        assert conflicts[0][0] == "foo"
+        assert str(canonical) in conflicts[0][1]
+        # The conflicting canonical content is untouched.
+        assert (canonical / "junk.txt").read_text(encoding="utf-8") == "keep me"
+        assert not (canonical / "SKILL.md").exists()
+
+    def test_dry_run_previews_the_same_conflict_skip(self, tmp_path):
+        """dry_run parity: the preview reports the conflict exactly like the
+        real run would (rank-10 contract: skip decisions identical)."""
+        self._seed_runtime_skill(tmp_path)
+        canonical = self._seed_conflicted_canonical(tmp_path)
+
+        result = extract_skills_to_canonical(tmp_path, overwrite=True, dry_run=True)
+
+        assert result.imported == []
+        conflicts = [s for s in result.skipped if s[2] == "target_conflict"]
+        assert len(conflicts) == 1, result.skipped
+        assert (canonical / "junk.txt").read_text(encoding="utf-8") == "keep me"
+
+    def test_without_overwrite_existing_canonical_still_wins(self, tmp_path):
+        """Ordering pin: without --overwrite the long-standing
+        ``canonical_exists`` skip fires first — the conflict skip only
+        applies to the overwrite path."""
+        self._seed_runtime_skill(tmp_path)
+        self._seed_conflicted_canonical(tmp_path)
+
+        result = extract_skills_to_canonical(tmp_path, overwrite=False)
+
+        codes = [s[2] for s in result.skipped]
+        assert codes == ["canonical_exists"], result.skipped

--- a/packages/memtomem/tests/test_context_skills_staging.py
+++ b/packages/memtomem/tests/test_context_skills_staging.py
@@ -479,3 +479,167 @@ class TestLockBudget:
         other_runtimes = {rt for rt, _p in result.generated}
         assert other_runtimes, result.skipped
         assert "claude_skills" not in other_runtimes
+
+
+class TestTargetConflict:
+    """#1229: a pre-existing non-skill destination (a directory with content
+    but no SKILL.md, or a plain file) made ``_promote_staging`` raise
+    IsADirectoryError/NotADirectoryError out of ``generate_all_skills`` —
+    an uncaught mid-batch crash that also left the project_shared batch
+    partially promoted. The sync paths now preflight the same refusal
+    predicate (``_target_conflict``) under the destination locks and convert
+    it into a typed ``target_conflict`` skip; the promote calls keep a
+    residual catch for non-gateway writers landing between preflight and
+    promote (the sidecar lock only serializes gateway writers)."""
+
+    def test_project_shared_preexisting_conflict_skips_only_that_destination(
+        self, tmp_path: Path
+    ) -> None:
+        """Batch path: the conflicted destination becomes a typed skip BEFORE
+        anything is promoted; every other destination still fans out and the
+        conflicting user content is left byte-identical."""
+        _seed_canonical_skill(tmp_path, name="foo")
+        gemini_dst = SKILL_GENERATORS["gemini_skills"].target_dir(
+            tmp_path, "foo", scope="project_shared"
+        )
+        assert gemini_dst is not None
+        gemini_dst.mkdir(parents=True)
+        (gemini_dst / "notes.txt").write_text("hand-made WIP", encoding="utf-8")
+
+        result = generate_all_skills(tmp_path)  # must not raise
+
+        conflicts = [s for s in result.skipped if s[2] == skip_codes.TARGET_CONFLICT]
+        assert len(conflicts) == 1, result.skipped
+        assert conflicts[0][0] == "foo"
+        assert str(gemini_dst) in conflicts[0][1]
+        # The conflicting directory is untouched.
+        assert (gemini_dst / "notes.txt").read_text(encoding="utf-8") == "hand-made WIP"
+        assert not (gemini_dst / SKILL_MANIFEST).exists()
+        # All other runtimes promoted.
+        promoted = {rt for rt, _p in result.generated}
+        assert "gemini_skills" not in promoted
+        assert {"claude_skills", "codex_skills", "kimi_skills"} <= promoted
+        # No staging or move-aside leftovers anywhere.
+        assert not list(gemini_dst.parent.glob(".staging-*"))
+        assert not list(gemini_dst.parent.glob(".old-*"))
+
+    def test_conflict_with_plain_file_destination(self, tmp_path: Path) -> None:
+        """NotADirectoryError flavor: the destination path exists as a FILE."""
+        _seed_canonical_skill(tmp_path, name="foo")
+        kimi_dst = SKILL_GENERATORS["kimi_skills"].target_dir(
+            tmp_path, "foo", scope="project_shared"
+        )
+        assert kimi_dst is not None
+        kimi_dst.parent.mkdir(parents=True)
+        kimi_dst.write_text("i am a file, not a skill dir", encoding="utf-8")
+
+        result = generate_all_skills(tmp_path)  # must not raise
+
+        conflicts = [s for s in result.skipped if s[2] == skip_codes.TARGET_CONFLICT]
+        assert len(conflicts) == 1, result.skipped
+        assert "not a directory" in conflicts[0][1]
+        assert kimi_dst.read_text(encoding="utf-8") == "i am a file, not a skill dir"
+        promoted = {rt for rt, _p in result.generated}
+        assert "kimi_skills" not in promoted
+        assert {"claude_skills", "codex_skills", "gemini_skills"} <= promoted
+
+    def test_batch_promote_conflict_after_preflight_is_typed_skip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Residual race in the batch path: a NON-gateway writer (the sidecar
+        lock only serializes gateway writers) lands conflicting content at a
+        destination after the preflight but before the promote loop. The
+        promote refusal is converted to the same typed skip and the rest of
+        the batch still promotes — previously this exact shape crashed with
+        earlier destinations already promoted."""
+        import memtomem.context.skills as skills_mod
+
+        _seed_canonical_skill(tmp_path, name="foo")
+        gemini_dst = SKILL_GENERATORS["gemini_skills"].target_dir(
+            tmp_path, "foo", scope="project_shared"
+        )
+        assert gemini_dst is not None
+
+        orig_scan = skills_mod.scan_artifact_tree
+
+        def planting_scan(staging, **kwargs):
+            out = orig_scan(staging, **kwargs)
+            if staging.parent == gemini_dst.parent:
+                # Simulated external writer: drops content at the destination
+                # AFTER its preflight ran (staging happens after preflight)
+                # and BEFORE the promote loop (which runs after all scans).
+                gemini_dst.mkdir(parents=True, exist_ok=True)
+                (gemini_dst / "intruder.txt").write_text("external", encoding="utf-8")
+            return out
+
+        monkeypatch.setattr(skills_mod, "scan_artifact_tree", planting_scan)
+        result = generate_all_skills(tmp_path)  # must not raise
+
+        conflicts = [s for s in result.skipped if s[2] == skip_codes.TARGET_CONFLICT]
+        assert len(conflicts) == 1, result.skipped
+        assert conflicts[0][0] == "foo"
+        assert (gemini_dst / "intruder.txt").read_text(encoding="utf-8") == "external"
+        promoted = {rt for rt, _p in result.generated}
+        assert "gemini_skills" not in promoted
+        assert {"claude_skills", "codex_skills", "kimi_skills"} <= promoted
+        assert not list(gemini_dst.parent.glob(".staging-*"))
+
+    def test_user_scope_preexisting_conflict_is_typed_per_item_skip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Per-item path (non-shared scope): the conflicted destination is a
+        typed skip before any stage/scan work; other runtimes still fan out."""
+        home = tmp_path / "home"
+        home.mkdir()
+        set_home(monkeypatch, home)
+        _seed_canonical_skill(tmp_path, name="foo", scope="user")
+        claude_dst = SKILL_GENERATORS["claude_skills"].target_dir(tmp_path, "foo", scope="user")
+        assert claude_dst is not None
+        claude_dst.mkdir(parents=True)
+        (claude_dst / "notes.txt").write_text("hand-made WIP", encoding="utf-8")
+
+        result = generate_all_skills(tmp_path, scope="user")  # must not raise
+
+        conflicts = [s for s in result.skipped if s[2] == skip_codes.TARGET_CONFLICT]
+        assert len(conflicts) == 1, result.skipped
+        assert conflicts[0][0] == "foo"
+        assert (claude_dst / "notes.txt").read_text(encoding="utf-8") == "hand-made WIP"
+        assert not (claude_dst / SKILL_MANIFEST).exists()
+        promoted = {rt for rt, _p in result.generated}
+        assert "claude_skills" not in promoted
+        assert promoted, result.skipped  # other runtimes unaffected
+
+    def test_user_scope_promote_conflict_after_preflight_is_typed_skip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Residual-race catch on the per-item promote (same shape as the
+        batch-path race test above, exercising the second code path)."""
+        import memtomem.context.skills as skills_mod
+
+        home = tmp_path / "home"
+        home.mkdir()
+        set_home(monkeypatch, home)
+        _seed_canonical_skill(tmp_path, name="foo", scope="user")
+        claude_dst = SKILL_GENERATORS["claude_skills"].target_dir(tmp_path, "foo", scope="user")
+        assert claude_dst is not None
+
+        orig_scan = skills_mod.scan_artifact_tree
+
+        def planting_scan(staging, **kwargs):
+            out = orig_scan(staging, **kwargs)
+            if staging.parent == claude_dst.parent:
+                claude_dst.mkdir(parents=True, exist_ok=True)
+                (claude_dst / "intruder.txt").write_text("external", encoding="utf-8")
+            return out
+
+        monkeypatch.setattr(skills_mod, "scan_artifact_tree", planting_scan)
+        result = generate_all_skills(tmp_path, scope="user")  # must not raise
+
+        conflicts = [s for s in result.skipped if s[2] == skip_codes.TARGET_CONFLICT]
+        assert len(conflicts) == 1, result.skipped
+        assert conflicts[0][0] == "foo"
+        assert (claude_dst / "intruder.txt").read_text(encoding="utf-8") == "external"
+        promoted = {rt for rt, _p in result.generated}
+        assert "claude_skills" not in promoted
+        assert promoted, result.skipped
+        assert not list(claude_dst.parent.glob(".staging-*"))

--- a/packages/memtomem/tests/web/test_context_gateway_rank10_confirm.py
+++ b/packages/memtomem/tests/web/test_context_gateway_rank10_confirm.py
@@ -305,3 +305,53 @@ def test_section_sync_lock_timeout_skip_toasts_warning_not_success(page, mm_web_
     assert page.locator("#toast-container .toast.toast-success").count() == 0, (
         "a lock_timeout run must not toast 'Sync completed'"
     )
+
+
+def test_section_sync_target_conflict_skip_toasts_warning_not_success(
+    page, mm_web_url: str
+) -> None:
+    """#1229: a destination holding non-skill content is now a typed
+    ``target_conflict`` skip (previously the engine crashed mid-batch with
+    IsADirectoryError and the route returned HTTP 500). Same toast contract
+    as ``lock_timeout``: an HTTP-200 response whose only outcome is the
+    typed skip must warn — falling through to "Sync completed" would hide
+    the skipped destination."""
+    install_default_stubs(page)
+    _stub_skills_list(page)
+    page.route(
+        "**/api/context/skills/sync**",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "generated": [],
+                    "skipped": [
+                        {
+                            "runtime": "claude_skills",
+                            "reason": (
+                                "refusing to overwrite non-skill directory: "
+                                "/fake/.claude/skills/foo (add a SKILL.md or "
+                                "remove the directory first)"
+                            ),
+                            "reason_code": "target_conflict",
+                        }
+                    ],
+                    "canonical_root": ".memtomem/skills",
+                }
+            ),
+        ),
+    )
+    page.goto(mm_web_url)
+    _open_skills_list(page)
+
+    page.locator("#settings-ctx-skills .ctx-sync-btn[data-type='skills']").click()
+    page.wait_for_selector("#confirm-modal:not([hidden])", timeout=2_000)
+    page.locator("#confirm-ok-btn").click()
+
+    toast = page.wait_for_selector("#toast-container .toast.toast-warning", timeout=4_000)
+    text = toast.text_content() or ""
+    assert "non-skill" in text, f"warning toast should carry the conflict reason, got {text!r}"
+    assert page.locator("#toast-container .toast.toast-success").count() == 0, (
+        "a target_conflict run must not toast 'Sync completed'"
+    )


### PR DESCRIPTION
## Summary

Fixes the #1229 catalog **major** finding (idx 24): a pre-existing non-skill directory at a fan-out destination (content but no `SKILL.md` — e.g. a hand-made WIP folder, or a dir where only a `.DS_Store` survived) made `_promote_staging` raise `IsADirectoryError` out of `generate_all_skills`, uncaught on every surface: CLI traceback, web sync route HTTP 500, MCP generic internal error. In the `project_shared` batch path the promote loop had already promoted earlier destinations when a later one raised, breaking the documented all-or-nothing contract (runtime-verified: `.claude`/`.gemini`/`.agents` promoted, crash on the conflicted `.kimi` target). Worse, `diff_skills` reports exactly such a directory as `missing target`, actively steering the user into the crashing sync.

## What changed

- New shared refusal predicate `_target_conflict(dst)` — single source of truth used by `_promote_staging` (which still raises for direct callers like `copy_skill`) and by the new preflights, so the two can never drift.
- **Batch path (`project_shared`)**: every destination is preflighted under the held destination locks, before anything stages or promotes — a conflicted destination becomes a typed `target_conflict` skip naming the path; the rest of the batch still promotes. Gate A privacy blocks still abort the whole batch before any promote, so the all-or-nothing privacy contract is unchanged.
- **Per-item path (user scope)**: same preflight right after lock acquisition (no wasted stage+scan on a conflicted destination).
- Residual catch around both promote calls for non-gateway writers landing between preflight and promote — the sidecar lock only serializes gateway writers; the skip is loud, never silent.
- **Import direction (same bug shape, full-tree sweep)**: `extract_skills_to_canonical` with `--overwrite` onto a non-skill canonical destination crashed `copy_skill` mid-batch (the web import routes surfaced it as HTTP 500). Same typed skip, also evaluated under `dry_run` so the rank-10 import preview reports the same decision as a real run.
- Surface chain mirrors the `lock_timeout` precedent: `_skip_reasons.py` constant + `SkipCode` literal entry; CLI / MCP / web routes pass the typed skip through unchanged; the single-section Sync toast in `context-gateway.js` gets a `target_conflict` branch — a conflict-only result now warns with the backend reason instead of toasting "Sync completed" — with en/ko locale keys (parity-tested) and an `index.html` `?v=65` bump.

## Tests

- `test_context_skills_staging.py::TestTargetConflict` (5): batch preflight (others promote, conflicting content byte-identical, no `.staging-*`/`.old-*` leftovers), plain-file destination (`NotADirectoryError` flavor), user-scope per-item skip, and two race-residual tests that plant conflicting content via a `scan_artifact_tree` wrapper after preflight but before promote.
- `test_context_skills.py::TestExtractTargetConflict` (3): `--overwrite` conflict skip, dry-run parity, and an ordering pin that `canonical_exists` still wins without `--overwrite`.
- Playwright toast pin in `tests/web/test_context_gateway_rank10_confirm.py` mirroring the `lock_timeout` one.
- The 7 behavior tests were validated to fail (engine crash) on the unfixed code first.

Gates: skills + i18n files 124 passed · `test_web_routes_context.py` 101 passed and rank10 Playwright 7 passed (isolated runs — the rank10+routes same-session combination failure is the known pre-existing suite issue from #1227) · tests-js vitest 139 passed · ruff check/format clean · mypy clean.

Part of #1229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
