### PR TITLE
ux(context): give parse-error and invalid-name rows a diagnostic surface (#1229)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -235,9 +235,14 @@ def _print_skills_diff(root: Path, *, scope: TargetScope = "project_shared") -> 
     if not rows:
         click.echo(f"  (no skills to compare in {scope})")
         return
-    for runtime, name, status in rows:
+    for row in rows:
+        runtime, name, status = row
         color = "green" if status == "in sync" else "yellow"
-        click.secho(f"  {runtime:15s}  {name}  [{status}]  scope={scope}", fg=color)
+        # Diagnostic reason (parse error / invalid name rows, #1229 U7) —
+        # raw engine text is fine for the local operator.
+        reason = getattr(row, "reason", None)
+        suffix = f"  — {reason}" if reason else ""
+        click.secho(f"  {runtime:15s}  {name}  [{status}]  scope={scope}{suffix}", fg=color)
 
 
 # ── Sub-agent sub-handlers (Phase 2) ─────────────────────────────────
@@ -338,9 +343,14 @@ def _print_agents_diff(root: Path, *, scope: TargetScope = "project_shared") -> 
     if not rows:
         click.echo(f"  (no sub-agents to compare in {scope})")
         return
-    for runtime, name, status in rows:
+    for row in rows:
+        runtime, name, status = row
         color = "green" if status == "in sync" else "yellow"
-        click.secho(f"  {runtime:15s}  {name}  [{status}]  scope={scope}", fg=color)
+        # Diagnostic reason (parse error / invalid name rows, #1229 U7) —
+        # raw engine text is fine for the local operator.
+        reason = getattr(row, "reason", None)
+        suffix = f"  — {reason}" if reason else ""
+        click.secho(f"  {runtime:15s}  {name}  [{status}]  scope={scope}{suffix}", fg=color)
 
 
 # ── Slash-command sub-handlers (Phase 3) ─────────────────────────────
@@ -444,9 +454,14 @@ def _print_commands_diff(root: Path, *, scope: TargetScope = "project_shared") -
     if not rows:
         click.echo(f"  (no commands to compare in {scope})")
         return
-    for runtime, name, status in rows:
+    for row in rows:
+        runtime, name, status = row
         color = "green" if status == "in sync" else "yellow"
-        click.secho(f"  {runtime:17s}  {name}  [{status}]  scope={scope}", fg=color)
+        # Diagnostic reason (parse error / invalid name rows, #1229 U7) —
+        # raw engine text is fine for the local operator.
+        reason = getattr(row, "reason", None)
+        suffix = f"  — {reason}" if reason else ""
+        click.secho(f"  {runtime:17s}  {name}  [{status}]  scope={scope}{suffix}", fg=color)
 
 
 # ── Settings sub-handlers (Phase D) ─────────────────────────────────

--- a/packages/memtomem/src/memtomem/context/_runtime_targets.py
+++ b/packages/memtomem/src/memtomem/context/_runtime_targets.py
@@ -175,6 +175,49 @@ def runtime_fanout_root(
     return (project_root / entry).resolve()
 
 
+class DiffRow(tuple):
+    """One diff result row, optionally carrying a diagnostic ``reason``.
+
+    Iterates and unpacks as the historical 3-tuple ``(runtime, name,
+    status)`` — every existing positional consumer (CLI printers, MCP
+    tools, web groupers, external callers of the public ``diff_*``
+    functions) keeps working unchanged, and equality against a plain
+    3-tuple still holds. Consumers that want diagnostics read
+    ``row.reason`` (#1229 U7: the bare "parse error" status carried no
+    file path or cause anywhere; "invalid name" rows ride the same
+    field with the ``validate_name`` message).
+
+    ``reason`` is raw, unsanitized engine text (exception messages embed
+    absolute source paths) — web routes sanitize at the wire boundary,
+    CLI/MCP print it for the local operator verbatim.
+    """
+
+    reason: str | None
+
+    def __new__(cls, runtime: str, name: str, status: str, reason: str | None = None) -> "DiffRow":
+        row = super().__new__(cls, (runtime, name, status))
+        row.reason = reason
+        return row
+
+    @property
+    def runtime(self) -> str:
+        return self[0]
+
+    @property
+    def name(self) -> str:
+        return self[1]
+
+    @property
+    def status(self) -> str:
+        return self[2]
+
+    def __repr__(self) -> str:  # diagnostics show up in test failures
+        return (
+            f"DiffRow(runtime={self[0]!r}, name={self[1]!r}, "
+            f"status={self[2]!r}, reason={self.reason!r})"
+        )
+
+
 def runtime_artifact_listing(
     artifact: ArtifactKind,
     runtime: str,
@@ -183,8 +226,8 @@ def runtime_artifact_listing(
     *,
     file_suffix: str | None = None,
     dir_manifest: str | None = None,
-) -> tuple[set[str], list[str]]:
-    """Return ``(valid_names, invalid_raw_names)`` under the runtime root.
+) -> tuple[set[str], list[tuple[str, str]]]:
+    """Return ``(valid_names, invalid_entries)`` under the runtime root.
 
     Replaces the per-module helpers ``_runtime_agent_names`` /
     ``_runtime_command_names`` and the inline runtime-listing in
@@ -202,11 +245,12 @@ def runtime_artifact_listing(
       every directory containing the named manifest file. Used for
       skills where each artifact is a directory tree.
 
-    ``invalid_raw_names`` carries entries that match the artifact shape
-    but fail :func:`validate_name` — diff surfaces them as a dedicated
-    ``"invalid name"`` status row instead of silently dropping them
-    (#1229: an unmanaged runtime artifact used to be invisible, so the
-    dashboard read fully in-sync while extract emitted a visible
+    ``invalid_entries`` carries ``(raw_name, reason)`` pairs for entries
+    that match the artifact shape but fail :func:`validate_name` — diff
+    surfaces them as a dedicated ``"invalid name"`` status row (with the
+    validation message as the row reason) instead of silently dropping
+    them (#1229: an unmanaged runtime artifact used to be invisible, so
+    the dashboard read fully in-sync while extract emitted a visible
     ``INVALID_NAME`` skip for the very same file). The names are raw,
     unsanitized strings — web rendering escapes them, and log emission
     keeps going through the structured ``extra`` dict (never the message).
@@ -224,7 +268,7 @@ def runtime_artifact_listing(
         return set(), []
     kind = f"{artifact[:-1]} name"
     names: set[str] = set()
-    invalid: list[str] = []
+    invalid: list[tuple[str, str]] = []
     if file_suffix is not None:
         entries = ((p.stem, p) for p in root.iterdir() if p.is_file() and p.suffix == file_suffix)
     else:
@@ -243,7 +287,7 @@ def runtime_artifact_listing(
         try:
             names.add(validate_name(raw_name, kind=kind))
         except InvalidNameError as exc:
-            invalid.append(raw_name)
+            invalid.append((raw_name, str(exc)))
             logger.warning(
                 "Skipping invalid runtime artifact name",
                 extra={

--- a/packages/memtomem/src/memtomem/context/_runtime_targets.py
+++ b/packages/memtomem/src/memtomem/context/_runtime_targets.py
@@ -211,6 +211,13 @@ class DiffRow(tuple):
     def status(self) -> str:
         return self[2]
 
+    def __getnewargs__(self) -> tuple[str, str, str, str | None]:
+        # Pickle reconstructs via ``__new__(cls, *args)`` — without this the
+        # 3-element tuple state reaches a 4-arg constructor and unpickling
+        # fails, breaking public diff_* callers that cache rows or pass them
+        # through multiprocessing (Codex review).
+        return (self[0], self[1], self[2], self.reason)
+
     def __repr__(self) -> str:  # diagnostics show up in test failures
         return (
             f"DiffRow(runtime={self[0]!r}, name={self[1]!r}, "

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -47,6 +47,7 @@ from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
 from memtomem.context._runtime_targets import (
+    DiffRow,
     runtime_artifact_listing,
     runtime_artifact_names,
     runtime_fanout_root,
@@ -1012,13 +1013,23 @@ def diff_agents(
     # Unreadable / unparseable canonicals keep the stem / dir-name key
     # (``None`` value) so their "parse error" row still names the file.
     canonical_index: dict[str, SubAgent | None] = {}
+    # Parse failures keep the exception text (it embeds the source path) so
+    # the "parse error" row can carry a diagnostic reason — pre-#1229 the
+    # exception was swallowed here without even a log line.
+    parse_failures: dict[str, str] = {}
     for path, layout in list_canonical_agents(project_root, scope=scope):
         fallback_name = path.parent.name if layout == "dir" else path.stem
         try:
             text = path.read_bytes().decode("utf-8", errors="replace")
             parsed = _parse_canonical_agent_text(text, source=path, layout=layout)
-        except (OSError, AgentParseError):
+        except OSError as exc:
             canonical_index[fallback_name] = None
+            parse_failures[fallback_name] = f"unreadable: {exc}"
+            logger.warning("canonical agent %s unreadable: %s", path, exc)
+        except AgentParseError as exc:
+            canonical_index[fallback_name] = None
+            parse_failures[fallback_name] = str(exc)
+            logger.warning("canonical agent %s failed to parse: %s", path, exc)
         else:
             canonical_index[parsed.name] = parsed
     canonical_names = set(canonical_index)
@@ -1040,9 +1051,9 @@ def diff_agents(
         # runtime artifact existed (#1229). Surface them as a dedicated row;
         # a canonical "parse error" row of the same fallback name wins
         # (only possible when the canonical stem itself is invalid).
-        for raw_name in invalid_runtime_names:
+        for raw_name, invalid_reason in invalid_runtime_names:
             if raw_name not in canonical_names:
-                results.append((gen_name, raw_name, "invalid name"))
+                results.append(DiffRow(gen_name, raw_name, "invalid name", invalid_reason))
         for name in sorted(canonical_names | runtime_names):
             # Unparseable canonical (including an invalid *effective* name —
             # frontmatter name, or stem fallback) checked BEFORE the
@@ -1050,7 +1061,7 @@ def diff_agents(
             # create the runtime file, which it never can — the row showed
             # a permanent drift no sync clears (#1229).
             if name in canonical_names and canonical_index[name] is None:
-                results.append((gen_name, name, "parse error"))
+                results.append(DiffRow(gen_name, name, "parse error", parse_failures.get(name)))
                 continue
             if name in canonical_names and name not in runtime_names:
                 results.append((gen_name, name, "missing target"))

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -44,7 +44,11 @@ from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
 from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
-from memtomem.context._runtime_targets import runtime_artifact_listing, runtime_fanout_root
+from memtomem.context._runtime_targets import (
+    DiffRow,
+    runtime_artifact_listing,
+    runtime_fanout_root,
+)
 from memtomem.context._sync_atomic import (
     AtomicSyncAdapter,
     AtomicSyncResult,
@@ -783,13 +787,22 @@ def diff_commands(
     # decode — mirrors diff_agents; see the comment there for the phantom
     # drift + UnicodeDecodeError rationale (#1229).
     canonical_index: dict[str, SlashCommand | None] = {}
+    # Mirrors diff_agents: keep the exception text for the "parse error"
+    # row's diagnostic reason (#1229; previously swallowed without logging).
+    parse_failures: dict[str, str] = {}
     for path, layout in list_canonical_commands(project_root, scope=scope):
         fallback_name = path.parent.name if layout == "dir" else path.stem
         try:
             text = path.read_bytes().decode("utf-8", errors="replace")
             parsed = _parse_canonical_command_text(text, source=path, layout=layout)
-        except (OSError, CommandParseError):
+        except OSError as exc:
             canonical_index[fallback_name] = None
+            parse_failures[fallback_name] = f"unreadable: {exc}"
+            logger.warning("canonical command %s unreadable: %s", path, exc)
+        except CommandParseError as exc:
+            canonical_index[fallback_name] = None
+            parse_failures[fallback_name] = str(exc)
+            logger.warning("canonical command %s failed to parse: %s", path, exc)
         else:
             canonical_index[parsed.name] = parsed
     canonical_names = set(canonical_index)
@@ -810,16 +823,16 @@ def diff_commands(
         # (log-only) — surface them as a dedicated row; a canonical "parse
         # error" row of the same fallback name wins (#1229, mirrors
         # diff_agents).
-        for raw_name in invalid_runtime_names:
+        for raw_name, invalid_reason in invalid_runtime_names:
             if raw_name not in canonical_names:
-                results.append((gen_name, raw_name, "invalid name"))
+                results.append(DiffRow(gen_name, raw_name, "invalid name", invalid_reason))
 
         for name in sorted(canonical_names | runtime_names):
             # Unparseable canonical checked BEFORE missing-target — the
             # "missing target" label implied sync would create the file,
             # which it never can (#1229, mirrors diff_agents).
             if name in canonical_names and canonical_index[name] is None:
-                results.append((gen_name, name, "parse error"))
+                results.append(DiffRow(gen_name, name, "parse error", parse_failures.get(name)))
                 continue
             if name in canonical_names and name not in runtime_names:
                 results.append((gen_name, name, "missing target"))

--- a/packages/memtomem/src/memtomem/context/mcp_servers.py
+++ b/packages/memtomem/src/memtomem/context/mcp_servers.py
@@ -23,6 +23,7 @@ from typing import Any
 from memtomem import privacy
 from memtomem.context._atomic import atomic_write_text
 from memtomem.context._names import validate_name
+from memtomem.context._runtime_targets import DiffRow
 
 CANONICAL_MCP_SERVER_ROOT = ".memtomem/mcp-servers"
 PROJECT_MCP_CONFIG = ".mcp.json"
@@ -166,22 +167,27 @@ def _read_project_mcp_config(path: Path) -> dict[str, Any]:
 
 def diff_mcp_servers(project_root: Path) -> list[tuple[str, str, str]]:
     target = _project_mcp_path(project_root)
+    target_parse_reason: str | None = None
     try:
         target_config = _read_project_mcp_config(target)
         target_servers = target_config.get("mcpServers") or {}
-    except McpServerParseError:
+    except McpServerParseError as exc:
         target_servers = None
+        # A broken .mcp.json marks EVERY canonical row "parse error" — the
+        # reason must say so, or the user chases N healthy canonical files
+        # (#1229 U7).
+        target_parse_reason = str(exc)
 
     rows: list[tuple[str, str, str]] = []
     for path in list_canonical_mcp_servers(project_root):
         name = path.stem
         try:
             canonical = parse_canonical_mcp_server(path).definition
-        except McpServerParseError:
-            rows.append((MCP_RUNTIME, name, "parse error"))
+        except McpServerParseError as exc:
+            rows.append(DiffRow(MCP_RUNTIME, name, "parse error", str(exc)))
             continue
         if target_servers is None:
-            rows.append((MCP_RUNTIME, name, "parse error"))
+            rows.append(DiffRow(MCP_RUNTIME, name, "parse error", target_parse_reason))
             continue
         if name not in target_servers:
             rows.append((MCP_RUNTIME, name, "missing target"))

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -46,7 +46,11 @@ from memtomem.context._names import (
     is_internal_artifact_dir,
     validate_name,
 )
-from memtomem.context._runtime_targets import runtime_artifact_listing, runtime_fanout_root
+from memtomem.context._runtime_targets import (
+    DiffRow,
+    runtime_artifact_listing,
+    runtime_fanout_root,
+)
 from memtomem.context.privacy_scan import (
     raise_or_collect,
     scan_artifact_tree,
@@ -1030,7 +1034,7 @@ def diff_skills(
     # for SYNC (generate must never fan out an invalid dir), which made them
     # fully invisible — no diff row anywhere (#1229). Enumerate them once
     # here for the dedicated "invalid name" status.
-    invalid_canonical_names: list[str] = []
+    invalid_canonical_names: list[tuple[str, str]] = []
     if canonical_root.is_dir():
         for entry in sorted(canonical_root.iterdir()):
             if not entry.is_dir() or not (entry / SKILL_MANIFEST).is_file():
@@ -1039,8 +1043,8 @@ def diff_skills(
                 continue
             try:
                 validate_name(entry.name, kind="skill name")
-            except InvalidNameError:
-                invalid_canonical_names.append(entry.name)
+            except InvalidNameError as exc:
+                invalid_canonical_names.append((entry.name, str(exc)))
 
     for gen_name, gen in SKILL_GENERATORS.items():
         # ADR-0011 PR-E3 cleanup item #1: query the table directly via
@@ -1057,8 +1061,10 @@ def diff_skills(
         # that failed validation plus the canonical-side rejects above
         # (#1229; deduplicated when the same invalid name exists on both
         # sides).
-        for raw_name in sorted({*invalid_runtime_names, *invalid_canonical_names}):
-            results.append((gen_name, raw_name, "invalid name"))
+        invalid_by_name = dict(invalid_canonical_names)
+        invalid_by_name.update(dict(invalid_runtime_names))
+        for raw_name in sorted(invalid_by_name):
+            results.append(DiffRow(gen_name, raw_name, "invalid name", invalid_by_name[raw_name]))
 
         for name in sorted(canonical_names | runtime_names):
             if name in canonical_names and name not in runtime_names:

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -753,8 +753,11 @@ async def mem_context_diff(
             if lines:
                 lines.append("")
             lines.append("Skills:")
-            for runtime, name, status in rows:
-                lines.append(f"  {runtime}: {name} [{status}]")
+            for row in rows:
+                runtime, name, status = row
+                reason = getattr(row, "reason", None)
+                suffix = f" — {reason}" if reason else ""
+                lines.append(f"  {runtime}: {name} [{status}]{suffix}")
         else:
             lines.append("No skills to compare.")
 
@@ -764,8 +767,11 @@ async def mem_context_diff(
             if lines:
                 lines.append("")
             lines.append("Sub-agents:")
-            for runtime, name, status in rows:
-                lines.append(f"  {runtime}: {name} [{status}]")
+            for row in rows:
+                runtime, name, status = row
+                reason = getattr(row, "reason", None)
+                suffix = f" — {reason}" if reason else ""
+                lines.append(f"  {runtime}: {name} [{status}]{suffix}")
         else:
             lines.append("No sub-agents to compare.")
 
@@ -775,8 +781,11 @@ async def mem_context_diff(
             if lines:
                 lines.append("")
             lines.append("Commands:")
-            for runtime, name, status in rows:
-                lines.append(f"  {runtime}: {name} [{status}]")
+            for row in rows:
+                runtime, name, status = row
+                reason = getattr(row, "reason", None)
+                suffix = f" — {reason}" if reason else ""
+                lines.append(f"  {runtime}: {name} [{status}]{suffix}")
         else:
             lines.append("No commands to compare.")
 

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -32,7 +32,7 @@ from memtomem.context.agents import (
 )
 from memtomem.context.detector import AGENT_DIRS
 from memtomem.context.privacy_scan import PrivacyScanError
-from memtomem.web.routes.context_gateway import sanitize_diff_reason
+from memtomem.web.routes.context_gateway import read_text_lenient, sanitize_diff_reason
 from memtomem.web.routes.context_projects import (
     resolve_scope_root,
     resolve_scope_root_cascade_gated,
@@ -487,14 +487,20 @@ async def diff_agent(
         canonical_path = _safe_rel(agent_path, project_root)
         # Lenient read — a non-UTF-8 canonical must render a diagnosable
         # parse-error pane, not crash the endpoint (#1233 contract).
-        canonical_content = agent_path.read_bytes().decode("utf-8", errors="replace")
+        canonical_content = read_text_lenient(agent_path)
         # Re-parse so this pane agrees with the list badge: the raw string
         # compare below reported a malformed canonical as "out of sync" /
         # "in sync" while the list said "parse error" (#1229 U7).
-        try:
-            _parse_canonical_agent_text(canonical_content, source=agent_path, layout=layout)
-        except AgentParseError as exc:
-            parse_error_reason = sanitize_diff_reason(str(exc), project_root)
+        if canonical_content is None:
+            # Unreadable canonical (permission, race) — same tolerant path as
+            # the engine diff: every runtime row reports a diagnosable parse
+            # error instead of a 500 (Codex review).
+            parse_error_reason = sanitize_diff_reason(f"unreadable: {agent_path}", project_root)
+        else:
+            try:
+                _parse_canonical_agent_text(canonical_content, source=agent_path, layout=layout)
+            except AgentParseError as exc:
+                parse_error_reason = sanitize_diff_reason(str(exc), project_root)
 
     runtimes = []
     for gen_name, gen in AGENT_GENERATORS.items():
@@ -510,7 +516,9 @@ async def diff_agent(
                 "reason": parse_error_reason,
             }
             if target.is_file():
-                entry["runtime_content"] = target.read_bytes().decode("utf-8", errors="replace")
+                runtime_preview = read_text_lenient(target)
+                if runtime_preview is not None:
+                    entry["runtime_content"] = runtime_preview
             runtimes.append(entry)
             continue
         if canonical_content is None and not target.is_file():
@@ -522,11 +530,13 @@ async def diff_agent(
                 {
                     "runtime": gen_name,
                     "status": "missing canonical",
-                    "runtime_content": target.read_bytes().decode("utf-8", errors="replace"),
+                    "runtime_content": read_text_lenient(target),
                 }
             )
         else:
-            runtime_content = target.read_bytes().decode("utf-8", errors="replace")
+            # Unreadable runtime ≡ parity can't be asserted — report drift,
+            # never mask it (the engine diff contract).
+            runtime_content = read_text_lenient(target)
             runtimes.append(
                 {
                     "runtime": gen_name,

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -21,6 +21,7 @@ from memtomem.context.agents import (
     CANONICAL_AGENT_ROOT,
     AgentParseError,
     SubAgent,
+    _parse_canonical_agent_text,
     canonical_agent_name,
     diff_agents,
     extract_agents_to_canonical,
@@ -31,6 +32,7 @@ from memtomem.context.agents import (
 )
 from memtomem.context.detector import AGENT_DIRS
 from memtomem.context.privacy_scan import PrivacyScanError
+from memtomem.web.routes.context_gateway import sanitize_diff_reason
 from memtomem.web.routes.context_projects import (
     resolve_scope_root,
     resolve_scope_root_cascade_gated,
@@ -125,8 +127,12 @@ async def list_agents(
     diffs = diff_agents(project_root, scope=target_scope)
 
     by_name: dict[str, list[dict]] = {}
-    for runtime, agent_name, status in diffs:
-        by_name.setdefault(agent_name, []).append({"runtime": runtime, "status": status})
+    for row in diffs:
+        entry: dict[str, object] = {"runtime": row[0], "status": row[2]}
+        reason = sanitize_diff_reason(getattr(row, "reason", None), project_root)
+        if reason:
+            entry["reason"] = reason
+        by_name.setdefault(row[1], []).append(entry)
 
     agents: list[dict[str, object]] = []
     canonical_names: set[str] = set()
@@ -474,9 +480,21 @@ async def diff_agent(
     name, resolved = _resolve_existing_agent(project_root, name, scope=target_scope)
 
     canonical_content = None
+    canonical_path = None
+    parse_error_reason = None
     if resolved is not None:
-        agent_path, _layout = resolved
-        canonical_content = agent_path.read_text(encoding="utf-8")
+        agent_path, layout = resolved
+        canonical_path = _safe_rel(agent_path, project_root)
+        # Lenient read — a non-UTF-8 canonical must render a diagnosable
+        # parse-error pane, not crash the endpoint (#1233 contract).
+        canonical_content = agent_path.read_bytes().decode("utf-8", errors="replace")
+        # Re-parse so this pane agrees with the list badge: the raw string
+        # compare below reported a malformed canonical as "out of sync" /
+        # "in sync" while the list said "parse error" (#1229 U7).
+        try:
+            _parse_canonical_agent_text(canonical_content, source=agent_path, layout=layout)
+        except AgentParseError as exc:
+            parse_error_reason = sanitize_diff_reason(str(exc), project_root)
 
     runtimes = []
     for gen_name, gen in AGENT_GENERATORS.items():
@@ -484,6 +502,16 @@ async def diff_agent(
         # for the rationale (#1229). NO_FANOUT tiers return None → skipped.
         target = gen.target_file(project_root, name, scope=target_scope)
         if target is None:
+            continue
+        if parse_error_reason is not None:
+            entry: dict[str, object] = {
+                "runtime": gen_name,
+                "status": "parse error",
+                "reason": parse_error_reason,
+            }
+            if target.is_file():
+                entry["runtime_content"] = target.read_bytes().decode("utf-8", errors="replace")
+            runtimes.append(entry)
             continue
         if canonical_content is None and not target.is_file():
             continue
@@ -494,11 +522,11 @@ async def diff_agent(
                 {
                     "runtime": gen_name,
                     "status": "missing canonical",
-                    "runtime_content": target.read_text(encoding="utf-8"),
+                    "runtime_content": target.read_bytes().decode("utf-8", errors="replace"),
                 }
             )
         else:
-            runtime_content = target.read_text(encoding="utf-8")
+            runtime_content = target.read_bytes().decode("utf-8", errors="replace")
             runtimes.append(
                 {
                     "runtime": gen_name,
@@ -507,7 +535,12 @@ async def diff_agent(
                 }
             )
 
-    return {"name": name, "canonical_content": canonical_content, "runtimes": runtimes}
+    return {
+        "name": name,
+        "canonical_content": canonical_content,
+        "canonical_path": canonical_path,
+        "runtimes": runtimes,
+    }
 
 
 # ── Sync ─────────────────────────────────────────────────────────────────

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -31,7 +31,7 @@ from memtomem.context.commands import (
 )
 from memtomem.context.detector import COMMAND_DIRS
 from memtomem.context.privacy_scan import PrivacyScanError
-from memtomem.web.routes.context_gateway import sanitize_diff_reason
+from memtomem.web.routes.context_gateway import read_text_lenient, sanitize_diff_reason
 from memtomem.web.routes.context_projects import (
     resolve_scope_root,
     resolve_scope_root_cascade_gated,
@@ -481,11 +481,17 @@ async def diff_command(
         # Lenient read + re-parse — mirrors diff_agent: the pane must agree
         # with the list badge instead of raw-comparing a malformed canonical
         # into "out of sync" / "in sync" (#1229 U7).
-        canonical_content = cmd_path.read_bytes().decode("utf-8", errors="replace")
-        try:
-            _parse_canonical_command_text(canonical_content, source=cmd_path, layout=layout)
-        except CommandParseError as exc:
-            parse_error_reason = sanitize_diff_reason(str(exc), project_root)
+        canonical_content = read_text_lenient(cmd_path)
+        if canonical_content is None:
+            # Unreadable canonical (permission, race) — same tolerant path as
+            # the engine diff: every runtime row reports a diagnosable parse
+            # error instead of a 500 (Codex review).
+            parse_error_reason = sanitize_diff_reason(f"unreadable: {cmd_path}", project_root)
+        else:
+            try:
+                _parse_canonical_command_text(canonical_content, source=cmd_path, layout=layout)
+            except CommandParseError as exc:
+                parse_error_reason = sanitize_diff_reason(str(exc), project_root)
 
     runtimes = []
     for gen_name, gen in COMMAND_GENERATORS.items():
@@ -501,7 +507,9 @@ async def diff_command(
                 "reason": parse_error_reason,
             }
             if target.is_file():
-                entry["runtime_content"] = target.read_bytes().decode("utf-8", errors="replace")
+                runtime_preview = read_text_lenient(target)
+                if runtime_preview is not None:
+                    entry["runtime_content"] = runtime_preview
             runtimes.append(entry)
             continue
         if canonical_content is None and not target.is_file():
@@ -513,11 +521,13 @@ async def diff_command(
                 {
                     "runtime": gen_name,
                     "status": "missing canonical",
-                    "runtime_content": target.read_bytes().decode("utf-8", errors="replace"),
+                    "runtime_content": read_text_lenient(target),
                 }
             )
         else:
-            runtime_content = target.read_bytes().decode("utf-8", errors="replace")
+            # Unreadable runtime ≡ parity can't be asserted — report drift,
+            # never mask it (the engine diff contract).
+            runtime_content = read_text_lenient(target)
             # For commands, content won't be byte-identical (placeholder rewrites)
             # so we always provide the runtime content for diff view.
             runtimes.append(

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -16,6 +16,7 @@ from memtomem.context import versioning
 from memtomem.context._atomic import atomic_write_text
 from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context.commands import (
+    _parse_canonical_command_text,
     CANONICAL_COMMAND_ROOT,
     COMMAND_DIR_FILENAME,
     COMMAND_GENERATORS,
@@ -30,6 +31,7 @@ from memtomem.context.commands import (
 )
 from memtomem.context.detector import COMMAND_DIRS
 from memtomem.context.privacy_scan import PrivacyScanError
+from memtomem.web.routes.context_gateway import sanitize_diff_reason
 from memtomem.web.routes.context_projects import (
     resolve_scope_root,
     resolve_scope_root_cascade_gated,
@@ -115,8 +117,12 @@ async def list_commands(
     diffs = diff_commands(project_root, scope=target_scope)
 
     by_name: dict[str, list[dict]] = {}
-    for runtime, cmd_name, status in diffs:
-        by_name.setdefault(cmd_name, []).append({"runtime": runtime, "status": status})
+    for row in diffs:
+        entry: dict[str, object] = {"runtime": row[0], "status": row[2]}
+        reason = sanitize_diff_reason(getattr(row, "reason", None), project_root)
+        if reason:
+            entry["reason"] = reason
+        by_name.setdefault(row[1], []).append(entry)
 
     commands: list[dict[str, object]] = []
     canonical_names: set[str] = set()
@@ -467,9 +473,19 @@ async def diff_command(
     name, resolved = _resolve_existing_command(project_root, name, scope=target_scope)
 
     canonical_content = None
+    canonical_path = None
+    parse_error_reason = None
     if resolved is not None:
-        cmd_path, _layout = resolved
-        canonical_content = cmd_path.read_text(encoding="utf-8")
+        cmd_path, layout = resolved
+        canonical_path = _safe_rel(cmd_path, project_root)
+        # Lenient read + re-parse — mirrors diff_agent: the pane must agree
+        # with the list badge instead of raw-comparing a malformed canonical
+        # into "out of sync" / "in sync" (#1229 U7).
+        canonical_content = cmd_path.read_bytes().decode("utf-8", errors="replace")
+        try:
+            _parse_canonical_command_text(canonical_content, source=cmd_path, layout=layout)
+        except CommandParseError as exc:
+            parse_error_reason = sanitize_diff_reason(str(exc), project_root)
 
     runtimes = []
     for gen_name, gen in COMMAND_GENERATORS.items():
@@ -477,6 +493,16 @@ async def diff_command(
         # for the rationale (#1229). NO_FANOUT tiers return None → skipped.
         target = gen.target_file(project_root, name, scope=target_scope)
         if target is None:
+            continue
+        if parse_error_reason is not None:
+            entry: dict[str, object] = {
+                "runtime": gen_name,
+                "status": "parse error",
+                "reason": parse_error_reason,
+            }
+            if target.is_file():
+                entry["runtime_content"] = target.read_bytes().decode("utf-8", errors="replace")
+            runtimes.append(entry)
             continue
         if canonical_content is None and not target.is_file():
             continue
@@ -487,11 +513,11 @@ async def diff_command(
                 {
                     "runtime": gen_name,
                     "status": "missing canonical",
-                    "runtime_content": target.read_text(encoding="utf-8"),
+                    "runtime_content": target.read_bytes().decode("utf-8", errors="replace"),
                 }
             )
         else:
-            runtime_content = target.read_text(encoding="utf-8")
+            runtime_content = target.read_bytes().decode("utf-8", errors="replace")
             # For commands, content won't be byte-identical (placeholder rewrites)
             # so we always provide the runtime content for diff view.
             runtimes.append(
@@ -502,7 +528,12 @@ async def diff_command(
                 }
             )
 
-    return {"name": name, "canonical_content": canonical_content, "runtimes": runtimes}
+    return {
+        "name": name,
+        "canonical_content": canonical_content,
+        "canonical_path": canonical_path,
+        "runtimes": runtimes,
+    }
 
 
 # ── Sync ─────────────────────────────────────────────────────────────────

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, Query
@@ -110,6 +111,25 @@ def _redact_message(message: str) -> str:
     if len(redacted) > _ERROR_MESSAGE_LIMIT:
         redacted = redacted[:_ERROR_MESSAGE_LIMIT]
     return redacted
+
+
+def sanitize_diff_reason(message: str | None, project_root: Path) -> str | None:
+    """Display-sanitize an engine diff-row ``reason`` for the wire (#1229 U7).
+
+    Engine reasons are raw exception text with absolute source paths
+    EMBEDDED in arbitrary message strings (not bare paths), so plain
+    ``Path.relative_to`` doesn't apply: strip the project-root prefix
+    wherever it appears inside the message, then apply the same
+    HOME-collapse + secret-shape whole-replace + truncation contract as
+    the overview ``error_message`` field. Shared by every context_* list
+    and per-name diff route so the sanitization boundary cannot drift
+    per kind.
+    """
+    if not message:
+        return None
+    root = str(project_root)
+    cleaned = message.replace(root + os.sep, "").replace(root, ".")
+    return _redact_message(cleaned)
 
 
 def _compute_last_synced_at(project_root: Path, target_scope: TargetScope) -> str | None:

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -132,6 +132,20 @@ def sanitize_diff_reason(message: str | None, project_root: Path) -> str | None:
     return _redact_message(cleaned)
 
 
+def read_text_lenient(path: Path) -> str | None:
+    """Best-effort text read for diff payload previews (#1229 U7).
+
+    ``None`` on any OSError (permission, race-deleted) — a per-name diff
+    endpoint must keep diagnosing instead of 500ing while the engine diff
+    reports the same file as a typed row; non-UTF-8 bytes decode with
+    U+FFFD replacement (the #1233 lenient-read contract).
+    """
+    try:
+        return path.read_bytes().decode("utf-8", errors="replace")
+    except OSError:
+        return None
+
+
 def _compute_last_synced_at(project_root: Path, target_scope: TargetScope) -> str | None:
     """Return ISO8601 UTC timestamp of the most recently touched canonical artifact.
 

--- a/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
@@ -28,6 +28,7 @@ from memtomem.context.mcp_servers import (
     scan_mcp_server_text,
 )
 from memtomem.web.routes._locks import _gateway_lock
+from memtomem.web.routes.context_gateway import sanitize_diff_reason
 from memtomem.web.routes.context_projects import (
     resolve_scope_root,
     resolve_writable_scope_root,
@@ -83,10 +84,13 @@ async def list_mcp_servers(
             "canonical_root": CANONICAL_MCP_SERVER_ROOT,
             "scanned_dirs": [".mcp.json"],
         }
-    diff_by_name = {
-        name: [{"runtime": runtime, "status": status}]
-        for runtime, name, status in diff_mcp_servers(project_root)
-    }
+    diff_by_name: dict[str, list[dict]] = {}
+    for row in diff_mcp_servers(project_root):
+        entry: dict[str, object] = {"runtime": row[0], "status": row[2]}
+        reason = sanitize_diff_reason(getattr(row, "reason", None), project_root)
+        if reason:
+            entry["reason"] = reason
+        diff_by_name[row[1]] = [entry]
     servers = []
     for path in list_canonical_mcp_servers(project_root):
         name = path.stem
@@ -330,6 +334,7 @@ async def diff_mcp_server(
         return {
             "name": name,
             "canonical_content": None,
+            "canonical_path": None,
             "runtimes": [
                 {"runtime": MCP_RUNTIME, "status": "missing canonical", "runtime_content": None}
             ],
@@ -337,12 +342,19 @@ async def diff_mcp_server(
     path = canonical_mcp_server_path(project_root, name)
     canonical_content = None
     canonical_definition = None
+    reason: str | None = None
     if path.is_file():
-        canonical_content = path.read_text(encoding="utf-8")
+        # Lenient read — a non-UTF-8 canonical must render a diagnosable
+        # parse-error pane, not crash the endpoint.
+        canonical_content = path.read_bytes().decode("utf-8", errors="replace")
         try:
-            canonical_definition = parse_canonical_mcp_server(path).definition
-        except McpServerParseError:
-            pass
+            canonical_definition = parse_mcp_server_text(
+                canonical_content, name=name, source=path
+            ).definition
+        except McpServerParseError as exc:
+            # Canonical-side parse failure — the reason names the canonical
+            # file (#1229 U7; previously discarded).
+            reason = sanitize_diff_reason(str(exc), project_root)
 
     status = "missing target"
     runtime_content = None
@@ -353,26 +365,31 @@ async def diff_mcp_server(
         try:
             import json
 
-            config = json.loads(mcp_path.read_text(encoding="utf-8"))
+            config = json.loads(mcp_path.read_bytes().decode("utf-8", errors="replace"))
             target_definition = (config.get("mcpServers") or {}).get(name)
             if target_definition is None:
                 status = "missing target"
             else:
                 runtime_content = format_mcp_server_definition(target_definition)
                 status = "in sync" if target_definition == canonical_definition else "out of sync"
-        except Exception:
+        except Exception as exc:
             status = "parse error"
+            # Target-side failure: the canonical is healthy — the reason must
+            # point at .mcp.json so the user doesn't chase the canonical file.
+            reason = sanitize_diff_reason(f"invalid JSON in .mcp.json: {exc}", project_root)
 
+    runtime_entry: dict[str, object] = {
+        "runtime": MCP_RUNTIME,
+        "status": status,
+        "runtime_content": runtime_content,
+    }
+    if reason:
+        runtime_entry["reason"] = reason
     return {
         "name": name,
         "canonical_content": canonical_content,
-        "runtimes": [
-            {
-                "runtime": MCP_RUNTIME,
-                "status": status,
-                "runtime_content": runtime_content,
-            }
-        ],
+        "canonical_path": _safe_rel(path, project_root),
+        "runtimes": [runtime_entry],
     }
 
 

--- a/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
@@ -28,7 +28,7 @@ from memtomem.context.mcp_servers import (
     scan_mcp_server_text,
 )
 from memtomem.web.routes._locks import _gateway_lock
-from memtomem.web.routes.context_gateway import sanitize_diff_reason
+from memtomem.web.routes.context_gateway import read_text_lenient, sanitize_diff_reason
 from memtomem.web.routes.context_projects import (
     resolve_scope_root,
     resolve_writable_scope_root,
@@ -344,17 +344,21 @@ async def diff_mcp_server(
     canonical_definition = None
     reason: str | None = None
     if path.is_file():
-        # Lenient read — a non-UTF-8 canonical must render a diagnosable
-        # parse-error pane, not crash the endpoint.
-        canonical_content = path.read_bytes().decode("utf-8", errors="replace")
-        try:
-            canonical_definition = parse_mcp_server_text(
-                canonical_content, name=name, source=path
-            ).definition
-        except McpServerParseError as exc:
-            # Canonical-side parse failure — the reason names the canonical
-            # file (#1229 U7; previously discarded).
-            reason = sanitize_diff_reason(str(exc), project_root)
+        # Lenient read — a non-UTF-8 or unreadable canonical must render a
+        # diagnosable parse-error pane, not crash the endpoint.
+        canonical_content = read_text_lenient(path)
+        if canonical_content is None:
+            reason = sanitize_diff_reason(f"unreadable: {path}", project_root)
+            canonical_content = ""
+        else:
+            try:
+                canonical_definition = parse_mcp_server_text(
+                    canonical_content, name=name, source=path
+                ).definition
+            except McpServerParseError as exc:
+                # Canonical-side parse failure — the reason names the
+                # canonical file (#1229 U7; previously discarded).
+                reason = sanitize_diff_reason(str(exc), project_root)
 
     status = "missing target"
     runtime_content = None

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -28,6 +28,7 @@ from memtomem.context.skills import (
 )
 from memtomem.config import TargetScope
 from memtomem.web.routes._locks import _gateway_lock
+from memtomem.web.routes.context_gateway import sanitize_diff_reason
 from memtomem.web.routes.context_projects import (
     resolve_scope_root,
     resolve_scope_root_cascade_gated,
@@ -117,8 +118,12 @@ async def list_skills(
 
     # Group diff tuples by skill name
     by_name: dict[str, list[dict]] = {}
-    for runtime, skill_name, status in diffs:
-        by_name.setdefault(skill_name, []).append({"runtime": runtime, "status": status})
+    for row in diffs:
+        entry: dict[str, object] = {"runtime": row[0], "status": row[2]}
+        reason = sanitize_diff_reason(getattr(row, "reason", None), project_root)
+        if reason:
+            entry["reason"] = reason
+        by_name.setdefault(row[1], []).append(entry)
 
     skills: list[dict[str, object]] = []
     for skill_dir in canonicals:

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -87,7 +87,11 @@ function renderRuntimeBadges(runtimes) {
   return '<div class="ctx-runtime-badges">' +
     runtimes.map(r => {
       const short = r.runtime.replace(/_skills|_commands|_agents/g, '');
-      return `<span class="ctx-runtime-badge ${_ctxStatusCls[r.status] || ''}" title="${escapeHtml(r.runtime)}">${escapeHtml(_ctxRuntimeLabel(short))}: ${escapeHtml(_ctxStatusText(r.status))}</span>`;
+      // U7 (#1229): surface the server-sanitized diagnostic reason as a
+      // tooltip on the list-card badge — the leaf pane carries the full
+      // rendering; the card gets the at-a-glance cause.
+      const title = r.reason ? `${r.runtime} — ${r.reason}` : r.runtime;
+      return `<span class="ctx-runtime-badge ${_ctxStatusCls[r.status] || ''}" title="${escapeHtml(title)}">${escapeHtml(_ctxRuntimeLabel(short))}: ${escapeHtml(_ctxStatusText(r.status))}</span>`;
     }).join('') + '</div>';
 }
 
@@ -133,6 +137,26 @@ function _ctxSyncOverwriteWarning(impact) {
   return impact && impact.overwrite > 0
     ? t('settings.ctx.confirm_sync_overwrite_warning', { overwrite: impact.overwrite })
     : '';
+}
+
+// U7 (#1229): per-runtime diagnostic block under a parse-error /
+// invalid-name badge — server-sanitized reason text plus a fix-it hint
+// naming the canonical file. Empty for healthy rows and for rows whose
+// payload predates the reason field (older cached responses).
+function _ctxDiagnosticDetail(rt, canonicalPath) {
+  const broken = rt.status === 'parse error' || rt.status === 'invalid name';
+  if (!broken) return '';
+  let html = '<div class="ctx-diagnostic-detail">';
+  if (rt.reason) {
+    html += `<div class="ctx-diagnostic-reason">${escapeHtml(rt.reason)}</div>`;
+  }
+  if (rt.status === 'parse error' && canonicalPath) {
+    html += `<div class="ctx-diagnostic-hint">${escapeHtml(
+      t('settings.ctx.parse_error_hint', { path: canonicalPath }),
+    )}</div>`;
+  }
+  html += '</div>';
+  return html === '<div class="ctx-diagnostic-detail"></div>' ? '' : html;
 }
 
 function renderDroppedChips(fields) {
@@ -4211,6 +4235,7 @@ async function _ctxLoadDiff(type, name, detailEl) {
       for (const rt of data.runtimes) {
         html += `<div style="margin-bottom:12px">`;
         html += `<strong>${escapeHtml(rt.runtime)}</strong> ${_ctxBadge(rt.status)}`;
+        html += _ctxDiagnosticDetail(rt, data.canonical_path);
         if (rt.dropped_fields && rt.dropped_fields.length) {
           html += `<div style="margin-top:4px">${renderDroppedChips(rt.dropped_fields)}</div>`;
         }
@@ -4277,6 +4302,7 @@ async function _ctxLoadRuntimeOnlyDetail(type, name, detailEl, opts = {}) {
       for (const rt of data.runtimes) {
         html += `<div style="margin-bottom:12px">`;
         html += `<strong>${escapeHtml(rt.runtime)}</strong> ${_ctxBadge(rt.status)}`;
+        html += _ctxDiagnosticDetail(rt, data.canonical_path);
         if (rt.runtime_content != null) {
           html += `<pre class="ctx-content-pre" style="margin-top:6px">${escapeHtml(rt.runtime_content)}</pre>`;
         }

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=102" />
+  <link rel="stylesheet" href="/style.css?v=103" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -1468,7 +1468,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=17"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=67"></script>
+  <script src="/context-gateway.js?v=68"></script>
   <script src="/context-portal.js?v=2"></script>
   <script src="/path-picker.js?v=3"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -439,6 +439,7 @@
   "settings.ctx.status_missing_canonical": "Not yet imported",
   "settings.ctx.status_parse_error": "Parse error",
   "settings.ctx.status_invalid_name": "Invalid name",
+  "settings.ctx.parse_error_hint": "Fix the file at {path}, then click Refresh.",
   "settings.ctx.badge_synced": "synced",
   "settings.ctx.badge_missing_target": "not in runtime",
   "settings.ctx.badge_missing_canonical": "not imported",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -439,6 +439,7 @@
   "settings.ctx.status_missing_canonical": "아직 가져오지 않음",
   "settings.ctx.status_parse_error": "파싱 오류",
   "settings.ctx.status_invalid_name": "잘못된 이름",
+  "settings.ctx.parse_error_hint": "{path} 파일을 수정한 뒤 새로 고침을 누르세요.",
   "settings.ctx.badge_synced": "동기화",
   "settings.ctx.badge_missing_target": "런타임에 없음",
   "settings.ctx.badge_missing_canonical": "미가져옴",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -3861,6 +3861,11 @@ body.help-hidden #help-toggle { opacity: 0.5; }
    sanitized error_message from the overview envelope). Single line with
    ellipsis — the full text rides the title tooltip and the aria-label. */
 .ctx-overview-error-detail { font-size: 0.72rem; color: var(--muted); margin-top: 6px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* U7 (#1229): per-runtime diagnostic block under a parse-error / invalid-name
+   badge in the diff / runtime-only panes — sanitized reason + fix-it hint. */
+.ctx-diagnostic-detail { margin-top: 4px; font-size: 0.78rem; }
+.ctx-diagnostic-reason { color: var(--muted); font-family: var(--mono, monospace); word-break: break-word; }
+.ctx-diagnostic-hint { color: var(--muted); margin-top: 2px; }
 /* Pointer line sits BELOW the nav button (sibling, not child). Inset it
    horizontally to match the nav button's 16px padding so the visual gutter
    stays continuous, and pull it up against the nav button's bottom padding

--- a/packages/memtomem/tests-js/ctx-parse-error-diagnostics.test.mjs
+++ b/packages/memtomem/tests-js/ctx-parse-error-diagnostics.test.mjs
@@ -1,0 +1,74 @@
+/* U7 (#1229): parse-error / invalid-name rows render a diagnostic block —
+ * server-sanitized reason + a fix-it hint naming the canonical file — in the
+ * diff pane and the runtime-only detail, and the list-card badge tooltip
+ * carries the reason. Healthy rows render nothing extra (negative pins).
+ *
+ * `_ctxDiagnosticDetail` and `renderRuntimeBadges` are global function
+ * declarations, callable directly off the booted window.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+async function boot() {
+  const dom = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+  await dom.window.I18N.init();
+  return dom.window;
+}
+
+describe('diagnostic detail block (_ctxDiagnosticDetail)', () => {
+  it('renders reason + interpolated hint for a parse-error row', async () => {
+    const window = await boot();
+    const html = window._ctxDiagnosticDetail(
+      { status: 'parse error', reason: 'missing YAML frontmatter: .memtomem/agents/broken.md' },
+      '.memtomem/agents/broken.md',
+    );
+    expect(html).toContain('ctx-diagnostic-reason');
+    expect(html).toContain('missing YAML frontmatter');
+    // The hint names the canonical file (settings.ctx.parse_error_hint).
+    expect(html).toContain('.memtomem/agents/broken.md');
+    expect(html).toContain('Refresh');
+  });
+
+  it('renders the validate_name reason for an invalid-name row (no hint without a canonical)', async () => {
+    const window = await boot();
+    const html = window._ctxDiagnosticDetail(
+      { status: 'invalid name', reason: "invalid agent name '-bad': leading dash" },
+      null,
+    );
+    expect(html).toContain('leading dash');
+    expect(html).not.toContain('ctx-diagnostic-hint');
+  });
+
+  it('escapes HTML in the reason (raw names are attacker-adjacent strings)', async () => {
+    const window = await boot();
+    const html = window._ctxDiagnosticDetail(
+      { status: 'parse error', reason: '<img src=x onerror=alert(1)>' },
+      null,
+    );
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;img');
+  });
+
+  it('renders nothing for healthy rows and for diagnostic rows without data (negative pins)', async () => {
+    const window = await boot();
+    expect(window._ctxDiagnosticDetail({ status: 'in sync' }, '.memtomem/x.md')).toBe('');
+    expect(window._ctxDiagnosticDetail({ status: 'out of sync', reason: 'x' }, null)).toBe('');
+    // Parse error with neither reason nor canonical path → empty, not an
+    // empty styled box.
+    expect(window._ctxDiagnosticDetail({ status: 'invalid name' }, null)).toBe('');
+  });
+});
+
+describe('list-card badge tooltip', () => {
+  it('carries the reason in the title attribute when present', async () => {
+    const window = await boot();
+    const html = window.renderRuntimeBadges([
+      { runtime: 'claude_agents', status: 'parse error', reason: 'missing YAML frontmatter' },
+      { runtime: 'gemini_agents', status: 'in sync' },
+    ]);
+    expect(html).toContain('claude_agents — missing YAML frontmatter');
+    // Healthy badge keeps the bare runtime-name tooltip.
+    expect(html).toContain('title="gemini_agents"');
+  });
+});

--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -526,6 +526,41 @@ class TestDiffAgents:
         claude_rows = [(n, s) for r, n, s in rows if r == "claude_agents" and n == "-bad"]
         assert claude_rows == [("-bad", "parse error")]
 
+    def test_parse_error_row_carries_reason_with_source_path(self, tmp_path, codex_home):
+        """U7 (#1229): the 'parse error' row carries the exception text —
+        which embeds the source path — instead of a bare status; healthy
+        rows keep reason None (pin-and-invert)."""
+        _make_canonical_agent(tmp_path, "broken", "no frontmatter at all\n")
+        _make_canonical_agent(tmp_path, "healthy", SAMPLE_MINIMAL_AGENT)
+        rows = diff_agents(tmp_path)
+        broken = [r for r in rows if r[1] == "broken"]
+        assert broken
+        for row in broken:
+            assert row[2] == "parse error"
+            assert "frontmatter" in (row.reason or "")
+            assert "broken.md" in (row.reason or "")
+        healthy = [r for r in rows if r[1] == "helper"]
+        assert healthy
+        assert all(getattr(r, "reason", None) is None for r in healthy)
+
+    def test_invalid_name_row_carries_validation_reason(self, tmp_path, codex_home):
+        claude_dir = tmp_path / ".claude/agents"
+        claude_dir.mkdir(parents=True)
+        (claude_dir / "-bad.md").write_text(SAMPLE_MINIMAL_AGENT, encoding="utf-8")
+        rows = diff_agents(tmp_path)
+        row = next(r for r in rows if r[2] == "invalid name")
+        assert "invalid agent name" in (row.reason or "")
+
+    def test_diff_rows_still_unpack_as_three_tuples(self, tmp_path, codex_home):
+        """API-compat pin: DiffRow iterates as the historical 3-tuple, and
+        equality against plain tuples holds — external positional consumers
+        of the public diff_* functions must not break."""
+        _make_canonical_agent(tmp_path, "broken", "no frontmatter at all\n")
+        rows = diff_agents(tmp_path)
+        for runtime, name, status in rows:  # raises ValueError if widened
+            assert isinstance(runtime, str) and isinstance(name, str) and isinstance(status, str)
+        assert ("claude_agents", "broken", "parse error") in rows
+
     def test_whitespace_only_drift_detected_and_converges(self, tmp_path, codex_home):
         """Whitespace-only drift is real drift: sync writes render output
         byte-exact, so diff must not ``.strip()`` it away — pre-fix a padded

--- a/packages/memtomem/tests/test_context_commands.py
+++ b/packages/memtomem/tests/test_context_commands.py
@@ -489,6 +489,16 @@ class TestDiffCommands:
         statuses = {s for _, n, s in rows if n == "broken"}
         assert statuses == {"parse error"}
 
+    def test_parse_error_row_carries_reason(self, tmp_path):
+        """U7 (#1229): mirrors diff_agents — the row reason embeds the
+        source path via the exception text."""
+        _make_canonical_command(tmp_path, "broken", "---\nname: bad name\n---\n\nbody\n")
+        rows = diff_commands(tmp_path)
+        row = next(r for r in rows if r[1] == "broken")
+        assert row[2] == "parse error"
+        assert "invalid command name" in (row.reason or "")
+        assert "broken.md" in (row.reason or "")
+
     def test_whitespace_only_drift_detected_and_converges(self, tmp_path):
         """Whitespace-only drift is real drift: sync writes render output
         byte-exact, so diff must not ``.strip()`` it away — pre-fix a padded

--- a/packages/memtomem/tests/test_context_mcp_servers.py
+++ b/packages/memtomem/tests/test_context_mcp_servers.py
@@ -89,3 +89,21 @@ def test_no_canonical_root_returns_empty_skip(tmp_path: Path) -> None:
     assert result.skipped == [
         ("project_mcp", "No canonical MCP server definitions found", "no_canonical_root")
     ]
+
+
+def test_diff_parse_error_reasons_distinguish_canonical_from_target(tmp_path: Path) -> None:
+    """U7 (#1229): a canonical-parse failure names the canonical file; a
+    broken .mcp.json marks every canonical row 'parse error' with a reason
+    naming .mcp.json — so the user never chases N healthy canonical files."""
+    bad = tmp_path / ".memtomem" / "mcp-servers" / "bad.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text("{not json", encoding="utf-8")
+    rows = diff_mcp_servers(tmp_path)
+    assert rows[0][2] == "parse error"
+    assert "bad.json" in (rows[0].reason or "")
+
+    bad.write_text(json.dumps({"command": "uvx"}), encoding="utf-8")
+    (tmp_path / ".mcp.json").write_text("{broken", encoding="utf-8")
+    rows = diff_mcp_servers(tmp_path)
+    assert rows[0][2] == "parse error"
+    assert ".mcp.json" in (rows[0].reason or "")

--- a/packages/memtomem/tests/test_context_runtime_targets.py
+++ b/packages/memtomem/tests/test_context_runtime_targets.py
@@ -218,3 +218,22 @@ def test_runtime_artifact_listing_returns_invalid_names(tmp_path: Path) -> None:
     assert runtime_artifact_names(
         "agents", "claude", tmp_path, "project_shared", file_suffix=".md"
     ) == {"ok"}
+
+
+def test_diff_row_pickles_and_unpacks_like_a_tuple() -> None:
+    """DiffRow compat pins (#1229 U7): 3-unpack, tuple equality, and pickle
+    round-trip (Codex review — unpickling calls __new__ with the tuple state,
+    which needs __getnewargs__ to carry all four constructor args)."""
+    import pickle
+
+    from memtomem.context._runtime_targets import DiffRow
+
+    row = DiffRow("claude_agents", "broken", "parse error", "missing YAML frontmatter")
+    runtime, name, status = row
+    assert (runtime, name, status) == ("claude_agents", "broken", "parse error")
+    assert row == ("claude_agents", "broken", "parse error")
+    assert hash(row) == hash(("claude_agents", "broken", "parse error"))
+
+    clone = pickle.loads(pickle.dumps(row))
+    assert clone == row
+    assert clone.reason == "missing YAML frontmatter"

--- a/packages/memtomem/tests/test_context_runtime_targets.py
+++ b/packages/memtomem/tests/test_context_runtime_targets.py
@@ -211,7 +211,9 @@ def test_runtime_artifact_listing_returns_invalid_names(tmp_path: Path) -> None:
         "agents", "claude", tmp_path, "project_shared", file_suffix=".md"
     )
     assert names == {"ok"}
-    assert invalid == ["-bad", "bad name"]
+    # (raw_name, reason) pairs — the reason rides the diff row (#1229 U7).
+    assert [n for n, _ in invalid] == ["-bad", "bad name"]
+    assert all("invalid agent name" in r for _, r in invalid)
 
     assert runtime_artifact_names(
         "agents", "claude", tmp_path, "project_shared", file_suffix=".md"

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -1022,6 +1022,7 @@ class TestNoHardcodedStrings:
             "settings.ctx.badge_empty",
             "settings.ctx.badge_error",
             "settings.ctx.status_parse_error",
+            "settings.ctx.parse_error_hint",
             "settings.ctx.refresh",
             "settings.ctx.refresh_tooltip",
             "settings.ctx.refresh_aria",

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -1564,6 +1564,42 @@ class TestAgentCRUD:
 
 class TestDiffAgent:
     @pytest.mark.anyio
+    async def test_malformed_canonical_reports_parse_error_with_reason(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """U7 (#1229): the per-name diff used to raw-compare a malformed
+        canonical into 'out of sync'/'in sync' while the list badge said
+        'parse error' — it now re-parses and emits the parse-error rows with
+        a sanitized reason and the canonical_path for the fix-it hint."""
+        _make_agent(tmp_path, "broken", "no frontmatter at all\n")
+        rt_dir = tmp_path / ".claude" / "agents"
+        rt_dir.mkdir(parents=True)
+        (rt_dir / "broken.md").write_text(_AGENT_CONTENT, encoding="utf-8")
+
+        r = await client.get("/api/context/agents/broken/diff")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["canonical_path"] == ".memtomem/agents/broken.md"
+        claude_rt = [rt for rt in data["runtimes"] if rt["runtime"] == "claude_agents"][0]
+        assert claude_rt["status"] == "parse error"
+        assert "frontmatter" in claude_rt["reason"]
+        # Sanitized: the absolute tmp_path root never crosses the wire.
+        assert str(tmp_path) not in claude_rt["reason"]
+        # Runtime content still previews for the side-by-side view.
+        assert "runtime_content" in claude_rt
+
+    @pytest.mark.anyio
+    async def test_healthy_canonical_payload_has_canonical_path_and_no_reason(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        _make_agent(tmp_path, "fine")
+        r = await client.get("/api/context/agents/fine/diff")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["canonical_path"] == ".memtomem/agents/fine.md"
+        assert all("reason" not in rt for rt in data["runtimes"])
+
+    @pytest.mark.anyio
     async def test_diff_user_tier_resolves_user_runtime(
         self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
@@ -1855,3 +1891,34 @@ class TestImportSurfaceAttribution:
         r = await client.post("/api/context/skills/solo/import", json={})
         assert r.status_code == 200
         assert set(surfaces) == {"web_context_skills_import"}
+
+
+# ---------------------------------------------------------------------------
+# U7 (#1229) — list endpoints carry sanitized diagnostic reasons
+# ---------------------------------------------------------------------------
+
+
+class TestListDiagnosticReasons:
+    @pytest.mark.anyio
+    async def test_parse_error_entry_carries_sanitized_reason(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        _make_agent(tmp_path, "broken", "no frontmatter at all\n")
+        r = await client.get("/api/context/agents")
+        assert r.status_code == 200
+        item = [a for a in r.json()["agents"] if a["name"] == "broken"][0]
+        entries = [e for e in item["runtimes"] if e["status"] == "parse error"]
+        assert entries
+        for e in entries:
+            assert "frontmatter" in e["reason"]
+            assert "broken.md" in e["reason"]
+            # Embedded absolute path stripped at the route boundary — the
+            # engine reason text embeds str(source_path).
+            assert str(tmp_path) not in e["reason"]
+
+    @pytest.mark.anyio
+    async def test_healthy_entries_have_no_reason_key(self, client: AsyncClient, tmp_path: Path):
+        _make_agent(tmp_path, "fine")
+        r = await client.get("/api/context/agents")
+        item = [a for a in r.json()["agents"] if a["name"] == "fine"][0]
+        assert all("reason" not in e for e in item["runtimes"])

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -1589,6 +1589,31 @@ class TestDiffAgent:
         assert "runtime_content" in claude_rt
 
     @pytest.mark.anyio
+    @pytest.mark.skipif(
+        os.name == "nt" or os.geteuid() == 0,
+        reason="needs POSIX permissions and a non-root user",
+    )
+    async def test_unreadable_canonical_diagnoses_instead_of_500(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """A PermissionError on the canonical must produce parse-error rows
+        with an 'unreadable' reason — the engine diff reports the same file
+        as a typed row, so a 500 here would contradict the list badge
+        (Codex review on U7)."""
+        path = _make_agent(tmp_path, "locked")
+        path.chmod(0)
+        try:
+            r = await client.get("/api/context/agents/locked/diff")
+        finally:
+            path.chmod(0o644)
+        assert r.status_code == 200
+        data = r.json()
+        rows = data["runtimes"]
+        assert rows
+        assert all(rt["status"] == "parse error" for rt in rows)
+        assert all("unreadable" in rt["reason"] for rt in rows)
+
+    @pytest.mark.anyio
     async def test_healthy_canonical_payload_has_canonical_path_and_no_reason(
         self, client: AsyncClient, tmp_path: Path
     ):

--- a/packages/memtomem/tests/test_web_routes_context_mcp_servers.py
+++ b/packages/memtomem/tests/test_web_routes_context_mcp_servers.py
@@ -226,3 +226,30 @@ async def test_PUT_force_default_false_still_409s(client: AsyncClient, tmp_path:
     assert r.status_code == 409
     assert r.json()["status"] == "aborted"
     assert path.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.anyio
+async def test_diff_reasons_distinguish_canonical_vs_mcp_json(
+    client: AsyncClient, tmp_path: Path
+) -> None:
+    """U7 (#1229): per-name diff reasons name the file that actually broke —
+    canonical .json vs the project .mcp.json — and the payload carries
+    canonical_path for the fix-it hint."""
+    bad = tmp_path / ".memtomem" / "mcp-servers" / "bad.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text("{not json", encoding="utf-8")
+    r = await client.get("/api/context/mcp-servers/bad/diff")
+    assert r.status_code == 200
+    data = r.json()
+    assert Path(data["canonical_path"]) == Path(".memtomem/mcp-servers/bad.json")
+    rt = data["runtimes"][0]
+    assert rt["status"] == "parse error"
+    assert "bad.json" in rt["reason"]
+    assert str(tmp_path) not in rt["reason"]
+
+    bad.write_text(json.dumps({"command": "uvx"}), encoding="utf-8")
+    (tmp_path / ".mcp.json").write_text("{broken", encoding="utf-8")
+    r = await client.get("/api/context/mcp-servers/bad/diff")
+    rt = r.json()["runtimes"][0]
+    assert rt["status"] == "parse error"
+    assert ".mcp.json" in rt["reason"]


### PR DESCRIPTION
U7 from the Context Gateway review catalog (#1229) — the last open finding.

## "Parse error" told you something broke, never what or where

The diff layer emitted the bare status string with no message — in `diff_agents`/`diff_commands` the exception was swallowed **without even logging** — and the UI faithfully rendered a red badge with no file path, no cause, no fix guidance on tile, list card, or diff pane. Verification also found a fresh contradiction: the per-name diff endpoints never re-parsed the canonical (raw string compare), so a malformed canonical rendered "out of sync"/"in sync" in the pane while the list badge said "parse error".

## Engine: `DiffRow` — diagnostics without an API break

A tuple **subclass** that iterates, compares, and hashes as the historical `(runtime, name, status)` 3-tuple while carrying a `.reason` attribute (plus `__getnewargs__` for pickle round-trips). Every existing positional consumer — CLI printers, MCP tools, web groupers, external callers of the public `diff_*` functions — keeps working unchanged; the Codex design gate weighed NamedTuple-widening vs a parallel detailed API, and the subclass beats both (no breaking change, no drift-prone second API). Reasons are captured at the existing catch sites (exception text embeds the source path; the agents/commands sites also gain the missing `logger.warning`), invalid-name rows (#1243) carry the `validate_name` message via the listing's new `(raw_name, reason)` pairs, and `diff_mcp_servers` distinguishes canonical-parse from broken-`.mcp.json` — which marks *every* canonical row, so the reason must name the file that actually broke.

## Wire: additive, sanitized at the boundary

List endpoints emit `runtimes[]` entries with an optional `reason`, sanitized by a shared `sanitize_diff_reason` (project-root prefix stripped from **embedded** message text — engine reasons are arbitrary strings, not bare paths — then the established HOME-collapse + secret-shape whole-replace + truncation). Per-name diff endpoints for agents/commands now **re-parse** the canonical and emit per-runtime parse-error rows with reason + runtime preview, closing the pane-vs-badge contradiction; all three per-name payloads (agents, commands, mcp-servers) gain `canonical_path` for the fix-it hint. All content reads in those routes go through a tolerant `read_text_lenient` (non-UTF-8 → U+FFFD per the #1233 contract; `PermissionError` → diagnosable "unreadable" rows instead of a 500 — per Codex impl review). The overview tile stays count-only per ADR-0009 §2 / #1228 — leaf-first diagnosis, intentionally preserved.

## UI + CLI + MCP: 5-surface parity

The diff pane and runtime-only detail render a diagnostic block under broken badges (escaped reason + "Fix the file at {path}, then click Refresh."); list-card badge tooltips carry the reason; `mm context diff` and `mem_context_diff` print a `— reason` suffix. en/ko keys under the parity gate; `?v` bumps context-gateway.js 68 / style.css 103.

## Reviews

Design gated by Codex before implementation (NEEDS-FIX → adopted: embedded-path sanitizer, `canonical_path` on all three payloads, exact mcp reason assignment, runtime-only vitest, lenient-read criteria; its per-name scope blocker was stale — #1232 already passes `scope=target_scope`, verified). Implementation reviewed by Codex (NEEDS-FIX → both Majors fixed in the follow-up commit: pickle support, tolerant reads).

## Tests

Engine reason pins (agents/commands/mcp, healthy-row `None` negatives, the 3-tuple/equality/pickle compat pin), route pins (sanitized reasons on list entries, per-name re-parse + `canonical_path` + no-abs-path-leak, unreadable-canonical 200, mcp canonical-vs-`.mcp.json` reasons), i18n key pin, and a new vitest (`ctx-parse-error-diagnostics.test.mjs`: reason+hint rendering, XSS escape, healthy/empty negatives, badge tooltip). Full dual gate green: 446 + 219 web pytest, 151 vitest.

Closes out the #1229 catalog. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
