### PR TITLE
fix(context): wiki update deletion fidelity — reconcile upstream deletions, detect local ones (#1247 B1)

### DIFF
--- a/docs/adr/0008-wiki-layer.md
+++ b/docs/adr/0008-wiki-layer.md
@@ -92,7 +92,7 @@ be reconsidered in v2 if a real workflow demands it.
          │  mm context install <type> <name>   (copytree + lockfile pin)
          ▼
 <project>/.memtomem/                 ← project canonical (Invariant 1)
-├── lock.json                        ← { skills: { foo: { wiki_commit, installed_at } } }
+├── lock.json                        ← { skills: { foo: { wiki_commit, installed_at, files, files_commit } } }
 ├── skills/<name>/SKILL.md + overrides/...
 ├── agents/<name>/...
 └── commands/<name>/...
@@ -157,11 +157,13 @@ are out of scope for the install/upgrade lifecycle.
   "skills": {
     "foo": {
       "wiki_commit": "abc123def4567890abc123def4567890abc12345",
-      "installed_at": "2026-04-30T12:34:56Z"
+      "installed_at": "2026-04-30T12:34:56Z",
+      "files": ["SKILL.md", "scripts/run.py"],
+      "files_commit": "abc123def4567890abc123def4567890abc12345"
     }
   },
-  "agents":   { "bar": { "wiki_commit": "…", "installed_at": "…" } },
-  "commands": { "baz": { "wiki_commit": "…", "installed_at": "…" } }
+  "agents":   { "bar": { "wiki_commit": "…", "installed_at": "…", "files": ["…"], "files_commit": "…" } },
+  "commands": { "baz": { "wiki_commit": "…", "installed_at": "…", "files": ["…"], "files_commit": "…" } }
 }
 ```
 
@@ -170,6 +172,20 @@ are out of scope for the install/upgrade lifecycle.
 for readability; the stored value is always full-length to avoid
 abbreviation collisions across projects that share a wiki and to keep
 `git checkout <wiki_commit>` directly usable for forensics.
+
+`files` / `files_commit` (added with the #1247 deletion-fidelity work)
+record the installed file set as sorted POSIX relpaths plus the commit
+they describe. They power deletion-aware dirty detection (a
+manifest-recorded file missing from disk is a local edit) and update
+reconciliation (files the wiki dropped are removed instead of carried
+additively). Consumers MUST honor the manifest only when
+`files_commit == wiki_commit` and the shape validates
+(`manifest_from_entry`): `upsert_entry` preserves unknown keys, so an
+entry rewritten by a pre-manifest tool keeps a stale `files` list while
+the pin moves — the commit pairing detects exactly that. Entries
+without a valid manifest degrade to the pre-manifest behavior
+(deletions invisible to the dirty walk; reconcile falls back to the
+`mtime <= installed_at` guard).
 
 Reads MUST preserve unknown top-level and per-entry fields (round-trip
 through plain `dict` is sufficient). The `version` field is reserved for

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -1565,6 +1565,11 @@ def update_cmd(
     rel_dest = result.dest.relative_to(root) if result.dest.is_relative_to(root) else result.dest
     click.echo(f"  → {rel_dest}/")
     click.echo(f"  {result.files_written} file(s) updated")
+    if result.files_removed:
+        click.secho(
+            f"  {len(result.files_removed)} file(s) removed (deleted upstream)",
+            fg="yellow",
+        )
     if result.bak_files_written:
         click.secho(
             f"  {len(result.bak_files_written)} dirty file(s) preserved as .bak",
@@ -1694,7 +1699,7 @@ def _run_update_all(
         src = wiki.root / asset_type_plural / name
         dest = c.project_root / ".memtomem" / asset_type_plural / name
         try:
-            _apply_update(
+            upd = _apply_update(
                 c.project_root,
                 asset_type_plural,
                 name,
@@ -1712,7 +1717,10 @@ def _run_update_all(
             click.secho(f"  ✗ {c.project_root}: {exc}", fg="red")
             failures += 1
         else:
-            click.secho(f"  ✓ {c.project_root}: updated", fg="green")
+            removed_note = (
+                f" ({len(upd.files_removed)} file(s) removed)" if upd.files_removed else ""
+            )
+            click.secho(f"  ✓ {c.project_root}: updated{removed_note}", fg="green")
             successes += 1
 
     click.echo(
@@ -1995,7 +2003,7 @@ def _run_install_all(
 
         # state ∈ {"install", "skip" with --force, "refuse"} — execute
         try:
-            _apply_pinned_install(root, c, wiki=wiki, force=force)
+            pinned = _apply_pinned_install(root, c, wiki=wiki, force=force)
         except StaleInstallError as exc:
             # state=refuse without --force shouldn't reach here; defense in depth.
             click.secho(f"  ✗ {c.asset_type}/{c.name}: {exc}", fg="red")
@@ -2011,8 +2019,14 @@ def _run_install_all(
             click.secho(f"  ✗ {c.asset_type}/{c.name}: {exc}", fg="red")
             failures += 1
         else:
+            removed_note = (
+                f" ({len(pinned.files_removed)} leftover file(s) removed)"
+                if pinned.files_removed
+                else ""
+            )
             click.secho(
-                f"  ✓ {c.asset_type}/{c.name}: installed at pin {c.pin_commit[:12]}", fg="green"
+                f"  ✓ {c.asset_type}/{c.name}: installed at pin {c.pin_commit[:12]}{removed_note}",
+                fg="green",
             )
             successes += 1
 

--- a/packages/memtomem/src/memtomem/context/_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_atomic.py
@@ -59,11 +59,13 @@ COPY_SKIP_NAMES: frozenset[str] = frozenset({".git", ".DS_Store", "__pycache__"}
 DIRTY_SKIP_SUFFIXES: frozenset[str] = frozenset({".bak"})
 """Suffix patterns the installed-file walker excludes.
 
-Shared by :func:`copy_tree_atomic` (no-op there in practice; wikis don't
-carry ``.bak`` files under normal operation) and
-:func:`iter_installed_files` (the real filter for
+Shared by :func:`iter_installed_files` (the filter for
 :func:`memtomem.context.dirty.is_asset_dirty` and the install-time
-capture helper).
+capture helper) and, via ``skip_suffixes``, by the wiki-install
+``copy_tree_atomic`` call sites — so the installed surface equals the
+tracked surface and a wiki-shipped ``*.bak`` can neither dodge dirty
+tracking nor collide with the ``--force`` preservation namespace
+(#1247).
 
 ``.bak`` — sibling files created by ``mm context update --force`` to
 preserve user edits before overwriting with wiki bytes. They live in the
@@ -192,6 +194,7 @@ def copy_tree_atomic(
     *,
     mode: int = 0o644,
     skip_top_level: frozenset[str] | None = None,
+    skip_suffixes: frozenset[str] = frozenset(),
 ) -> int:
     """Recursively mirror *src* → *dst*, each file via :func:`atomic_write_bytes`.
 
@@ -205,7 +208,13 @@ def copy_tree_atomic(
     depth. ``skip_top_level`` names additional entries skipped ONLY at the
     root of this call (it is deliberately not propagated into the recursion),
     so e.g. a skill's top-level ``overrides/`` source can be excluded without
-    also dropping a legitimate nested ``scripts/overrides/``. Skipping during
+    also dropping a legitimate nested ``scripts/overrides/``. ``skip_suffixes``
+    excludes entries by suffix at every depth — the wiki-install copies pass
+    :data:`DIRTY_SKIP_SUFFIXES` so the installed surface equals the tracked
+    surface (a wiki-shipped ``*.bak`` would be invisible to the dirty walk,
+    the manifest, and reconcile, and would collide with the ``--force``
+    preservation namespace; #1247). The skills staging mirror deliberately
+    passes nothing — its diff parity compares full trees. Skipping during
     the copy (rather than deleting afterwards) means those bytes never touch
     *dst* — no crash window where they exist, no silent leak if a later delete
     fails. Symlinks are skipped with a warning — this helper promises a
@@ -219,6 +228,8 @@ def copy_tree_atomic(
     for entry in src.iterdir():
         if entry.name in COPY_SKIP_NAMES or entry.name in extra_skip:
             continue
+        if entry.suffix in skip_suffixes:
+            continue
         if entry.is_symlink():
             logger.warning("copy_tree_atomic: skipping symlink %s", entry)
             continue
@@ -228,7 +239,7 @@ def copy_tree_atomic(
             written += 1
         elif entry.is_dir():
             # skip_top_level intentionally not threaded into the recursion.
-            written += copy_tree_atomic(entry, target, mode=mode)
+            written += copy_tree_atomic(entry, target, mode=mode, skip_suffixes=skip_suffixes)
     return written
 
 

--- a/packages/memtomem/src/memtomem/context/dirty.py
+++ b/packages/memtomem/src/memtomem/context/dirty.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from memtomem.context._atomic import iter_installed_files
-from memtomem.context.lockfile import Lockfile
+from memtomem.context.lockfile import Lockfile, manifest_from_entry
 
 __all__ = [
     "DirtyReason",
@@ -50,11 +50,12 @@ DirtyReason = Literal["clean", "dirty", "never_installed", "missing_dest"]
 class DirtyReport:
     """Outcome of a dirty check on a single installed asset.
 
-    - ``reason="clean"`` — dest exists and every checked file's mtime is
-      ``<= installed_at_epoch``.
+    - ``reason="clean"`` — dest exists, every checked file's mtime is
+      ``<= installed_at_epoch``, and no manifest entry is missing.
     - ``reason="dirty"`` — at least one checked file has
-      ``mtime > installed_at_epoch``; the offending paths are in
-      ``dirty_files``.
+      ``mtime > installed_at_epoch`` (paths in ``dirty_files``) and/or at
+      least one manifest-recorded file is gone from disk (paths in
+      ``missing_files``) — a user deletion is a local edit too (#1247).
     - ``reason="never_installed"`` — no usable lockfile entry;
       ``installed_at`` is ``None`` and ``dirty_files`` / ``checked_files``
       are empty. Returned for both "no entry at all" and "entry exists
@@ -63,12 +64,31 @@ class DirtyReport:
     - ``reason="missing_dest"`` — lockfile entry exists but
       ``<project>/.memtomem/<type>/<name>/`` was deleted; ``installed_at``
       is the lockfile value, ``dirty_files`` empty.
+
+    ``missing_files`` is populated only when the entry carries a valid
+    file manifest (see
+    :func:`memtomem.context.lockfile.manifest_from_entry`); legacy entries
+    keep the pre-manifest behavior (deletions invisible).
     """
 
     reason: DirtyReason
     installed_at: str | None
     dirty_files: tuple[Path, ...]
     checked_files: int
+    missing_files: tuple[Path, ...] = ()
+
+    def summary(self) -> str:
+        """Human-readable local-edit summary for messages and status rows.
+
+        Covers both edit classes so a missing-only report can't render as
+        "0 file(s) modified locally" (#1247 design-gate M4).
+        """
+        parts: list[str] = []
+        if self.dirty_files:
+            parts.append(f"{len(self.dirty_files)} file(s) modified locally")
+        if self.missing_files:
+            parts.append(f"{len(self.missing_files)} file(s) deleted locally")
+        return " and ".join(parts) if parts else "0 file(s) changed"
 
 
 def is_asset_dirty(
@@ -123,14 +143,25 @@ def is_asset_dirty(
 
     dirty: list[Path] = []
     checked = 0
+    present_rels: set[str] = set()
     for file_path in iter_installed_files(dest):
         checked += 1
+        present_rels.add(file_path.relative_to(dest).as_posix())
         if file_path.stat().st_mtime > installed_at_epoch:
             dirty.append(file_path)
 
+    # Deletion detection (#1247): a manifest-recorded file gone from disk
+    # is a local edit. Valid-manifest entries only — legacy/stale/malformed
+    # manifests degrade to the pre-manifest behavior (deletions invisible).
+    missing: list[Path] = []
+    manifest = manifest_from_entry(lock_entry)
+    if manifest is not None:
+        missing = [dest / rel for rel in sorted(manifest - present_rels)]
+
     return DirtyReport(
-        reason="dirty" if dirty else "clean",
+        reason="dirty" if (dirty or missing) else "clean",
         installed_at=installed_at,
         dirty_files=tuple(dirty),
         checked_files=checked,
+        missing_files=tuple(missing),
     )

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 from memtomem.context._atomic import (
+    DIRTY_SKIP_SUFFIXES,
     copy_tree_atomic,
     installed_at_from_dest,
     iter_installed_files,
@@ -337,7 +338,7 @@ def _install_asset(
         )
 
     dest.parent.mkdir(parents=True, exist_ok=True)
-    files_written = copy_tree_atomic(src, dest)
+    files_written = copy_tree_atomic(src, dest, skip_suffixes=DIRTY_SKIP_SUFFIXES)
 
     installed_at = installed_at_from_dest(dest)
     lock.upsert_entry(
@@ -537,7 +538,7 @@ def _apply_update(
             bak_paths.append(bak)
 
     dest.parent.mkdir(parents=True, exist_ok=True)
-    files_written = copy_tree_atomic(src, dest)
+    files_written = copy_tree_atomic(src, dest, skip_suffixes=DIRTY_SKIP_SUFFIXES)
 
     # Mirror semantics (#1247): drop dest files the wiki no longer ships.
     # Membership uses the COPIER's effective file set (iter_installed_files

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -540,12 +540,17 @@ def _apply_update(
     files_written = copy_tree_atomic(src, dest)
 
     # Mirror semantics (#1247): drop dest files the wiki no longer ships.
-    # The guard epoch is the PRE-update install timestamp (the same basis
-    # ``dirty_report`` classified against) — the freshly captured value
-    # below is >= every current mtime and would approve deleting anything.
+    # Membership uses the COPIER's effective file set (iter_installed_files
+    # shares copy_tree_atomic's skip rules) — a bare (src / rel).is_file()
+    # would count a symlink the copier skips as present, stranding the old
+    # regular file in dest (Codex implementation-gate M1). The guard epoch
+    # is the PRE-update install timestamp (the same basis ``dirty_report``
+    # classified against) — the freshly captured value below is >= every
+    # current mtime and would approve deleting anything.
+    src_files = {p.relative_to(src).as_posix() for p in iter_installed_files(src)}
     files_removed = _reconcile_removed_files(
         dest,
-        src_has=lambda rel: (src / rel).is_file(),
+        src_has=lambda rel: rel in src_files,
         old_installed_at_epoch=_installed_at_epoch(lock_entry),
         baked=(
             frozenset(dirty_report.dirty_files)
@@ -831,7 +836,7 @@ def _classify_for_install_all(
         report = is_asset_dirty(project_root, asset_type, name, lock_entry=entry)
         if report.reason == "dirty":
             state: Literal["install", "skip", "refuse", "orphan", "error"] = "refuse"
-            reason: str | None = f"{len(report.dirty_files)} file(s) modified locally"
+            reason: str | None = report.summary()
         else:
             # clean / missing_dest / never_installed all collapse to "skip" here:
             # missing_dest is impossible (we already saw dest.exists()), and

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -23,17 +23,26 @@ clobbered") without depending on PR-D's mtime/dirty detection. PR-D's
 
 from __future__ import annotations
 
+import logging
 import shutil
+from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal, cast
 
-from memtomem.context._atomic import copy_tree_atomic, installed_at_from_dest
+from memtomem.context._atomic import (
+    copy_tree_atomic,
+    installed_at_from_dest,
+    iter_installed_files,
+)
 from memtomem.context._names import validate_name
 from memtomem.context.dirty import DirtyReport, is_asset_dirty
-from memtomem.context.lockfile import Lockfile, LockfileVersionError
+from memtomem.context.lockfile import Lockfile, LockfileVersionError, manifest_from_entry
 from memtomem.wiki.store import CommitNotFoundError as CommitNotFoundError
 from memtomem.wiki.store import WikiStore
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "AlreadyInstalledError",
@@ -81,7 +90,12 @@ class StaleInstallError(RuntimeError):
 
 @dataclass(frozen=True)
 class InstallResult:
-    """Outcome of a successful install. Display-oriented; not persisted."""
+    """Outcome of a successful install. Display-oriented; not persisted.
+
+    ``files_removed`` is populated only by the ``install --all --force``
+    re-extraction path, which reconciles dest-only leftovers against the
+    pinned commit's file set (#1247); a fresh install never removes.
+    """
 
     asset_type: Literal["skills", "agents", "commands"]
     name: str
@@ -89,6 +103,7 @@ class InstallResult:
     installed_at: str
     dest: Path
     files_written: int
+    files_removed: tuple[Path, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -100,10 +115,11 @@ class UpdateResult:
       ``installed_at`` is the value previously recorded (echoed for
       display) and ``files_written``/``bak_files_written`` are empty.
     - ``was_no_op=False`` means a real refresh happened: the dest tree
-      was overwritten with wiki bytes, ``installed_at`` was re-captured
-      after the copy, and any dirty files were preserved at the listed
-      ``.bak`` paths (only populated when ``--force`` was used against
-      a dirty asset).
+      was mirrored to the wiki bytes — files written/overwritten AND
+      dest files absent upstream reconciled away (``files_removed``,
+      #1247) — ``installed_at`` was re-captured after the copy, and any
+      dirty files were preserved at the listed ``.bak`` paths (only
+      populated when ``--force`` was used against a dirty asset).
     """
 
     asset_type: Literal["skills", "agents", "commands"]
@@ -115,6 +131,7 @@ class UpdateResult:
     bak_files_written: tuple[Path, ...]
     dest: Path
     files_written: int
+    files_removed: tuple[Path, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -186,6 +203,89 @@ def install_command(
     return _install_asset(project_root, "commands", name, wiki=wiki)
 
 
+def _installed_at_epoch(lock_entry: dict[str, Any]) -> float | None:
+    """Parse the entry's ``installed_at`` to an epoch, or ``None``.
+
+    Tolerant on purpose: the reconcile mtime guard must degrade to "keep"
+    (never delete) when the timestamp is missing or malformed.
+    """
+    raw = lock_entry.get("installed_at")
+    if not isinstance(raw, str):
+        return None
+    try:
+        return datetime.fromisoformat(raw).timestamp()
+    except ValueError:
+        return None
+
+
+def _manifest_relpaths(dest: Path) -> list[str]:
+    """The asset's installed file set as sorted POSIX relpaths.
+
+    Walks via :func:`iter_installed_files` — the exact set the dirty
+    checker and ``installed_at`` capture observe, so the recorded manifest
+    can never disagree with the walker about membership.
+    """
+    return sorted(p.relative_to(dest).as_posix() for p in iter_installed_files(dest))
+
+
+def _reconcile_removed_files(
+    dest: Path,
+    *,
+    src_has: Callable[[str], bool],
+    old_installed_at_epoch: float | None,
+    baked: frozenset[Path],
+    manifest: frozenset[str] | None,
+) -> tuple[Path, ...]:
+    """Delete dest files absent from the copy source (#1247).
+
+    ``copy_tree_atomic`` is an additive mirror; without this pass a file
+    removed upstream survives in dest forever while the lockfile claims
+    the new commit and status reports ``ok``. Decision rule per dest-only
+    file (walked via :func:`iter_installed_files`, so ``.bak`` siblings
+    and skip-listed names are never candidates):
+
+    1. ``manifest`` valid and relpath **not** recorded → user-added file:
+       keep (never silently delete user-authored content).
+    2. Recorded in the manifest (or no usable manifest — legacy entry):
+       delete when its mtime is ``<= old_installed_at_epoch`` (provably
+       untouched bytes from a previous wiki copy) **or** when it is in
+       ``baked`` (the ``--force`` path just preserved its ``.bak``).
+    3. Anything else (fresh mtime, no ``.bak``, provenance unknown) →
+       keep with a warning. Unreachable through the normal classify →
+       refuse/--force flow, but the ``--all`` confirm gap can race edits
+       past a stale dirty report — when in doubt, never delete.
+
+    Directories the deletions empty are pruned bottom-up (``dest`` itself
+    always survives). Returns the removed paths.
+    """
+    removed: list[Path] = []
+    for f in list(iter_installed_files(dest)):
+        rel = f.relative_to(dest).as_posix()
+        if src_has(rel):
+            continue
+        if manifest is not None and rel not in manifest:
+            logger.debug("reconcile: keeping user-added file %s", f)
+            continue
+        provably_old = (
+            old_installed_at_epoch is not None and f.stat().st_mtime <= old_installed_at_epoch
+        )
+        if not (provably_old or f in baked):
+            logger.warning("reconcile: keeping dest-only file with fresh mtime and no .bak: %s", f)
+            continue
+        f.unlink(missing_ok=True)
+        removed.append(f)
+
+    for f in removed:
+        parent = f.parent
+        while parent != dest:
+            try:
+                parent.rmdir()
+            except OSError:
+                break  # non-empty (or already gone) — stop pruning this chain
+            parent = parent.parent
+    return tuple(removed)
+
+
 def _install_asset(
     project_root: Path | str,
     asset_type: str,
@@ -245,6 +345,8 @@ def _install_asset(
         validated,
         wiki_commit=wiki_commit,
         installed_at=installed_at,
+        files=_manifest_relpaths(dest),
+        files_commit=wiki_commit,
     )
 
     return InstallResult(
@@ -408,17 +510,19 @@ def _apply_update(
     each dirty file is preserved alongside the wiki bytes as
     ``<file>.bak`` before the copy. ``shutil.copy2`` is used so the
     user's edit-mtime survives onto the ``.bak`` (atomic_write_bytes
-    would lose it). ``installed_at`` is captured *after* the copy
-    completes, mirroring the C2a (#630) install invariant so a
-    follow-up dirty check can't false-positive on this update's own
-    writes.
+    would lose it). After the copy, dest files absent from the wiki
+    source are reconciled away (:func:`_reconcile_removed_files`,
+    #1247) so the refreshed tree mirrors the wiki instead of growing
+    additively. ``installed_at`` is captured *after* copy + reconcile,
+    mirroring the C2a (#630) install invariant so a follow-up dirty
+    check can't false-positive on this update's own writes.
     """
     if dirty_report.reason == "dirty" and not force:
         raise StaleInstallError(
-            f"{asset_type}/{name}: {len(dirty_report.dirty_files)} file(s) "
-            f"modified locally since install at {dirty_report.installed_at}; "
+            f"{asset_type}/{name}: {dirty_report.summary()} "
+            f"since install at {dirty_report.installed_at}; "
             f"pass --force to overwrite "
-            f"(each dirty file gets a .bak sibling)"
+            f"(each modified file gets a .bak sibling; deleted files are restored)"
         )
 
     bak_paths: list[Path] = []
@@ -435,6 +539,22 @@ def _apply_update(
     dest.parent.mkdir(parents=True, exist_ok=True)
     files_written = copy_tree_atomic(src, dest)
 
+    # Mirror semantics (#1247): drop dest files the wiki no longer ships.
+    # The guard epoch is the PRE-update install timestamp (the same basis
+    # ``dirty_report`` classified against) — the freshly captured value
+    # below is >= every current mtime and would approve deleting anything.
+    files_removed = _reconcile_removed_files(
+        dest,
+        src_has=lambda rel: (src / rel).is_file(),
+        old_installed_at_epoch=_installed_at_epoch(lock_entry),
+        baked=(
+            frozenset(dirty_report.dirty_files)
+            if force and dirty_report.reason == "dirty"
+            else frozenset()
+        ),
+        manifest=manifest_from_entry(lock_entry),
+    )
+
     installed_at = installed_at_from_dest(dest)
     lock = Lockfile.at(project_root)
     lock.upsert_entry(
@@ -442,6 +562,8 @@ def _apply_update(
         name,
         wiki_commit=wiki_commit,
         installed_at=installed_at,
+        files=_manifest_relpaths(dest),
+        files_commit=wiki_commit,
     )
 
     old_wiki_commit = cast(str, lock_entry.get("wiki_commit", ""))
@@ -456,6 +578,7 @@ def _apply_update(
         bak_files_written=tuple(bak_paths),
         dest=dest,
         files_written=files_written,
+        files_removed=files_removed,
     )
 
 
@@ -565,7 +688,7 @@ def _classify_for_all_update(
         report = is_asset_dirty(project_root, asset_type, name, lock_entry=lock_entry)
         if report.reason == "dirty":
             state: Literal["update", "unchanged", "refuse", "error"] = "refuse"
-            reason: str | None = f"{len(report.dirty_files)} file(s) modified locally since install"
+            reason: str | None = f"{report.summary()} since install"
         else:
             state = "update"
             reason = None
@@ -777,9 +900,11 @@ def _apply_pinned_install(
         )
 
     if classification.state == "refuse" and not force:
+        refuse_report = classification.dirty_report
+        local_edits = refuse_report.summary() if refuse_report is not None else "local edits"
         raise StaleInstallError(
-            f"{asset_type}/{name}: local edits would be clobbered; "
-            f"pass --force to overwrite (each dirty file gets a .bak sibling)"
+            f"{asset_type}/{name}: {local_edits} would be clobbered; "
+            f"pass --force to overwrite (each modified file gets a .bak sibling)"
         )
 
     bak_paths: list[Path] = []
@@ -793,6 +918,27 @@ def _apply_pinned_install(
 
     files_written = wiki.copy_asset_at_commit(pin, asset_type, name, dest)
 
+    # Mirror semantics (#1247): a re-extraction over an existing dest must
+    # also retire dest-only leftovers (pre-B1 additive-update residue,
+    # carried files from a different pin). Membership comes from the pin's
+    # ls-tree set — the extraction tmpdir is internal to
+    # ``copy_asset_at_commit`` (design-gate M2).
+    files_removed: tuple[Path, ...] = ()
+    if classification.state in ("skip", "refuse"):
+        expected = set(wiki.asset_files_at_commit(pin, asset_type, name))
+        entry = classification.lock_entry or {}
+        files_removed = _reconcile_removed_files(
+            dest,
+            src_has=lambda rel: rel in expected,
+            old_installed_at_epoch=_installed_at_epoch(entry),
+            baked=(
+                frozenset(classification.dirty_report.dirty_files)
+                if classification.state == "refuse" and classification.dirty_report is not None
+                else frozenset()
+            ),
+            manifest=manifest_from_entry(entry),
+        )
+
     installed_at = installed_at_from_dest(dest)
     lock = Lockfile.at(project_root)
     # CRITICAL: wiki_commit stays at the pin we just restored to —
@@ -802,6 +948,8 @@ def _apply_pinned_install(
         name,
         wiki_commit=pin,
         installed_at=installed_at,
+        files=_manifest_relpaths(dest),
+        files_commit=pin,
     )
 
     return InstallResult(
@@ -811,4 +959,5 @@ def _apply_pinned_install(
         installed_at=installed_at,
         dest=dest,
         files_written=files_written,
+        files_removed=files_removed,
     )

--- a/packages/memtomem/src/memtomem/context/lockfile.py
+++ b/packages/memtomem/src/memtomem/context/lockfile.py
@@ -37,6 +37,7 @@ __all__ = [
     "LOCKFILE_VERSION",
     "Lockfile",
     "LockfileVersionError",
+    "manifest_from_entry",
     "utcnow_iso8601_z",
 ]
 
@@ -62,6 +63,43 @@ def utcnow_iso8601_z() -> str:
     ``installed_at`` values for ordering.
     """
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def manifest_from_entry(entry: dict[str, Any]) -> frozenset[str] | None:
+    """Return the entry's validated file manifest, or ``None``.
+
+    The manifest (``files`` + ``files_commit``, written by install/update
+    since #1247) is honored only when it provably describes the entry's
+    current pin AND is well-formed:
+
+    - ``files_commit`` is a ``str`` equal to ``entry["wiki_commit"]`` —
+      ``upsert_entry`` preserves unknown keys, so an entry rewritten by an
+      *older* tool keeps a stale ``files`` list while the pin moves; the
+      commit pairing detects that.
+    - ``files`` is a list of non-empty ``str`` POSIX relpaths — no leading
+      ``/``, no ``..`` segment, no ``\\``. ``lock.json`` can be git-tracked
+      and hand-merged, so malformed shapes are an ordinary event and must
+      degrade to "no manifest", never crash or mis-answer membership.
+    """
+    files = entry.get("files")
+    files_commit = entry.get("files_commit")
+    wiki_commit = entry.get("wiki_commit")
+    if not isinstance(files_commit, str) or not isinstance(wiki_commit, str):
+        return None
+    if files_commit != wiki_commit:
+        return None
+    if not isinstance(files, list):
+        return None
+    out: set[str] = set()
+    for item in files:
+        if not isinstance(item, str) or not item:
+            return None
+        if item.startswith("/") or "\\" in item:
+            return None
+        if ".." in item.split("/"):
+            return None
+        out.add(item)
+    return frozenset(out)
 
 
 class Lockfile:
@@ -174,14 +212,25 @@ class Lockfile:
         *,
         wiki_commit: str,
         installed_at: str,
+        files: list[str] | None = None,
+        files_commit: str | None = None,
     ) -> None:
         """Insert or replace the ``(asset_type, name)`` entry.
 
         Holds the sidecar lock for the load + mutate + write triple.
         Preserves all unknown sibling and per-entry keys verbatim — only
-        the two mandated fields are written, anything else under
+        the mandated fields are written, anything else under
         ``doc[asset_type][name]`` survives.
+
+        ``files`` / ``files_commit`` (#1247): the installed file manifest,
+        stored sorted. Both must be passed together. Omitting them leaves
+        any previously recorded manifest untouched (same unknown-key
+        preservation contract as the rest of the entry) — consumers detect
+        the resulting staleness via the ``files_commit`` pairing, see
+        :func:`manifest_from_entry`.
         """
+        if (files is None) != (files_commit is None):
+            raise ValueError("files and files_commit must be passed together")
         with _file_lock(_lock_path_for(self._path)):
             doc = self.load()
             section = doc.get(asset_type)
@@ -196,6 +245,9 @@ class Lockfile:
                 merged = {}
             merged["wiki_commit"] = wiki_commit
             merged["installed_at"] = installed_at
+            if files is not None:
+                merged["files"] = sorted(files)
+                merged["files_commit"] = files_commit
             section[name] = merged
 
             atomic_write_bytes(

--- a/packages/memtomem/src/memtomem/context/status.py
+++ b/packages/memtomem/src/memtomem/context/status.py
@@ -64,8 +64,9 @@ class StatusRow:
     callers abbreviate to 12 for display per ADR-0008 line 149.
     ``installed_at`` is the ISO-8601Z value from the lockfile (whatever
     was last written; not re-validated here). ``dirty_file_count`` is
-    populated only for ``state == "dirty"`` and reflects the count of
-    files with ``mtime > installed_at_epoch``.
+    populated only for ``state == "dirty"`` and counts local edits of
+    both classes: files with ``mtime > installed_at_epoch`` plus
+    manifest-recorded files deleted from disk (#1247).
 
     ``reason`` is a human-readable detail line that the CLI appends in
     parens after the row. Common contents: ``"N file(s) modified
@@ -160,8 +161,8 @@ def classify_status(
             reason = "dest missing"
         elif report.reason == "dirty":
             state = "dirty"
-            dirty_count = len(report.dirty_files)
-            reason = f"{dirty_count} file(s) modified locally"
+            dirty_count = len(report.dirty_files) + len(report.missing_files)
+            reason = report.summary()
         else:  # report.reason == "clean"
             if not wiki_present:
                 state = "stale-pin"

--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -252,6 +252,37 @@ class WikiStore:
         # Deferred import: install.py imports wiki.store at module load;
         # the reverse import here would cycle. Local resolves at call time.
         from memtomem.context._atomic import copy_tree_atomic
+
+        src_prefix = f"{asset_type}/{name}/"
+        inner_relpaths = self.asset_files_at_commit(commit, asset_type, name)
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(dir=dest.parent) as tmpdir:
+            tmpdir_path = Path(tmpdir)
+            for inner in inner_relpaths:
+                target = tmpdir_path / inner
+                target.parent.mkdir(parents=True, exist_ok=True)
+                content = subprocess.run(
+                    ["git", "show", f"{commit}:{src_prefix}{inner}"],
+                    cwd=self.root,
+                    check=True,
+                    capture_output=True,
+                )
+                target.write_bytes(content.stdout)
+            return copy_tree_atomic(tmpdir_path, dest)
+
+    def asset_files_at_commit(self, commit: str, asset_type: str, name: str) -> list[str]:
+        """List the asset's file relpaths (relative to the asset dir) at *commit*.
+
+        ``git ls-tree -r --name-only`` against the commit's objects — the
+        wiki working tree is never consulted. Raises
+        :class:`CommitNotFoundError` for an unreachable SHA and
+        :class:`memtomem.context.install.AssetNotFoundError` when the asset
+        path has no files at that revision. Used by
+        :meth:`copy_asset_at_commit` for extraction and by
+        ``mm context install --all`` reconciliation, which needs the
+        expected file set without re-extracting (#1247).
+        """
         from memtomem.context.install import AssetNotFoundError
 
         self.require_exists()
@@ -263,31 +294,19 @@ class WikiStore:
             ["ls-tree", "-r", "--name-only", commit, "--", src_prefix],
             cwd=self.root,
         )
-        relpaths = [line for line in ls_result.stdout.splitlines() if line.startswith(src_prefix)]
-        if not relpaths:
+        inner_relpaths = [
+            line[len(src_prefix) :]
+            for line in ls_result.stdout.splitlines()
+            # The startswith filter guards against odd git path output; the
+            # truthiness check drops a bare prefix row (ls-tree -r shouldn't
+            # yield one, but guard against odd git versions).
+            if line.startswith(src_prefix) and line[len(src_prefix) :]
+        ]
+        if not inner_relpaths:
             raise AssetNotFoundError(
                 f"{asset_type}/{name} not present at commit {commit[:12]} in {self.root}"
             )
-
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        with tempfile.TemporaryDirectory(dir=dest.parent) as tmpdir:
-            tmpdir_path = Path(tmpdir)
-            for relpath in relpaths:
-                inner = relpath[len(src_prefix) :]
-                if not inner:
-                    # The prefix itself; ls-tree -r shouldn't yield this
-                    # but guard against odd git versions.
-                    continue
-                target = tmpdir_path / inner
-                target.parent.mkdir(parents=True, exist_ok=True)
-                content = subprocess.run(
-                    ["git", "show", f"{commit}:{relpath}"],
-                    cwd=self.root,
-                    check=True,
-                    capture_output=True,
-                )
-                target.write_bytes(content.stdout)
-            return copy_tree_atomic(tmpdir_path, dest)
+        return inner_relpaths
 
     def list_assets(self, asset_type: str | None = None) -> list[WikiAsset]:
         """Enumerate asset directories under the wiki.

--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -251,7 +251,7 @@ class WikiStore:
         """
         # Deferred import: install.py imports wiki.store at module load;
         # the reverse import here would cycle. Local resolves at call time.
-        from memtomem.context._atomic import copy_tree_atomic
+        from memtomem.context._atomic import DIRTY_SKIP_SUFFIXES, copy_tree_atomic
 
         src_prefix = f"{asset_type}/{name}/"
         inner_relpaths = self.asset_files_at_commit(commit, asset_type, name)
@@ -269,7 +269,7 @@ class WikiStore:
                     capture_output=True,
                 )
                 target.write_bytes(content.stdout)
-            return copy_tree_atomic(tmpdir_path, dest)
+            return copy_tree_atomic(tmpdir_path, dest, skip_suffixes=DIRTY_SKIP_SUFFIXES)
 
     def asset_files_at_commit(self, commit: str, asset_type: str, name: str) -> list[str]:
         """List the asset's file relpaths (relative to the asset dir) at *commit*.

--- a/packages/memtomem/tests/test_context_install.py
+++ b/packages/memtomem/tests/test_context_install.py
@@ -431,8 +431,13 @@ def test_cli_install_already_installed_classified_message(
 # ── Lockfile assertions about the live install ──────────────────────────
 
 
-def test_lockfile_contains_only_two_keys_per_entry(wiki_root: Path, tmp_path: Path) -> None:
-    """Schema discipline: install writes exactly the two mandated keys."""
+def test_lockfile_contains_only_mandated_keys_per_entry(wiki_root: Path, tmp_path: Path) -> None:
+    """Schema discipline: install writes exactly the mandated keys.
+
+    ``files`` + ``files_commit`` joined the schema with the #1247
+    deletion-fidelity work (the installed file manifest enabling
+    deletion-dirty detection and update reconciliation).
+    """
     _initialized_wiki(wiki_root)
     _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
     project = tmp_path
@@ -441,4 +446,6 @@ def test_lockfile_contains_only_two_keys_per_entry(wiki_root: Path, tmp_path: Pa
     lock = Lockfile.at(project)
     entry = lock.read_entry("skills", "foo")
     assert entry is not None
-    assert set(entry) == {"wiki_commit", "installed_at"}
+    assert set(entry) == {"wiki_commit", "installed_at", "files", "files_commit"}
+    assert entry["files"] == ["SKILL.md"]
+    assert entry["files_commit"] == entry["wiki_commit"]

--- a/packages/memtomem/tests/test_context_install_all.py
+++ b/packages/memtomem/tests/test_context_install_all.py
@@ -18,8 +18,10 @@ and construct dest + lockfile via the live install path so the
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -484,3 +486,44 @@ def test_classify_execute_race_pin_pruned_mid_loop(
 
 # silence "imported but unused" if a future test needs the fixture
 _ = pytest
+
+
+# ── B1: pinned re-extraction reconciles dest-only files (#1247) ──────────
+
+
+def test_force_reextraction_removes_stale_dest_only_file(
+    wiki_root: Path, tmp_path: Path, monkeypatch
+) -> None:
+    """``install --all --force`` re-extracts at the pin; a dest-only file
+    whose mtime predates ``installed_at`` (a pre-B1 additive-update leftover)
+    must be reconciled away, not carried forever."""
+    _initialized_wiki(wiki_root)
+    pin = _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"pinned\n"})
+    install_skill(tmp_path, "foo")
+
+    dest = tmp_path / ".memtomem" / "skills" / "foo"
+    stale = dest / "leftover.md"
+    stale.write_bytes(b"stale wiki bytes\n")
+    # Backdate so the file reads as old wiki bytes (mtime <= installed_at):
+    # the legacy-entry deletion rule, not the user-added keep rule.
+    past = datetime.now(timezone.utc).timestamp() - 3600
+    os.utime(stale, (past, past))
+    # Pre-B1 entries carry no manifest — simulate one by stripping the keys.
+    lock_path = tmp_path / ".memtomem" / "lock.json"
+    doc = json.loads(lock_path.read_text(encoding="utf-8"))
+    doc["skills"]["foo"].pop("files", None)
+    doc["skills"]["foo"].pop("files_commit", None)
+    lock_path.write_text(json.dumps(doc), encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["install", "--all", "--yes", "--force"])
+
+    assert result.exit_code == 0, result.output
+    assert not stale.exists()
+    assert (dest / "SKILL.md").read_bytes() == b"pinned\n"
+    lock_doc = json.loads(lock_path.read_text(encoding="utf-8"))
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == pin
+    # Manifest recorded against the pin on re-extraction.
+    assert lock_doc["skills"]["foo"]["files"] == ["SKILL.md"]
+    assert lock_doc["skills"]["foo"]["files_commit"] == pin

--- a/packages/memtomem/tests/test_context_install_all.py
+++ b/packages/memtomem/tests/test_context_install_all.py
@@ -527,3 +527,22 @@ def test_force_reextraction_removes_stale_dest_only_file(
     # Manifest recorded against the pin on re-extraction.
     assert lock_doc["skills"]["foo"]["files"] == ["SKILL.md"]
     assert lock_doc["skills"]["foo"]["files_commit"] == pin
+
+
+def test_classify_install_all_missing_only_dirty_reason(wiki_root: Path, tmp_path: Path) -> None:
+    """Codex implementation-gate M2: a manifest-detected deletion with zero
+    modified files must not classify-print as '0 file(s) modified locally'."""
+    from memtomem.context.install import _classify_for_install_all
+
+    store = _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"x\n", "gone.md": b"y\n"})
+    install_skill(tmp_path, "foo")
+    (tmp_path / ".memtomem" / "skills" / "foo" / "gone.md").unlink()
+
+    rows = _classify_for_install_all(tmp_path, wiki=store)
+
+    assert len(rows) == 1
+    assert rows[0].state == "refuse"
+    assert rows[0].reason is not None
+    assert "deleted locally" in rows[0].reason
+    assert "0 file(s) modified" not in rows[0].reason

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -1019,3 +1019,197 @@ def test_cli_update_no_wiki_dirty_warn_when_clean(
 
     assert result.exit_code == 0, result.output
     assert "wiki has uncommitted changes" not in result.output
+
+
+# ── B1: upstream-deletion reconcile + deletion-dirty (#1247) ─────────────
+
+
+def _delete_wiki_skill_file(wiki_root_path: Path, name: str, relpath: str) -> str:
+    """``git rm`` one file from a wiki skill + commit. Returns the new SHA.
+
+    Removes the file from the wiki working tree too (``git rm``), so the
+    live-tree copy source ``_update_asset`` reads matches the new commit.
+    """
+    subprocess.run(
+        ["git", "-C", str(wiki_root_path), "rm", "-q", f"skills/{name}/{relpath}"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(wiki_root_path), "commit", "-m", f"delete {name}/{relpath}"],
+        check=True,
+        capture_output=True,
+    )
+    return WikiStore.at_default().current_commit()
+
+
+def _lock_entry(project: Path, asset_type: str, name: str) -> dict:
+    doc = json.loads((project / ".memtomem" / "lock.json").read_text(encoding="utf-8"))
+    return doc[asset_type][name]
+
+
+def _rewrite_lock_entry(project: Path, asset_type: str, name: str, entry: dict) -> None:
+    lock_path = project / ".memtomem" / "lock.json"
+    doc = json.loads(lock_path.read_text(encoding="utf-8"))
+    doc[asset_type][name] = entry
+    lock_path.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+
+
+def test_update_removes_upstream_deleted_file(wiki_root: Path, tmp_path: Path) -> None:
+    """Core #1247 reported-critical: update must delete files removed upstream.
+
+    Pre-B1 the additive copy left ``scripts/run-old.py`` on disk forever
+    while the lockfile claimed the new commit and status said ``ok``.
+    """
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"v1\n", "scripts/run-old.py": b"old\n"})
+    install_skill(tmp_path, "web")
+
+    new_sha = _delete_wiki_skill_file(wiki_root, "web", "scripts/run-old.py")
+    result = update_skill(tmp_path, "web")
+
+    dest = tmp_path / ".memtomem" / "skills" / "web"
+    assert not (dest / "scripts" / "run-old.py").exists()
+    # The directory the removal emptied is pruned too.
+    assert not (dest / "scripts").exists()
+    assert (dest / "SKILL.md").read_bytes() == b"v1\n"
+
+    assert [p.name for p in result.files_removed] == ["run-old.py"]
+
+    entry = _lock_entry(tmp_path, "skills", "web")
+    assert entry["wiki_commit"] == new_sha
+    assert entry["files"] == ["SKILL.md"]
+    assert entry["files_commit"] == new_sha
+
+
+def test_update_force_removes_deleted_and_edited_file_with_bak(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """Upstream-deleted + locally-edited: refuse without --force; with
+    --force the edit is preserved as ``.bak`` and the live file is removed."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"v1\n", "notes.md": b"wiki\n"})
+    install_skill(tmp_path, "web")
+
+    dest = tmp_path / ".memtomem" / "skills" / "web"
+    (dest / "notes.md").write_bytes(b"user edit\n")
+    _bump_mtime(dest / "notes.md")
+
+    _delete_wiki_skill_file(wiki_root, "web", "notes.md")
+
+    with pytest.raises(StaleInstallError):
+        update_skill(tmp_path, "web")
+
+    result = update_skill(tmp_path, "web", force=True)
+
+    assert (dest / "notes.md.bak").read_bytes() == b"user edit\n"
+    assert not (dest / "notes.md").exists()
+    assert [p.name for p in result.files_removed] == ["notes.md"]
+
+
+def test_update_force_keeps_user_added_file_when_manifest_present(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """Manifest rule 1: a dest-only file NOT in the recorded manifest is
+    user-authored content — never silently deleted, even under --force."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"v1\n"})
+    install_skill(tmp_path, "web")
+
+    dest = tmp_path / ".memtomem" / "skills" / "web"
+    (dest / "extra.md").write_bytes(b"mine\n")
+    _bump_mtime(dest / "extra.md")
+
+    _modify_wiki_skill(wiki_root, "web", {"SKILL.md": b"v2\n"})
+
+    result = update_skill(tmp_path, "web", force=True)
+
+    assert (dest / "extra.md").read_bytes() == b"mine\n"
+    assert result.files_removed == ()
+
+
+def test_update_legacy_entry_removes_stale_dest_only_file(wiki_root: Path, tmp_path: Path) -> None:
+    """Legacy lock entry (no manifest): a dest-only file whose mtime is
+    ``<= installed_at`` is provably old wiki bytes — removed."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"v1\n", "old.md": b"old\n"})
+    install_skill(tmp_path, "web")
+
+    # Simulate a pre-B1 entry: strip the manifest keys.
+    entry = _lock_entry(tmp_path, "skills", "web")
+    entry.pop("files", None)
+    entry.pop("files_commit", None)
+    _rewrite_lock_entry(tmp_path, "skills", "web", entry)
+
+    _delete_wiki_skill_file(wiki_root, "web", "old.md")
+    result = update_skill(tmp_path, "web")
+
+    dest = tmp_path / ".memtomem" / "skills" / "web"
+    assert not (dest / "old.md").exists()
+    assert [p.name for p in result.files_removed] == ["old.md"]
+
+
+def test_update_noop_with_user_deleted_file_does_not_resurrect(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """Codex design-gate M1 regression: unchanged wiki HEAD short-circuits
+    to a no-op BEFORE the dirty walk — nothing is written, so a user-deleted
+    file must stay deleted (diagnosis surface is ``mm context status``)."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"v1\n", "extra.md": b"x\n"})
+    install_skill(tmp_path, "web")
+
+    dest = tmp_path / ".memtomem" / "skills" / "web"
+    (dest / "extra.md").unlink()
+
+    result = update_skill(tmp_path, "web")
+
+    assert result.was_no_op is True
+    assert not (dest / "extra.md").exists()
+
+
+def test_update_refuses_on_user_deleted_file_after_wiki_advance(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """Deletion-dirty (#1247 item 12): after the wiki advances, a user-deleted
+    file counts as a local edit — refuse without --force; --force restores it
+    as an explicit, informed action."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"v1\n", "keep.md": b"k\n"})
+    install_skill(tmp_path, "web")
+
+    dest = tmp_path / ".memtomem" / "skills" / "web"
+    (dest / "keep.md").unlink()
+
+    _modify_wiki_skill(wiki_root, "web", {"SKILL.md": b"v2\n"})
+
+    with pytest.raises(StaleInstallError) as excinfo:
+        update_skill(tmp_path, "web")
+    assert "deleted" in str(excinfo.value)
+
+    result = update_skill(tmp_path, "web", force=True)
+    assert (dest / "keep.md").read_bytes() == b"k\n"
+    assert result.was_no_op is False
+
+
+def test_update_stale_manifest_guard_ignores_mismatched_files_commit(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """An entry whose ``files_commit`` doesn't match ``wiki_commit`` (older
+    tool rewrote the entry, or a hand-merged lock.json) must behave as if no
+    manifest exists: no missing-file dirty, legacy mtime rule applies."""
+    from memtomem.context.dirty import is_asset_dirty
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"v1\n", "a.md": b"a\n"})
+    install_skill(tmp_path, "web")
+
+    entry = _lock_entry(tmp_path, "skills", "web")
+    entry["files_commit"] = "0" * 40
+    _rewrite_lock_entry(tmp_path, "skills", "web", entry)
+
+    (tmp_path / ".memtomem" / "skills" / "web" / "a.md").unlink()
+
+    report = is_asset_dirty(tmp_path, "skills", "web")
+    assert report.reason == "clean"
+    assert report.missing_files == ()

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -1241,3 +1241,34 @@ def test_update_removes_file_replaced_by_symlink_upstream(wiki_root: Path, tmp_p
     assert [p.name for p in result.files_removed] == ["link.md"]
     entry = _lock_entry(tmp_path, "skills", "web")
     assert entry["files"] == ["SKILL.md"]
+
+
+def test_wiki_shipped_bak_never_installed_or_stranded(wiki_root: Path, tmp_path: Path) -> None:
+    """#1247 item 10 (re-review major): the wiki-install copies share the
+    walker's suffix skip, so a wiki-shipped ``*.bak`` is never installed —
+    it can't dodge dirty tracking, collide with the ``--force`` preservation
+    namespace, or strand stale bytes when upstream later replaces it."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"v1\n", "leftover.md.bak": b"wiki bak\n"})
+    result = install_skill(tmp_path, "web")
+
+    dest = tmp_path / ".memtomem" / "skills" / "web"
+    assert not (dest / "leftover.md.bak").exists()
+    assert result.files_written == 1
+    assert _lock_entry(tmp_path, "skills", "web")["files"] == ["SKILL.md"]
+
+    # Upstream replaces the .bak with a symlink (the re-review repro shape):
+    # update stays clean — nothing was installed, so nothing can go stale.
+    src_bak = wiki_root / "skills" / "web" / "leftover.md.bak"
+    src_bak.unlink()
+    src_bak.symlink_to("SKILL.md")
+    subprocess.run(["git", "-C", str(wiki_root), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root), "commit", "-m", "replace bak with symlink"],
+        check=True,
+        capture_output=True,
+    )
+
+    upd = update_skill(tmp_path, "web")
+    assert upd.files_removed == ()
+    assert not (dest / "leftover.md.bak").exists()

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -1213,3 +1213,31 @@ def test_update_stale_manifest_guard_ignores_mismatched_files_commit(
     report = is_asset_dirty(tmp_path, "skills", "web")
     assert report.reason == "clean"
     assert report.missing_files == ()
+
+
+def test_update_removes_file_replaced_by_symlink_upstream(wiki_root: Path, tmp_path: Path) -> None:
+    """Codex implementation-gate M1: ``copy_tree_atomic`` skips symlinks, so
+    a wiki file replaced by a symlink is NOT written to dest — reconcile
+    membership must use the copier's effective file set, or the old regular
+    file survives and is recorded clean in the manifest."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"v1\n", "link.md": b"regular\n"})
+    install_skill(tmp_path, "web")
+
+    src_link = wiki_root / "skills" / "web" / "link.md"
+    src_link.unlink()
+    src_link.symlink_to("SKILL.md")
+    subprocess.run(["git", "-C", str(wiki_root), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root), "commit", "-m", "replace link.md with symlink"],
+        check=True,
+        capture_output=True,
+    )
+
+    result = update_skill(tmp_path, "web")
+
+    dest = tmp_path / ".memtomem" / "skills" / "web"
+    assert not (dest / "link.md").exists()
+    assert [p.name for p in result.files_removed] == ["link.md"]
+    entry = _lock_entry(tmp_path, "skills", "web")
+    assert entry["files"] == ["SKILL.md"]

--- a/packages/memtomem/tests/test_dirty.py
+++ b/packages/memtomem/tests/test_dirty.py
@@ -15,6 +15,7 @@ the strict ``>`` boundary on every platform.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -379,3 +380,93 @@ class TestInstalledAtFromDest:
             f"{actual_mtime} ({f.stat().st_mtime_ns}ns) — the µs ceiling "
             "regressed."
         )
+
+
+# ── B1: manifest-based deletion-dirty (#1247 item 12) ────────────────────
+
+
+def _setup_installed_with_manifest(
+    project: Path,
+    asset_type: str,
+    name: str,
+    files: dict[str, bytes],
+) -> str:
+    """Like :func:`_setup_installed` but records the B1 file manifest
+    (``files`` + ``files_commit`` matching ``wiki_commit``)."""
+    dest = project / ".memtomem" / asset_type / name
+    dest.mkdir(parents=True)
+    for relpath, data in files.items():
+        target = dest / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+
+    installed_at = installed_at_from_dest(dest)
+    Lockfile.at(project).upsert_entry(
+        asset_type,
+        name,
+        wiki_commit="0" * 40,
+        installed_at=installed_at,
+        files=sorted(files),
+        files_commit="0" * 40,
+    )
+    return installed_at
+
+
+def test_user_deleted_file_reports_missing(tmp_path: Path) -> None:
+    """A manifest entry absent from disk classifies the asset dirty with the
+    relpath in ``missing_files`` — pre-B1 this was the guaranteed false
+    negative (clean → silent resurrection on the next update)."""
+    _setup_installed_with_manifest(
+        tmp_path, "skills", "web", {"SKILL.md": b"v1\n", "scripts/run.py": b"r\n"}
+    )
+
+    (tmp_path / ".memtomem" / "skills" / "web" / "scripts" / "run.py").unlink()
+
+    report = is_asset_dirty(tmp_path, "skills", "web")
+    assert report.reason == "dirty"
+    assert report.dirty_files == ()
+    assert [str(p) for p in report.missing_files] == [
+        str(tmp_path / ".memtomem" / "skills" / "web" / "scripts" / "run.py")
+    ]
+
+
+def test_intact_manifest_stays_clean(tmp_path: Path) -> None:
+    """Negative pin: manifest present and every file on disk → clean."""
+    _setup_installed_with_manifest(tmp_path, "skills", "web", {"SKILL.md": b"v1\n"})
+
+    report = is_asset_dirty(tmp_path, "skills", "web")
+    assert report.reason == "clean"
+    assert report.missing_files == ()
+
+
+@pytest.mark.parametrize(
+    "files_value, files_commit_value",
+    [
+        ("not-a-list", "0" * 40),  # files not a list
+        ([42], "0" * 40),  # non-str member
+        (["../escape.md"], "0" * 40),  # path traversal
+        (["/abs.md"], "0" * 40),  # absolute path
+        (["a\\b.md"], "0" * 40),  # backslash separator
+        (["SKILL.md"], "f" * 40),  # files_commit mismatch
+        (["SKILL.md"], None),  # files_commit missing
+    ],
+)
+def test_malformed_or_stale_manifest_ignored(
+    tmp_path: Path, files_value: object, files_commit_value: object
+) -> None:
+    """Codex design-gate M3: lock.json is git-tracked and hand-mergeable —
+    any malformed manifest shape degrades to pre-B1 semantics (no manifest),
+    never a crash or a wrong membership check."""
+    _setup_installed(tmp_path, "skills", "web", {"SKILL.md": b"v1\n"})
+
+    lock_path = tmp_path / ".memtomem" / "lock.json"
+    doc = json.loads(lock_path.read_text(encoding="utf-8"))
+    entry = doc["skills"]["web"]
+    entry["files"] = files_value
+    if files_commit_value is not None:
+        entry["files_commit"] = files_commit_value
+    lock_path.write_text(json.dumps(doc), encoding="utf-8")
+
+    report = is_asset_dirty(tmp_path, "skills", "web")
+    assert report.reason == "clean"
+    assert report.missing_files == ()

--- a/packages/memtomem/tests/test_lockfile.py
+++ b/packages/memtomem/tests/test_lockfile.py
@@ -258,3 +258,52 @@ def test_remove_entry_preserves_siblings_and_unknown_fields(tmp_path: Path) -> N
     assert doc["skills"]["beta"]["wiki_commit"] == "b" * 40
     assert doc["skills"]["beta"]["compat"] == "v2"  # unknown per-entry field kept
     assert doc["future_root"] == "preserved"  # unknown top-level field kept
+
+
+# ── B1: file manifest fields (#1247) ─────────────────────────────────────
+
+
+def test_upsert_records_manifest_keys(tmp_path: Path) -> None:
+    """``files`` is stored sorted (POSIX relpaths) with its pairing
+    ``files_commit`` so consumers can detect stale manifests."""
+    lock = Lockfile.at(tmp_path)
+    lock.upsert_entry(
+        "skills",
+        "web",
+        wiki_commit="a" * 40,
+        installed_at="2026-06-11T00:00:00.000000Z",
+        files=["scripts/run.py", "SKILL.md"],
+        files_commit="a" * 40,
+    )
+
+    doc = json.loads((tmp_path / ".memtomem" / "lock.json").read_text(encoding="utf-8"))
+    entry = doc["skills"]["web"]
+    assert entry["files"] == ["SKILL.md", "scripts/run.py"]
+    assert entry["files_commit"] == "a" * 40
+
+
+def test_upsert_without_manifest_preserves_existing_manifest_keys(tmp_path: Path) -> None:
+    """Omitting ``files`` on a later upsert must not strip a previously
+    recorded manifest — same unknown-key preservation contract as the rest
+    of the entry; staleness is handled by the ``files_commit`` guard."""
+    lock = Lockfile.at(tmp_path)
+    lock.upsert_entry(
+        "skills",
+        "web",
+        wiki_commit="a" * 40,
+        installed_at="2026-06-11T00:00:00.000000Z",
+        files=["SKILL.md"],
+        files_commit="a" * 40,
+    )
+    lock.upsert_entry(
+        "skills",
+        "web",
+        wiki_commit="b" * 40,
+        installed_at="2026-06-12T00:00:00.000000Z",
+    )
+
+    doc = json.loads((tmp_path / ".memtomem" / "lock.json").read_text(encoding="utf-8"))
+    entry = doc["skills"]["web"]
+    assert entry["files"] == ["SKILL.md"]
+    assert entry["files_commit"] == "a" * 40  # now stale — guard ignores it
+    assert entry["wiki_commit"] == "b" * 40


### PR DESCRIPTION
Part of #1247 — fix batch B1 (the reported-critical install/update family). Resolves backlog items **2/14** (additive-only update), **12** (silent resurrection of user-deleted files), and **10** (wiki-shipped `*.bak` install asymmetry). Item **15** (`installed_at` capture race) stays open on #1247 — the real fix is content digests, which is a cost decision worth its own design pass.

## What was broken

- **Update never removed upstream-deleted files** (reported-critical): `copy_tree_atomic` iterates src only, `_apply_update` pinned the new `wiki_commit`, and post-copy max-mtime capture classified stale files clean forever — dest silently diverged from wiki HEAD while `mm context status` reported `ok`. `install --all --force` funnels through the same copy, so the recovery verb couldn't repair the divergence either.
- **Deletions were invisible to dirty detection**: the walker only sees files that exist, so a user-deleted file classified clean and the next update silently resurrected it — the one local-edit class with a guaranteed false negative.
- **Wiki-shipped `*.bak` files were installed but untracked**: the copier didn't share the walker's suffix skip, so such files dodged dirty tracking and the manifest, and sat in the namespace `update --force` uses for preservation siblings.

## What this PR does

1. **Reconcile after copy** (`_reconcile_removed_files`): update and pinned re-extraction delete dest files absent from the copy source — but only when provably safe: the file's mtime predates the *pre-update* `installed_at` (old wiki bytes), or its `.bak` was just written by `--force`. With a valid manifest, files not recorded there are user-authored and always kept; anything of unknown provenance is kept with a warning (the `--all` confirm gap can race edits past a stale dirty report — when in doubt, never delete). Emptied directories are pruned; `files_removed` is surfaced on `UpdateResult`/`InstallResult` and in the CLI output.
2. **Lockfile file manifest**: entries now record `files` (sorted POSIX relpaths) + `files_commit`. The commit pairing is the staleness guard — `upsert_entry` preserves unknown keys, so a pre-manifest tool rewriting an entry leaves a stale list while the pin moves; consumers honor the manifest only when `files_commit == wiki_commit` and the shape validates (`manifest_from_entry` — `lock.json` can be git-tracked and hand-merged, so malformed shapes degrade to pre-manifest semantics, never crash). Schema documented in ADR-0008.
3. **Deletion-aware dirty detection**: with a valid manifest, `is_asset_dirty` reports missing files as local edits (`DirtyReport.missing_files`); update refuses without `--force`, and restoring a deletion becomes an explicit choice. Summaries cover both edit classes everywhere they render (`StaleInstallError`, `update --all` / `install --all` classification, status rows) so a missing-only report can't print as "0 file(s) modified locally". Unchanged-HEAD updates keep the no-op short-circuit — nothing is written, so nothing can resurrect; status is the diagnosis surface there (regression-pinned).
4. **Copier/walker symmetry**: `copy_tree_atomic` gains an opt-in `skip_suffixes`; the three wiki-install sites pass `DIRTY_SKIP_SUFFIXES` so the installed surface equals the tracked surface. Reconcile membership uses the copier's effective file set (`iter_installed_files(src)` / pin `ls-tree` via the new `WikiStore.asset_files_at_commit`), so a wiki file replaced by a symlink — which the copier skips by contract — can't strand its old regular copy. The skills staging mirror is deliberately unchanged (verified: its diff parity compares full trees).

## Verification

- 22 new tests across `test_context_update.py`, `test_dirty.py`, `test_lockfile.py`, `test_context_install_all.py`; the behavioral ones were run pre-fix and failed for the claimed reason (file persisting, clean-on-deletion, `0 file(s) modified locally`, stranded symlink replacement — the latter two reproduced independently by the review gate).
- Full suite: 6201 passed, 11 skipped (CI filter `-m "not ollama"`; `test_session_tracing` excluded locally per the known #1249 env leak). `ruff check` + `ruff format --check` clean; `mypy` clean on touched files.
- Codex gates: design gate (NEEDS-FIX → resolutions folded in), implementation review (NEEDS-FIX ×2 → fixed with regression tests), final re-verify **SHIP** with zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
