### PR TITLE
fix(context): attribute Gate A audits to their real ingress surface (#1229)

### DIFF
--- a/packages/memtomem/src/memtomem/context/_gate_a.py
+++ b/packages/memtomem/src/memtomem/context/_gate_a.py
@@ -106,6 +106,7 @@ def apply_gate_a(
     audit_context: dict[str, object],
     message_kind: str,
     imported_so_far: int,
+    surface: str = "cli_context_init",
 ) -> GateAOutcome:
     """Run :func:`privacy.enforce_write_guard` and decide proceed / skip / abort.
 
@@ -149,6 +150,15 @@ def apply_gate_a(
             ("agent" / "skill" / "command"). Distinct from the plural
             ``kind`` field that callers usually carry inside
             ``audit_context``.
+        surface: Audit identifier forwarded verbatim to
+            :func:`privacy.enforce_write_guard` — it dimensions the
+            privacy ``record()`` counter and tags the force-unsafe
+            bypass audit log line, distinguishing every ingress surface.
+            Callers pass their own literal: the CLI relies on the
+            default ``"cli_context_init"``, the Web import routes pass
+            ``"web_context_<kind>_import"``, and the MCP tool passes
+            ``"mcp_context_init"`` (#1229 — previously every surface
+            was misattributed to the CLI literal).
         imported_so_far: Number of artifacts already imported in this
             run; passed through to the cleanup hint in the
             ClickException message. **Invariant**: callers must compute
@@ -160,7 +170,7 @@ def apply_gate_a(
     """
     guard = privacy.enforce_write_guard(
         content_text,
-        surface="cli_context_init",
+        surface=surface,
         force_unsafe=force_unsafe_import,
         scope=scope,
         audit_context=audit_context,

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -797,6 +797,7 @@ def extract_agents_to_canonical(
     scope: TargetScope = "project_shared",
     force_unsafe_import: bool = False,
     dry_run: bool = False,
+    surface: str = "cli_context_init",
 ) -> ExtractResult:
     """Import existing Claude / Gemini agent files into ``.memtomem/agents/``.
 
@@ -917,6 +918,7 @@ def extract_agents_to_canonical(
                 src=md_file,
                 scope=scope,
                 force_unsafe_import=force_unsafe_import,
+                surface=surface,
                 audit_context={
                     "source": str(md_file),
                     "target": str(dst),

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -543,6 +543,7 @@ def extract_commands_to_canonical(
     scope: TargetScope = "project_shared",
     force_unsafe_import: bool = False,
     dry_run: bool = False,
+    surface: str = "cli_context_init",
 ) -> ExtractResult:
     """Import existing Claude/Gemini command files into the scoped canonical dir.
 
@@ -639,6 +640,7 @@ def extract_commands_to_canonical(
                 src=md_file,
                 scope=scope,
                 force_unsafe_import=force_unsafe_import,
+                surface=surface,
                 # Mirror agents.py audit_context shape — SOC pipelines grep
                 # both ``source=`` and ``target=`` for incident triage;
                 # commands' earlier omission was a sibling-parity gap
@@ -714,6 +716,7 @@ def extract_commands_to_canonical(
                 src=toml_file,
                 scope=scope,
                 force_unsafe_import=force_unsafe_import,
+                surface=surface,
                 audit_context={
                     "source": str(toml_file),
                     "target": str(dst),

--- a/packages/memtomem/src/memtomem/context/privacy_scan.py
+++ b/packages/memtomem/src/memtomem/context/privacy_scan.py
@@ -4,7 +4,10 @@ Sibling of :mod:`memtomem.context._gate_a` (the runtime → canonical
 import-side gate). Both share :func:`memtomem.privacy.enforce_write_guard`
 underneath, but the two surfaces differ on:
 
-* ``surface=`` string — ``"cli_context_sync"`` vs ``"cli_context_init"``.
+* ``surface=`` string — ``"cli_context_sync"`` vs the import side's
+  caller-supplied surface (default ``"cli_context_init"``; the Web import
+  routes pass ``"web_context_<kind>_import"`` and the MCP tool passes
+  ``"mcp_context_init"`` — #1229).
 * ``force_unsafe`` valve — sync has none (ADR §5: canonical → runtime
   fan-out is a write-amplifying loop, so a single bypass-flagged content
   would propagate to every registered runtime; the ADR explicitly

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -760,6 +760,7 @@ def extract_skills_to_canonical(
     scope: TargetScope = "project_shared",
     force_unsafe_import: bool = False,
     dry_run: bool = False,
+    surface: str = "cli_context_init",
 ) -> ExtractResult:
     """Import existing runtime skills into the scoped canonical directory.
 
@@ -889,6 +890,7 @@ def extract_skills_to_canonical(
                     src=src_file,
                     scope=scope,
                     force_unsafe_import=force_unsafe_import,
+                    surface=surface,
                     audit_context={
                         "source_file": str(src_file),
                         "skill_name": skill_name,

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -334,6 +334,7 @@ async def mem_context_init(
                 overwrite=overwrite,
                 scope=artifact_scope,
                 force_unsafe_import=force_unsafe_import,
+                surface="mcp_context_init",
             )
         except PrivacyScanError as exc:
             return f"privacy block: {exc.message}"
@@ -355,6 +356,7 @@ async def mem_context_init(
                 overwrite=overwrite,
                 scope=artifact_scope,
                 force_unsafe_import=force_unsafe_import,
+                surface="mcp_context_init",
             )
         except PrivacyScanError as exc:
             return f"privacy block: {exc.message}"
@@ -373,6 +375,7 @@ async def mem_context_init(
                 overwrite=overwrite,
                 scope=artifact_scope,
                 force_unsafe_import=force_unsafe_import,
+                surface="mcp_context_init",
             )
         except PrivacyScanError as exc:
             return f"privacy block: {exc.message}"

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -586,7 +586,10 @@ async def import_agents(
         async with asyncio.timeout(60):
             async with _gateway_lock:
                 result = extract_agents_to_canonical(
-                    project_root, overwrite=overwrite, dry_run=dry_run
+                    project_root,
+                    overwrite=overwrite,
+                    dry_run=dry_run,
+                    surface="web_context_agents_import",
                 )
     except TimeoutError:
         raise HTTPException(503, "Agents import timed out — another sync may be in progress")
@@ -635,7 +638,10 @@ async def import_agent(
         async with asyncio.timeout(60):
             async with _gateway_lock:
                 result = extract_agents_to_canonical(
-                    project_root, overwrite=overwrite, only_name=name
+                    project_root,
+                    overwrite=overwrite,
+                    only_name=name,
+                    surface="web_context_agents_import",
                 )
     except TimeoutError:
         raise HTTPException(503, "Agent import timed out — another sync may be in progress")

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -576,7 +576,10 @@ async def import_commands(
         async with asyncio.timeout(60):
             async with _gateway_lock:
                 result = extract_commands_to_canonical(
-                    project_root, overwrite=overwrite, dry_run=dry_run
+                    project_root,
+                    overwrite=overwrite,
+                    dry_run=dry_run,
+                    surface="web_context_commands_import",
                 )
     except TimeoutError:
         raise HTTPException(503, "Commands import timed out — another sync may be in progress")
@@ -625,7 +628,10 @@ async def import_command(
         async with asyncio.timeout(60):
             async with _gateway_lock:
                 result = extract_commands_to_canonical(
-                    project_root, overwrite=overwrite, only_name=name
+                    project_root,
+                    overwrite=overwrite,
+                    only_name=name,
+                    surface="web_context_commands_import",
                 )
     except TimeoutError:
         raise HTTPException(503, "Command import timed out — another sync may be in progress")

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -543,7 +543,10 @@ async def import_skills(
         async with asyncio.timeout(60):
             async with _gateway_lock:
                 result = extract_skills_to_canonical(
-                    project_root, overwrite=overwrite, dry_run=dry_run
+                    project_root,
+                    overwrite=overwrite,
+                    dry_run=dry_run,
+                    surface="web_context_skills_import",
                 )
     except TimeoutError:
         raise HTTPException(503, "Skills import timed out — another sync may be in progress")
@@ -589,7 +592,10 @@ async def import_skill(
         async with asyncio.timeout(60):
             async with _gateway_lock:
                 result = extract_skills_to_canonical(
-                    project_root, overwrite=overwrite, only_name=name
+                    project_root,
+                    overwrite=overwrite,
+                    only_name=name,
+                    surface="web_context_skills_import",
                 )
     except TimeoutError:
         raise HTTPException(503, "Skill import timed out — another sync may be in progress")

--- a/packages/memtomem/tests/test_context_init_scope.py
+++ b/packages/memtomem/tests/test_context_init_scope.py
@@ -833,3 +833,76 @@ def test_extract_commands_audit_context_shape(
     assert captured["first"]["kind"] == "commands"  # plural
     assert captured["first"]["runtime"] == "claude"
     assert captured["first"]["command_name"] == "cmd"
+
+
+# ── #1229 — Gate A surface attribution ──────────────────────────────────
+
+
+def _capture_guard_surfaces(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Spy ``privacy.enforce_write_guard`` and record every call's ``surface``.
+
+    The surface string dimensions the privacy ``record()`` counter and tags
+    the force-unsafe bypass audit line — pre-#1229 every ingress surface was
+    hard-coded to the CLI literal, misattributing Web/MCP imports.
+    """
+    surfaces: list[str] = []
+
+    def spy(content_text: str, *, surface: str, **kw: Any) -> WriteGuardResult:
+        surfaces.append(surface)
+        return WriteGuardResult("pass", [])
+
+    monkeypatch.setattr("memtomem.context._gate_a.privacy.enforce_write_guard", spy)
+    return surfaces
+
+
+def test_extract_default_surface_is_cli_literal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No ``surface`` kwarg → the CLI literal (back-compat: ``mm context
+    init`` relies on the default)."""
+    home = tmp_path / "home"
+    set_home(monkeypatch, str(home))
+    proj = _make_project(tmp_path)
+    _seed_user_runtime_agents(home, "agt", "---\nname: agt\n---\nbody\n")
+
+    surfaces = _capture_guard_surfaces(monkeypatch)
+    extract_agents_to_canonical(proj, scope="user")
+    assert surfaces == ["cli_context_init"]
+
+
+def test_extract_surface_kwarg_reaches_gate_a_for_all_kinds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ``surface`` kwarg threads through every Gate A call site —
+    including BOTH command branches (Claude ``.md`` and Gemini ``.toml``);
+    missing the second would silently misattribute only Gemini-sourced
+    commands."""
+    home = tmp_path / "home"
+    set_home(monkeypatch, str(home))
+    proj = _make_project(tmp_path)
+    _seed_user_runtime_agents(home, "agt", "---\nname: agt\n---\nbody\n")
+    skill = home / ".claude" / "skills" / "myskill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: myskill\n---\nbody\n", encoding="utf-8")
+    claude_cmds = home / ".claude" / "commands"
+    claude_cmds.mkdir(parents=True)
+    (claude_cmds / "cmd.md").write_text("---\nname: cmd\n---\nbody\n", encoding="utf-8")
+    gemini_cmds = home / ".gemini" / "commands"
+    gemini_cmds.mkdir(parents=True)
+    (gemini_cmds / "gcmd.toml").write_text(
+        'description = "g"\nprompt = "gemini prompt"\n', encoding="utf-8"
+    )
+
+    surfaces = _capture_guard_surfaces(monkeypatch)
+    extract_agents_to_canonical(proj, scope="user", surface="probe_agents")
+    assert surfaces == ["probe_agents"]
+
+    surfaces.clear()
+    extract_skills_to_canonical(proj, scope="user", surface="probe_skills")
+    assert surfaces == ["probe_skills"]
+
+    surfaces.clear()
+    extract_commands_to_canonical(proj, scope="user", surface="probe_commands")
+    assert surfaces == ["probe_commands", "probe_commands"]  # claude + gemini branches

--- a/packages/memtomem/tests/test_server_tools_context_scope.py
+++ b/packages/memtomem/tests/test_server_tools_context_scope.py
@@ -367,3 +367,40 @@ async def test_mem_context_diff_settings_scope_passes_through_explicit_scope(
     captured.clear()
     await mem_context_diff(include="settings")
     assert captured == [None]
+
+
+@pytest.mark.anyio
+async def test_mem_context_init_uses_mcp_surface(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gate A audit attribution (#1229): imports driven by the MCP tool must
+    reach the privacy audit log as ``mcp_context_init``, not the CLI literal."""
+    from memtomem.privacy import WriteGuardResult
+
+    _make_project(tmp_path, monkeypatch)
+    home = tmp_path / "home"
+    set_home(monkeypatch, home)
+    agents = home / ".claude" / "agents"
+    agents.mkdir(parents=True)
+    (agents / "agt.md").write_text(_clean_agent_body("agt"), encoding="utf-8")
+    skill = home / ".claude" / "skills" / "sk"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: sk\n---\nbody\n", encoding="utf-8")
+    cmds = home / ".claude" / "commands"
+    cmds.mkdir(parents=True)
+    (cmds / "cmd.md").write_text("---\nname: cmd\n---\nbody\n", encoding="utf-8")
+
+    surfaces: list[str] = []
+
+    def spy(content_text, *, surface, **kw):
+        surfaces.append(surface)
+        return WriteGuardResult("pass", [])
+
+    monkeypatch.setattr("memtomem.context._gate_a.privacy.enforce_write_guard", spy)
+
+    out = await mem_context_init(include="skills,agents,commands", scope="user")
+
+    assert out.startswith("Imported") or "Imported" in out
+    assert surfaces, "Gate A never ran"
+    assert set(surfaces) == {"mcp_context_init"}

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -1794,3 +1794,64 @@ class TestCommandTargetScopePlumbing:
             json={"content": "# x\n", "mtime_ns": "0"},
         )
         assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Gate A surface attribution (#1229)
+# ---------------------------------------------------------------------------
+
+
+class TestImportSurfaceAttribution:
+    """Web imports must reach the privacy audit log under their own surface
+    string — pre-#1229 every ingress was misattributed to the CLI literal
+    ``cli_context_init``."""
+
+    def _spy_surfaces(self, monkeypatch) -> list[str]:
+        from memtomem.privacy import WriteGuardResult
+
+        surfaces: list[str] = []
+
+        def spy(content_text, *, surface, **kw):
+            surfaces.append(surface)
+            return WriteGuardResult("pass", [])
+
+        monkeypatch.setattr("memtomem.context._gate_a.privacy.enforce_write_guard", spy)
+        return surfaces
+
+    @pytest.mark.anyio
+    async def test_bulk_imports_use_web_surfaces(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch
+    ):
+        _make_runtime_skill(tmp_path, ".claude/skills", "s1", "# S\n")
+        agents_dir = tmp_path / ".claude" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "a1.md").write_text("---\nname: a1\n---\nbody\n", encoding="utf-8")
+        commands_dir = tmp_path / ".claude" / "commands"
+        commands_dir.mkdir(parents=True)
+        (commands_dir / "c1.md").write_text("---\nname: c1\n---\nbody\n", encoding="utf-8")
+
+        surfaces = self._spy_surfaces(monkeypatch)
+
+        r = await client.post("/api/context/skills/import", json={})
+        assert r.status_code == 200
+        assert set(surfaces) == {"web_context_skills_import"}
+
+        surfaces.clear()
+        r = await client.post("/api/context/agents/import", json={})
+        assert r.status_code == 200
+        assert set(surfaces) == {"web_context_agents_import"}
+
+        surfaces.clear()
+        r = await client.post("/api/context/commands/import", json={})
+        assert r.status_code == 200
+        assert set(surfaces) == {"web_context_commands_import"}
+
+    @pytest.mark.anyio
+    async def test_single_name_import_uses_web_surface(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch
+    ):
+        _make_runtime_skill(tmp_path, ".claude/skills", "solo", "# S\n")
+        surfaces = self._spy_surfaces(monkeypatch)
+        r = await client.post("/api/context/skills/solo/import", json={})
+        assert r.status_code == 200
+        assert set(surfaces) == {"web_context_skills_import"}


### PR DESCRIPTION
One minor from the Context Gateway review catalog (#1229).

## Gate A audits attributed Web/MCP imports to the CLI

`apply_gate_a` hard-coded `surface="cli_context_init"` in its `privacy.enforce_write_guard` call, so every import driven by the Web routes (bulk + single-name, all three kinds) and the MCP `mem_context_init` tool was misattributed to the CLI in the privacy `record()` counters and the force-unsafe bypass audit log — the exact per-surface distinction `privacy.py` documents as the purpose of the field, and the module's own docstring stresses SOC-pipeline grep stability on audit fields.

`apply_gate_a` and the three `extract_*_to_canonical` functions grow a keyword-only `surface` parameter defaulting to the CLI literal (public-API back-compat; `mm context init` is unchanged). Entry points pass their own literal:

- **Web import routes** (6 sites): `web_context_{skills,agents,commands}_import` — per-kind rather than the catalog's single `web_context_import`, for counter granularity, matching the existing `web_context_mcp_servers_{create,update}` convention (`record()` dimensions only by surface; kind lives in `audit_context`, which reaches the log line but not the counter). Bulk and single-name endpoints of one kind share the string.
- **MCP** (3 sites inside `mem_context_init`): `mcp_context_init` — matches the tool name and the `mcp_context_version_create` convention (the catalog's `mcp_context_import` doesn't correspond to any tool).

Commands have **two** Gate A sites (the Claude `.md` branch and the Gemini TOML branch); both forward the kwarg, and the engine test seeds a Gemini TOML to pin the second branch — missing it would have silently misattributed only Gemini-sourced commands. `audit_context` is untouched (SOC grep shape preserved, pinned by the existing D2 shape tests). `privacy_scan`'s sync-vs-init surface contrast docstring updated to the caller-supplied reality.

Out of scope (noted during verification, same class but different direction): the sync/generate path also hard-codes `cli_context_sync`/`cli_context_migrate` while being reachable from Web/MCP — left for a follow-up decision rather than piggybacked here.

## Tests

Engine level: default-is-CLI pin; explicit `surface` kwarg reaches Gate A for all three kinds, with the commands case asserting **two** captures (Claude + Gemini branches). Web level: bulk imports of all three kinds + a single-name import each spy the per-kind literal. MCP level: `mem_context_init(include="skills,agents,commands")` spies `mcp_context_init` across all fan-outs.

Part of #1229. Reviewed by Codex (SHIP, no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
