### PR TITLE
fix(context): import kimi-only skills and stop surfacing crash-leftover staging dirs (#1229)

### DIFF
--- a/docs/adr/0001-context-gateway-sync-policies.md
+++ b/docs/adr/0001-context-gateway-sync-policies.md
@@ -15,14 +15,17 @@ traversal order:
 | Artifact   | Priority (first wins)                |
 |------------|--------------------------------------|
 | Agents     | `.claude/agents` → `.gemini/agents`  |
-| Skills     | `claude_skills` → `gemini_skills` → `codex_skills` (detector order) |
+| Skills     | `claude_skills` → `gemini_skills` → `codex_skills` → `kimi_skills` (detector order) |
 | Commands   | `.claude/commands` → `.gemini/commands` |
 
 Codex agents fan out to project-scope `<project>/.codex/agents/` (symmetric
 with Claude/Gemini); Codex prompts remain user-scope (`~/.codex/prompts/`,
 no project-scope equivalent). Both are **never** imported — fan-out is
 one-way (canonical → Codex) so the canonical entry stays the single source
-of truth.
+of truth. Kimi agents are likewise export-only: the YAML rendering is lossy
+(drops tools/model/skills/isolation/kind/temperature) and not
+round-trippable. Kimi *skills* are byte-identical SKILL.md trees and are
+imported (last in detector order).
 
 **Why this order:** Claude Code is the primary authoring surface in most
 memtomem workflows.  Gemini CLI is experimental and Codex is

--- a/packages/memtomem/src/memtomem/context/_names.py
+++ b/packages/memtomem/src/memtomem/context/_names.py
@@ -28,6 +28,7 @@ __all__ = [
     "InvalidNameError",
     "Layout",
     "OVERRIDE_FORMATS",
+    "is_internal_artifact_dir",
     "validate_name",
 ]
 
@@ -87,6 +88,26 @@ GENERATOR_VENDOR: dict[str, str] = {
 
 class InvalidNameError(ValueError):
     """Raised when a context-gateway name fails validation."""
+
+
+# Skill sync stages into ``.staging-<name>-<pid>-<rand>.tmp`` and moves the
+# old tree aside as ``.old-<name>-<pid>-<rand>.tmp`` (``skills._stage_skill``
+# / ``skills._promote_staging``). A SIGKILL between those steps leaves a full
+# skill tree (including SKILL.md) behind, and the composite name passes
+# :func:`validate_name` — so every discovery loop must skip these explicitly
+# or the leftover shows up as a phantom diff row and even round-trips through
+# extract back into canonical (#1229).
+_INTERNAL_DIR_RE = re.compile(r"^\.(?:staging|old)-.*\.tmp$")
+
+
+def is_internal_artifact_dir(name: str) -> bool:
+    """True for context-gateway internal staging/move-aside directory names.
+
+    These are *our own* crash artifacts, not user content — discovery loops
+    (canonical listing, runtime scans, extract, detect, status) skip them
+    silently rather than warning about an invalid name.
+    """
+    return _INTERNAL_DIR_RE.match(name) is not None
 
 
 def validate_name(s: object, *, kind: str = "name") -> str:

--- a/packages/memtomem/src/memtomem/context/_names.py
+++ b/packages/memtomem/src/memtomem/context/_names.py
@@ -92,12 +92,17 @@ class InvalidNameError(ValueError):
 
 # Skill sync stages into ``.staging-<name>-<pid>-<rand>.tmp`` and moves the
 # old tree aside as ``.old-<name>-<pid>-<rand>.tmp`` (``skills._stage_skill``
-# / ``skills._promote_staging``). A SIGKILL between those steps leaves a full
-# skill tree (including SKILL.md) behind, and the composite name passes
+# / ``skills._promote_staging``; ``<pid>`` is decimal, ``<rand>`` is
+# ``token_hex(3)`` = 6 hex chars). A SIGKILL between those steps leaves a
+# full skill tree (including SKILL.md) behind, and the composite name passes
 # :func:`validate_name` — so every discovery loop must skip these explicitly
 # or the leftover shows up as a phantom diff row and even round-trips through
-# extract back into canonical (#1229).
-_INTERNAL_DIR_RE = re.compile(r"^\.(?:staging|old)-.*\.tmp$")
+# extract back into canonical (#1229). The pattern pins the EXACT generated
+# shape including the pid+rand suffix: ``validate_name`` accepts dot-prefixed
+# ``.tmp`` names, so a looser ``.staging-*.tmp`` match would silently hide —
+# and let the sync-time reaper delete — a legitimately named user skill like
+# ``.staging-notes.tmp`` (Codex review on #1229).
+_INTERNAL_DIR_RE = re.compile(r"^\.(?:staging|old)-.+-\d+-[0-9a-f]{6}\.tmp$")
 
 
 def is_internal_artifact_dir(name: str) -> bool:
@@ -105,7 +110,10 @@ def is_internal_artifact_dir(name: str) -> bool:
 
     These are *our own* crash artifacts, not user content — discovery loops
     (canonical listing, runtime scans, extract, detect, status) skip them
-    silently rather than warning about an invalid name.
+    silently rather than warning about an invalid name, and
+    ``skills._reap_stale_internal_dirs`` deletes them under the destination
+    sidecar lock. Both sides MUST use this one predicate so "hidden" and
+    "deletable" can never drift apart.
     """
     return _INTERNAL_DIR_RE.match(name) is not None
 

--- a/packages/memtomem/src/memtomem/context/_runtime_targets.py
+++ b/packages/memtomem/src/memtomem/context/_runtime_targets.py
@@ -44,7 +44,7 @@ import logging
 from pathlib import Path
 
 from memtomem.config import TargetScope
-from memtomem.context._names import InvalidNameError, validate_name
+from memtomem.context._names import InvalidNameError, is_internal_artifact_dir, validate_name
 from memtomem.context.scope_resolver import ArtifactKind
 
 logger = logging.getLogger(__name__)
@@ -219,8 +219,15 @@ def runtime_artifact_names(
         entries = ((p.stem, p) for p in root.iterdir() if p.is_file() and p.suffix == file_suffix)
     else:
         assert dir_manifest is not None  # mypy narrow
+        # Skip our own crash-leftover staging/move-aside trees (silently —
+        # they are internal artifacts, not user content): they contain a
+        # full SKILL.md mirror and would otherwise surface as phantom
+        # "missing canonical" diff rows (#1229). Agents/commands leftovers
+        # are ``.tmp`` *files*, already excluded by the suffix match above.
         entries = (
-            (p.name, p) for p in root.iterdir() if p.is_dir() and (p / dir_manifest).is_file()
+            (p.name, p)
+            for p in root.iterdir()
+            if p.is_dir() and (p / dir_manifest).is_file() and not is_internal_artifact_dir(p.name)
         )
     for raw_name, path in entries:
         try:

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -804,8 +804,12 @@ def extract_agents_to_canonical(
     nothing touching disk.
 
     Codex TOML is **not** imported (one-way conversion; too lossy to round-trip
-    without reconstructing fields we dropped on the way out). First occurrence
-    wins across runtimes (Claude before Gemini — deterministic order).
+    without reconstructing fields we dropped on the way out). Kimi agent YAML
+    is likewise export-only: the renderer drops tools/model/skills/isolation/
+    kind/temperature and wraps description+body into
+    ``system_prompt_args.ROLE_ADDITIONAL`` — not round-trippable. First
+    occurrence wins across runtimes (Claude before Gemini — deterministic
+    order).
 
     ADR-0011 PR-E2: ``scope`` selects both the canonical destination and the
     runtime source (per-scope import — ``scope="user"`` reads

--- a/packages/memtomem/src/memtomem/context/detector.py
+++ b/packages/memtomem/src/memtomem/context/detector.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+from memtomem.context._names import is_internal_artifact_dir
+
 DetectedKind = Literal["file", "skill_dir", "agent_file", "command_file"]
 
 
@@ -138,6 +140,10 @@ def detect_skill_dirs(project_root: Path) -> list[DetectedFile]:
                 if not skill_md.is_file():
                     # Silently skip non-skill sub-directories so that users can
                     # keep auxiliary folders side-by-side with real skills.
+                    continue
+                if is_internal_artifact_dir(skill_dir.name):
+                    # Crash-leftover staging/move-aside trees from skill sync
+                    # carry a SKILL.md mirror — never count them (#1229).
                     continue
                 found.append(
                     DetectedFile(

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -310,6 +310,12 @@ def _reap_stale_internal_dirs(dst: Path) -> None:
         return
     for pattern in (f".staging-{dst.name}-*.tmp", f".old-{dst.name}-*.tmp"):
         for stale in parent.glob(pattern):
+            # The glob narrows by destination name; the shared predicate makes
+            # the kill decision — a user skill named e.g.
+            # ``.staging-<dst>-notes.tmp`` matches the glob but not the
+            # pid+rand shape and must never be deleted (Codex review, #1229).
+            if not is_internal_artifact_dir(stale.name):
+                continue
             logger.debug("reaping stale internal artifact dir %s", stale)
             shutil.rmtree(stale, ignore_errors=True)
 

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -12,7 +12,7 @@ runtime-specific directories:
 
 Anthropic released the Agent Skills spec as an open standard in 2025-12 and
 OpenAI adopted the same SKILL.md format for Codex CLI, so the on-disk payload
-is byte-identical across all three runtimes today. We still route everything
+is byte-identical across all four runtimes today. We still route everything
 through a ``SkillGenerator`` registry so Phase 2+ can introduce per-runtime
 frontmatter rewriting without touching callers.
 """
@@ -40,7 +40,12 @@ from memtomem.context._atomic import (
 )
 from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
-from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, validate_name
+from memtomem.context._names import (
+    GENERATOR_VENDOR,
+    InvalidNameError,
+    is_internal_artifact_dir,
+    validate_name,
+)
 from memtomem.context._runtime_targets import runtime_artifact_names, runtime_fanout_root
 from memtomem.context.privacy_scan import (
     raise_or_collect,
@@ -214,6 +219,12 @@ def list_canonical_skills(
     skills: list[Path] = []
     for entry in sorted(root.iterdir()):
         if entry.is_dir() and (entry / SKILL_MANIFEST).is_file():
+            if is_internal_artifact_dir(entry.name):
+                # Crash-leftover staging/move-aside trees from our own sync
+                # (#1229) — never list them as canonical skills, or the next
+                # generate fans the junk out to every runtime.
+                logger.debug("skip internal artifact dir %s", entry)
+                continue
             try:
                 validate_name(entry.name, kind="skill name")
             except InvalidNameError as exc:
@@ -278,6 +289,29 @@ def _stage_skill(src: Path, dst: Path, *, strip_overrides: bool = False) -> Path
         shutil.rmtree(staging, ignore_errors=True)
         raise
     return staging
+
+
+def _reap_stale_internal_dirs(dst: Path) -> None:
+    """Remove crash-leftover staging/move-aside trees for ``dst``.
+
+    A SIGKILL between :func:`_stage_skill` and the cleanup in
+    :func:`_promote_staging` leaves ``.staging-<name>-*.tmp`` /
+    ``.old-<name>-*.tmp`` trees behind that no later run reaps (the
+    staging-exists check only matches the new pid+rand suffix) (#1229).
+
+    Safe ONLY while holding ``_lock_path_for(dst)``: every gateway writer
+    for the same destination holds that lock across its stage→promote
+    sequence, so no live staging tree for this dst can exist while we do.
+    The extract/copy_skill path holds no locks — canonical-root leftovers
+    are handled by discovery filtering only, never by GC.
+    """
+    parent = dst.parent
+    if not parent.is_dir():
+        return
+    for pattern in (f".staging-{dst.name}-*.tmp", f".old-{dst.name}-*.tmp"):
+        for stale in parent.glob(pattern):
+            logger.debug("reaping stale internal artifact dir %s", stale)
+            shutil.rmtree(stale, ignore_errors=True)
 
 
 def _target_conflict(dst: Path) -> OSError | None:
@@ -470,6 +504,10 @@ def generate_all_skills(
                         )
                     )
                     return SkillSyncResult(generated=generated, skipped=skipped)
+                # All destination locks held — safe point to reap crash
+                # leftovers before they collide with fresh staging work.
+                for stale_dst in sorted({dst for _, _, _, dst in work}, key=str):
+                    _reap_stale_internal_dirs(stale_dst)
                 for target, _gen, skill_dir, dst in work:
                     # Preflight the promote refusal predicate while the
                     # destination locks are held, BEFORE anything stages: a
@@ -621,6 +659,8 @@ def generate_all_skills(
                 )
                 continue
             with dst_lock:
+                # Lock held — safe point to reap crash leftovers for this dst.
+                _reap_stale_internal_dirs(dst)
                 # Preflight the promote refusal predicate (same conversion to
                 # a typed skip as the project_shared batch above, #1229) —
                 # before staging so a conflicted destination wastes no
@@ -718,7 +758,7 @@ def extract_skills_to_canonical(
     """Import existing runtime skills into the scoped canonical directory.
 
     When the same skill name appears in multiple runtimes, the first one wins
-    (deterministic order: claude → gemini → codex). Existing canonical
+    (deterministic order: claude → gemini → codex → kimi). Existing canonical
     entries are preserved unless ``overwrite=True``.
 
     ``dry_run`` (rank-10 import preview) runs the full scan + name validation
@@ -772,7 +812,7 @@ def extract_skills_to_canonical(
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = []
     seen: dict[str, str] = {}  # skill_name → first runtime label
 
-    for runtime in ("claude", "gemini", "codex"):
+    for runtime in ("claude", "gemini", "codex", "kimi"):
         try:
             runtime_dir = runtime_fanout_root("skills", runtime, scope, project_root)
         except KeyError:
@@ -782,6 +822,11 @@ def extract_skills_to_canonical(
         runtime_label = f"{runtime} ({runtime_dir})"
         for skill_dir in sorted(runtime_dir.iterdir()):
             if not skill_dir.is_dir() or not (skill_dir / SKILL_MANIFEST).is_file():
+                continue
+            if is_internal_artifact_dir(skill_dir.name):
+                # Our own crash-leftover staging/move-aside trees — never
+                # import them as skills.
+                logger.debug("skip internal artifact dir %s", skill_dir)
                 continue
             skill_name = skill_dir.name
             if only_name is not None and skill_name != only_name:

--- a/packages/memtomem/src/memtomem/context/status.py
+++ b/packages/memtomem/src/memtomem/context/status.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from memtomem.config import TargetScope
+from memtomem.context._names import is_internal_artifact_dir
 from memtomem.context.agents import AGENT_DIR_FILENAME
 from memtomem.context.commands import COMMAND_DIR_FILENAME
 from memtomem.context.dirty import is_asset_dirty
@@ -248,6 +249,10 @@ def _scan_draft_tier(scope: TargetScope, project_root: Path | None) -> Iterator[
                 # Skip directories that don't satisfy the kind's
                 # manifest contract — same convention as migrate's
                 # source-scope probe.
+                continue
+            if is_internal_artifact_dir(entry.name):
+                # Crash-leftover staging/move-aside trees from skill sync —
+                # not local drafts (#1229).
                 continue
             seen_names.add(entry.name)
             yield StatusRow(

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -412,7 +412,7 @@
   "settings.ctx.sync_lock_timeout": "Sync didn't run — another process is holding a destination lock. Try again in a moment.",
   "settings.ctx.sync_target_conflict": "Sync skipped a conflicting destination — {reason}",
   "settings.ctx.sync_dropped": "{count} field(s) dropped during sync",
-  "settings.ctx.import_priority": "When the same name exists in more than one runtime, the Claude copy is imported (then Antigravity). Codex is pushed to but never read back.",
+  "settings.ctx.import_priority": "When the same name exists in more than one runtime, the first copy found is imported, scanning runtimes in a fixed order (Claude first, then Antigravity; skills also import from Codex and Kimi). Other runtimes are export-only and never read back.",
   "settings.ctx.import_result": "{imported} imported, {skipped} skipped",
   "settings.ctx.import_success": "Import completed",
   "settings.ctx.delete_success": "\"{name}\" deleted",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -412,7 +412,7 @@
   "settings.ctx.sync_lock_timeout": "동기화가 실행되지 않았습니다 — 다른 프로세스가 대상 잠금을 잡고 있습니다. 잠시 후 다시 시도하세요.",
   "settings.ctx.sync_target_conflict": "충돌하는 대상을 건너뛰었습니다 — {reason}",
   "settings.ctx.sync_dropped": "동기화 중 {count}개 필드가 제거됨",
-  "settings.ctx.import_priority": "같은 이름이 여러 런타임에 있으면 Claude 사본을 가져오고 그다음 Antigravity 순입니다. Codex 로는 내보내기만 하고 읽어오지 않습니다.",
+  "settings.ctx.import_priority": "같은 이름이 여러 런타임에 있으면 정해진 순서로 스캔해 처음 발견한 사본을 가져옵니다 (Claude 먼저, 그다음 Antigravity; 스킬은 Codex 와 Kimi 에서도 가져옵니다). 그 외 런타임으로는 내보내기만 하고 읽어오지 않습니다.",
   "settings.ctx.import_result": "{imported}개 가져옴, {skipped}개 건너뜀",
   "settings.ctx.import_success": "가져오기 완료",
   "settings.ctx.delete_success": "\"{name}\" 삭제됨",

--- a/packages/memtomem/tests/test_context_extract_scope_kwarg.py
+++ b/packages/memtomem/tests/test_context_extract_scope_kwarg.py
@@ -135,6 +135,18 @@ def test_extract_skills_project_shared_reads_project_runtime(home: Path, proj: P
         assert (proj / ".memtomem" / "skills") in p.parents
 
 
+def test_extract_skills_user_reads_kimi_user_runtime(home: Path, proj: Path) -> None:
+    """Kimi joined the skills extract order (#1229) — at user scope the
+    source is ``~/.kimi/skills`` and the destination stays user-tier."""
+    _write_skill(home / ".kimi" / "skills", "kimi_user_skill")
+
+    result = extract_skills_to_canonical(proj, scope="user")
+    names = [p.name for p in result.imported]
+    assert "kimi_user_skill" in names
+    for p in result.imported:
+        assert (home / ".memtomem" / "skills") in p.parents
+
+
 def test_extract_skills_project_local_no_fanout(home: Path, proj: Path) -> None:
     _write_skill(home / ".claude" / "skills", "user_skill")
     result = extract_skills_to_canonical(proj, scope="project_local")

--- a/packages/memtomem/tests/test_context_runtime_targets.py
+++ b/packages/memtomem/tests/test_context_runtime_targets.py
@@ -169,3 +169,29 @@ def test_runtime_artifact_names_skips_invalid_manifest_dirs(
         and getattr(record, "artifact_name") == "-bad"
         for record in caplog.records
     )
+
+
+def test_runtime_artifact_names_skips_internal_staging_dirs(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Crash-leftover staging/move-aside trees carry a SKILL.md mirror and
+    pass validate_name — the dir_manifest branch must drop them SILENTLY
+    (they are our own artifacts, not user content) so diff never shows a
+    phantom 'missing canonical' row (#1229)."""
+    good = tmp_path / ".claude" / "skills" / "ok"
+    good.mkdir(parents=True)
+    (good / "SKILL.md").write_text("", encoding="utf-8")
+    for leftover in (".staging-ok-99999-abc123.tmp", ".old-ok-99999-abc123.tmp"):
+        d = tmp_path / ".claude" / "skills" / leftover
+        d.mkdir()
+        (d / "SKILL.md").write_text("", encoding="utf-8")
+
+    names = runtime_artifact_names(
+        "skills", "claude", tmp_path, "project_shared", dir_manifest="SKILL.md"
+    )
+
+    assert names == {"ok"}
+    # Silent skip — contrast with the InvalidNameError warning path above.
+    assert not any(
+        record.message == "Skipping invalid runtime artifact name" for record in caplog.records
+    )

--- a/packages/memtomem/tests/test_context_skills.py
+++ b/packages/memtomem/tests/test_context_skills.py
@@ -58,6 +58,16 @@ class TestCanonicalDiscovery:
         (tmp_path / CANONICAL_SKILL_ROOT / "not-a-skill").mkdir(parents=True)
         assert list_canonical_skills(tmp_path) == []
 
+    def test_skips_staging_leftovers(self, tmp_path):
+        """A crashed import leaves ``.staging-*.tmp`` under the canonical
+        root with a full SKILL.md mirror — listing it would fan the junk out
+        to every runtime on the next sync (#1229)."""
+        for leftover in (".staging-a-99999-abc123.tmp", ".old-a-99999-abc123.tmp"):
+            d = tmp_path / CANONICAL_SKILL_ROOT / leftover
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
+        assert list_canonical_skills(tmp_path) == []
+
 
 class TestCopySkill:
     def test_copies_manifest_only(self, tmp_path):
@@ -301,6 +311,14 @@ class TestDetectSkillDirs:
         found = detect_skill_dirs(tmp_path)
         assert found == []
 
+    def test_ignores_staging_leftovers(self, tmp_path):
+        """Crash-leftover staging trees carry a SKILL.md mirror — they must
+        not inflate detect/init preview counts (#1229)."""
+        d = tmp_path / ".claude/skills/.staging-a-99999-abc123.tmp"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
+        assert detect_skill_dirs(tmp_path) == []
+
     def test_empty_project(self, tmp_path):
         assert detect_skill_dirs(tmp_path) == []
 
@@ -325,6 +343,62 @@ class TestExtractSkills:
         assert len(result.skipped) == 1
         assert result.skipped[0][0] == "shared"
         assert "already imported" in result.skipped[0][1]
+
+    def test_imports_from_kimi(self, tmp_path):
+        """A kimi-only skill is importable — diff reported it as 'missing
+        canonical' while the extract loop never read .kimi/skills, making
+        Import a silent no-op with no skip record (#1229)."""
+        skill = tmp_path / ".kimi/skills/kimi-only"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
+        result = extract_skills_to_canonical(tmp_path)
+        assert len(result.imported) == 1
+        assert (tmp_path / CANONICAL_SKILL_ROOT / "kimi-only/SKILL.md").exists()
+        assert result.skipped == []
+
+    def test_kimi_loses_dedup_to_claude(self, tmp_path):
+        """Order pin: kimi is scanned LAST, so existing first-wins outcomes
+        are unchanged — a claude copy beats a kimi copy of the same name."""
+        for runtime_dir, body in ((".claude/skills", "claude wins\n"), (".kimi/skills", "kimi\n")):
+            skill = tmp_path / runtime_dir / "shared"
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text(body, encoding="utf-8")
+        result = extract_skills_to_canonical(tmp_path)
+        assert len(result.imported) == 1
+        canonical = tmp_path / CANONICAL_SKILL_ROOT / "shared/SKILL.md"
+        assert canonical.read_text(encoding="utf-8") == "claude wins\n"
+        assert len(result.skipped) == 1
+        assert "already imported" in result.skipped[0][1]
+
+    def test_kimi_missing_canonical_diff_row_is_importable(self, tmp_path):
+        """Diff↔extract parity: a 'missing canonical' row for a kimi-only
+        skill must be actionable by import (the regression shape from #1229
+        — the UI offered an Import CTA that 404'd)."""
+        skill = tmp_path / ".kimi/skills/kimi-only"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
+
+        rows = diff_skills(tmp_path)
+        assert ("kimi_skills", "kimi-only", "missing canonical") in rows
+
+        result = extract_skills_to_canonical(tmp_path, only_name="kimi-only")
+        assert len(result.imported) == 1
+
+    def test_staging_leftover_not_imported(self, tmp_path):
+        """A crash-leftover staging tree under a runtime root contains a full
+        SKILL.md mirror and passes validate_name — it must not round-trip
+        into canonical (#1229). Silent skip: no skip record, no warning."""
+        for leftover in (
+            ".staging-code-review-99999-abc123.tmp",
+            ".old-code-review-99999-abc123.tmp",
+        ):
+            d = tmp_path / ".claude/skills" / leftover
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
+        result = extract_skills_to_canonical(tmp_path)
+        assert result.imported == []
+        assert result.skipped == []
+        assert list_canonical_skills(tmp_path) == []
 
     def test_does_not_overwrite_without_flag(self, tmp_path):
         src = tmp_path / ".claude/skills/existing"
@@ -442,6 +516,19 @@ class TestDiffSkills:
         (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
         rows = diff_skills(tmp_path)
         assert any(status == "missing canonical" for _, _, status in rows)
+
+    def test_staging_leftovers_produce_no_phantom_rows(self, tmp_path):
+        """Crash-leftover staging/move-aside trees under either root must not
+        surface as phantom 'missing canonical' / 'missing target' rows
+        (#1229)."""
+        runtime_leftover = tmp_path / ".claude/skills/.staging-a-99999-abc123.tmp"
+        runtime_leftover.mkdir(parents=True)
+        (runtime_leftover / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
+        canonical_leftover = tmp_path / CANONICAL_SKILL_ROOT / ".old-a-99999-abc123.tmp"
+        canonical_leftover.mkdir(parents=True)
+        (canonical_leftover / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
+
+        assert diff_skills(tmp_path) == []
 
     @pytest.mark.skipif(
         os.name == "nt" or os.geteuid() == 0,

--- a/packages/memtomem/tests/test_context_skills_staging.py
+++ b/packages/memtomem/tests/test_context_skills_staging.py
@@ -226,6 +226,60 @@ class TestCopySkillBackCompat:
         assert (dst / SKILL_MANIFEST).read_bytes() == (src / SKILL_MANIFEST).read_bytes()
 
 
+class TestStaleLeftoverReaping:
+    """Crash-leftover staging/move-aside trees are reaped under the held dst
+    lock and are recognized by the shared discovery filter (#1229)."""
+
+    def test_staging_names_match_internal_predicate(self, tmp_path: Path) -> None:
+        """Construction↔predicate parity pin: the exact names _stage_skill and
+        _promote_staging produce must satisfy is_internal_artifact_dir — if
+        either f-string shape changes, this fails before the filters drift."""
+        from memtomem.context._names import is_internal_artifact_dir
+
+        src = _seed_canonical_skill(tmp_path, name="parity")
+        dst = tmp_path / ".claude/skills/parity"
+        staging = _stage_skill(src, dst)
+        try:
+            assert is_internal_artifact_dir(staging.name), staging.name
+        finally:
+            import shutil
+
+            shutil.rmtree(staging, ignore_errors=True)
+        # _promote_staging's move-aside shape (not exercised without a crash):
+        assert is_internal_artifact_dir(".old-parity-12345-abc123.tmp")
+        # Negative pins: real skills and user dot-dirs never match.
+        assert not is_internal_artifact_dir("parity")
+        assert not is_internal_artifact_dir(".hidden-skill")
+
+    @pytest.mark.parametrize("scope", ["project_shared", "user"])
+    def test_generate_reaps_stale_leftovers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, scope: str
+    ) -> None:
+        """Pre-existing stale staging/old trees next to a destination are
+        removed by the next sync (which holds the dst sidecar lock), and the
+        real skill still promotes."""
+        home = tmp_path / "home"
+        set_home(monkeypatch, str(home))
+        _seed_canonical_skill(tmp_path, name="hello", scope=scope)
+        gen = SKILL_GENERATORS["claude_skills"]
+        dst = gen.target_dir(tmp_path, "hello", scope=scope)  # type: ignore[arg-type]
+        assert dst is not None
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        stale_staging = dst.parent / ".staging-hello-999999-abc123.tmp"
+        stale_staging.mkdir()
+        (stale_staging / SKILL_MANIFEST).write_text("stale\n", encoding="utf-8")
+        stale_old = dst.parent / ".old-hello-999999-abc123.tmp"
+        stale_old.mkdir()
+        (stale_old / SKILL_MANIFEST).write_text("stale\n", encoding="utf-8")
+
+        result = generate_all_skills(tmp_path, runtimes=["claude_skills"], scope=scope)  # type: ignore[arg-type]
+
+        assert ("claude_skills", dst) in result.generated
+        assert not stale_staging.exists()
+        assert not stale_old.exists()
+        assert (dst / SKILL_MANIFEST).is_file()
+
+
 class TestGenerateAllSkillsStagingFlow:
     def test_clean_canonical_promotes(self, tmp_path: Path) -> None:
         _seed_canonical_skill(tmp_path, name="hello")

--- a/packages/memtomem/tests/test_context_skills_staging.py
+++ b/packages/memtomem/tests/test_context_skills_staging.py
@@ -247,9 +247,47 @@ class TestStaleLeftoverReaping:
             shutil.rmtree(staging, ignore_errors=True)
         # _promote_staging's move-aside shape (not exercised without a crash):
         assert is_internal_artifact_dir(".old-parity-12345-abc123.tmp")
-        # Negative pins: real skills and user dot-dirs never match.
+        # Negative pins: real skills and user dot-dirs never match — including
+        # valid user names that mimic the prefix/suffix but lack the generated
+        # pid+rand shape (Codex review: a looser match would hide and even
+        # delete them).
         assert not is_internal_artifact_dir("parity")
         assert not is_internal_artifact_dir(".hidden-skill")
+        assert not is_internal_artifact_dir(".staging-notes.tmp")
+        assert not is_internal_artifact_dir(".old-archive.tmp")
+        assert not is_internal_artifact_dir(".staging-parity-notes.tmp")
+        assert not is_internal_artifact_dir(".staging-parity-12345-xyz.tmp")
+
+    def test_reap_spares_user_dirs_matching_glob_but_not_shape(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A user skill dir whose name matches the reap GLOB but not the
+        generated pid+rand shape must survive the sync-time reaper."""
+        home = tmp_path / "home"
+        set_home(monkeypatch, str(home))
+        _seed_canonical_skill(tmp_path, name="hello")
+        gen = SKILL_GENERATORS["claude_skills"]
+        dst = gen.target_dir(tmp_path, "hello")
+        assert dst is not None
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        user_dir = dst.parent / ".staging-hello-notes.tmp"
+        user_dir.mkdir()
+        (user_dir / SKILL_MANIFEST).write_text("user content\n", encoding="utf-8")
+
+        generate_all_skills(tmp_path, runtimes=["claude_skills"])
+
+        assert user_dir.is_dir()
+        assert (user_dir / SKILL_MANIFEST).read_text(encoding="utf-8") == "user content\n"
+
+    def test_discovery_keeps_user_dirs_mimicking_prefix(self, tmp_path: Path) -> None:
+        """Discovery loops must still LIST a user skill named like the
+        staging prefix without the pid+rand shape."""
+        from memtomem.context.skills import list_canonical_skills
+
+        d = tmp_path / ".memtomem/skills/.staging-notes.tmp"
+        d.mkdir(parents=True)
+        (d / SKILL_MANIFEST).write_text("user content\n", encoding="utf-8")
+        assert [s.name for s in list_canonical_skills(tmp_path)] == [".staging-notes.tmp"]
 
     @pytest.mark.parametrize("scope", ["project_shared", "user"])
     def test_generate_reaps_stale_leftovers(

--- a/packages/memtomem/tests/test_context_status.py
+++ b/packages/memtomem/tests/test_context_status.py
@@ -414,6 +414,17 @@ def test_classify_status_scans_project_local_drafts(wiki_root: Path, tmp_path: P
         assert row.reason is None
 
 
+def test_draft_scan_skips_staging_leftovers(wiki_root: Path, tmp_path: Path) -> None:
+    """Crash-leftover staging trees under a draft-tier canonical root must
+    not surface as local-draft rows (#1229)."""
+    _initialized_wiki(wiki_root)
+    _seed_local_draft(tmp_path, "skills", ".staging-x-99999-abc123.tmp", "SKILL.md")
+
+    _, rows = classify_status(tmp_path)
+
+    assert not any(r.name == ".staging-x-99999-abc123.tmp" for r in rows)
+
+
 def test_classify_status_skips_directories_missing_kind_manifest(
     wiki_root: Path, tmp_path: Path
 ) -> None:

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -1034,6 +1034,18 @@ class TestImportOneSkill:
         assert not (tmp_path / ".memtomem" / "skills" / "beta").exists()
 
     @pytest.mark.anyio
+    async def test_import_single_kimi_only(self, client: AsyncClient, tmp_path: Path):
+        """A kimi-only skill is importable — the extract loop skipped
+        .kimi/skills, so this exact request 404'd while the diff pane showed
+        'missing canonical' with an Import CTA (#1229)."""
+        _make_runtime_skill(tmp_path, ".kimi/skills", "kimi-only", "# K\n")
+        r = await client.post("/api/context/skills/kimi-only/import", json={})
+        assert r.status_code == 200
+        data = r.json()
+        assert [i["name"] for i in data["imported"]] == ["kimi-only"]
+        assert (tmp_path / ".memtomem" / "skills" / "kimi-only" / SKILL_MANIFEST).is_file()
+
+    @pytest.mark.anyio
     async def test_404_when_no_runtime_match(self, client: AsyncClient, tmp_path: Path):
         _make_runtime_skill(tmp_path, ".claude/skills", "alpha", "# A\n")
         r = await client.post("/api/context/skills/ghost/import", json={})


### PR DESCRIPTION
Two skills minors from the Context Gateway review catalog (#1229).

## 1. Kimi-only skills: diff said "missing canonical", import was a silent no-op

`extract_skills_to_canonical` scanned only `claude/gemini/codex` while `KimiSkillsGenerator` is registered and the fan-out table maps `.kimi/skills` at user and project_shared tiers. Consequences: a kimi-only skill showed a "missing canonical" diff row whose **Import CTA hard-404'd** ("No runtime skill named … to import"), bulk import returned `imported=[] skipped=[]` with no skip record, and the import responses' `scanned_dirs` field already *claimed* `.kimi/skills` was scanned. ADR-0001 pins skills import priority as "detector order" — which includes `kimi_skills` — so the loop contradicted its own accepted ADR.

Kimi is appended **last**, preserving every existing first-wins outcome (pinned by a claude-beats-kimi dedup test). The SKILL.md payload is byte-identical across runtimes (plain copy fan-out), so the import is lossless. Kimi *agents* stay export-only (lossy one-way YAML) — now documented in the extract docstring and ADR-0001 alongside the Codex exclusion. The `import_priority` receipt copy ("Codex is pushed to but never read back") was already factually wrong for skills; reworded truthfully in both locales (locales are fetched `no-store`, no cache-bust needed).

## 2. Crash-leftover `.staging-*`/`.old-*` trees surfaced as phantom artifacts

A SIGKILL between stage and promote-cleanup leaves `.staging-<name>-<pid>-<rand>.tmp` / `.old-…` trees containing a full SKILL.md mirror; the composite name passes `validate_name` and no later run reaped them. They surfaced as phantom "missing canonical" diff rows, were imported back into canonical by extract, inflated `mm context detect`/init counts, appeared as bogus local-draft status rows — and a canonical-side leftover from a crashed import **fanned out to every runtime** on the next sync (self-propagating junk).

Fix: a shared `is_internal_artifact_dir` predicate in `_names` filters all five discovery loops (canonical listing, extract, `runtime_artifact_names` dir-manifest branch, `detect_skill_dirs`, status draft scan) silently — these are our own artifacts, not user content. `generate_all_skills` additionally garbage-collects stale trees per destination **while holding that destination's sidecar lock** (any live writer holds the same lock, so no live staging can be reaped); the lock-less extract path filters only, never GCs. Agents/commands are unaffected: their atomic-write leftovers are `.tmp` *files*, already excluded by the diff suffix match.

Per Codex review (one Major, fixed in the second commit): the predicate pins the **exact generated shape** (decimal pid + 6-hex rand), because `validate_name` accepts dot-prefixed `.tmp` names — a looser `.staging-*.tmp` match would have hidden a legitimately named user skill and let the reaper delete `.staging-<dst>-notes.tmp`. The reaper re-checks every glob hit against the shared predicate, and negative tests pin the mimicking-name cases on both sides. A construction↔predicate parity test pins the staging f-string shapes against the regex.

## Tests

13 new pins validated to fail against unfixed code: kimi import (engine + user-scope + web single-item route + diff↔extract parity + dedup order), leftover filtering across all five loops, lock-held GC (both scope branches), predicate parity, and the user-name-mimicry negatives.

Part of #1229. Codex review: NEEDS-FIX → fixed → covered by negative pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
