### PR TITLE
fix(context): stop emitting bool Kimi timeouts and cosmetic empty hooks keys (#1229)

### DIFF
--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -367,7 +367,11 @@ def _merge_hooks_record(
         if not isinstance(rules, list):
             continue
         if event not in existing_hooks:
-            existing_hooks[event] = list(rules)
+            # An empty contribution list only matters for events already in
+            # the target (Pass 1 prunes stale owned rules there); copying it
+            # into a target that never had the event is pure noise.
+            if rules:
+                existing_hooks[event] = list(rules)
             continue
 
         # Same loud-refusal contract one level down: ``list()`` over a dict
@@ -475,7 +479,13 @@ def _merge_hooks_record(
         else:
             del existing_hooks[event]
 
-    merged["hooks"] = existing_hooks
+    # Write the worked copy back only when the target already had the key
+    # (Pass 1/2 replacements and the stale-owned prune must land) or the merge
+    # produced content — injecting a cosmetic ``"hooks": {}`` into a target
+    # that never had one made diff report a false "out of sync" and sync
+    # rewrite the user's file just to add the empty key (#1229).
+    if "hooks" in merged or existing_hooks:
+        merged["hooks"] = existing_hooks
     return merged, warnings
 
 
@@ -718,7 +728,7 @@ def _render_kimi_hooks(contributions: dict) -> tuple[str, list[str]]:
                     f"command = {_toml_string(command)}",
                 ]
                 timeout = handler.get("timeout")
-                if isinstance(timeout, (int, float)):
+                if isinstance(timeout, (int, float)) and not isinstance(timeout, bool):
                     rows.append(f"timeout = {timeout}")
                 chunks.append("\n".join(rows))
     return "\n\n".join(chunks), warnings

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -143,7 +143,8 @@ class TestClaudeSettingsMergeSemantic:
         assert written["permissions"] == existing["permissions"]
         assert written["env"] == existing["env"]
         assert written["mcpServers"] == existing["mcpServers"]
-        assert written["hooks"] == {}
+        # No cosmetic "hooks": {} key for an empty canonical (#1229).
+        assert "hooks" not in written
 
 
 class TestClaudeSettingsMergeAdditive:
@@ -731,6 +732,104 @@ class TestKimiSettingsMerge:
         # TOML source (backslash backslash before ``bfoo``) must survive the
         # re-sync — template processing halved it to a single backslash.
         assert "\\\\bfoo" in text
+
+    def test_bool_timeout_omitted_from_rendered_toml(self, kimi_home, tmp_path):
+        """``timeout: true`` in a canonical handler must not render as
+        ``timeout = True`` — Python's ``str(True)`` is not valid TOML, and the
+        invalid write bricked the target into a permanent per-target error
+        status on every later sync and diff (#1229)."""
+        target = kimi_home / ".kimi" / "config.toml"
+        target.write_text('theme = "dark"\n', encoding="utf-8")
+        _make_canonical_settings(
+            tmp_path,
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        _rule("Bash", "echo bool", timeout=True),
+                        _rule("Bash", "echo int", timeout=5000),
+                    ]
+                }
+            },
+        )
+
+        first = generate_all_settings(tmp_path, scope="user")["kimi_settings"]
+        assert first.status == "ok"
+        text = target.read_text(encoding="utf-8")
+        assert "timeout = True" not in text  # the invalid-TOML signature
+        assert "timeout = 5000" in text  # numeric timeouts still rendered
+        parsed = tomllib.loads(text)  # whole file must stay valid TOML
+        assert [h["command"] for h in parsed["hooks"]] == ["echo bool", "echo int"]
+
+        # Pre-fix, the corrupting first sync itself reported ok and every
+        # LATER pass was bricked: re-sync and diff must stay healthy.
+        second = generate_all_settings(tmp_path, scope="user")["kimi_settings"]
+        assert second.status == "ok"
+        assert diff_settings(tmp_path, scope="user")["kimi_settings"].status == "in sync"
+
+
+class TestNoCosmeticHooksKey:
+    """Empty/absent canonical hooks must not inject a cosmetic ``"hooks": {}``
+    key into targets that never had one (#1229) — diff reported a false
+    "out of sync" and sync rewrote the user's settings file just to add it."""
+
+    @pytest.mark.parametrize("canonical", [{}, {"hooks": {}}])
+    def test_sync_does_not_inject_hooks_key(self, claude_home, tmp_path, canonical):
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(json.dumps({"model": "opus"}) + "\n", encoding="utf-8")
+        _make_canonical_settings(tmp_path, canonical)
+
+        results = generate_all_settings(tmp_path, scope="user")
+        assert results["claude_settings"].status == "ok"
+        written = _read_target(claude_home)
+        assert written["model"] == "opus"
+        assert "hooks" not in written
+
+    @pytest.mark.parametrize("canonical", [{}, {"hooks": {}}])
+    def test_diff_reports_in_sync(self, claude_home, tmp_path, canonical):
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(json.dumps({"model": "opus"}) + "\n", encoding="utf-8")
+        _make_canonical_settings(tmp_path, canonical)
+
+        results = diff_settings(tmp_path, scope="user")
+        assert results["claude_settings"].status == "in sync"
+
+    def test_preexisting_empty_hooks_key_is_kept(self, claude_home, tmp_path):
+        """A user-authored ``"hooks": {}`` key is never removed."""
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(json.dumps({"hooks": {}}) + "\n", encoding="utf-8")
+        _make_canonical_settings(tmp_path, {"hooks": {}})
+
+        assert diff_settings(tmp_path, scope="user")["claude_settings"].status == "in sync"
+        results = generate_all_settings(tmp_path, scope="user")
+        assert results["claude_settings"].status == "ok"
+        assert _read_target(claude_home)["hooks"] == {}
+
+    def test_empty_contrib_event_not_copied_into_hookless_target(self, claude_home, tmp_path):
+        """An event mapped to an empty list contributes nothing — it must not
+        materialize a hooks record in a target that never had one."""
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(json.dumps({"model": "opus"}) + "\n", encoding="utf-8")
+        _make_canonical_settings(tmp_path, {"hooks": {"PreToolUse": []}})
+
+        assert diff_settings(tmp_path, scope="user")["claude_settings"].status == "in sync"
+        generate_all_settings(tmp_path, scope="user")
+        assert "hooks" not in _read_target(claude_home)
+
+    def test_empty_contrib_event_still_prunes_owned_rules(self, claude_home, tmp_path):
+        """Guard: skipping empty contribution events applies only to events the
+        target never had — an existing event must still go through Pass 1 so
+        stale memtomem-owned rules are pruned."""
+        target = claude_home / ".claude" / "settings.json"
+        owned = _marked(_rule("Write", "mm index"), "PostToolUse")
+        user_rule = _rule("Bash", "echo user")
+        target.write_text(
+            json.dumps({"hooks": {"PostToolUse": [owned, user_rule]}}) + "\n", encoding="utf-8"
+        )
+        _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": []}})
+
+        results = generate_all_settings(tmp_path, scope="user")
+        assert results["claude_settings"].status == "ok"
+        assert _read_target(claude_home)["hooks"]["PostToolUse"] == [user_rule]
 
 
 class TestClaudeSettingsMergeConcurrent:


### PR DESCRIPTION
Two settings fan-out minors from the Context Gateway review catalog (#1229).

## 1. Kimi renderer emitted `timeout = True` — invalid TOML bricked the target

`_render_kimi_hooks` gated the timeout line on `isinstance(timeout, (int, float))`, which includes `bool`; Python renders `True`/`False` while TOML booleans must be lowercase. A canonical handler carrying `"timeout": true` produced invalid TOML: the corrupting sync itself reported `ok`, then every subsequent sync **and** diff hit `TOMLDecodeError` → `_MALFORMED` → permanent per-target `error` status ("fix the file manually" — by #1235 design the engine never rewrites a malformed target). The Gemini renderer already excluded bool for exactly this class of problem; the Kimi path now mirrors that guard, so a bool timeout renders the `[[hooks]]` row set without a timeout line.

Note: this does not self-heal an already-corrupted `config.toml` (intentional #1235 behavior) — affected users delete the `timeout = True` line or the managed block once, then sync recovers.

## 2. Empty/absent canonical hooks injected a cosmetic `"hooks": {}` key

`_merge_hooks_record` unconditionally assigned `merged["hooks"]`, so with a canonical `.memtomem/settings.json` of `{}` or `{"hooks": {}}`:

- `diff_settings` reported a false **"out of sync"** for any target without a hooks key (dashboard tile, `mm context diff`, MCP diff — all transitively), and
- running sync rewrote `~/.claude/settings.json` (and the codex/gemini targets) just to add the empty key.

The web hooks panel (`_compare_hooks`) already reported `no_hooks` for the same state, so the two surfaces disagreed. The key is now assigned only when the target already had it (Pass 1/2 replacements and stale-owned pruning still land — guarded by tests) or the merge produced content. An empty contribution event list is likewise no longer copied into a target that never had that event, while still pruning stale owned rules on events the target does have.

## Tests

- `timeout=True` + `timeout=5000` canonical: rendered TOML stays parseable, bool line omitted, numeric kept; second sync and diff stay healthy (pre-fix: bricked into `error`).
- Cosmetic-key matrix: sync no longer injects the key, diff reports "in sync" (both `{}` and `{"hooks": {}}` canonicals), pre-existing user `"hooks": {}` is kept, empty contribution events don't materialize the record but still prune owned rules.
- All new tests validated to fail against unfixed code; existing `test_preserves_unrelated_keys` updated (its `written["hooks"] == {}` assertion pinned the cosmetic-key behavior incidentally).

Part of #1229. Reviewed by Codex (SHIP, no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
