### PR TITLE
fix(context): attribute sync/generate and migrate Gate A audits to their real ingress surface (#1246)

### DIFF
--- a/packages/memtomem/src/memtomem/context/_sync_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_sync_atomic.py
@@ -166,6 +166,7 @@ def sync_atomic_artifact(
     on_drop: str = "ignore",
     *,
     scope: TargetScope = "project_shared",
+    surface: str = "cli_context_sync",
 ) -> AtomicSyncResult:
     """Fan out every canonical artifact to the requested runtimes (atomic-file shape).
 
@@ -183,6 +184,16 @@ def sync_atomic_artifact(
         scope: ADR-0011 PR-E3 — selects canonical root and runtime fan-out
             destination. Default ``project_shared`` preserves pre-PR-E3
             behavior.
+        surface: Audit identifier forwarded verbatim to
+            :func:`privacy.enforce_write_guard` via both
+            :func:`scan_text_content` sites (canonical bytes AND
+            per-vendor override bytes) — it dimensions the privacy
+            ``record()`` counter and tags the blocked/bypassed audit
+            log line. Callers pass their own literal: the CLI relies on
+            the default ``"cli_context_sync"``, the Web sync routes
+            pass ``"web_context_<kind>_sync"``, and the MCP tools pass
+            ``"mcp_context_generate"`` / ``"mcp_context_sync"`` (#1246
+            — sibling of the import-side #1242 fix).
 
     Returns:
         :class:`AtomicSyncResult` carrying ``generated``, ``dropped``, and
@@ -326,7 +337,7 @@ def sync_atomic_artifact(
             file_scan = scan_text_content(
                 item_text,
                 source_path=scan_source,
-                surface="cli_context_sync",
+                surface=surface,
                 scope=scope,
                 project_root=project_root,
             )
@@ -371,7 +382,7 @@ def sync_atomic_artifact(
                     file_scan = scan_text_content(
                         override_text,
                         source_path=override_path,
-                        surface="cli_context_sync",
+                        surface=surface,
                         scope=scope,
                         project_root=project_root,
                     )

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -733,6 +733,7 @@ def generate_all_agents(
     *,
     scope: TargetScope = "project_shared",
     label: str | None = None,
+    surface: str = "cli_context_sync",
 ) -> AgentSyncResult:
     """Fan out every canonical sub-agent to the requested runtimes.
 
@@ -755,6 +756,11 @@ def generate_all_agents(
             the working ``agent.md``. ``None`` / ``"latest"`` preserve today's
             behavior byte-for-byte (the working file). Per-artifact resolution
             failures isolate as skips; they never abort the whole fan-out.
+        surface: Gate A audit identifier, forwarded verbatim to the
+            engine's privacy scans. The CLI relies on the default
+            ``"cli_context_sync"``; the Web sync route passes
+            ``"web_context_agents_sync"`` and the MCP tools pass
+            ``"mcp_context_generate"`` / ``"mcp_context_sync"`` (#1246).
     """
     adapter = _AGENT_ADAPTER
     if label is not None and label != "latest":
@@ -772,6 +778,7 @@ def generate_all_agents(
             strict=strict,
             on_drop=on_drop,
             scope=scope,
+            surface=surface,
         ),
     )
 

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -457,6 +457,7 @@ def generate_all_commands(
     *,
     scope: TargetScope = "project_shared",
     label: str | None = None,
+    surface: str = "cli_context_sync",
 ) -> CommandSyncResult:
     """Fan out every canonical command to the requested runtimes.
 
@@ -479,6 +480,11 @@ def generate_all_commands(
             the working ``command.md``. ``None`` / ``"latest"`` preserve
             today's behavior byte-for-byte. Per-artifact resolution failures
             isolate as skips.
+        surface: Gate A audit identifier, forwarded verbatim to the
+            engine's privacy scans. The CLI relies on the default
+            ``"cli_context_sync"``; the Web sync route passes
+            ``"web_context_commands_sync"`` and the MCP tools pass
+            ``"mcp_context_generate"`` / ``"mcp_context_sync"`` (#1246).
     """
     adapter = _COMMAND_ADAPTER
     if label is not None and label != "latest":
@@ -493,6 +499,7 @@ def generate_all_commands(
             strict=strict,
             on_drop=on_drop,
             scope=scope,
+            surface=surface,
         ),
     )
 

--- a/packages/memtomem/src/memtomem/context/migrate.py
+++ b/packages/memtomem/src/memtomem/context/migrate.py
@@ -905,6 +905,7 @@ def migrate_scope(
     to_scope: TargetScope,
     project_root: Path,
     apply_: bool,
+    surface: str = "cli_context_migrate",
 ) -> MigrateScopeResult:
     """Move a canonical artifact between ADR-0011 scope tiers.
 
@@ -934,6 +935,13 @@ def migrate_scope(
     10. Best-effort cleanup of stale src runtime fan-out targets
         (``~/.claude/agents/<name>.md`` etc.) — outside the lock so a
         partial cleanup failure does not roll back the canonical move.
+
+    Args:
+        surface: Gate A audit identifier forwarded to the step-7
+            staging scan. The CLI relies on the default
+            ``"cli_context_migrate"``; the MCP tool passes
+            ``"mcp_context_artifact_migrate"`` (#1246 — previously
+            MCP-driven moves were misattributed to the CLI literal).
 
     Returns:
         :class:`MigrateScopeResult` with ``moved=True`` on apply
@@ -998,7 +1006,7 @@ def migrate_scope(
             if to_scope == "project_shared":
                 scan = scan_artifact_tree(
                     staging,
-                    surface="cli_context_migrate",
+                    surface=surface,
                     scope=to_scope,
                     project_root=project_root,
                     on_blocked="fail_fast",

--- a/packages/memtomem/src/memtomem/context/privacy_scan.py
+++ b/packages/memtomem/src/memtomem/context/privacy_scan.py
@@ -4,10 +4,14 @@ Sibling of :mod:`memtomem.context._gate_a` (the runtime → canonical
 import-side gate). Both share :func:`memtomem.privacy.enforce_write_guard`
 underneath, but the two surfaces differ on:
 
-* ``surface=`` string — ``"cli_context_sync"`` vs the import side's
-  caller-supplied surface (default ``"cli_context_init"``; the Web import
-  routes pass ``"web_context_<kind>_import"`` and the MCP tool passes
-  ``"mcp_context_init"`` — #1229).
+* ``surface=`` string — caller-supplied on both sides. Sync defaults to
+  ``"cli_context_sync"`` (migrate: ``"cli_context_migrate"``); the Web
+  sync routes pass ``"web_context_<kind>_sync"`` and the MCP tools pass
+  ``"mcp_context_generate"`` / ``"mcp_context_sync"`` /
+  ``"mcp_context_artifact_migrate"`` (#1246). The import side defaults
+  to ``"cli_context_init"``; the Web import routes pass
+  ``"web_context_<kind>_import"`` and the MCP tool passes
+  ``"mcp_context_init"`` (#1229).
 * ``force_unsafe`` valve — sync has none (ADR §5: canonical → runtime
   fan-out is a write-amplifying loop, so a single bypass-flagged content
   would propagate to every registered runtime; the ADR explicitly
@@ -147,7 +151,8 @@ def scan_artifact_tree(
             blocks — replacement chars (U+FFFD) cannot themselves
             match the ASCII-only regex pattern set, so this does not
             create false positives on benign binary assets.
-        surface: Audit-log surface tag — typically ``"cli_context_sync"``.
+        surface: Audit-log surface tag — e.g. ``"cli_context_sync"``,
+            ``"web_context_skills_sync"``, ``"mcp_context_artifact_migrate"``.
             Used by :func:`enforce_write_guard` to attribute the outcome
             to the calling code path.
         scope: Destination scope. Determines block-vs-skip semantics

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -433,6 +433,7 @@ def generate_all_skills(
     runtimes: list[str] | None = None,
     *,
     scope: TargetScope = "project_shared",
+    surface: str = "cli_context_sync",
 ) -> SkillSyncResult:
     """Fan out every canonical skill to the requested runtime targets.
 
@@ -443,6 +444,17 @@ def generate_all_skills(
         scope: ADR-0011 PR-E3 — selects canonical root and runtime
             fan-out destination. Default ``project_shared`` preserves
             pre-PR-E3 behavior.
+        surface: Audit identifier forwarded verbatim to
+            :func:`privacy.enforce_write_guard` via both
+            :func:`scan_artifact_tree` sites (the project_shared batch
+            and the per-destination path) — it dimensions the privacy
+            ``record()`` counter and tags the blocked/bypassed audit
+            log line. Callers pass their own literal: the CLI relies on
+            the default ``"cli_context_sync"``, the Web sync route
+            passes ``"web_context_skills_sync"``, and the MCP tools
+            pass ``"mcp_context_generate"`` / ``"mcp_context_sync"``
+            (#1246 — previously every surface was misattributed to the
+            CLI literal; sibling of the import-side #1242 fix).
     """
     generated: list[tuple[str, Path]] = []
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = []
@@ -570,7 +582,7 @@ def generate_all_skills(
 
                     scan = scan_artifact_tree(
                         staging,
-                        surface="cli_context_sync",
+                        surface=surface,
                         scope=scope,
                         project_root=project_root,
                         on_blocked="fail_fast",
@@ -714,7 +726,7 @@ def generate_all_skills(
                     # 3. Scan.
                     scan = scan_artifact_tree(
                         staging,
-                        surface="cli_context_sync",
+                        surface=surface,
                         scope=scope,
                         project_root=project_root,
                         on_blocked="fail_fast",

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -601,7 +601,9 @@ async def mem_context_generate(
 
     if "skills" in inc:
         try:
-            skill_result = generate_all_skills(root, scope=artifact_scope)
+            skill_result = generate_all_skills(
+                root, scope=artifact_scope, surface="mcp_context_generate"
+            )
         except PrivacyScanError as exc:
             return f"privacy block: {exc.message}"
         if skill_result.generated:
@@ -616,7 +618,12 @@ async def mem_context_generate(
     if "agents" in inc:
         try:
             agent_result = generate_all_agents(
-                root, strict=strict, on_drop=on_drop, scope=artifact_scope, label=label_norm
+                root,
+                strict=strict,
+                on_drop=on_drop,
+                scope=artifact_scope,
+                label=label_norm,
+                surface="mcp_context_generate",
             )
         except StrictDropError as exc:
             return f"strict error: {exc}"
@@ -639,7 +646,12 @@ async def mem_context_generate(
     if "commands" in inc:
         try:
             command_result = generate_all_commands(
-                root, strict=strict, on_drop=on_drop, scope=artifact_scope, label=label_norm
+                root,
+                strict=strict,
+                on_drop=on_drop,
+                scope=artifact_scope,
+                label=label_norm,
+                surface="mcp_context_generate",
             )
         except CommandStrictDropError as exc:
             return f"strict error: {exc}"
@@ -923,7 +935,9 @@ async def mem_context_sync(
 
     if "skills" in inc:
         try:
-            skill_result = generate_all_skills(root, scope=artifact_scope)
+            skill_result = generate_all_skills(
+                root, scope=artifact_scope, surface="mcp_context_sync"
+            )
         except PrivacyScanError as exc:
             return f"privacy block: {exc.message}"
         if skill_result.generated:
@@ -939,7 +953,12 @@ async def mem_context_sync(
     if "agents" in inc:
         try:
             agent_result = generate_all_agents(
-                root, strict=strict, on_drop=on_drop, scope=artifact_scope, label=label_norm
+                root,
+                strict=strict,
+                on_drop=on_drop,
+                scope=artifact_scope,
+                label=label_norm,
+                surface="mcp_context_sync",
             )
         except StrictDropError as exc:
             return f"strict error: {exc}"
@@ -963,7 +982,12 @@ async def mem_context_sync(
     if "commands" in inc:
         try:
             command_result = generate_all_commands(
-                root, strict=strict, on_drop=on_drop, scope=artifact_scope, label=label_norm
+                root,
+                strict=strict,
+                on_drop=on_drop,
+                scope=artifact_scope,
+                label=label_norm,
+                surface="mcp_context_sync",
             )
         except CommandStrictDropError as exc:
             return f"strict error: {exc}"
@@ -1413,6 +1437,7 @@ async def mem_context_artifact_migrate(
                 to_scope=cast(TargetScope, to),
                 project_root=project_root,
                 apply_=apply,
+                surface="mcp_context_artifact_migrate",
             )
         except (FileNotFoundError, ValueError) as exc:
             return f"error: {exc}"

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -574,7 +574,9 @@ async def sync_agents(
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
-                result = generate_all_agents(project_root, on_drop=on_drop)
+                result = generate_all_agents(
+                    project_root, on_drop=on_drop, surface="web_context_agents_sync"
+                )
     except TimeoutError:
         raise HTTPException(503, "Agents sync timed out — another sync may be in progress")
     except PrivacyScanError as exc:

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -567,7 +567,9 @@ async def sync_commands(
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
-                result = generate_all_commands(project_root, on_drop=on_drop)
+                result = generate_all_commands(
+                    project_root, on_drop=on_drop, surface="web_context_commands_sync"
+                )
     except TimeoutError:
         raise HTTPException(503, "Commands sync timed out — another sync may be in progress")
     except PrivacyScanError as exc:

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -500,7 +500,9 @@ async def sync_skills(
                 # ``_SKILLS_LOCK_BUDGET_S`` (30s < 60s) bounds the lock
                 # waits, so a timed-out request cannot orphan a worker
                 # thread that writes after the 503 already went out.
-                result = await asyncio.to_thread(generate_all_skills, project_root)
+                result = await asyncio.to_thread(
+                    generate_all_skills, project_root, surface="web_context_skills_sync"
+                )
     except TimeoutError:
         raise HTTPException(503, "Skills sync timed out — another sync may be in progress")
     except PrivacyScanError as exc:

--- a/packages/memtomem/tests/test_context_sync_surface_attribution.py
+++ b/packages/memtomem/tests/test_context_sync_surface_attribution.py
@@ -1,0 +1,181 @@
+"""Gate A surface attribution for the sync/generate and migrate directions (#1246).
+
+Sibling of the import-side pins in ``test_context_init_scope.py`` (#1242):
+the ``surface=`` string dimensions the privacy ``record()`` counter and
+tags the blocked audit log line, distinguishing every ingress surface.
+Pre-#1246 the sync/generate and migrate engines hard-coded the CLI
+literals (``cli_context_sync`` / ``cli_context_migrate``), so every Web-
+or MCP-driven privacy decision was misattributed to the CLI.
+
+Spy point: ``memtomem.context.privacy_scan.privacy.enforce_write_guard``
+— the one chokepoint all three engines funnel through
+(``generate_all_skills``'s two ``scan_artifact_tree`` sites, the atomic
+agents/commands engine's two ``scan_text_content`` sites, and
+``migrate_scope``'s staging scan).
+
+Layer pins for the Web routes live in ``test_web_routes_context.py``;
+the MCP tool pins live in ``test_server_tools_context_scope.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from memtomem.context.agents import generate_all_agents
+from memtomem.context.commands import generate_all_commands
+from memtomem.context.migrate import migrate_scope
+from memtomem.context.scope_resolver import canonical_artifact_dir
+from memtomem.context.skills import SKILL_MANIFEST, generate_all_skills
+from memtomem.privacy import WriteGuardResult
+
+from .helpers import set_home
+
+
+def _capture_guard_surfaces(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Spy ``privacy.enforce_write_guard`` and record every call's ``surface``."""
+    surfaces: list[str] = []
+
+    def spy(content_text: str, *, surface: str, **kw: Any) -> WriteGuardResult:
+        surfaces.append(surface)
+        return WriteGuardResult("pass", [])
+
+    monkeypatch.setattr("memtomem.context.privacy_scan.privacy.enforce_write_guard", spy)
+    return surfaces
+
+
+def _seed_skill(project_root: Path, name: str, *, scope: str) -> Path:
+    root = canonical_artifact_dir("skills", scope, project_root)  # type: ignore[arg-type]
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / SKILL_MANIFEST).write_text("# test skill\n", encoding="utf-8")
+    return skill_dir
+
+
+def _seed_agent_dir_with_override(project_root: Path, name: str) -> None:
+    """Dir-layout canonical + a claude override — exercises BOTH atomic-engine
+    scan sites (canonical bytes and override bytes) in one fan-out."""
+    agent_dir = canonical_artifact_dir("agents", "project_shared", project_root) / name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "agent.md").write_text(
+        f"---\nname: {name}\ndescription: example\n---\nbody\n", encoding="utf-8"
+    )
+    overrides = agent_dir / "overrides"
+    overrides.mkdir()
+    (overrides / "claude.md").write_text("# claude override\n", encoding="utf-8")
+
+
+class TestSkillsSyncSurface:
+    def test_project_shared_batch_site(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """The project_shared all-or-nothing batch path: default pins the CLI
+        literal; the kwarg threads through to the same scan site."""
+        _seed_skill(tmp_path, "sk", scope="project_shared")
+        surfaces = _capture_guard_surfaces(monkeypatch)
+
+        generate_all_skills(tmp_path, runtimes=["claude_skills"])
+        assert surfaces == ["cli_context_sync"]
+
+        surfaces.clear()
+        generate_all_skills(tmp_path, runtimes=["claude_skills"], surface="probe_skills_batch")
+        assert surfaces == ["probe_skills_batch"]
+
+    def test_per_destination_site(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """The non-shared per-destination path is a SECOND scan site in
+        ``generate_all_skills`` — missing it would silently misattribute
+        every user/project_local fan-out."""
+        home = tmp_path / "home"
+        set_home(monkeypatch, str(home))
+        _seed_skill(tmp_path, "sk", scope="user")
+        surfaces = _capture_guard_surfaces(monkeypatch)
+
+        generate_all_skills(tmp_path, runtimes=["claude_skills"], scope="user")
+        assert surfaces == ["cli_context_sync"]
+
+        surfaces.clear()
+        generate_all_skills(
+            tmp_path, runtimes=["claude_skills"], scope="user", surface="probe_skills_per_dst"
+        )
+        assert surfaces == ["probe_skills_per_dst"]
+
+
+class TestAtomicEngineSurface:
+    def test_agents_canonical_and_override_sites(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The shared atomic engine scans canonical bytes AND per-vendor
+        override bytes — both sites must carry the caller's surface."""
+        _seed_agent_dir_with_override(tmp_path, "agt")
+        surfaces = _capture_guard_surfaces(monkeypatch)
+
+        generate_all_agents(tmp_path, runtimes=["claude_agents"])
+        assert surfaces == ["cli_context_sync", "cli_context_sync"]  # canonical + override
+
+        surfaces.clear()
+        generate_all_agents(tmp_path, runtimes=["claude_agents"], surface="probe_agents")
+        assert surfaces == ["probe_agents", "probe_agents"]
+
+    def test_commands_wrapper_threads_surface(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Both thin wrappers bind the same engine; each must forward the
+        kwarg (a wrapper that drops it would silently fall back to the
+        CLI literal for that artifact kind only)."""
+        commands = canonical_artifact_dir("commands", "project_shared", tmp_path)
+        commands.mkdir(parents=True, exist_ok=True)
+        (commands / "cmd.md").write_text("---\ndescription: example\n---\nbody\n", encoding="utf-8")
+        surfaces = _capture_guard_surfaces(monkeypatch)
+
+        generate_all_commands(tmp_path, runtimes=["claude_commands"])
+        assert surfaces == ["cli_context_sync"]
+
+        surfaces.clear()
+        generate_all_commands(tmp_path, runtimes=["claude_commands"], surface="probe_commands")
+        assert surfaces == ["probe_commands"]
+
+
+class TestMigrateScopeSurface:
+    def _seed_user_agent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        home = tmp_path / "home"
+        set_home(monkeypatch, str(home))
+        user_agents = canonical_artifact_dir("agents", "user", tmp_path)
+        user_agents.mkdir(parents=True, exist_ok=True)
+        path = user_agents / "agt.md"
+        path.write_text("---\nname: agt\ndescription: example\n---\nbody\n", encoding="utf-8")
+        return path
+
+    def test_default_surface_is_cli_literal(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        self._seed_user_agent(tmp_path, monkeypatch)
+        surfaces = _capture_guard_surfaces(monkeypatch)
+
+        result = migrate_scope(
+            "agents",
+            "agt",
+            from_scope="user",
+            to_scope="project_shared",
+            project_root=tmp_path,
+            apply_=True,
+        )
+
+        assert result.moved
+        assert surfaces == ["cli_context_migrate"]
+
+    def test_surface_kwarg_reaches_staging_scan(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        self._seed_user_agent(tmp_path, monkeypatch)
+        surfaces = _capture_guard_surfaces(monkeypatch)
+
+        result = migrate_scope(
+            "agents",
+            "agt",
+            from_scope="user",
+            to_scope="project_shared",
+            project_root=tmp_path,
+            apply_=True,
+            surface="probe_migrate",
+        )
+
+        assert result.moved
+        assert surfaces == ["probe_migrate"]

--- a/packages/memtomem/tests/test_server_tools_context_scope.py
+++ b/packages/memtomem/tests/test_server_tools_context_scope.py
@@ -404,3 +404,106 @@ async def test_mem_context_init_uses_mcp_surface(
     assert out.startswith("Imported") or "Imported" in out
     assert surfaces, "Gate A never ran"
     assert set(surfaces) == {"mcp_context_init"}
+
+
+# ── #1246 — Gate A sync/migrate surface attribution ──────────────────────
+
+
+def _capture_sync_surfaces(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Spy the sync-side privacy chokepoint and record every ``surface``.
+
+    ``privacy_scan`` funnels all three sync engines (the skills staging
+    walk, the atomic agents/commands engine, ``migrate_scope``'s staging
+    scan) through ``privacy.enforce_write_guard`` — one spy covers them
+    all. Sibling of the import-side ``_gate_a`` spy above (#1229).
+    """
+    from memtomem.privacy import WriteGuardResult
+
+    surfaces: list[str] = []
+
+    def spy(content_text, *, surface, **kw):
+        surfaces.append(surface)
+        return WriteGuardResult("pass", [])
+
+    monkeypatch.setattr("memtomem.context.privacy_scan.privacy.enforce_write_guard", spy)
+    return surfaces
+
+
+def _seed_shared_artifacts(project: Path) -> None:
+    skill = project / ".memtomem" / "skills" / "sk"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# sk\n", encoding="utf-8")
+    agents = project / ".memtomem" / "agents"
+    agents.mkdir(parents=True)
+    (agents / "agt.md").write_text(_clean_agent_body("agt"), encoding="utf-8")
+    commands = project / ".memtomem" / "commands"
+    commands.mkdir(parents=True)
+    (commands / "cmd.md").write_text("---\ndescription: example\n---\nbody\n", encoding="utf-8")
+
+
+@pytest.mark.anyio
+async def test_mem_context_generate_uses_mcp_surface(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gate A audit attribution (#1246): sync-direction scans driven by the
+    MCP generate tool must reach the privacy audit log as
+    ``mcp_context_generate``, not the CLI literal ``cli_context_sync``."""
+    project = _make_project(tmp_path, monkeypatch)
+    set_home(monkeypatch, tmp_path / "home")
+    _seed_shared_artifacts(project)
+    surfaces = _capture_sync_surfaces(monkeypatch)
+
+    out = await mem_context_generate(include="skills,agents,commands")
+
+    assert surfaces, f"Gate A never ran: {out}"
+    assert set(surfaces) == {"mcp_context_generate"}
+
+
+@pytest.mark.anyio
+async def test_mem_context_sync_uses_mcp_surface(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same as the generate pin, but through ``mem_context_sync`` — the two
+    tools call the same engines and must remain distinguishable in the
+    audit log (the surface matches the tool name, #1242 convention)."""
+    project = _make_project(tmp_path, monkeypatch)
+    set_home(monkeypatch, tmp_path / "home")
+    _seed_shared_artifacts(project)
+    surfaces = _capture_sync_surfaces(monkeypatch)
+
+    out = await mem_context_sync(include="skills,agents,commands")
+
+    assert surfaces, f"Gate A never ran: {out}"
+    assert set(surfaces) == {"mcp_context_sync"}
+
+
+@pytest.mark.anyio
+async def test_mem_context_artifact_migrate_uses_mcp_surface(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scope-tier moves driven by the MCP tool must attribute their Gate A
+    staging scan to ``mcp_context_artifact_migrate`` (the tool name), not
+    ``cli_context_migrate``."""
+    from memtomem.server.tools.context import mem_context_artifact_migrate
+
+    project = _make_project(tmp_path, monkeypatch)
+    set_home(monkeypatch, tmp_path / "home")
+    user_agents = canonical_artifact_dir("agents", "user", project)
+    user_agents.mkdir(parents=True, exist_ok=True)
+    (user_agents / "agt.md").write_text(_clean_agent_body("agt"), encoding="utf-8")
+    surfaces = _capture_sync_surfaces(monkeypatch)
+
+    out = await mem_context_artifact_migrate(
+        asset_type="agents",
+        name="agt",
+        from_scope="user",
+        to_scope="project_shared",
+        apply=True,
+        confirm_project_shared=True,
+    )
+
+    assert (project / ".memtomem" / "agents" / "agt.md").exists(), out
+    assert surfaces == ["mcp_context_artifact_migrate"]

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -1947,3 +1947,51 @@ class TestListDiagnosticReasons:
         r = await client.get("/api/context/agents")
         item = [a for a in r.json()["agents"] if a["name"] == "fine"][0]
         assert all("reason" not in e for e in item["runtimes"])
+
+
+# ---------------------------------------------------------------------------
+# Gate A sync surface attribution (#1246)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncSurfaceAttribution:
+    """Web syncs must reach the privacy audit log under their own surface
+    string — pre-#1246 every sync ingress was misattributed to the CLI
+    literal ``cli_context_sync``. Sibling of the import-side
+    ``TestImportSurfaceAttribution`` pins (#1229/#1242); the spy point
+    differs because sync funnels through ``privacy_scan``, not ``_gate_a``.
+    """
+
+    def _spy_surfaces(self, monkeypatch) -> list[str]:
+        from memtomem.privacy import WriteGuardResult
+
+        surfaces: list[str] = []
+
+        def spy(content_text, *, surface, **kw):
+            surfaces.append(surface)
+            return WriteGuardResult("pass", [])
+
+        monkeypatch.setattr("memtomem.context.privacy_scan.privacy.enforce_write_guard", spy)
+        return surfaces
+
+    @pytest.mark.anyio
+    async def test_syncs_use_web_surfaces(self, client: AsyncClient, tmp_path: Path, monkeypatch):
+        _make_skill(tmp_path, "s1")
+        _make_agent(tmp_path, "a1")
+        _make_command(tmp_path, "c1")
+
+        surfaces = self._spy_surfaces(monkeypatch)
+
+        r = await client.post("/api/context/skills/sync")
+        assert r.status_code == 200, r.text
+        assert surfaces and set(surfaces) == {"web_context_skills_sync"}
+
+        surfaces.clear()
+        r = await client.post("/api/context/agents/sync", json={})
+        assert r.status_code == 200, r.text
+        assert surfaces and set(surfaces) == {"web_context_agents_sync"}
+
+        surfaces.clear()
+        r = await client.post("/api/context/commands/sync", json={})
+        assert r.status_code == 200, r.text
+        assert surfaces and set(surfaces) == {"web_context_commands_sync"}


### PR DESCRIPTION
Closes #1246. Sibling of the import-side fix #1242 (#1229 campaign), same class, opposite direction.

## Problem

The sync/generate engines and the scope-tier migrate path hard-coded their CLI surface literals while being reachable from non-CLI ingress:

- `generate_all_skills` — two `scan_artifact_tree(..., surface="cli_context_sync")` sites (project_shared batch + per-destination)
- `sync_atomic_artifact` (shared agents/commands engine) — two `scan_text_content(..., surface="cli_context_sync")` sites (canonical bytes + per-vendor override bytes)
- `migrate_scope` — `scan_artifact_tree(..., surface="cli_context_migrate")` on the staging tree

Reachable from `POST /api/context/{skills,agents,commands}/sync` and from MCP `mem_context_generate` / `mem_context_sync` / `mem_context_artifact_migrate` — so every Web- or MCP-driven sync/migrate privacy decision was attributed to the CLI in the privacy `record()` counters and the blocked audit log.

## Fix (mirrors #1242)

- The engines and their thin wrappers (`generate_all_agents` / `generate_all_commands`) grow a keyword-only `surface: str` defaulting to the current literals — public-API back-compat, CLI unchanged.
- Web sync routes pass `web_context_{kind}_sync`; MCP tools pass `mcp_context_generate` / `mcp_context_sync` / `mcp_context_artifact_migrate`.
- `audit_context` shape untouched (SOC grep stability). No JS/i18n — surface strings are audit identifiers, never UI copy.

## Divergences from the issue sketch (verified at `main`)

- **`migrate_one` grows no `surface` parameter**: it has no Gate A call site — flat→dir layout conversion is a byte-identical same-scope move (see the trust-boundary note on `adopt_flat_to_dir`). Only `migrate_scope` scans.
- **MCP migrate surface is `mcp_context_artifact_migrate`**, not the sketched `mcp_context_migrate`: the tool is named `mem_context_artifact_migrate`, and the issue's own convention ("match the tool names") plus the `mcp_context_version_create` precedent follow the tool name.

## Tests

Mirror #1242's: spy `enforce_write_guard` at the `privacy_scan` chokepoint, pin every default and every entry point's literal:

- `test_context_sync_surface_attribution.py` (new) — both `generate_all_skills` scan sites, both atomic-engine sites (canonical + override), both wrappers, `migrate_scope` default + kwarg
- `test_server_tools_context_scope.py` — `mcp_context_generate` / `mcp_context_sync` / `mcp_context_artifact_migrate`
- `test_web_routes_context.py` — `web_context_{skills,agents,commands}_sync`

Every pin was mutation-validated: reverting any single threaded site to its literal (4 spot checks across engine/skills/web/MCP) makes the corresponding test fail.

Gates: full `pytest -m "not ollama"` (6206 passed; 4 pre-existing machine-local `test_session_tracing` failures unrelated to this diff — the file builds `Mem2MemConfig()` without isolating `~/.memtomem/config.json`), `ruff check` + `format --check` clean, `mypy` adds no new errors in touched files. Codex review of `01b5ad28..3c9b586b`: SHIP, no findings.

Refs #1229, #1242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
