### PR TITLE
fix(context): gate wiki-install ingress and settings rule promote behind Gate A (#1247 B2)

### DIFF
--- a/docs/adr/0008-wiki-layer.md
+++ b/docs/adr/0008-wiki-layer.md
@@ -40,10 +40,13 @@ Introduce four new surfaces, each governed by an invariant:
 
 `mm context install` snapshots a wiki artifact as a **directory tree**
 (`shutil.copytree` semantics) into the project — including any
-`overrides/` subdirectory. Fan-out (`generate_all_skills`,
-`generate_all_agents`, `generate_all_commands`) reads only from the
-project tree, never from the wiki. CI machines, archived projects, and
-machines without the wiki all run fan-out unchanged.
+`overrides/` subdirectory. Install runs the ADR-0011 Gate A privacy
+scan over the wiki bytes before the copy; a `project_shared` hit
+refuses with no dest or lockfile residue (#1247). Fan-out
+(`generate_all_skills`, `generate_all_agents`, `generate_all_commands`)
+reads only from the project tree, never from the wiki. CI machines,
+archived projects, and machines without the wiki all run fan-out
+unchanged.
 
 ### Invariant 2 — Explicit conflict surface for local edits
 
@@ -52,7 +55,10 @@ modified after install (mtime > `lockfile.installed_at`).
 
 Default behavior: refuse with a clear error. `--force` overwrites and
 leaves a `.bak` copy of each clobbered file. This mirrors ADR-0001's
-on_drop policy of never silently dropping data.
+on_drop policy of never silently dropping data. The `.bak` write is
+itself a `project_shared` write: `--force` scans each dirty file before
+its `.bak` lands, and a privacy hit refuses the whole update before any
+`.bak` or copy is written (#1247, ADR-0011 Gate A).
 
 ### Invariant 3 — Wiki is optional, project is authoritative
 

--- a/docs/adr/0011-canonical-artifact-scope-hierarchy.md
+++ b/docs/adr/0011-canonical-artifact-scope-hierarchy.md
@@ -225,6 +225,18 @@ and the runtime fan-out is about to write. A new
 content before each fan-out write; if hits exist and the canonical is
 project_shared, the sync write is blocked regardless of `--force-unsafe`.
 
+> **2026-06 (#1247):** Gate A also fires on wiki ingress — `mm context
+> install` / `update` (incl. `--all` and the `--force` `.bak`
+> preservation copy) scan the wiki bytes (HEAD or pinned git objects)
+> before anything lands in `project_shared` — and on the web settings
+> `rules/promote` write, which scans the exact appended hooks fragment
+> (event key included). Every first-party byte path into
+> `project_shared` now scans before landing. Gate B's confirm prompt is
+> intentionally absent on install/update: those verbs have no `--scope`
+> choice (dest is `project_shared` by construction), so the explicit
+> command itself carries the surface intent; only the scan half was
+> missing.
+
 **Gate B (surface).** Explicit `--scope project_shared` flag plus
 confirm prompt at the CLI/MCP write surface (`mm mem add`,
 `mm context init`, `mm context migrate --to project_shared`). The flag must be passed

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -814,6 +814,12 @@ read-only in the Web UI, so use the matching `--scope user` CLI flow. The
 `project_local` tier is a gitignored draft tier; use `--scope project_local`
 to seed drafts, and expect sync to report the no-runtime-fan-out skip.
 
+All writes into the git-tracked `.memtomem/` tree — sync fan-out, `mm context
+install`/`update` from the wiki, version create, and the web hook-rule
+promote — pass the ADR-0011 §5 privacy gate first: a detected secret
+hard-refuses the write with no bypass flag, because git history cannot be
+retracted.
+
 For multi-device sync, treat project-shared Context Gateway files as part of
 the project repo: commit `<project>/.memtomem/context.md`,
 `<project>/.memtomem/{agents,skills,commands}/`, and

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -478,6 +478,10 @@ mm context sync --include=agents,commands --label production # deploy the labele
 
 Run `mm context --help` for the full fan-out matrix across editors (Claude Code, Cursor, Gemini CLI, OpenAI Codex, GitHub Copilot) and per-runtime field-drop details.
 
+> **Note:** writes targeting `project_shared` (sync, install/update, version
+> create, hook-rule promote) are privacy-scanned and refuse on detected
+> secrets — git history is forever, so there is no force bypass (ADR-0011 §5).
+
 For multi-device use, treat the project-shared `.memtomem/` tree as part of
 that project repo. Commit `.memtomem/context.md`, `.memtomem/agents/`,
 `.memtomem/skills/`, `.memtomem/commands/`, and `.memtomem/settings.json`

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -1456,6 +1456,11 @@ def install_cmd(
         raise click.ClickException(str(exc)) from exc
     except LockfileVersionError as exc:
         raise click.ClickException(str(exc)) from exc
+    except PrivacyScanError as exc:
+        # Gate A refusal (ADR-0011 §5, #1247) — exc.message carries the
+        # remediation hint; ClickException keeps the secret-free message
+        # and exits 1 without a traceback.
+        raise click.ClickException(exc.message) from exc
 
     click.secho(
         f"Installed {result.asset_type}/{result.name} (wiki {result.wiki_commit[:12]})",
@@ -1549,6 +1554,9 @@ def update_cmd(
         raise click.ClickException(str(exc)) from exc
     except LockfileVersionError as exc:
         raise click.ClickException(str(exc)) from exc
+    except PrivacyScanError as exc:
+        # Gate A refusal (ADR-0011 §5, #1247) — see install_cmd's arm.
+        raise click.ClickException(exc.message) from exc
 
     if result.was_no_op:
         click.secho(
@@ -1709,9 +1717,16 @@ def _run_update_all(
                 lock_entry=c.lock_entry,
                 dirty_report=c.dirty_report,
                 force=force,
+                surface="cli_context_update_all",
             )
         except StaleInstallError as exc:
             click.secho(f"  ✗ {c.project_root}: {exc}", fg="red")
+            failures += 1
+        except PrivacyScanError as exc:
+            # Gate A refusal (ADR-0011 §5, #1247): this project's row fails,
+            # the batch continues — a secret in one project's tree must not
+            # block clean siblings.
+            click.secho(f"  ✗ {c.project_root}: {exc.message}", fg="red")
             failures += 1
         except OSError as exc:
             click.secho(f"  ✗ {c.project_root}: {exc}", fg="red")
@@ -1727,6 +1742,12 @@ def _run_update_all(
         f"\nSummary: {successes} updated, {failures} failed, "
         f"{len(classifications) - successes - failures} unchanged."
     )
+
+    # Mirror _run_install_all: row failures must surface as a non-zero exit
+    # so scripts can detect a partially failed batch (#1247 — previously
+    # update --all always exited 0, even with red rows).
+    if failures:
+        raise click.exceptions.Exit(1)
 
 
 def _print_classification_table(
@@ -2007,6 +2028,11 @@ def _run_install_all(
         except StaleInstallError as exc:
             # state=refuse without --force shouldn't reach here; defense in depth.
             click.secho(f"  ✗ {c.asset_type}/{c.name}: {exc}", fg="red")
+            failures += 1
+        except PrivacyScanError as exc:
+            # Gate A refusal (ADR-0011 §5, #1247): poisoned asset's row
+            # fails, clean siblings still install.
+            click.secho(f"  ✗ {c.asset_type}/{c.name}: {exc.message}", fg="red")
             failures += 1
         except CommitNotFoundError as exc:
             # Race: commit was reachable at classify time, gone now.

--- a/packages/memtomem/src/memtomem/context/_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_atomic.py
@@ -26,7 +26,7 @@ import tempfile
 import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Iterator
 
 import portalocker
@@ -40,6 +40,7 @@ __all__ = [
     "atomic_write_text",
     "copy_tree_atomic",
     "installed_at_from_dest",
+    "is_copy_skipped_rel",
     "iter_installed_files",
 ]
 
@@ -241,6 +242,26 @@ def copy_tree_atomic(
             # skip_top_level intentionally not threaded into the recursion.
             written += copy_tree_atomic(entry, target, mode=mode, skip_suffixes=skip_suffixes)
     return written
+
+
+def is_copy_skipped_rel(rel: str | PurePosixPath) -> bool:
+    """True when :func:`copy_tree_atomic` (with ``DIRTY_SKIP_SUFFIXES``) would not mirror *rel*.
+
+    Rel-path form of the walker skip rules, for callers that enumerate
+    relative paths instead of dirents (the pinned-install scan and
+    extraction over ``git ls-tree`` output, #1247). A rel is skipped when
+    ANY path segment is named in :data:`COPY_SKIP_NAMES` or carries a
+    suffix in :data:`DIRTY_SKIP_SUFFIXES` — matching the copier, which
+    applies both checks to files and directories at every depth. Keep the
+    three rule carriers in lockstep: this predicate,
+    :func:`copy_tree_atomic`, and :func:`iter_installed_files` (symlink
+    skipping is dirent-only and cannot be expressed on a rel string).
+    """
+    parts = PurePosixPath(rel).parts
+    return any(
+        part in COPY_SKIP_NAMES or PurePosixPath(part).suffix in DIRTY_SKIP_SUFFIXES
+        for part in parts
+    )
 
 
 def iter_installed_files(root: Path) -> Iterator[Path]:

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -35,11 +35,17 @@ from memtomem.context._atomic import (
     DIRTY_SKIP_SUFFIXES,
     copy_tree_atomic,
     installed_at_from_dest,
+    is_copy_skipped_rel,
     iter_installed_files,
 )
 from memtomem.context._names import validate_name
 from memtomem.context.dirty import DirtyReport, is_asset_dirty
 from memtomem.context.lockfile import Lockfile, LockfileVersionError, manifest_from_entry
+from memtomem.context.privacy_scan import (
+    raise_or_collect,
+    scan_artifact_tree,
+    scan_text_content,
+)
 from memtomem.wiki.store import CommitNotFoundError as CommitNotFoundError
 from memtomem.wiki.store import WikiStore
 
@@ -287,6 +293,128 @@ def _reconcile_removed_files(
     return tuple(removed)
 
 
+def _gate_a_scan_src_tree(
+    src: Path,
+    *,
+    surface: str,
+    project_root: Path,
+    asset_type: str,
+    name: str,
+) -> None:
+    """Gate A over the copier's effective file set of a wiki working-tree asset.
+
+    Iterates :func:`iter_installed_files` rather than handing the directory
+    to :func:`scan_artifact_tree` directly — the walker shares
+    ``copy_tree_atomic``'s skip rules, so a wiki-shipped ``*.bak`` that the
+    copier would never install cannot false-block the install (#1247;
+    scan set == copy set). Raises
+    :class:`memtomem.context.privacy_scan.PrivacyBlockedError` on the first
+    hit; callers run this BEFORE any dest mutation so refusal leaves zero
+    residue.
+    """
+    kind = asset_type.removesuffix("s")
+    for path in iter_installed_files(src):
+        result = scan_artifact_tree(
+            path, surface=surface, scope="project_shared", project_root=project_root
+        )
+        if result.blocked:
+            blocked = result.blocked[0]
+            raise_or_collect(
+                blocked,
+                scope="project_shared",
+                kind=kind,
+                artifact_name=name,
+                remediation_hint=(
+                    f"Remove the secret from the wiki copy at {blocked.path} "
+                    f"and re-run — wiki bytes must be clean before they can land "
+                    f"in the git-tracked project tree."
+                ),
+            )
+
+
+def _gate_a_scan_dirty_files(
+    dirty_files: tuple[Path, ...] | list[Path] | frozenset[Path],
+    *,
+    surface: str,
+    project_root: Path,
+    asset_type: str,
+    name: str,
+) -> None:
+    """Gate A over the dirty dest files a ``--force`` run would ``.bak``-snapshot.
+
+    The ``.bak`` sibling is a NEW file in the git-tracked tree (mirroring the
+    version-create snapshot standard): a secret in a locally edited file must
+    refuse the forced update before any ``.bak`` lands, not silently
+    duplicate into a second commit-able path (#1247).
+    """
+    kind = asset_type.removesuffix("s")
+    for path in sorted(dirty_files):
+        result = scan_artifact_tree(
+            path, surface=surface, scope="project_shared", project_root=project_root
+        )
+        if result.blocked:
+            blocked = result.blocked[0]
+            raise_or_collect(
+                blocked,
+                scope="project_shared",
+                kind=kind,
+                artifact_name=name,
+                remediation_hint=(
+                    f"Remove the secret from {blocked.path} (a local edit that "
+                    f"--force would preserve as a .bak sibling in the git-tracked "
+                    f"tree), then re-run with --force."
+                ),
+            )
+
+
+def _gate_a_scan_pinned_asset(
+    wiki: WikiStore,
+    pin: str,
+    asset_type: str,
+    name: str,
+    *,
+    surface: str,
+    project_root: Path,
+) -> None:
+    """Gate A over the bytes a pinned re-extraction would write.
+
+    The wiki working tree is irrelevant here — the extractor reads git
+    objects at *pin*, so the scan does too (:meth:`WikiStore.
+    read_asset_file_at_commit`), which also closes the scan→write TOCTOU:
+    a commit's bytes are immutable. Rels are filtered with
+    :func:`is_copy_skipped_rel`, the same predicate the extractor applies,
+    so the scan observes exactly the file set that would land. Bytes decode
+    with ``errors="replace"`` mirroring :func:`scan_artifact_tree`'s
+    contract — an ASCII secret embedded in a non-UTF8 blob still blocks.
+    """
+    kind = asset_type.removesuffix("s")
+    for rel in wiki.asset_files_at_commit(pin, asset_type, name):
+        if is_copy_skipped_rel(rel):
+            continue
+        text = wiki.read_asset_file_at_commit(pin, asset_type, name, rel).decode(
+            "utf-8", errors="replace"
+        )
+        scan = scan_text_content(
+            text,
+            source_path=wiki.root / asset_type / name / rel,
+            surface=surface,
+            scope="project_shared",
+            project_root=project_root,
+        )
+        if scan.decision in ("blocked", "blocked_project_shared"):
+            raise_or_collect(
+                scan,
+                scope="project_shared",
+                kind=kind,
+                artifact_name=name,
+                remediation_hint=(
+                    f"The pinned wiki commit {pin[:12]} ships a secret in "
+                    f"{asset_type}/{name}/{rel}; fix the asset in the wiki and "
+                    f"re-pin to a clean commit before restoring."
+                ),
+            )
+
+
 def _install_asset(
     project_root: Path | str,
     asset_type: str,
@@ -336,6 +464,18 @@ def _install_asset(
             f"run `mm context update {asset_type_singular} {validated}` "
             f"to refresh from wiki HEAD"
         )
+
+    # Gate A (ADR-0011 §5, #1247): wiki bytes are user-tier — secrets are
+    # legal there — but dest is the git-tracked project_shared canonical.
+    # Scan before mkdir so refusal leaves zero residue (no empty type dir,
+    # no dest bytes, no lockfile entry).
+    _gate_a_scan_src_tree(
+        src,
+        surface="cli_context_install",
+        project_root=project_root,
+        asset_type=asset_type,
+        name=validated,
+    )
 
     dest.parent.mkdir(parents=True, exist_ok=True)
     files_written = copy_tree_atomic(src, dest, skip_suffixes=DIRTY_SKIP_SUFFIXES)
@@ -493,6 +633,7 @@ def _apply_update(
     lock_entry: dict[str, Any],
     dirty_report: DirtyReport,
     force: bool,
+    surface: str = "cli_context_update",
 ) -> UpdateResult:
     """Execute an already-classified update.
 
@@ -524,6 +665,25 @@ def _apply_update(
             f"since install at {dirty_report.installed_at}; "
             f"pass --force to overwrite "
             f"(each modified file gets a .bak sibling; deleted files are restored)"
+        )
+
+    # Gate A (ADR-0011 §5, #1247): both scans precede the .bak loop — the
+    # first dest mutation with no rollback — so a privacy refusal leaves
+    # no .bak, no copied bytes, and (upserts trail copies) no lockfile drift.
+    _gate_a_scan_src_tree(
+        src,
+        surface=surface,
+        project_root=project_root,
+        asset_type=asset_type,
+        name=name,
+    )
+    if force and dirty_report.reason == "dirty":
+        _gate_a_scan_dirty_files(
+            dirty_report.dirty_files,
+            surface=surface,
+            project_root=project_root,
+            asset_type=asset_type,
+            name=name,
         )
 
     bak_paths: list[Path] = []
@@ -867,6 +1027,7 @@ def _apply_pinned_install(
     *,
     wiki: WikiStore,
     force: bool,
+    surface: str = "cli_context_install_all",
 ) -> InstallResult:
     """Execute one install at the pinned commit.
 
@@ -911,6 +1072,28 @@ def _apply_pinned_install(
         raise StaleInstallError(
             f"{asset_type}/{name}: {local_edits} would be clobbered; "
             f"pass --force to overwrite (each modified file gets a .bak sibling)"
+        )
+
+    # Gate A (ADR-0011 §5, #1247): scan the pin's git objects (the exact
+    # bytes the extractor would write) plus any dirty files a --force run
+    # would .bak — both BEFORE the .bak loop, the first dest mutation.
+    _gate_a_scan_pinned_asset(
+        wiki,
+        pin,
+        asset_type,
+        name,
+        surface=surface,
+        project_root=project_root,
+    )
+    if classification.state == "refuse" and force:
+        report = classification.dirty_report
+        assert report is not None  # state=refuse always carries a report
+        _gate_a_scan_dirty_files(
+            report.dirty_files,
+            surface=surface,
+            project_root=project_root,
+            asset_type=asset_type,
+            name=name,
         )
 
     bak_paths: list[Path] = []

--- a/packages/memtomem/src/memtomem/context/privacy_scan.py
+++ b/packages/memtomem/src/memtomem/context/privacy_scan.py
@@ -290,6 +290,7 @@ def format_scan_block_message(
     scope: TargetScope,
     kind: str,
     artifact_name: str | None = None,
+    remediation_hint: str | None = None,
 ) -> str:
     """User-facing message body for project_shared sync block.
 
@@ -313,10 +314,26 @@ def format_scan_block_message(
             "leak"). Used in the remediation hint —
             ``mm context migrate <kind>s <artifact_name> ...``. ``None``
             falls back to a generic hint.
+        remediation_hint: Caller-supplied replacement for the default
+            sync-side remediation lines. The stock hint prescribes
+            ``mm context migrate ... --to project_local`` — wrong for
+            ingress surfaces where the secret lives upstream (wiki
+            install/update: fix the wiki asset; settings promote: fix
+            the hook rule) rather than in a canonical the user could
+            migrate (#1247). ``None`` keeps the historical message
+            byte-identical for the existing sync/migrate callers.
 
     Returns:
         Multi-line string carried by :class:`PrivacyBlockedError`.
     """
+    if remediation_hint is not None:
+        return (
+            f"Gate A: {blocked.path.name} contains {blocked.hits_count} privacy "
+            f"pattern hit(s); write to scope='{scope}' rejected. git history "
+            f"is forever — no force bypass available for project_shared "
+            f"(ADR-0011 §5).\n"
+            f"  {remediation_hint}"
+        )
     cli_kind = f"{kind}s"  # singular → plural for the migrate CLI choice
     target_hint = (
         f"mm context migrate {cli_kind} {artifact_name} --to project_local"
@@ -340,6 +357,7 @@ def raise_or_collect(
     scope: TargetScope,
     kind: str,
     artifact_name: str | None = None,
+    remediation_hint: str | None = None,
 ) -> tuple[skip_codes.SkipCode, str]:
     """Branch on ``scope``: raise for project_shared, return skip tuple otherwise.
 
@@ -352,7 +370,11 @@ def raise_or_collect(
     """
     if scope == "project_shared":
         message = format_scan_block_message(
-            blocked, scope=scope, kind=kind, artifact_name=artifact_name
+            blocked,
+            scope=scope,
+            kind=kind,
+            artifact_name=artifact_name,
+            remediation_hint=remediation_hint,
         )
         raise PrivacyBlockedError(
             message,

--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -14,6 +14,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from memtomem.config import TargetScope
+from memtomem.context.privacy_scan import format_scan_block_message, scan_text_content
 from memtomem.context.settings import (
     CANONICAL_SETTINGS_FILE,
     resolve_scope_path,
@@ -828,6 +829,47 @@ async def promote_target_rule(
                 if isinstance(match, dict):
                     return JSONResponse(status_code=409, content=match)
                 _rules, rule = match
+
+                # Gate A (ADR-0011 §5, #1247): the canonical
+                # .memtomem/settings.json is git-tracked project_shared. Scan
+                # the EXACT fragment the append would write — {event: [rule]}
+                # — because body.event is a free string that lands as a JSON
+                # key (a secret-shaped event key must block too, not just a
+                # secret in the rule body). Scope is hardcoded
+                # project_shared: the route's target_scope is the tier being
+                # READ from; using it would skip-warn private tiers, the
+                # exact case this gate exists for. Placed before the consent
+                # gate so a doomed promote never completes a
+                # needs_confirmation round-trip.
+                fragment = json.dumps(
+                    {body.event: [rule]},
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                )
+                fragment_scan = scan_text_content(
+                    fragment,
+                    source_path=target_path,
+                    surface="web_settings_rule_promote",
+                    scope="project_shared",
+                    project_root=project_root,
+                )
+                if fragment_scan.decision in ("blocked", "blocked_project_shared"):
+                    raise HTTPException(
+                        422,
+                        format_scan_block_message(
+                            fragment_scan,
+                            scope="project_shared",
+                            kind="hook rule",
+                            artifact_name=label,
+                            remediation_hint=(
+                                f"Remove the secret from the hook rule in "
+                                f"{target_path}, or keep the rule in your "
+                                f"private tier."
+                            ),
+                        ),
+                    )
+
                 if target_scope in ("user", "project_local") and not body.confirm_private_to_shared:
                     return {
                         "status": "needs_confirmation",

--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -9,6 +9,7 @@ ADR-0008's roadmap.
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import tempfile
 from dataclasses import dataclass
@@ -21,6 +22,9 @@ WIKI_ASSET_TYPES: tuple[str, ...] = ("skills", "agents", "commands")
 """Asset directory names at the wiki root. Order is significant for listing."""
 
 _INITIAL_COMMIT_MESSAGE = "Initialize memtomem wiki"
+
+_FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
+"""Canonical lockfile-pin shape — full 40-hex lowercase object id."""
 
 _README_TEMPLATE = """# memtomem wiki
 
@@ -181,8 +185,15 @@ class WikiStore:
         before attempting per-file extraction.
 
         Returns ``False`` when the commit is missing OR when *commit*
-        is malformed (empty string, non-hex chars, etc.) — the caller
-        should not need to validate the SHA shape upfront.
+        is malformed — the caller should not need to validate the SHA
+        shape upfront. "Malformed" is enforced as anything that is not
+        a full 40-hex object id: a symbolic ref (``main``) or an
+        abbreviated SHA would otherwise satisfy ``cat-file`` while
+        breaking the pin contract — refs move, so a hand-edited
+        lockfile pin of ``main`` would let the scanned bytes diverge
+        from the extracted bytes and make ``install --all`` restores
+        non-reproducible (#1247 Gate A review). Pins written by mm are
+        always full-length (:meth:`current_commit`).
 
         Raises :class:`WikiNotFoundError` if the wiki itself is missing
         — the caller decides whether that's a hard error or a
@@ -190,7 +201,7 @@ class WikiStore:
         reachability info; install --all refuses).
         """
         self.require_exists()
-        if not commit:
+        if not commit or _FULL_SHA_RE.fullmatch(commit) is None:
             return False
         result = subprocess.run(
             ["git", "cat-file", "-e", f"{commit}^{{commit}}"],
@@ -251,25 +262,47 @@ class WikiStore:
         """
         # Deferred import: install.py imports wiki.store at module load;
         # the reverse import here would cycle. Local resolves at call time.
-        from memtomem.context._atomic import DIRTY_SKIP_SUFFIXES, copy_tree_atomic
+        from memtomem.context._atomic import (
+            DIRTY_SKIP_SUFFIXES,
+            copy_tree_atomic,
+            is_copy_skipped_rel,
+        )
 
-        src_prefix = f"{asset_type}/{name}/"
         inner_relpaths = self.asset_files_at_commit(commit, asset_type, name)
 
         dest.parent.mkdir(parents=True, exist_ok=True)
         with tempfile.TemporaryDirectory(dir=dest.parent) as tmpdir:
             tmpdir_path = Path(tmpdir)
             for inner in inner_relpaths:
+                # Filter BEFORE reading: the final copy would skip these
+                # anyway, but materializing them first would park unscanned
+                # wiki bytes inside the git-tracked ``.memtomem/`` tree —
+                # surviving a crash/SIGKILL as commit-able residue, and
+                # invisible to the pinned-install Gate A scan, which uses
+                # the same predicate (#1247).
+                if is_copy_skipped_rel(inner):
+                    continue
                 target = tmpdir_path / inner
                 target.parent.mkdir(parents=True, exist_ok=True)
-                content = subprocess.run(
-                    ["git", "show", f"{commit}:{src_prefix}{inner}"],
-                    cwd=self.root,
-                    check=True,
-                    capture_output=True,
-                )
-                target.write_bytes(content.stdout)
+                target.write_bytes(self.read_asset_file_at_commit(commit, asset_type, name, inner))
             return copy_tree_atomic(tmpdir_path, dest, skip_suffixes=DIRTY_SKIP_SUFFIXES)
+
+    def read_asset_file_at_commit(self, commit: str, asset_type: str, name: str, rel: str) -> bytes:
+        """Read one asset file's bytes at *commit* straight from git objects.
+
+        ``git show <commit>:<asset_type>/<name>/<rel>`` — the wiki working
+        tree is never consulted, so the bytes are immutable for a given
+        commit. Shared by :meth:`copy_asset_at_commit` (extraction) and the
+        pinned-install Gate A privacy scan (#1247), which must observe
+        exactly the bytes the extractor would write.
+        """
+        result = subprocess.run(
+            ["git", "show", f"{commit}:{asset_type}/{name}/{rel}"],
+            cwd=self.root,
+            check=True,
+            capture_output=True,
+        )
+        return result.stdout
 
     def asset_files_at_commit(self, commit: str, asset_type: str, name: str) -> list[str]:
         """List the asset's file relpaths (relative to the asset dir) at *commit*.

--- a/packages/memtomem/tests/test_context_atomic.py
+++ b/packages/memtomem/tests/test_context_atomic.py
@@ -15,6 +15,7 @@ from memtomem.context._atomic import (
     _lock_path_for,
     atomic_write_bytes,
     atomic_write_text,
+    iter_installed_files,
 )
 
 
@@ -186,3 +187,64 @@ class TestFileLockTimeout:
         lock = _lock_path_for(tmp_path / "data.json")
         with _file_lock(lock):
             pass
+
+
+class TestIsCopySkippedRel:
+    """``is_copy_skipped_rel`` is the single enumerator behind the pinned-path
+    scan/copy parity (#1247) — its verdict must match the walkers' skip rules.
+
+    The predicate ships with the privacy-gate fix, so it is imported inside
+    each test: pre-fix that errors per-test without breaking file collection."""
+
+    @pytest.mark.parametrize(
+        "rel",
+        [
+            "foo.md.bak",  # DIRTY_SKIP_SUFFIXES at the top level
+            "nested/dir/foo.md.bak",  # …and at depth
+            "__pycache__/x.py",  # COPY_SKIP_NAMES as a leading dir part
+            "a/.git/b",  # …as an interior dir part
+            ".DS_Store",  # …as the filename itself
+        ],
+    )
+    def test_true_for_skipped_rels(self, rel: str) -> None:
+        from memtomem.context._atomic import is_copy_skipped_rel
+
+        assert is_copy_skipped_rel(rel) is True
+
+    @pytest.mark.parametrize(
+        "rel",
+        [
+            "notes.md",
+            "nested/dir/file.md",
+            "bak",  # bare filename, not a .bak suffix
+            "foo.bak.md",  # final suffix is .md — an interior .bak doesn't count
+        ],
+    )
+    def test_false_for_kept_rels(self, rel: str) -> None:
+        from memtomem.context._atomic import is_copy_skipped_rel
+
+        assert is_copy_skipped_rel(rel) is False
+
+    def test_agrees_with_installed_file_walker(self, tmp_path: Path) -> None:
+        """Both directions on a real tree: predicate-skipped ⇔ walker-skipped,
+        so the pinned-path enumerator cannot drift from the HEAD-path walker."""
+        from memtomem.context._atomic import is_copy_skipped_rel
+
+        verdicts = {
+            "SKILL.md": False,
+            "scripts/run.sh": False,
+            "foo.md.bak": True,
+            "nested/old.md.bak": True,
+            "__pycache__/junk.pyc": True,
+            ".DS_Store": True,
+        }
+        root = tmp_path / "asset"
+        for rel in verdicts:
+            target = root / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(b"x")
+
+        walked = {p.relative_to(root).as_posix() for p in iter_installed_files(root)}
+        for rel, skipped in verdicts.items():
+            assert is_copy_skipped_rel(rel) is skipped
+            assert (rel in walked) is (not skipped)

--- a/packages/memtomem/tests/test_context_install.py
+++ b/packages/memtomem/tests/test_context_install.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from memtomem import privacy
 from memtomem.cli.context_cmd import context as context_group
 from memtomem.context._names import InvalidNameError
 from memtomem.context.install import (
@@ -26,6 +27,7 @@ from memtomem.context.install import (
     install_skill,
 )
 from memtomem.context.lockfile import LOCKFILE_VERSION, Lockfile
+from memtomem.context.privacy_scan import PrivacyBlockedError
 from memtomem.wiki.store import WikiNotFoundError, WikiStore
 
 
@@ -449,3 +451,82 @@ def test_lockfile_contains_only_mandated_keys_per_entry(wiki_root: Path, tmp_pat
     assert set(entry) == {"wiki_commit", "installed_at", "files", "files_commit"}
     assert entry["files"] == ["SKILL.md"]
     assert entry["files_commit"] == entry["wiki_commit"]
+
+
+# ── Gate A on wiki-install ingress (ADR-0011 §5, #1247 id 3) ─────────────
+
+# AKIA fixture per feedback_force_unsafe_redaction_valve_only.md — a clean
+# string never trips the scan, so every block assertion below would
+# false-pass without it.
+SECRET = "api_key=AKIA1234567890ABCDEF"
+
+
+@pytest.fixture(autouse=True)
+def _reset_privacy_counters():
+    """Zeroed counters so surface-attribution asserts see only their own test."""
+    privacy.reset_for_tests()
+    yield
+    privacy.reset_for_tests()
+
+
+def test_install_blocks_secret_in_wiki_src_zero_residue(wiki_root: Path, tmp_path: Path) -> None:
+    """Gate A fires on wiki ingress: a poisoned ``SKILL.md`` never lands —
+    scan precedes ``dest.parent.mkdir`` and the lockfile upsert, so a
+    refusal leaves zero residue in the project tree."""
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "leak", {"SKILL.md": b"# leak skill\n" + SECRET.encode() + b"\n"})
+    project = tmp_path
+
+    with pytest.raises(PrivacyBlockedError) as excinfo:
+        install_skill(project, "leak")
+
+    assert not (project / ".memtomem" / "skills" / "leak").exists()
+    assert Lockfile.at(project).read_entry("skills", "leak") is None
+    # Matched bytes never reach the error message (path + hit count only).
+    assert "AKIA1234567890ABCDEF" not in excinfo.value.message
+    # Audit attributes the block to the single-install ingress surface
+    # (#1246/#1248 rule), not a sibling sync/migrate surface.
+    by_tool = privacy.snapshot()["by_tool"]
+    assert by_tool.get("cli_context_install", {}).get("blocked", 0) == 1
+    assert "cli_context_sync" not in by_tool
+
+
+def test_install_no_false_block_on_wiki_shipped_bak(wiki_root: Path, tmp_path: Path) -> None:
+    """Scan set == copy set: a wiki-shipped secret ``.bak`` is outside the
+    copier's effective set (#1250), so it must neither land in dest nor
+    false-block the otherwise-clean install."""
+    _initialized_wiki(wiki_root)
+    _seed_skill(
+        wiki_root,
+        "foo",
+        {
+            "SKILL.md": b"# clean skill\n",
+            "foo.md.bak": SECRET.encode() + b"\n",
+        },
+    )
+    project = tmp_path
+
+    result = install_skill(project, "foo")  # must NOT raise
+
+    dest = project / ".memtomem" / "skills" / "foo"
+    assert (dest / "SKILL.md").read_bytes() == b"# clean skill\n"
+    assert result.files_written == 1
+    assert not list(dest.rglob("*.bak"))
+
+
+def test_cli_install_privacy_block_exit_and_message(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    """CLI boundary: Gate A block maps to ``click.ClickException`` (exit 1)
+    with the remediation message — never a traceback, never the secret."""
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "leak", {"SKILL.md": b"# leak skill\n" + SECRET.encode() + b"\n"})
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["install", "skill", "leak"])
+
+    assert result.exit_code == 1, result.output
+    assert "Gate A" in result.output
+    assert "AKIA1234567890ABCDEF" not in result.output
+    assert "Traceback" not in result.output

--- a/packages/memtomem/tests/test_context_install_all.py
+++ b/packages/memtomem/tests/test_context_install_all.py
@@ -58,7 +58,12 @@ def _seed_wiki_asset(
         target = asset_dir / relpath
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(data)
-    subprocess.run(["git", "-C", str(wiki_root_path), "add", "."], check=True, capture_output=True)
+    # ``-f`` so a developer/global gitignore (e.g. ``*.bak``) cannot
+    # silently drop a deliberately seeded file and make a test vacuous —
+    # mirrors test_wiki_store's ``_seed_skill(force_add=...)`` pattern.
+    subprocess.run(
+        ["git", "-C", str(wiki_root_path), "add", "-f", "."], check=True, capture_output=True
+    )
     subprocess.run(
         ["git", "-C", str(wiki_root_path), "commit", "-m", f"add {asset_type}/{name}"],
         check=True,
@@ -546,3 +551,245 @@ def test_classify_install_all_missing_only_dirty_reason(wiki_root: Path, tmp_pat
     assert rows[0].reason is not None
     assert "deleted locally" in rows[0].reason
     assert "0 file(s) modified" not in rows[0].reason
+
+
+# ── B2: Gate A on batch wiki ingress (#1247 ids 3) ──────────────────────
+
+# AKIA fixture per feedback_force_unsafe_redaction_valve_only.md — a clean
+# string would let force_unsafe=False scans pass and false-negative every
+# block assertion below.
+SECRET = "api_key=AKIA1234567890ABCDEF"
+
+
+def _repin_lockfile_entry(project_root: Path, asset_type: str, name: str, pin: str) -> Path:
+    """Re-point a lockfile entry at *pin* without an ingress install — a
+    poisoned HEAD install would itself be gated post-fix, so the poisoned
+    pin must be planted directly. Drops the manifest keys so they can't
+    disagree with the new pin."""
+    lock_path = project_root / ".memtomem" / "lock.json"
+    doc = json.loads(lock_path.read_text(encoding="utf-8"))
+    doc[asset_type][name]["wiki_commit"] = pin
+    doc[asset_type][name].pop("files", None)
+    doc[asset_type][name].pop("files_commit", None)
+    lock_path.write_text(json.dumps(doc), encoding="utf-8")
+    return lock_path
+
+
+def _seed_known_projects(path: Path, project_roots: list[Path]) -> None:
+    """Write a ``known_projects.json`` listing the given roots (mirrors
+    ``test_context_update.py`` so update --all behavior parity is easy
+    to reason about)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    doc = {
+        "version": 1,
+        "projects": [
+            {"root": str(p), "added_at": "2026-01-01T00:00:00.000000Z", "label": None}
+            for p in project_roots
+        ],
+    }
+    path.write_text(json.dumps(doc), encoding="utf-8")
+
+
+def _patch_known_projects_path(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
+    """Make ``ContextGatewayConfig()`` in the CLI return *path* (mirrors
+    ``test_context_update.py``)."""
+
+    class _FakeCfg:
+        known_projects_path = path
+
+    monkeypatch.setattr(
+        "memtomem.cli.context_cmd.ContextGatewayConfig",
+        lambda: _FakeCfg(),
+    )
+
+
+class TestPrivacyGateBatchIngress:
+    """ADR-0011 §5 Gate A on the wiki-install batch ingress surfaces
+    (``install --all`` pinned re-extraction, ``update --all`` --force
+    dirty-file ``.bak`` copies) — #1247 id 3."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_privacy_counters(self):
+        from memtomem import privacy
+
+        privacy.reset_for_tests()
+        yield
+        privacy.reset_for_tests()
+
+    def test_pinned_parity_wiki_shipped_bak_no_false_block_no_bak_in_dest(
+        self, wiki_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Scan set == copy set: a wiki-shipped secret ``.bak`` never lands
+        in dest (#1250), so the pinned re-extraction must not false-block
+        on it (design test 4b — pins existing behavior pre-fix)."""
+        _initialized_wiki(wiki_root)
+        _seed_wiki_asset(
+            wiki_root,
+            "skills",
+            "foo",
+            {
+                "SKILL.md": b"pinned\n",
+                "foo.md": b"doc\n",
+                "foo.md.bak": (SECRET + "\n").encode(),
+            },
+        )
+        # Precondition: the secret .bak really is committed at the pin —
+        # otherwise the no-false-block assertion below would pass vacuously.
+        ls_tree = subprocess.run(
+            ["git", "-C", str(wiki_root), "ls-tree", "-r", "--name-only", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert "skills/foo/foo.md.bak" in ls_tree.stdout
+
+        install_skill(tmp_path, "foo")
+        dest = tmp_path / ".memtomem" / "skills" / "foo"
+        shutil.rmtree(dest)
+
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(context_group, ["install", "--all", "--yes"])
+
+        assert result.exit_code == 0, result.output
+        assert "1 installed" in result.output
+        # No false block — the .bak is outside the copier's effective set.
+        assert "Gate A" not in result.output
+        assert (dest / "SKILL.md").read_bytes() == b"pinned\n"
+        assert (dest / "foo.md").read_bytes() == b"doc\n"
+        assert list(dest.rglob("*.bak")) == []
+
+    def test_pinned_non_utf8_blob_with_embedded_secret_blocks(
+        self, wiki_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``errors="replace"`` decode policy: ASCII AKIA bytes between
+        undecodable garbage at the pin must still block (design test 4d)."""
+        from memtomem import privacy
+
+        _initialized_wiki(wiki_root)
+        _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"clean\n"})
+        install_skill(tmp_path, "foo")
+        poisoned_pin = _advance_wiki(
+            wiki_root,
+            "skills",
+            "foo",
+            {"blob.bin": b"\xff\xfe" + SECRET.encode() + b"\xff"},
+        )
+        lock_path = _repin_lockfile_entry(tmp_path, "skills", "foo", poisoned_pin)
+        dest = tmp_path / ".memtomem" / "skills" / "foo"
+        shutil.rmtree(dest)
+
+        monkeypatch.chdir(tmp_path)
+        privacy.reset_for_tests()  # drop setup-time install attributions
+        runner = CliRunner()
+        result = runner.invoke(context_group, ["install", "--all", "--yes"])
+
+        assert result.exit_code == 1, result.output
+        assert "Gate A" in result.output
+        assert "1 failed" in result.output
+        # Zero residue: refusal precedes any dest write or lockfile upsert.
+        assert not dest.exists()
+        doc_after = json.loads(lock_path.read_text(encoding="utf-8"))
+        assert doc_after["skills"]["foo"]["wiki_commit"] == poisoned_pin
+        assert "files" not in doc_after["skills"]["foo"]
+        # Matched bytes never echo back through the CLI.
+        assert "AKIA1234567890ABCDEF" not in result.output
+        # Surface attribution: the batch ingress, not the single-install surface.
+        by_tool = privacy.snapshot()["by_tool"]
+        assert by_tool["cli_context_install_all"]["blocked"] >= 1
+        assert "cli_context_install" not in by_tool
+
+    def test_install_all_isolates_poisoned_row_clean_sibling_lands(
+        self, wiki_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Row isolation: one poisoned pin red-✗s its own row only — the
+        clean sibling still lands (dest + lockfile), exit 1 (design test 5,
+        install --all leg)."""
+        _initialized_wiki(wiki_root)
+        good_pin = _seed_wiki_asset(wiki_root, "skills", "good", {"SKILL.md": b"good\n"})
+        install_skill(tmp_path, "good")
+        _seed_wiki_asset(wiki_root, "skills", "bad", {"SKILL.md": b"clean\n"})
+        install_skill(tmp_path, "bad")
+        poisoned_pin = _advance_wiki(
+            wiki_root, "skills", "bad", {"SKILL.md": ("# doc\n" + SECRET + "\n").encode()}
+        )
+        _repin_lockfile_entry(tmp_path, "skills", "bad", poisoned_pin)
+        shutil.rmtree(tmp_path / ".memtomem" / "skills" / "good")
+        shutil.rmtree(tmp_path / ".memtomem" / "skills" / "bad")
+
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(context_group, ["install", "--all", "--yes"])
+
+        assert result.exit_code == 1, result.output
+        assert "Gate A" in result.output
+        assert "1 installed" in result.output
+        assert "1 failed" in result.output
+        # Clean row landed: dest bytes + lockfile pin both intact.
+        good_dest = tmp_path / ".memtomem" / "skills" / "good"
+        assert (good_dest / "SKILL.md").read_bytes() == b"good\n"
+        lock_doc = json.loads((tmp_path / ".memtomem" / "lock.json").read_text(encoding="utf-8"))
+        assert lock_doc["skills"]["good"]["wiki_commit"] == good_pin
+        assert lock_doc["skills"]["good"]["files"] == ["SKILL.md"]
+        # Poisoned row left zero residue.
+        assert not (tmp_path / ".memtomem" / "skills" / "bad").exists()
+        assert "AKIA1234567890ABCDEF" not in result.output
+
+    def test_update_all_isolates_secret_dirty_project_no_bak(
+        self, wiki_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``update --all --force`` row isolation: a secret in project A's
+        dirty dest blocks A's ``.bak`` copy without sinking clean project B
+        (design test 5, update --all leg — R2 major 2 shape)."""
+        from memtomem import privacy
+
+        _initialized_wiki(wiki_root)
+        v1 = _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"v1\n"})
+        proj_a = tmp_path / "proj_a"
+        proj_a.mkdir()
+        proj_b = tmp_path / "proj_b"
+        proj_b.mkdir()
+        install_skill(proj_a, "foo")
+        install_skill(proj_b, "foo")
+
+        edited = proj_a / ".memtomem" / "skills" / "foo" / "SKILL.md"
+        dirty_bytes = ("# local\n" + SECRET + "\n").encode()
+        edited.write_bytes(dirty_bytes)
+        _bump_mtime(edited)
+
+        v2 = _advance_wiki(wiki_root, "skills", "foo", {"SKILL.md": b"v2\n"})
+
+        known = tmp_path / "known.json"
+        _seed_known_projects(known, [proj_a, proj_b])
+        _patch_known_projects_path(monkeypatch, known)
+
+        cwd = tmp_path / "cwdproj"
+        cwd.mkdir()
+        (cwd / ".git").mkdir()
+        monkeypatch.chdir(cwd)
+
+        privacy.reset_for_tests()  # drop setup-time install attributions
+        runner = CliRunner()
+        result = runner.invoke(
+            context_group, ["update", "skill", "foo", "--all", "--yes", "--force"]
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "Gate A" in result.output
+        assert "1 updated" in result.output
+        assert "1 failed" in result.output
+        # Project A: refusal precedes the .bak copy — no .bak, dirty bytes
+        # intact, lockfile pin unchanged.
+        assert list(proj_a.rglob("*.bak")) == []
+        assert edited.read_bytes() == dirty_bytes
+        lock_a = json.loads((proj_a / ".memtomem" / "lock.json").read_text(encoding="utf-8"))
+        assert lock_a["skills"]["foo"]["wiki_commit"] == v1
+        # Project B: updated to wiki HEAD.
+        assert (proj_b / ".memtomem" / "skills" / "foo" / "SKILL.md").read_bytes() == b"v2\n"
+        lock_b = json.loads((proj_b / ".memtomem" / "lock.json").read_text(encoding="utf-8"))
+        assert lock_b["skills"]["foo"]["wiki_commit"] == v2
+        assert "AKIA1234567890ABCDEF" not in result.output
+        # Surface attribution: the batch surface, not the single-update one.
+        by_tool = privacy.snapshot()["by_tool"]
+        assert by_tool["cli_context_update_all"]["blocked"] >= 1
+        assert "cli_context_update" not in by_tool

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -18,6 +18,7 @@ import pytest
 from click.testing import CliRunner
 from httpx import ASGITransport, AsyncClient
 
+from memtomem import privacy
 from memtomem.context.settings import (
     CANONICAL_SETTINGS_FILE,
     ClaudeSettingsGenerator,
@@ -101,6 +102,11 @@ def _read_target(claude_home) -> dict:
     """Read the merged settings.json from the fake HOME."""
     path = claude_home / ".claude" / "settings.json"
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+# AKIA fixture per feedback_force_unsafe_redaction_valve_only.md — a generic
+# placeholder would pass the real scanner and false-negative every block assert.
+SECRET = "api_key=AKIA1234567890ABCDEF"
 
 
 # ── Merge tests ─────────────────────────────────────────────────────
@@ -2246,3 +2252,107 @@ class TestSettingsHttpLayer:
         )
         # The user-tier file was NOT touched.
         assert user_target.read_text(encoding="utf-8") == user_authored
+
+    # ── Promote privacy gate (ADR-0011 §5 Gate A — #1247 id 50) ──────────────
+
+    async def test_promote_blocks_secret_in_rule_command(self, client, claude_home, tmp_path):
+        """Gate A fires on promote — a secret-bearing rule never reaches shared canonical."""
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(
+            json.dumps({"hooks": {"PreToolUse": [_rule("Bash", SECRET)]}}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        diff = await client.get("/api/context/settings?target_scope=user")
+        assert diff.status_code == 200
+        body = diff.json()
+        row = body["target_hooks"]["configured"][0]
+
+        before = privacy.snapshot()["by_tool"].get("web_settings_rule_promote", {})
+        resp = await client.post(
+            "/api/context/settings/rules/promote?target_scope=user",
+            json={
+                "event": row["event"],
+                "matcher": row["matcher"],
+                "rule_index": row["rule_index"],
+                "rule_hash": row["rule_hash"],
+                "target_mtime_ns": body["target_mtime_ns"],
+                "canonical_mtime_ns": body["canonical_mtime_ns"],
+                "confirm_private_to_shared": True,
+            },
+        )
+        assert resp.status_code == 422, resp.text
+        # The detail names the gate; the matched bytes never echo back.
+        assert "Gate A" in resp.json()["detail"]
+        assert "AKIA1234567890ABCDEF" not in resp.text
+        assert not (tmp_path / CANONICAL_SETTINGS_FILE).exists()
+        # Surface attribution: the block records against the web promote
+        # ingress, not a borrowed CLI/sync surface (#1246/#1248 rule).
+        after = privacy.snapshot()["by_tool"]["web_settings_rule_promote"]
+        assert after["blocked"] == before.get("blocked", 0) + 1
+
+    async def test_promote_scans_before_private_consent_gate(self, client, claude_home, tmp_path):
+        """Gate A fail-fasts ahead of the needs_confirmation consent round-trip."""
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(
+            json.dumps({"hooks": {"PreToolUse": [_rule("Bash", SECRET)]}}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        diff = await client.get("/api/context/settings?target_scope=user")
+        assert diff.status_code == 200
+        body = diff.json()
+        row = body["target_hooks"]["configured"][0]
+
+        # No confirm_private_to_shared: pre-gate this returned the 200
+        # needs_confirmation envelope. The scan must win even though the
+        # write was still one confirmation away — and the 422 also pins
+        # the hardcoded project_shared scan scope: passing the route's
+        # target_scope ("user") would make raise_or_collect return a skip
+        # tuple instead of raising, so no 422 could surface here.
+        resp = await client.post(
+            "/api/context/settings/rules/promote?target_scope=user",
+            json={
+                "event": row["event"],
+                "matcher": row["matcher"],
+                "rule_index": row["rule_index"],
+                "rule_hash": row["rule_hash"],
+                "target_mtime_ns": body["target_mtime_ns"],
+                "canonical_mtime_ns": body["canonical_mtime_ns"],
+            },
+        )
+        assert resp.status_code == 422, resp.text
+        assert "needs_confirmation" not in resp.text
+        assert "Gate A" in resp.json()["detail"]
+        assert "AKIA1234567890ABCDEF" not in resp.text
+        assert not (tmp_path / CANONICAL_SETTINGS_FILE).exists()
+
+    async def test_promote_blocks_secret_shaped_event_key(self, client, claude_home, tmp_path):
+        """The scanned fragment covers the event key, not just the rule body."""
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(
+            json.dumps({"hooks": {SECRET: [_rule("", "echo clean")]}}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        diff = await client.get("/api/context/settings?target_scope=user")
+        assert diff.status_code == 200
+        body = diff.json()
+        row = body["target_hooks"]["configured"][0]
+        assert row["event"] == SECRET  # sanity: the poisoned key is the promote target
+
+        resp = await client.post(
+            "/api/context/settings/rules/promote?target_scope=user",
+            json={
+                "event": row["event"],
+                "matcher": row["matcher"],
+                "rule_index": row["rule_index"],
+                "rule_hash": row["rule_hash"],
+                "target_mtime_ns": body["target_mtime_ns"],
+                "canonical_mtime_ns": body["canonical_mtime_ns"],
+                "confirm_private_to_shared": True,
+            },
+        )
+        assert resp.status_code == 422, resp.text
+        assert "AKIA1234567890ABCDEF" not in resp.text
+        assert not (tmp_path / CANONICAL_SETTINGS_FILE).exists()

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -22,6 +22,7 @@ import pytest
 from click.testing import CliRunner
 
 import memtomem.context.install as install_module
+from memtomem import privacy
 from memtomem.cli.context_cmd import context as context_group
 from memtomem.context._names import InvalidNameError
 from memtomem.context.install import (
@@ -34,6 +35,7 @@ from memtomem.context.install import (
     update_command,
     update_skill,
 )
+from memtomem.context.privacy_scan import PrivacyBlockedError
 from memtomem.wiki.store import WikiStore
 
 
@@ -899,7 +901,10 @@ def test_cli_update_all_mid_loop_fs_error_continues(
     runner = CliRunner()
     result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--yes"])
 
-    assert result.exit_code == 0, result.output
+    # Row failures now exit 1 (mirrors install --all, #1247) — the point
+    # pinned here is CONTINUATION, not a clean exit: the batch must not
+    # abort on the first row's failure.
+    assert result.exit_code == 1, result.output
     # First project marked ✗, second project marked ✓ — both rows reached.
     assert "✗" in result.output
     assert "simulated fs error" in result.output
@@ -1272,3 +1277,104 @@ def test_wiki_shipped_bak_never_installed_or_stranded(wiki_root: Path, tmp_path:
     upd = update_skill(tmp_path, "web")
     assert upd.files_removed == ()
     assert not (dest / "leftover.md.bak").exists()
+
+
+# ── B2: Gate A on update ingress (#1247 id 3) ────────────────────────────
+
+
+# AKIA fixture per feedback_force_unsafe_redaction_valve_only.md — clean
+# strings would pass the scan and false-negative every block assertion.
+SECRET = "api_key=AKIA1234567890ABCDEF"
+
+
+class TestUpdatePrivacyGate:
+    """Gate A on the update ingress (ADR-0011 §5, design tests 2 / 3 / 9)."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_privacy_counters(self):
+        privacy.reset_for_tests()
+        yield
+        privacy.reset_for_tests()
+
+    def test_update_blocks_on_poisoned_wiki_src(self, wiki_root: Path, tmp_path: Path) -> None:
+        """Design test 2: secret lands in the wiki → update hard-refuses
+        BEFORE any dest write — zero residue (old bytes, old pin, no .bak)."""
+        _initialized_wiki(wiki_root)
+        old_commit = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+        project = tmp_path
+        install_skill(project, "foo")
+
+        lock_path = project / ".memtomem" / "lock.json"
+        pre_lock_bytes = lock_path.read_bytes()
+
+        _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": f"v2\n{SECRET}\n".encode()})
+
+        with pytest.raises(PrivacyBlockedError):
+            update_skill(project, "foo")
+
+        dest = project / ".memtomem" / "skills" / "foo"
+        # Zero-residue: dest still carries the OLD clean bytes.
+        assert (dest / "SKILL.md").read_bytes() == b"v1\n"
+        # Lockfile untouched — wiki_commit is still the install-time pin.
+        assert _lock_entry(project, "skills", "foo")["wiki_commit"] == old_commit
+        assert lock_path.read_bytes() == pre_lock_bytes
+        # No .bak anywhere under dest (no preservation pass ran).
+        assert list(dest.rglob("*.bak")) == []
+
+    def test_force_update_blocks_on_secret_in_dirty_dest_file(
+        self, wiki_root: Path, tmp_path: Path
+    ) -> None:
+        """Design test 3: --force scans each dirty file BEFORE its .bak
+        copy2 — the secret never gets a second tracked copy."""
+        _initialized_wiki(wiki_root)
+        _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+        project = tmp_path
+        install_skill(project, "foo")
+
+        dest = project / ".memtomem" / "skills" / "foo"
+        edited = dest / "SKILL.md"
+        dirty_bytes = f"local edit\n{SECRET}\n".encode()
+        edited.write_bytes(dirty_bytes)
+        _bump_mtime(edited)
+
+        # Wiki advance is CLEAN — the block must come from the dirty-file
+        # scan, not the src scan.
+        _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+        lock_path = project / ".memtomem" / "lock.json"
+        pre_lock_bytes = lock_path.read_bytes()
+
+        with pytest.raises(PrivacyBlockedError):
+            update_skill(project, "foo", force=True)
+
+        # NO .bak landed; the dirty bytes are intact; lockfile untouched.
+        assert list(dest.rglob("*.bak")) == []
+        assert edited.read_bytes() == dirty_bytes
+        assert lock_path.read_bytes() == pre_lock_bytes
+        # Surface attribution (#1246/#1248 real-ingress rule): single-asset
+        # update audits as cli_context_update, never the batch surface.
+        by_tool = privacy.snapshot()["by_tool"]
+        assert by_tool["cli_context_update"]["blocked"] >= 1
+        assert "cli_context_update_all" not in by_tool
+
+    def test_cli_update_maps_block_to_exit_1_without_secret_echo(
+        self, wiki_root: Path, project_cwd: Path
+    ) -> None:
+        """Design test 9 (update leg): PrivacyBlockedError → ClickException,
+        exit 1, Gate A message shown, no secret echo, no traceback dump."""
+        _initialized_wiki(wiki_root)
+        _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+        install_skill(project_cwd, "foo")
+        _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": f"v2\n{SECRET}\n".encode()})
+
+        runner = CliRunner()
+        result = runner.invoke(context_group, ["update", "skill", "foo"])
+
+        assert result.exit_code == 1, result.output
+        # ClickException mapping pin: the Gate A message reaches stdout
+        # (an unhandled PrivacyBlockedError would leave output empty).
+        assert "Gate A" in result.output
+        # The block message must never echo the secret back (privacy.py
+        # contract: path + hit count only).
+        assert "AKIA1234567890ABCDEF" not in result.output
+        assert "Traceback" not in result.output

--- a/packages/memtomem/tests/test_web_invariants_registry.py
+++ b/packages/memtomem/tests/test_web_invariants_registry.py
@@ -141,6 +141,10 @@ _REDACTION_PROTECTED: frozenset[str] = frozenset(
     {
         "chunks.edit_chunk",
         "scratch.promote_scratch",
+        # Promote appends a private-tier hook rule (free-form command
+        # strings + a free-string event key) into the git-tracked shared
+        # canonical — Gate A fragment scan in-route (#1247).
+        "settings_sync.promote_target_rule",
         "system.add_memory",
         "system.upload_files",
     }
@@ -214,7 +218,6 @@ _REDACTION_EXEMPT: dict[str, str] = {
     "outside the LTM trust boundary; redaction not applicable",
     "settings_sync.apply_settings_sync": "structured settings merge; no free-form prose",
     "settings_sync.delete_target_rule": "structured settings hook rule deletion; no free-form prose",
-    "settings_sync.promote_target_rule": "structured settings hook rule promotion; no free-form prose",
     "settings_sync.resolve_conflict": "structured settings conflict resolution; no free-form prose",
     "system.embed_text": "ephemeral compute; no persistence",
     "system.add_memory_dir": "path-only payload, no prose",
@@ -277,8 +280,14 @@ def _iter_unsafe_route_handlers() -> list[tuple[str, str, str]]:
 
 
 def _function_calls_write_guard(module: str, function_name: str) -> bool:
-    """True iff ``function_name`` in ``module`` calls
-    ``privacy.enforce_write_guard`` somewhere in its body."""
+    """True iff ``function_name`` in ``module`` calls the privacy chokepoint.
+
+    Accepts ``privacy.enforce_write_guard(...)`` (direct chokepoint) and
+    ``scan_text_content(...)`` (the ``context.privacy_scan`` Gate A wrapper,
+    which calls ``enforce_write_guard`` internally — used by route handlers
+    that scan an in-memory fragment before a ``project_shared`` write,
+    e.g. ``settings_sync.promote_target_rule``, #1247).
+    """
     path = ROUTES_DIR / f"{module}.py"
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     for node in ast.walk(tree):
@@ -301,6 +310,12 @@ def _function_calls_write_guard(module: str, function_name: str) -> bool:
             # Match bare ``enforce_write_guard(...)`` after
             # ``from memtomem.privacy import enforce_write_guard``.
             if isinstance(f, ast.Name) and f.id == "enforce_write_guard":
+                return True
+            # Match ``scan_text_content(...)`` (qualified or bare) — the
+            # Gate A wrapper around enforce_write_guard.
+            if isinstance(f, ast.Name) and f.id == "scan_text_content":
+                return True
+            if isinstance(f, ast.Attribute) and f.attr == "scan_text_content":
                 return True
     return False
 

--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -225,21 +225,51 @@ class TestIsDirty:
 # ── helpers for commit-bound tests ──────────────────────────────────────
 
 
-def _seed_skill(wiki_root_path: Path, name: str, files: dict[str, bytes]) -> str:
-    """Add ``skills/<name>/`` to wiki + commit. Returns the commit SHA."""
+def _seed_skill(
+    wiki_root_path: Path,
+    name: str,
+    files: dict[str, bytes],
+    *,
+    force_add: bool = False,
+) -> str:
+    """Add ``skills/<name>/`` to wiki + commit. Returns the commit SHA.
+
+    ``force_add`` uses ``git add -f`` so names a developer's global gitignore
+    commonly covers (``*.bak``, ``__pycache__``) reliably land in the commit."""
     skill_dir = wiki_root_path / "skills" / name
     skill_dir.mkdir(parents=True, exist_ok=True)
     for relpath, data in files.items():
         target = skill_dir / relpath
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(data)
-    subprocess.run(["git", "-C", str(wiki_root_path), "add", "."], check=True, capture_output=True)
+    add_cmd = ["git", "-C", str(wiki_root_path), "add"]
+    if force_add:
+        add_cmd.append("-f")
+    add_cmd.append(".")
+    subprocess.run(add_cmd, check=True, capture_output=True)
     subprocess.run(
         ["git", "-C", str(wiki_root_path), "commit", "-m", f"add {name}"],
         check=True,
         capture_output=True,
     )
     return WikiStore.at_default().current_commit()
+
+
+def _record_store_git_argv(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+    """Spy every argv ``wiki.store`` hands to ``subprocess.run`` (delegating to
+    the real one) — pins which git objects ``copy_asset_at_commit`` reads."""
+    import memtomem.wiki.store as store_module
+
+    recorded: list[list[str]] = []
+    real_run = subprocess.run
+
+    def _recording_run(args: object, *pargs: object, **kwargs: object) -> object:
+        if isinstance(args, list | tuple):
+            recorded.append([str(a) for a in args])
+        return real_run(args, *pargs, **kwargs)
+
+    monkeypatch.setattr(store_module.subprocess, "run", _recording_run)
+    return recorded
 
 
 class TestCommitIsReachable:
@@ -258,6 +288,21 @@ class TestCommitIsReachable:
         store = WikiStore.at_default()
         store.init()
         assert store.commit_is_reachable("") is False
+
+    def test_symbolic_ref_is_not_reachable(self, wiki_root: Path) -> None:
+        """``main`` resolves for ``git cat-file`` but is NOT a pin — refs
+        move, so a hand-edited lockfile ref would let scanned bytes
+        diverge from extracted bytes (#1247 Gate A review)."""
+        store = WikiStore.at_default()
+        store.init()
+        assert store.commit_is_reachable("main") is False
+        assert store.commit_is_reachable("HEAD") is False
+
+    def test_abbreviated_sha_is_not_reachable(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        head = store.current_commit()
+        assert store.commit_is_reachable(head[:12]) is False
 
     def test_raises_when_wiki_absent(self, wiki_root: Path) -> None:
         store = WikiStore.at_default()
@@ -339,3 +384,75 @@ class TestCopyAssetAtCommit:
         store.copy_asset_at_commit(pin, "skills", "foo", dest)
 
         assert (dest / "SKILL.md").read_bytes() == b"committed\n"
+
+    def test_pinned_bak_rel_never_read_or_materialized(
+        self, wiki_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A wiki-shipped ``*.bak`` at the pin is filtered BEFORE ``git show`` —
+        its bytes must never reach a tempdir inside the project tree (#1247)."""
+        store = WikiStore.at_default()
+        store.init()
+        pin = _seed_skill(
+            wiki_root,
+            "foo",
+            {
+                "SKILL.md": b"# foo\n",
+                "foo.md.bak": b"api_key=AKIA1234567890ABCDEF\n",
+            },
+            force_add=True,
+        )
+        # Guard: seeding really tracked the .bak (force-add beat any global
+        # gitignore) — otherwise the spy assertions below pass vacuously.
+        ls_result = subprocess.run(
+            ["git", "-C", str(wiki_root), "ls-tree", "-r", "--name-only", pin],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert "skills/foo/foo.md.bak" in ls_result.stdout.splitlines()
+
+        recorded = _record_store_git_argv(monkeypatch)
+        dest = tmp_path / "out" / "foo"
+        files_written = store.copy_asset_at_commit(pin, "skills", "foo", dest)
+
+        show_args = [arg for argv in recorded if argv[:2] == ["git", "show"] for arg in argv]
+        assert any(arg.endswith(":skills/foo/SKILL.md") for arg in show_args)  # spy is live
+        assert not any("foo.md.bak" in arg for argv in recorded for arg in argv)
+        assert files_written == 1
+        assert (dest / "SKILL.md").read_bytes() == b"# foo\n"
+        assert not list(dest.rglob("*.bak"))
+
+    def test_pinned_pycache_rel_never_read_or_materialized(
+        self, wiki_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``COPY_SKIP_NAMES`` rels (``__pycache__``) get the same pre-``git
+        show`` filter as ``.bak`` suffixes — one shared skip predicate (#1247)."""
+        store = WikiStore.at_default()
+        store.init()
+        pin = _seed_skill(
+            wiki_root,
+            "foo",
+            {
+                "SKILL.md": b"# foo\n",
+                "__pycache__/junk.pyc": b"\x00not real bytecode\n",
+            },
+            force_add=True,
+        )
+        ls_result = subprocess.run(
+            ["git", "-C", str(wiki_root), "ls-tree", "-r", "--name-only", pin],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert "skills/foo/__pycache__/junk.pyc" in ls_result.stdout.splitlines()
+
+        recorded = _record_store_git_argv(monkeypatch)
+        dest = tmp_path / "out" / "foo"
+        files_written = store.copy_asset_at_commit(pin, "skills", "foo", dest)
+
+        show_args = [arg for argv in recorded if argv[:2] == ["git", "show"] for arg in argv]
+        assert any(arg.endswith(":skills/foo/SKILL.md") for arg in show_args)  # spy is live
+        assert not any("__pycache__" in arg for argv in recorded for arg in argv)
+        assert files_written == 1
+        assert (dest / "SKILL.md").read_bytes() == b"# foo\n"
+        assert not (dest / "__pycache__").exists()


### PR DESCRIPTION
## Summary

Closes the last two ungated first-party write paths into the git-tracked
`project_shared` tree, per ADR-0011 §5 "two gates fire on every
project_shared write" (#1247 backlog ids **3** and **50**, both
confirmed-major in the issue triage):

- **`mm context install` / `update`** (single, `--all`, pinned restore)
  copied wiki bytes — a user-tier store where secrets are legal — straight
  into `<project>/.memtomem/<type>/<name>` with no privacy scan, and the
  `--force` path duplicated dirty (possibly secret-bearing) dest files into
  new unscanned `.bak` siblings.
- **`POST /settings-sync/rules/promote`** appended a private-tier hook rule
  to the shared canonical behind a consent gate but no content scan — the
  only private→shared surface without one.

## Fix shape

**Install/update (CLI):** Gate A runs before the first dest mutation, so a
refusal leaves zero residue — no dest bytes, no `.bak`, no lockfile drift
(upserts already trail copies).

- HEAD paths scan the copier's effective file set (`iter_installed_files`),
  so a wiki-shipped `*.bak` the copier skips cannot false-block (#1250
  parity preserved).
- The pinned path scans git objects at the pin via the new
  `WikiStore.read_asset_file_at_commit` (immutable bytes — no scan→write
  TOCTOU), decoded `errors="replace"` so an ASCII secret inside a non-UTF8
  blob still blocks, filtered by the new shared `_atomic.is_copy_skipped_rel`
  predicate (scan set == materialized set == copied set).
- `--force` scans each dirty file before its `.bak` is created, mirroring
  the version-create snapshot standard.
- Batch rows fail individually (red ✗, batch continues), exit 1; surfaces
  are attributed per real ingress (`cli_context_install`,
  `cli_context_update`, `cli_context_update_all`, `cli_context_install_all`).

**Promote (web):** scans the exact appended canonical fragment
`{event: [rule]}` — `body.event` is a free string that lands as a JSON key,
so a secret-shaped event key blocks too — before the consent gate, returning
422 with a secret-free message (`web_settings_rule_promote`). Scope is
hardcoded `project_shared`; the route's `target_scope` is the tier being
*read*. The web-invariants registry now pins the in-route scan
(`promote_target_rule` moved to `_REDACTION_PROTECTED`; the AST acceptor
recognizes `scan_text_content` as a chokepoint wrapper).

Block messages take a per-surface `remediation_hint` (default `None` keeps
existing sync/migrate messages byte-identical).

## Incidental fixes (same call paths, disclosed per repo convention)

- `copy_asset_at_commit` no longer materializes skip-listed rels (`.bak`,
  `.git`, `__pycache__`, `.DS_Store`) into its extraction tmpdir under
  `.memtomem/<type>/` — previously a crash/SIGKILL could strand unscanned
  wiki bytes as commit-able residue inside the git-tracked tree.
- `mm context update --all` now exits 1 when any row fails, mirroring
  `install --all` (previously always exit 0; the mid-loop-error test's exit
  pin updated accordingly).
- `commit_is_reachable` now enforces its documented contract: only full
  40-hex object ids count as pins. A symbolic ref (`main`) in a hand-edited
  lockfile satisfied `git cat-file` while breaking pin immutability — the
  ref could move between the Gate A scan and the extraction.

## Docs

ADR-0011 §5 dated rider (Gate A now covers wiki ingress + promote; Gate B
confirm intentionally absent on install/update — those verbs have no
`--scope` choice, dest is project_shared by construction), ADR-0008
Invariants 1–2, `configuration.md` + `getting-started.md` gate notes.

## Tests

23 new tests across 6 files, all validated to **fail against the unmodified
tree first** (DID NOT RAISE / 200 / exit 0 / git-show spy), then green
post-fix; the two scan-set parity tests pass pre-fix by design, pinning
#1250 behavior. Full matrix: install/update/pinned blocks with zero-residue
asserts, non-UTF8 blob block, batch row isolation (2 assets / 2 projects),
promote rule + event-key blocks, consent-gate fail-fast, CLI exit-1 mapping
with no secret echo, `is_copy_skipped_rel` unit + walker-parity,
reachability shape rejection.

Gates: full `pytest -m "not ollama"` 6253 passed (4 `test_session_tracing`
fails reproduce on a clean tree — pre-existing local-env issue, known #1249
isolation gap), vitest 151 passed, ruff check + format clean, mypy no new
errors. Codex review: design gate ×3 rounds + implementation ×2 rounds →
SHIP (0 open findings).

Refs #1247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
