### PR TITLE
fix(context): normalize leading BOM in canonical parsers and make diff byte-exact (#1229)

### DIFF
--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -212,9 +212,12 @@ def _parse_canonical_agent_text(
     that captures bytes once to close the scan→write TOCTOU window
     (PR-E3 Codex review fold).
     """
-    # Normalize CRLF → LF so ``_FRONT_MATTER_RE`` (which anchors on ``\n``) matches
-    # files authored on Windows or by editors that emit CRLF.
-    content = content.replace("\r\n", "\n")
+    # Normalize a leading UTF-8 BOM and CRLF → LF so ``_FRONT_MATTER_RE``
+    # (which anchors at position 0 and on ``\n``) matches files authored on
+    # Windows or by editors that emit a BOM/CRLF. Exactly one leading BOM is
+    # stripped (mirroring the ``utf-8-sig`` decoder); a mid-file U+FEFF is a
+    # legitimate zero-width no-break space and is left alone.
+    content = content.removeprefix("﻿").replace("\r\n", "\n")
     m = _FRONT_MATTER_RE.match(content)
     if not m:
         raise AgentParseError(f"missing YAML frontmatter: {source}")
@@ -1072,22 +1075,21 @@ def diff_agents(
                 continue
 
             expected, _ = gen.render(agent)
-            # Lenient decode mirrors the canonical side (and sync): a stray
-            # non-UTF-8 byte means drift, not a diff-wide crash. An unreadable
-            # runtime file can't assert parity — report drift, never mask it.
+            # Byte-exact compare against what sync would write (Phase 2
+            # ``atomic_write_bytes`` of ``content.encode("utf-8")`` verbatim)
+            # — a ``.strip()`` compare reported whitespace-padded runtime
+            # files "in sync" while sync would rewrite them (#1229), and a
+            # lenient text decode collapses distinct invalid byte sequences
+            # to the same U+FFFD. Bytes cannot raise UnicodeDecodeError. An
+            # unreadable runtime file can't assert parity — report drift,
+            # never mask it.
             try:
-                actual = (
-                    target.read_bytes().decode("utf-8", errors="replace")
-                    if target.is_file()
-                    else ""
-                )
+                actual_bytes = target.read_bytes() if target.is_file() else b""
             except OSError:
                 results.append((gen_name, name, "out of sync"))
                 continue
-            if expected.strip() == actual.strip():
-                results.append((gen_name, name, "in sync"))
-            else:
-                results.append((gen_name, name, "out of sync"))
+            status = "in sync" if expected.encode("utf-8") == actual_bytes else "out of sync"
+            results.append((gen_name, name, status))
 
     return results
 

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -108,10 +108,13 @@ def _parse_canonical_command_text(
     """
     default_name = source.parent.name if layout == "dir" else source.stem
 
-    # Share agents.py's CRLF normalization — the shared ``_FRONT_MATTER_RE``
-    # anchors on ``\n`` only, so a CRLF file would otherwise parse as "no
-    # frontmatter" and silently fall through to the filename-based default.
-    content = content.replace("\r\n", "\n")
+    # Share agents.py's BOM + CRLF normalization — the shared
+    # ``_FRONT_MATTER_RE`` anchors at position 0 and on ``\n`` only, so a
+    # BOM-prefixed or CRLF file would otherwise parse as "no frontmatter" and
+    # silently fall through to the filename-based default, dropping
+    # description/model/allowed-tools while diff still reported "in sync"
+    # (#1229). Exactly one leading BOM is stripped (``utf-8-sig`` semantics).
+    content = content.removeprefix("﻿").replace("\r\n", "\n")
     m = _FRONT_MATTER_RE.match(content)
     if m is None:
         # Commands without frontmatter are tolerated — treat the whole file
@@ -498,7 +501,10 @@ _CANONICAL_DESC_LINE = re.compile(r"^description\s*:\s*(.*)$", re.MULTILINE)
 
 def _gemini_toml_to_canonical(toml_path: Path) -> str:
     """Render a canonical Markdown+YAML file from a Gemini TOML command."""
-    data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    # ``utf-8-sig`` so a BOM-prefixed Windows-authored .toml imports instead
+    # of skipping with a TOML parse error (tomllib rejects a raw BOM); it is
+    # a byte-for-byte no-op for BOM-less files.
+    data = tomllib.loads(toml_path.read_text(encoding="utf-8-sig"))
     prompt = str(data.get("prompt", ""))
     description = str(data.get("description", ""))
     body = _gemini_to_claude_body(prompt).rstrip() + "\n"
@@ -848,22 +854,21 @@ def diff_commands(
                 continue
 
             expected, _ = gen.render(cmd)
-            # Lenient decode mirrors the canonical side (and sync): a stray
-            # non-UTF-8 byte means drift, not a diff-wide crash. An unreadable
-            # runtime file can't assert parity — report drift, never mask it.
+            # Byte-exact compare against what sync would write (Phase 2
+            # ``atomic_write_bytes`` of ``content.encode("utf-8")`` verbatim)
+            # — a ``.strip()`` compare reported whitespace-padded runtime
+            # files "in sync" while sync would rewrite them (#1229), and a
+            # lenient text decode collapses distinct invalid byte sequences
+            # to the same U+FFFD. Bytes cannot raise UnicodeDecodeError. An
+            # unreadable runtime file can't assert parity — report drift,
+            # never mask it.
             try:
-                actual = (
-                    target.read_bytes().decode("utf-8", errors="replace")
-                    if target.is_file()
-                    else ""
-                )
+                actual_bytes = target.read_bytes() if target.is_file() else b""
             except OSError:
                 results.append((gen_name, name, "out of sync"))
                 continue
-            if expected.strip() == actual.strip():
-                results.append((gen_name, name, "in sync"))
-            else:
-                results.append((gen_name, name, "out of sync"))
+            status = "in sync" if expected.encode("utf-8") == actual_bytes else "out of sync"
+            results.append((gen_name, name, status))
 
     return results
 

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -167,7 +167,14 @@ def _parse_skill_description(content: str) -> str:
     so a flat-YAML scrape mirrors the same shape ``context/agents.py``
     uses. Falls back to the first non-blank body line so the UI never
     renders a blank meta header for a description-less skill.
+
+    Display-only normalization: one leading UTF-8 BOM is stripped so a
+    Windows-authored SKILL.md doesn't fall past the anchored regex and show
+    the literal frontmatter fence as its description (#1229). The skill
+    *content* served to the editor stays byte-faithful — skills fan out and
+    diff byte-exact by design.
     """
+    content = content.removeprefix("﻿")
     m = _SKILL_FRONT_MATTER_RE.match(content)
     if m:
         for line in m.group(1).splitlines():

--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -490,6 +490,23 @@ class TestDiffAgents:
         assert status_by_runtime["claude_agents"] == "out of sync"
         assert status_by_runtime["gemini_agents"] == "in sync"
 
+    def test_whitespace_only_drift_detected_and_converges(self, tmp_path, codex_home):
+        """Whitespace-only drift is real drift: sync writes render output
+        byte-exact, so diff must not ``.strip()`` it away — pre-fix a padded
+        runtime file showed "in sync" while sync would rewrite it (#1229).
+        One sync converges the drift back to "in sync"."""
+        _make_canonical_agent(tmp_path, "helper", SAMPLE_MINIMAL_AGENT)
+        generate_all_agents(tmp_path)
+        target = tmp_path / ".claude/agents/helper.md"
+        target.write_bytes(target.read_bytes() + b"\n")
+
+        status_by_runtime = {r: s for r, _, s in diff_agents(tmp_path)}
+        assert status_by_runtime["claude_agents"] == "out of sync"
+        assert status_by_runtime["gemini_agents"] == "in sync"
+
+        generate_all_agents(tmp_path)
+        assert all(s == "in sync" for _, _, s in diff_agents(tmp_path))
+
 
 class TestRuntimeAgentNames:
     """Pin the runtime-name lookup contract directly so a future revert of the
@@ -656,6 +673,44 @@ class TestCrlfParsing:
 
         assert rendered_first == rendered_second
         # And the rendered runtime file uses LF, not CRLF.
+        assert b"\r\n" not in rendered_first
+
+
+class TestBomParsing:
+    """#1229: the frontmatter regex anchors at position 0, so a leading UTF-8
+    BOM made BOM-prefixed canonical agents raise ``AgentParseError("missing
+    YAML frontmatter")`` — Windows-authored files must parse like clean ones."""
+
+    def test_bom_frontmatter_parses(self, tmp_path):
+        p = tmp_path / "bom.md"
+        p.write_bytes(b"\xef\xbb\xbf" + SAMPLE_FULL_AGENT.encode("utf-8"))
+        agent = parse_canonical_agent(p)
+        assert agent.name == "code-reviewer"
+        assert agent.model == "sonnet"
+        assert "﻿" not in agent.body
+
+    def test_mid_file_feff_preserved(self, tmp_path):
+        """Only the leading BOM is normalized — a mid-file U+FEFF is a
+        legitimate zero-width no-break space."""
+        p = tmp_path / "zwnbsp.md"
+        p.write_text(SAMPLE_MINIMAL_AGENT + "zero﻿width\n", encoding="utf-8")
+        agent = parse_canonical_agent(p)
+        assert "zero﻿width" in agent.body
+
+    def test_bom_crlf_roundtrip_is_idempotent(self, tmp_path):
+        """BOM+CRLF canonical → runtime must be byte-stable across re-syncs
+        and render BOM-free, LF-only runtime files."""
+        p = tmp_path / CANONICAL_AGENT_ROOT / "helper.md"
+        p.parent.mkdir(parents=True)
+        p.write_bytes(b"\xef\xbb\xbf" + SAMPLE_MINIMAL_AGENT.replace("\n", "\r\n").encode("utf-8"))
+
+        generate_all_agents(tmp_path, runtimes=["claude_agents"])
+        rendered_first = (tmp_path / ".claude/agents/helper.md").read_bytes()
+        generate_all_agents(tmp_path, runtimes=["claude_agents"])
+        rendered_second = (tmp_path / ".claude/agents/helper.md").read_bytes()
+
+        assert rendered_first == rendered_second
+        assert b"\xef\xbb\xbf" not in rendered_first
         assert b"\r\n" not in rendered_first
 
 

--- a/packages/memtomem/tests/test_context_commands.py
+++ b/packages/memtomem/tests/test_context_commands.py
@@ -471,6 +471,23 @@ class TestDiffCommands:
         assert status_by_runtime["claude_commands"] == "out of sync"
         assert status_by_runtime["gemini_commands"] == "in sync"
 
+    def test_whitespace_only_drift_detected_and_converges(self, tmp_path):
+        """Whitespace-only drift is real drift: sync writes render output
+        byte-exact, so diff must not ``.strip()`` it away — pre-fix a padded
+        runtime file showed "in sync" while sync would rewrite it (#1229).
+        One sync converges the drift back to "in sync"."""
+        _make_canonical_command(tmp_path, "hi", SAMPLE_MINIMAL_COMMAND)
+        generate_all_commands(tmp_path)
+        target = tmp_path / ".claude/commands/hi.md"
+        target.write_bytes(target.read_bytes() + b"\n")
+
+        status_by_runtime = {r: s for r, _, s in diff_commands(tmp_path)}
+        assert status_by_runtime["claude_commands"] == "out of sync"
+        assert status_by_runtime["gemini_commands"] == "in sync"
+
+        generate_all_commands(tmp_path)
+        assert all(s == "in sync" for _, _, s in diff_commands(tmp_path))
+
 
 class TestDetectCommandDirs:
     def test_empty(self, tmp_path):
@@ -579,3 +596,81 @@ class TestCrlfParsing:
         assert cmd.allowed_tools == ["Read", "Grep"]
         assert "$ARGUMENTS" in cmd.body
         assert "\r" not in cmd.body
+
+
+class TestBomParsing:
+    """#1229: the frontmatter regex anchors at position 0, so a BOM-prefixed
+    command parsed as frontmatter-less — description/argument-hint/
+    allowed-tools/model were SILENTLY dropped (the raw frontmatter became the
+    prompt body) while diff still reported "in sync"."""
+
+    def test_bom_frontmatter_parses(self, tmp_path):
+        p = tmp_path / CANONICAL_COMMAND_ROOT / "bom.md"
+        p.parent.mkdir(parents=True)
+        p.write_bytes(b"\xef\xbb\xbf" + SAMPLE_FULL_COMMAND.encode("utf-8"))
+        cmd = parse_canonical_command(p)
+        assert cmd.name == "bom"
+        assert cmd.description == "Review a file for issues"
+        assert cmd.argument_hint == "[file-path]"
+        assert cmd.allowed_tools == ["Read", "Grep"]
+        assert cmd.model == "sonnet"
+        assert "﻿" not in cmd.body
+
+    def test_bom_crlf_combo_parses(self, tmp_path):
+        p = tmp_path / CANONICAL_COMMAND_ROOT / "bomcrlf.md"
+        p.parent.mkdir(parents=True)
+        p.write_bytes(b"\xef\xbb\xbf" + SAMPLE_FULL_COMMAND.replace("\n", "\r\n").encode("utf-8"))
+        cmd = parse_canonical_command(p)
+        assert cmd.description == "Review a file for issues"
+        assert "\r" not in cmd.body
+        assert "﻿" not in cmd.body
+
+    def test_bom_frontmatterless_body_is_clean(self, tmp_path):
+        """The tolerated no-frontmatter branch no longer leaks the BOM into
+        the prompt body (``lstrip("\\n")`` never removed it)."""
+        p = tmp_path / CANONICAL_COMMAND_ROOT / "plain.md"
+        p.parent.mkdir(parents=True)
+        p.write_bytes(b"\xef\xbb\xbfSay hi.\n")
+        cmd = parse_canonical_command(p)
+        assert cmd.name == "plain"
+        assert cmd.body == "Say hi.\n"
+
+    def test_mid_file_feff_preserved(self, tmp_path):
+        """Only the leading BOM is normalized — a mid-file U+FEFF is a
+        legitimate zero-width no-break space."""
+        p = tmp_path / CANONICAL_COMMAND_ROOT / "zwnbsp.md"
+        p.parent.mkdir(parents=True)
+        p.write_text(SAMPLE_MINIMAL_COMMAND + "zero﻿width\n", encoding="utf-8")
+        cmd = parse_canonical_command(p)
+        assert "zero﻿width" in cmd.body
+
+    def test_bom_canonical_fans_out_metadata_and_stays_in_sync(self, tmp_path):
+        """End-to-end: BOM canonical → generate → rendered runtime file is
+        BOM-free and carries the real description (pre-fix it was dropped and
+        the BOM leaked into the body), and diff is genuinely in sync."""
+        p = tmp_path / CANONICAL_COMMAND_ROOT / "bom-e2e.md"
+        p.parent.mkdir(parents=True)
+        p.write_bytes(b"\xef\xbb\xbf" + SAMPLE_FULL_COMMAND.encode("utf-8"))
+        generate_all_commands(tmp_path)
+
+        rendered_path = tmp_path / ".claude/commands/bom-e2e.md"
+        assert b"\xef\xbb\xbf" not in rendered_path.read_bytes()
+        rendered = parse_canonical_command(rendered_path)
+        assert rendered.description == "Review a file for issues"
+        assert all(status == "in sync" for _, _, status in diff_commands(tmp_path))
+
+    def test_bom_gemini_toml_imports(self, tmp_path):
+        """tomllib rejects a raw BOM — reading Gemini TOML with ``utf-8-sig``
+        lets a BOM-prefixed Windows-authored .toml import instead of skipping
+        with a TOML parse error."""
+        d = tmp_path / ".gemini/commands"
+        d.mkdir(parents=True)
+        (d / "review.toml").write_bytes(
+            b"\xef\xbb\xbf" + b'description = "Review a file"\nprompt = "Review {{args}}."\n'
+        )
+        result = extract_commands_to_canonical(tmp_path)
+        assert len(result.imported) == 1
+        canonical = (tmp_path / CANONICAL_COMMAND_ROOT / "review" / "command.md").read_text(
+            encoding="utf-8"
+        )
+        assert "description: Review a file" in canonical

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -705,6 +705,22 @@ class TestReadSkill:
         assert r.status_code == 404
 
     @pytest.mark.anyio
+    async def test_bom_skill_description_parses(self, client: AsyncClient, tmp_path: Path):
+        """A BOM-prefixed SKILL.md must surface its frontmatter description,
+        not the literal frontmatter fence the anchored regex fell back to
+        pre-fix (#1229). The content payload stays byte-faithful."""
+        skill_dir = tmp_path / ".memtomem" / "skills" / "bom-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / SKILL_MANIFEST).write_bytes(
+            b"\xef\xbb\xbf---\ndescription: Windows-authored skill\n---\n\nBody.\n"
+        )
+        r = await client.get("/api/context/skills/bom-skill")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["fields"]["description"] == "Windows-authored skill"
+        assert data["content"].startswith("﻿")  # editor payload untouched
+
+    @pytest.mark.anyio
     async def test_auxiliary_files(self, client: AsyncClient, tmp_path: Path):
         _make_skill(tmp_path, "rich")
         scripts_dir = tmp_path / ".memtomem" / "skills" / "rich" / "scripts"


### PR DESCRIPTION
Two parse/diff minors from the Context Gateway review catalog (#1229).

## 1. Leading UTF-8 BOM made canonical files parse as frontmatter-less

The shared frontmatter regex anchors at position 0, so a BOM (common from Windows editors) pushed the match off. Impact differed by kind:

- **Commands degraded silently**: the whole file became the prompt body, `description`/`argument-hint`/`allowed-tools`/`model` were dropped without a `dropped` record, the BOM leaked into rendered runtime files as body text, and because diff re-renders from the same wrong parse, status stayed **"in sync"** — completely invisible.
- **Agents failed loudly** (`AgentParseError: missing YAML frontmatter`) — a typed skip, but still a parse failure for a file every other tool reads fine.

Both parsers now strip exactly one leading BOM (mirroring `utf-8-sig` decoder semantics) alongside the existing CRLF normalization; a mid-file U+FEFF is a legitimate zero-width no-break space and is preserved. Riders on the same bug shape, found during verification:

- the web skill-description scrape returned the literal `﻿---` fence as the display description for a BOM SKILL.md (display-only fix; the editor `content` payload stays byte-faithful — skills fan out and diff byte-exact by design), and
- the Gemini TOML import read (`tomllib` rejects a raw BOM with a parse error; reading with `utf-8-sig` lets BOM-prefixed `.toml` files import — a no-op for clean files).

Import byte-passthrough paths intentionally keep BOMs verbatim: with the parser fix, such canonicals now parse correctly instead of degrading.

## 2. `diff_agents`/`diff_commands` compared with `.strip()` — whitespace drift masked

The non-override branch reported whitespace-padded runtime files "in sync" while sync would rewrite them. This was internally inconsistent: the override branch and `_skill_effective_equal` already compare byte-exact, and sync writes render output verbatim (`content.encode("utf-8")` via `atomic_write_bytes`). The branch now compares bytes against exactly what sync would write. This also closes a second masking class introduced by the lenient text decode: two *different* invalid byte sequences both decode to U+FFFD and compared equal — bytes can't collide and can't raise `UnicodeDecodeError`.

Behavior flip is intentional and self-healing: previously-masked whitespace-only drift now reports "out of sync"; one sync converges it (pinned by tests). The non-UTF-8-canonical round trip still reports "in sync" — the canonical-side `errors='replace'` decode stays in lockstep with sync Phase 1, so the rendered U+FFFD encodes to the same bytes sync wrote.

## Tests

All new pins validated to fail against unfixed code (9 fail pre-fix; the 2 mid-file-U+FEFF preservation pins pass by design): BOM/BOM+CRLF parse for agents+commands, frontmatter-less BOM body hygiene, BOM canonical end-to-end fan-out (rendered file BOM-free with metadata intact, diff genuinely in sync), BOM Gemini TOML import, BOM SKILL.md description via web route, and whitespace-drift detect-and-converge for both diff functions.

Part of #1229. Reviewed by Codex (SHIP, no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
