### PR TITLE
fix(web): unify stale-write aborts on HTTP 409 and audit-log MCP server force-saves (#1229)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -31,6 +32,8 @@ from memtomem.web.routes.context_projects import (
     resolve_scope_root,
     resolve_writable_scope_root,
 )
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["context-mcp-servers"])
 
@@ -213,14 +216,24 @@ async def _update_mcp_server_impl(
         async with asyncio.timeout(60):
             async with _gateway_lock:
                 current_mtime_ns = path.stat().st_mtime_ns
-                if current_mtime_ns != body_mtime_ns and not body.force:
-                    return JSONResponse(
-                        status_code=409,
-                        content={
-                            "status": "aborted",
-                            "reason": "File was modified by another process. Reload and retry.",
-                            "mtime_ns": str(current_mtime_ns),
-                        },
+                if current_mtime_ns != body_mtime_ns:
+                    if not body.force:
+                        return JSONResponse(
+                            status_code=409,
+                            content={
+                                "status": "aborted",
+                                "reason": (
+                                    "File was modified by another process. Reload and retry."
+                                ),
+                                "mtime_ns": str(current_mtime_ns),
+                            },
+                        )
+                    logger.warning(
+                        "force-save bypassed mtime check on %s "
+                        "(client_mtime_ns=%s server_mtime_ns=%s)",
+                        path,
+                        body_mtime_ns,
+                        current_mtime_ns,
                     )
                 atomic_write_text(path, body.content)
                 new_mtime_ns = path.stat().st_mtime_ns

--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from memtomem.config import TargetScope
@@ -580,11 +581,14 @@ async def resolve_conflict(
                         or candidate.get("matcher", "") != body.matcher
                         or _rule_hash(candidate) != body.rule_hash
                     ):
-                        return {
-                            "status": "aborted",
-                            "reason": "Target rule changed. Refresh and retry.",
-                            "mtime_ns": str(target_path.stat().st_mtime_ns),
-                        }
+                        return JSONResponse(
+                            status_code=409,
+                            content={
+                                "status": "aborted",
+                                "reason": "Target rule changed. Refresh and retry.",
+                                "mtime_ns": str(target_path.stat().st_mtime_ns),
+                            },
+                        )
                     rules[body.rule_index] = proposed
                 else:
                     replaced = False
@@ -599,15 +603,20 @@ async def resolve_conflict(
                 # mtime check before write — protects against cross-process
                 # writers (CLI, manual edit) that the in-process lock can't see.
                 # Echo the current ``mtime_ns`` on abort so clients can refresh
-                # local state without an extra round-trip — matches the
-                # Skills/Commands/Agents 409 envelope contract.
+                # local state without an extra round-trip — HTTP 409 with the
+                # same body shape as the Skills/Commands/Agents stale-write
+                # envelope (the comment used to CLAIM that parity while the
+                # route returned 200, #1229).
                 current_mtime_ns = target_path.stat().st_mtime_ns
                 if current_mtime_ns != mtime_ns:
-                    return {
-                        "status": "aborted",
-                        "reason": "Target file was modified by another process. Retry.",
-                        "mtime_ns": str(current_mtime_ns),
-                    }
+                    return JSONResponse(
+                        status_code=409,
+                        content={
+                            "status": "aborted",
+                            "reason": "Target file was modified by another process. Retry.",
+                            "mtime_ns": str(current_mtime_ns),
+                        },
+                    )
 
                 target_hooks[body.event] = rules
                 target["hooks"] = target_hooks
@@ -755,7 +764,7 @@ async def delete_target_rule(
                     check_canonical=False,
                 )
                 if stale:
-                    return stale
+                    return JSONResponse(status_code=409, content=stale)
                 target = _load_settings_record(target_path, label="Target")
                 match = _target_rule_for_action(
                     target,
@@ -764,7 +773,7 @@ async def delete_target_rule(
                     canonical_path=canonical_path,
                 )
                 if isinstance(match, dict):
-                    return match
+                    return JSONResponse(status_code=409, content=match)
                 rules, _rule = match
                 del rules[body.rule_index]
                 target_hooks = _hooks_record(target, label="Target")
@@ -807,7 +816,7 @@ async def promote_target_rule(
                     body, target_path=target_path, canonical_path=canonical_path
                 )
                 if stale:
-                    return stale
+                    return JSONResponse(status_code=409, content=stale)
 
                 target = _load_settings_record(target_path, label="Target")
                 match = _target_rule_for_action(
@@ -817,7 +826,7 @@ async def promote_target_rule(
                     canonical_path=canonical_path,
                 )
                 if isinstance(match, dict):
-                    return match
+                    return JSONResponse(status_code=409, content=match)
                 _rules, rule = match
                 if target_scope in ("user", "project_local") and not body.confirm_private_to_shared:
                     return {

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1465,7 +1465,7 @@
   <script src="/settings-maintenance.js?v=3"></script>
   <script src="/settings-namespaces.js?v=9"></script>
   <script src="/settings-harness.js?v=2"></script>
-  <script src="/settings-hooks-watchdog.js?v=16"></script>
+  <script src="/settings-hooks-watchdog.js?v=17"></script>
   <script src="/timeline.js?v=3"></script>
   <script src="/context-gateway.js?v=65"></script>
   <script src="/context-portal.js?v=2"></script>

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -173,11 +173,19 @@ async function _hooksPostRuleAction(action, entry, confirmPrivateToShared) {
     headers,
     body: JSON.stringify(_hooksRuleActionPayload(entry, confirmPrivateToShared)),
   });
+  const body = await res.json().catch(() => ({}));
   if (!res.ok) {
-    const err = await res.json().catch(() => ({}));
-    throw new Error(_hooksErrDetail(err.detail, `Request failed: ${res.status}`));
+    // Stale-write aborts arrive as HTTP 409 with a status-keyed envelope
+    // ({status: 'aborted', reason, ...}) — pass them through to the callers'
+    // result.status handling. Any other failure (incl. the sync-eligibility
+    // write-guard's 409, whose body is {detail: {reason_code, ...}} with no
+    // status key) keeps throwing so its localized detail mapping renders.
+    if (res.status === 409 && typeof body.status === 'string') {
+      return body;
+    }
+    throw new Error(_hooksErrDetail(body.detail, `Request failed: ${res.status}`));
   }
-  return res.json();
+  return body;
 }
 
 async function _confirmHooksPromote(count, label) {
@@ -730,12 +738,17 @@ async function loadHooksSync() {
             headers,
             body: JSON.stringify(resolveBody),
           });
-          if (!r.ok) {
-            const err = await r.json().catch(() => ({}));
-            showToast(_hooksErrDetail(err.detail, t('toast.request_failed')), 'error');
+          const result = await r.json().catch(() => ({}));
+          // Stale-write aborts arrive as HTTP 409 with a status-keyed body
+          // ({status: 'aborted', reason, mtime_ns}) — route them into the
+          // existing result.status handling (error toast with the precise
+          // reason, conflict card stays, no reload). Other failures — incl.
+          // the sync-eligibility write-guard 409 whose body carries only
+          // {detail: {reason_code, ...}} — keep the generic detail toast.
+          if (!r.ok && !(r.status === 409 && typeof result.status === 'string')) {
+            showToast(_hooksErrDetail(result.detail, t('toast.request_failed')), 'error');
             return;
           }
-          const result = await r.json();
           if (result.status === 'ok') {
             showToast(result.reason);
             loadHooksSync();

--- a/packages/memtomem/tests-js/settings-hooks-rule-actions.test.mjs
+++ b/packages/memtomem/tests-js/settings-hooks-rule-actions.test.mjs
@@ -1,0 +1,88 @@
+/* Three-way response discrimination in `_hooksPostRuleAction` (#1229).
+ *
+ * Stale-write aborts from /api/context/settings/rules/{delete,promote} and
+ * /resolve arrive as HTTP 409 with a status-keyed envelope
+ * ({status: 'aborted', reason, ...}) — the helper must pass them through to
+ * the callers' `result.status` handling instead of throwing, while the OTHER
+ * 409 on the very same endpoints (the sync-eligibility write-guard, whose
+ * body is {detail: {reason_code, ...}} with no `status` key) must keep
+ * throwing so its localized detail mapping renders. HTTP 200 ok envelopes
+ * pass through unchanged.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+const ENTRY = { event: 'Stop', matcher: '', rule_index: 0, rule_hash: 'abc' };
+
+function fetchResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+async function bootWithRuleActionResponse(status, body) {
+  const dom = await bootApp({
+    scripts: ['i18n.js', 'app.js', 'settings-hooks-watchdog.js'],
+  });
+  const { window } = dom;
+  window.fetch = async (input) => {
+    const url = typeof input === 'string' ? input : input?.url;
+    if (url && url.includes('/api/session')) {
+      return fetchResponse(200, { csrf: 'test-token' });
+    }
+    if (url && url.includes('/api/context/settings/rules/')) {
+      return fetchResponse(status, body);
+    }
+    return fetchResponse(200, {});
+  };
+  return window;
+}
+
+describe('_hooksPostRuleAction stale-write 409 discrimination', () => {
+  it('passes a status-keyed 409 abort envelope through to the caller', async () => {
+    const window = await bootWithRuleActionResponse(409, {
+      status: 'aborted',
+      reason: 'Target rule changed. Refresh and retry.',
+      target_mtime_ns: '1',
+      canonical_mtime_ns: '2',
+    });
+    const result = await window._hooksPostRuleAction('delete', ENTRY, false);
+    expect(result.status).toBe('aborted');
+    expect(result.reason).toContain('Refresh and retry');
+    // The two-key freshness names are load-bearing for Promote All's token
+    // refresh — they must survive the pass-through untouched.
+    expect(result.target_mtime_ns).toBe('1');
+    expect(result.canonical_mtime_ns).toBe('2');
+  });
+
+  it('still throws on the sync-eligibility write-guard 409 (detail body, no status key)', async () => {
+    const window = await bootWithRuleActionResponse(409, {
+      detail: { reason_code: 'sync_paused', message: 'Sync is paused.' },
+    });
+    await expect(window._hooksPostRuleAction('delete', ENTRY, false)).rejects.toThrow();
+  });
+
+  it('throws on non-409 failures', async () => {
+    const window = await bootWithRuleActionResponse(503, {
+      detail: 'Delete timed out — another sync may be in progress',
+    });
+    await expect(window._hooksPostRuleAction('delete', ENTRY, false)).rejects.toThrow(
+      /timed out/,
+    );
+  });
+
+  it('returns the body on HTTP 200 ok envelopes', async () => {
+    const window = await bootWithRuleActionResponse(200, {
+      status: 'ok',
+      reason: 'Rule deleted from target',
+      target_mtime_ns: '3',
+      canonical_mtime_ns: '4',
+    });
+    const result = await window._hooksPostRuleAction('delete', ENTRY, false);
+    expect(result.status).toBe('ok');
+  });
+});

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -1973,7 +1973,9 @@ class TestSettingsHttpLayer:
                 "canonical_mtime_ns": diff.json()["canonical_mtime_ns"],
             },
         )
-        assert resp.status_code == 200
+        # Stale-write aborts are HTTP 409 with the status-keyed envelope,
+        # matching the Skills/Commands/Agents contract (#1229).
+        assert resp.status_code == 409
         assert resp.json()["status"] == "aborted"
         assert "echo changed" in target.read_text(encoding="utf-8")
 
@@ -2015,11 +2017,48 @@ class TestSettingsHttpLayer:
                 "canonical_mtime_ns": body["canonical_mtime_ns"],
             },
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 409
         assert resp.json()["status"] == "aborted"
 
         written = json.loads(target.read_text(encoding="utf-8"))
         assert written["hooks"]["PreToolUse"] == [second, first]
+
+    async def test_promote_aborts_with_409_when_mtime_is_stale(self, client, claude_home):
+        """Promote shares the same stale-write 409 contract as delete (#1229)."""
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(
+            json.dumps({"hooks": {"PreToolUse": [_rule("Bash", "echo original")]}}, indent=2)
+            + "\n",
+            encoding="utf-8",
+        )
+
+        diff = await client.get("/api/context/settings?target_scope=user")
+        body = diff.json()
+        row = body["target_hooks"]["configured"][0]
+        import os as _os
+
+        st = target.stat()
+        _os.utime(target, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+
+        resp = await client.post(
+            "/api/context/settings/rules/promote?target_scope=user",
+            json={
+                "event": row["event"],
+                "matcher": row["matcher"],
+                "rule_index": row["rule_index"],
+                "rule_hash": row["rule_hash"],
+                "target_mtime_ns": body["target_mtime_ns"],
+                "canonical_mtime_ns": body["canonical_mtime_ns"],
+                "confirm_private_to_shared": True,
+            },
+        )
+        assert resp.status_code == 409
+        out = resp.json()
+        assert out["status"] == "aborted"
+        # The two-key freshness names are load-bearing for Promote All's
+        # token refresh — pin they survive the 409 flip.
+        assert "target_mtime_ns" in out
+        assert "canonical_mtime_ns" in out
 
     async def test_sync_route_round_trip_unidirectional(self, client, claude_home, tmp_path):
         """ADR-0001 §5 c2 — unidirectional round-trip via the route layer.
@@ -2078,9 +2117,11 @@ class TestSettingsHttpLayer:
         but exercises ``POST /api/context/settings/resolve``: the
         route captures ``target_path.stat().st_mtime_ns`` before the
         load and rechecks before write. We bump mtime as a side effect
-        of the load so the recheck mismatches → HTTP 200 + ``{"status":
+        of the load so the recheck mismatches → HTTP 409 + ``{"status":
         "aborted", "reason": <... modified by another process ...>,
-        "mtime_ns": <current st_mtime_ns>}``.
+        "mtime_ns": <current st_mtime_ns>}`` (#1229 unified the HTTP
+        status with the Skills/Commands/Agents stale-write envelope;
+        the body shape is unchanged).
 
         Asserts the same triplet the Skills/Commands/Agents conflict
         tests pin (status / no-write content / current mtime_ns echo)
@@ -2128,7 +2169,7 @@ class TestSettingsHttpLayer:
                 "action": "use_proposed",
             },
         )
-        assert resp.status_code == 200
+        assert resp.status_code == 409
         body = resp.json()
         assert body["status"] == "aborted"
         assert "modified by another process" in body["reason"]

--- a/packages/memtomem/tests/test_web_routes_context_mcp_servers.py
+++ b/packages/memtomem/tests/test_web_routes_context_mcp_servers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -144,3 +145,84 @@ async def test_create_rejects_secret_shaped_content(client: AsyncClient) -> None
     assert r.status_code == 422
     assert "privacy pattern" in r.json()["detail"]
     assert secret not in r.text
+
+
+def _seed_canonical(tmp_path: Path, name: str) -> Path:
+    path = tmp_path / ".memtomem" / "mcp-servers" / f"{name}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_definition(), encoding="utf-8")
+    return path
+
+
+@pytest.mark.anyio
+async def test_PUT_force_bypasses_mtime_and_logs_warning(
+    client: AsyncClient, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Force-save parity with skills/commands/agents (#1229): every mtime
+    bypass emits a WARNING with the path plus BOTH mtime values so the
+    override is reconstructable from logs alone."""
+    path = _seed_canonical(tmp_path, "force-log")
+    server_mtime_ns = path.stat().st_mtime_ns
+    new_content = _definition("node")
+
+    with caplog.at_level(logging.WARNING):
+        r = await client.put(
+            "/api/context/mcp-servers/force-log",
+            json={"content": new_content, "mtime_ns": "0", "force": True},
+        )
+    assert r.status_code == 200, r.text
+    assert path.read_text(encoding="utf-8") == new_content
+
+    bypass_records = [rec for rec in caplog.records if "force-save bypassed" in rec.getMessage()]
+    assert bypass_records, caplog.text
+    msg = bypass_records[-1].getMessage()
+    assert str(path) in msg
+    assert "client_mtime_ns=0" in msg
+    assert f"server_mtime_ns={server_mtime_ns}" in msg
+
+
+@pytest.mark.anyio
+async def test_PATCH_force_logs_warning_too(
+    client: AsyncClient, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The PATCH alias routes through the same impl — same audit contract."""
+    _seed_canonical(tmp_path, "force-patch")
+    with caplog.at_level(logging.WARNING):
+        r = await client.patch(
+            "/api/context/mcp-servers/force-patch",
+            json={"content": _definition("node"), "mtime_ns": "0", "force": True},
+        )
+    assert r.status_code == 200, r.text
+    assert any("force-save bypassed" in rec.getMessage() for rec in caplog.records)
+
+
+@pytest.mark.anyio
+async def test_PUT_force_with_matching_mtime_stays_silent(
+    client: AsyncClient, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """force=True with a matching mtime bypasses nothing — no WARNING."""
+    path = _seed_canonical(tmp_path, "force-clean")
+    with caplog.at_level(logging.WARNING):
+        r = await client.put(
+            "/api/context/mcp-servers/force-clean",
+            json={
+                "content": _definition("node"),
+                "mtime_ns": str(path.stat().st_mtime_ns),
+                "force": True,
+            },
+        )
+    assert r.status_code == 200, r.text
+    assert not any("force-save bypassed" in rec.getMessage() for rec in caplog.records)
+
+
+@pytest.mark.anyio
+async def test_PUT_force_default_false_still_409s(client: AsyncClient, tmp_path: Path) -> None:
+    path = _seed_canonical(tmp_path, "stale")
+    original = path.read_text(encoding="utf-8")
+    r = await client.put(
+        "/api/context/mcp-servers/stale",
+        json={"content": _definition("node"), "mtime_ns": "0"},
+    )
+    assert r.status_code == 409
+    assert r.json()["status"] == "aborted"
+    assert path.read_text(encoding="utf-8") == original

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -1110,6 +1110,9 @@ class TestSettingsSync:
                     "proposed_hash": c["proposed_hash"],
                 },
             )
+            # Stale-write aborts are HTTP 409, matching the
+            # Skills/Commands/Agents envelope contract (#1229).
+            assert resp.status_code == 409
             body = resp.json()
             assert body["status"] == "aborted"
             assert "changed" in body["reason"].lower()

--- a/packages/memtomem/tests/web/test_settings_hooks_resolve_inline.py
+++ b/packages/memtomem/tests/web/test_settings_hooks_resolve_inline.py
@@ -3,22 +3,27 @@
 Audit goal (``scripts/context-gateway-review-plan.md`` 갭 3): pin the
 mtime-guard envelope contract for ``POST /api/context/settings/resolve``.
 
-The route returns HTTP 200 with ``{"status": "aborted", "reason": "...",
+The route returns HTTP 409 with ``{"status": "aborted", "reason": "...",
 "mtime_ns": "..."}`` when an external write changes the target file
-between the read and the write — **not** HTTP 409 (see
-``web/routes/settings_sync.py:329-334``). A regression that treats this
-envelope as success would silently overwrite a cross-process write — the
-exact failure mode this spec is meant to lock out.
+between the read and the write — matching the Skills/Commands/Agents
+stale-write envelope contract (#1229; this used to be HTTP 200). A
+regression that treats this envelope as success would silently overwrite
+a cross-process write — the exact failure mode this spec is meant to
+lock out.
 
-The handler's contract (``static/settings-hooks-watchdog.js:117-150``):
+The handler's contract (``static/settings-hooks-watchdog.js``):
 
 * ``showConfirm`` first; cancel returns without firing the POST.
 * On confirm, ``POST /api/context/settings/resolve``.
-* ``!r.ok`` (HTTP 4xx/5xx) → toast.error + return (no ``loadHooksSync``).
+* ``!r.ok`` and not a status-keyed 409 → toast.error + return (no
+  ``loadHooksSync``). The sync-eligibility write-guard's 409 carries
+  ``{detail: {reason_code, ...}}`` with no ``status`` key and stays on
+  this generic path.
 * ``r.ok`` (HTTP 200) → parse body. ``status === 'ok'`` → toast +
   ``loadHooksSync()`` (the conflict card vanishes after the GET).
-* Any other status (``aborted`` included) → toast.error + return; no
-  ``loadHooksSync`` call, so the conflict card stays in place.
+* Any other status-keyed body (the 409 ``aborted`` included) →
+  toast.error + return; no ``loadHooksSync`` call, so the conflict card
+  stays in place.
 """
 
 from __future__ import annotations
@@ -233,16 +238,18 @@ def test_resolve_ok_removes_conflict_card(page, mm_web_url: str) -> None:
 
 
 def test_resolve_aborted_envelope_keeps_card_and_emits_error_toast(page, mm_web_url: str) -> None:
-    """S3-b: POST ``/resolve`` returns HTTP 200 + ``{status: 'aborted',
+    """S3-b: POST ``/resolve`` returns HTTP 409 + ``{status: 'aborted',
     reason: ..., mtime_ns: ...}`` → error toast + conflict card stays +
     no post-resolve GET reload. Audit P0 mtime-guard regression lock.
 
-    The mtime guard contract returns HTTP 200 (not 409) — a regression
-    that only checks ``resp.ok`` and ignores ``result.status`` would
-    silently overwrite a cross-process write. The card-stays assertion
-    is the true regression catch: a buggy handler that calls
-    ``loadHooksSync()`` despite the aborted status would clear the card
-    even though the resolve never happened.
+    The mtime guard contract returns HTTP 409 with a status-keyed body
+    (#1229; previously 200) — a handler that only checks ``resp.ok``
+    would degrade the precise reason toast to a generic failure, and a
+    regression that ignores ``result.status`` would silently overwrite a
+    cross-process write. The card-stays assertion is the true regression
+    catch: a buggy handler that calls ``loadHooksSync()`` despite the
+    aborted status would clear the card even though the resolve never
+    happened.
 
     Symmetric pin: positive on the error toast text, negative on the
     conflict card not vanishing AND on the GET count not incrementing
@@ -259,7 +266,7 @@ def test_resolve_aborted_envelope_keeps_card_and_emits_error_toast(page, mm_web_
     def _resolve_aborted(route):
         resolve_calls.append(route.request.post_data_json or {})
         route.fulfill(
-            status=200,
+            status=409,
             content_type="application/json",
             body=json.dumps(
                 {


### PR DESCRIPTION
Two web-routes minors from the Context Gateway review catalog (#1229).

## 1. MCP server force-save bypassed the mtime guard with no audit WARNING

The skills/commands/agents update handlers all log a WARNING with both mtime values whenever `force=True` overrides a concurrent-modification conflict — the audit trail the conflict-resolution UI's comment explicitly promises. `_update_mcp_server_impl` supported the same `force` flag but silently fell through to the write (the module didn't even import `logging`), leaving an operator reconstructing a clobbered canonical MCP server definition with no trace. The guard now uses the nested sibling shape and logs the **verbatim** sibling message (`force-save bypassed mtime check on … (client_mtime_ns=… server_mtime_ns=…)`) inside the lock, right before the write — covering both PUT and the PATCH alias through the shared impl. `force=True` with a matching mtime stays silent (nothing was bypassed), pinned by test.

## 2. Stale-write aborts: HTTP 409 everywhere instead of 200-on-settings

The same failure class (mtime/identity conflict during a mutation) returned **409** from `PUT /context/{skills,commands,agents,mcp-servers}/{name}` but **200** from `POST /settings-sync/resolve` and `/settings-sync/rules/{delete,promote}` — and the resolve code comment explicitly claimed it "matches the Skills/Commands/Agents 409 envelope contract". The three endpoints' stale aborts (mtime CAS + identity-stale) now return `JSONResponse(409)` with **unchanged body shapes**:

- resolve keeps its single `mtime_ns` echo (already key-unified by an earlier PR);
- delete/promote keep the `target_mtime_ns`/`canonical_mtime_ns` pair — those two-key names are load-bearing (they mirror the GET diff payload and Promote All consumes both for freshness-token refresh), so the catalog's "unify key names" suggestion was intentionally **not** taken for them;
- `needs_confirmation` / `conflict` / `ok` envelopes stay 200 — interactive flow states, not failures.

The catalog's claim that "the frontend keys on body.status so this is backward-compatible" turned out to be wrong at HEAD: both JS consumers gated on `res.ok` *before* reading the body, so a backend-only flip would have degraded the precise reason toast to "Request failed: 409". Both fetch sites in `settings-hooks-watchdog.js` now pass a **status-keyed** 409 body through to the existing `result.status` handling. The discriminator matters because these endpoints already emit a *different* 409 — the sync-eligibility write-guard, whose body is `{detail: {reason_code, …}}` with no `status` key — which must keep throwing so its localized `reason_code` mapping renders (its suite stays green, pinning the other side). Cache-bust bumped to `?v=17`; stale cached JS against the new backend degrades only cosmetically (generic toast, no data risk).

## Tests

- mcp-servers: force-bypass WARNING with both mtimes (PUT + PATCH), silent-on-fresh-mtime pin, force-default-still-409s pin — the type was absent from the mutators parity matrix, which is why this gap survived.
- settings: existing 200-aborted pins flipped to 409 (resolve route-layer soft-abort, delete mtime-stale, delete identity-stale) plus a new promote-abort pin asserting the two-key envelope survives the flip.
- Playwright: the resolve-abort spec's mock and docstrings updated to the 409 contract — the card-stays/no-reload/error-toast assertions are unchanged and remain the regression lock.
- New vitest (`settings-hooks-rule-actions.test.mjs`, first coverage of this module): three-way discrimination in `_hooksPostRuleAction` — 409+status passes through (with the two-key names intact), write-guard 409 throws, non-409 failures throw, 200-ok passes through.

Part of #1229. Reviewed by Codex (SHIP, no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
