### PR TITLE
fix(context): refuse mutations over corrupt lockfile / known-projects store (#1247 B3)

### DIFF
--- a/docs/adr/0008-wiki-layer.md
+++ b/docs/adr/0008-wiki-layer.md
@@ -198,6 +198,17 @@ through plain `dict` is sufficient). The `version` field is reserved for
 schema migrations; future fields (`skill_version`, `compat`, `mode`) can
 be added forward-compatibly.
 
+A lockfile that exists but cannot be read as a JSON object (unreadable,
+invalid JSON / invalid UTF-8, non-object top level) MUST refuse mutations
+rather than silently re-baseline: write paths load-then-write the whole
+doc, so a tolerant "fresh empty doc" fallback would be persisted, wiping
+every sibling entry's install record. Strict reads raise
+(`LockfileCorruptError`, sibling of the version-mismatch error);
+diagnostic surfaces (`mm context status`) may degrade tolerantly but
+never write. A *missing* lockfile is the normal pre-install state and
+stays a write-safe empty default. The same refuse-don't-rebaseline rule
+applies to `known_projects.json` mutations (`KnownProjectsCorruptError`).
+
 ## Vendor format matrix
 
 `OVERRIDE_FORMATS = { (asset_type, vendor): (alias, extension) }` lives

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -61,7 +61,7 @@ from memtomem.context.migrate import (
     migrate_scope,
 )
 from memtomem.context.projects import KnownProjectsStore
-from memtomem.context.lockfile import LockfileVersionError
+from memtomem.context.lockfile import LockfileError
 from memtomem.context.status import classify_status, load_with_recovery, scan_user_artifacts
 from memtomem.context.generator import (
     GENERATORS,
@@ -1454,7 +1454,7 @@ def install_cmd(
         raise click.ClickException(str(exc)) from exc
     except InvalidNameError as exc:
         raise click.ClickException(str(exc)) from exc
-    except LockfileVersionError as exc:
+    except LockfileError as exc:
         raise click.ClickException(str(exc)) from exc
     except PrivacyScanError as exc:
         # Gate A refusal (ADR-0011 §5, #1247) — exc.message carries the
@@ -1552,7 +1552,7 @@ def update_cmd(
         raise click.ClickException(str(exc)) from exc
     except InvalidNameError as exc:
         raise click.ClickException(str(exc)) from exc
-    except LockfileVersionError as exc:
+    except LockfileError as exc:
         raise click.ClickException(str(exc)) from exc
     except PrivacyScanError as exc:
         # Gate A refusal (ADR-0011 §5, #1247) — see install_cmd's arm.
@@ -1955,7 +1955,7 @@ def _run_install_all(
 
     try:
         classifications = _classify_for_install_all(root, wiki=wiki)
-    except LockfileVersionError as exc:
+    except LockfileError as exc:
         raise click.ClickException(str(exc)) from exc
 
     if not classifications:

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -40,7 +40,7 @@ from memtomem.context._atomic import (
 )
 from memtomem.context._names import validate_name
 from memtomem.context.dirty import DirtyReport, is_asset_dirty
-from memtomem.context.lockfile import Lockfile, LockfileVersionError, manifest_from_entry
+from memtomem.context.lockfile import Lockfile, LockfileError, manifest_from_entry
 from memtomem.context.privacy_scan import (
     raise_or_collect,
     scan_artifact_tree,
@@ -810,7 +810,7 @@ def _classify_for_all_update(
         try:
             lock = Lockfile.at(project_root)
             lock_entry = lock.read_entry(asset_type, name)
-        except LockfileVersionError as exc:
+        except LockfileError as exc:
             out.append(
                 ProjectClassification(
                     project_root=project_root,

--- a/packages/memtomem/src/memtomem/context/lockfile.py
+++ b/packages/memtomem/src/memtomem/context/lockfile.py
@@ -36,6 +36,8 @@ __all__ = [
     "LOCKFILE_NAME",
     "LOCKFILE_VERSION",
     "Lockfile",
+    "LockfileCorruptError",
+    "LockfileError",
     "LockfileVersionError",
     "manifest_from_entry",
     "utcnow_iso8601_z",
@@ -46,12 +48,35 @@ LOCKFILE_NAME = "lock.json"
 LOCKFILE_VERSION = 1
 
 
-class LockfileVersionError(RuntimeError):
+class LockfileError(RuntimeError):
+    """Base for lockfile read failures raised by :meth:`Lockfile.load`.
+
+    Catch this to handle :class:`LockfileVersionError` and
+    :class:`LockfileCorruptError` in one clause — surfaces that degrade
+    (``mm context status``) or message-and-exit (CLI) treat both the same.
+    """
+
+
+class LockfileVersionError(LockfileError):
     """The lockfile carries a ``version`` this build does not understand.
 
     Raised by :meth:`Lockfile.load` with ``strict=True`` (the default for
     write paths). Diagnostic surfaces (e.g. a future ``mm context status``)
     can pass ``strict=False`` to recover the raw dict for inspection.
+    """
+
+
+class LockfileCorruptError(LockfileError):
+    """The lockfile exists but cannot be read as a JSON object.
+
+    Raised by :meth:`Lockfile.load` with ``strict=True`` (the default, and
+    what every write path uses) when the file is unreadable (``OSError``
+    other than missing), not valid JSON, or its top level is not an object.
+    Refusing here is load-bearing: ``upsert_entry`` loads inside the sidecar
+    lock and writes the doc back, so a tolerant reset would be *persisted*
+    with only the upserted entry, wiping every sibling asset's install
+    record (#1247 id 16). Only ``strict=False`` diagnostic reads keep the
+    tolerant empty-doc fallback.
     """
 
 
@@ -126,8 +151,14 @@ class Lockfile:
     def load(self, *, strict: bool = True) -> dict[str, Any]:
         """Return the lockfile dict.
 
-        - Missing file → ``{"version": LOCKFILE_VERSION}`` (write-safe default).
-        - Invalid JSON → log warning, return ``{"version": LOCKFILE_VERSION}``.
+        - Missing file → ``{"version": LOCKFILE_VERSION}`` (write-safe default,
+          both modes — an absent lockfile is the normal pre-install state).
+        - Unreadable / invalid JSON / non-object top level and ``strict=True``
+          → raise :class:`LockfileCorruptError`. Write paths load-then-write,
+          so a tolerant reset here would be persisted, destroying every
+          sibling entry (#1247 id 16).
+        - Same corrupt cases with ``strict=False`` → log warning, return
+          ``{"version": LOCKFILE_VERSION}`` (diagnostic surfaces degrade).
         - ``version`` ≠ ``LOCKFILE_VERSION`` and ``strict=True`` → raise
           :class:`LockfileVersionError` (canonical record; silent reset
           would clobber a forward-compatible lockfile written by a newer
@@ -135,21 +166,37 @@ class Lockfile:
         - ``version`` ≠ ``LOCKFILE_VERSION`` and ``strict=False`` → return
           the raw dict so diagnostic surfaces can render a useful message.
         """
+        hint = "fix or remove it (e.g. restore it from version control), then retry"
         try:
             raw = self._path.read_bytes()
         except FileNotFoundError:
             return {"version": LOCKFILE_VERSION}
         except OSError as exc:
+            if strict:
+                raise LockfileCorruptError(
+                    f"lockfile at {self._path} is unreadable ({exc}); {hint}"
+                ) from exc
             logger.warning("lockfile: read failed at %s: %s", self._path, exc)
             return {"version": LOCKFILE_VERSION}
 
         try:
             doc = json.loads(raw)
-        except json.JSONDecodeError as exc:
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            # UnicodeDecodeError: json.loads(bytes) decodes before parsing,
+            # so invalid UTF-8 raises it instead of JSONDecodeError — same
+            # corrupt-file class, same handling (Codex design review).
+            if strict:
+                raise LockfileCorruptError(
+                    f"lockfile at {self._path} is not valid JSON ({exc}); {hint}"
+                ) from exc
             logger.warning("lockfile: invalid JSON at %s, ignoring file: %s", self._path, exc)
             return {"version": LOCKFILE_VERSION}
 
         if not isinstance(doc, dict):
+            if strict:
+                raise LockfileCorruptError(
+                    f"lockfile at {self._path} top level is not a JSON object; {hint}"
+                )
             logger.warning("lockfile: top-level not an object at %s, ignoring", self._path)
             return {"version": LOCKFILE_VERSION}
 

--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -33,11 +33,27 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "ProjectScope",
     "ProjectHealth",
+    "KnownProjectsCorruptError",
     "KnownProjectsStore",
     "compute_scope_id",
     "discover_project_scopes",
     "annotate_project_health",
 ]
+
+
+class KnownProjectsCorruptError(RuntimeError):
+    """``known_projects.json`` exists but cannot be read as the expected doc.
+
+    Raised by :meth:`KnownProjectsStore.load` with ``strict=True`` (what every
+    mutator uses) when the file is unreadable (``OSError`` other than missing),
+    not valid JSON, not a dict, or carries an unknown ``version``. Mutators
+    load-then-rewrite the whole doc, so the tolerant ``[]`` fallback would be
+    *persisted* — ``add()`` would re-baseline the registered-project list to
+    just the new entry (#1247 id 16). Read-only discovery keeps the tolerant
+    default. Version mismatch is folded in (no separate version error like the
+    lockfile's): ``_write`` re-renders at the current version, so mutating a
+    future-version file is the same clobber hazard as mutating a corrupt one.
+    """
 
 
 # ── Scope id ─────────────────────────────────────────────────────────────
@@ -145,27 +161,52 @@ class KnownProjectsStore:
     def path(self) -> Path:
         return self._path
 
-    def load(self) -> list[_KnownProjectEntry]:
-        """Return entries in registration order; ``[]`` if file missing or unreadable."""
+    def load(self, *, strict: bool = False) -> list[_KnownProjectEntry]:
+        """Return entries in registration order.
+
+        Missing file → ``[]`` in both modes (the normal pre-registration
+        state). For an *existing* file that is unreadable, invalid JSON,
+        not a dict, or an unknown ``version``: ``strict=False`` (default —
+        read-only discovery) logs a warning and degrades to ``[]``;
+        ``strict=True`` (mutators) raises
+        :class:`KnownProjectsCorruptError` so the follow-up ``_write``
+        cannot persist the degraded empty list over the user's
+        registrations (#1247 id 16).
+        """
+        hint = "fix or remove it (e.g. restore it from version control), then retry"
         try:
             raw = self._path.read_bytes()
         except FileNotFoundError:
             return []
         except OSError as exc:
+            if strict:
+                raise KnownProjectsCorruptError(
+                    f"known_projects file at {self._path} is unreadable ({exc}); {hint}"
+                ) from exc
             logger.warning("known_projects: read failed: %s", exc)
             return []
 
         try:
             doc = json.loads(raw)
-        except json.JSONDecodeError as exc:
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            # UnicodeDecodeError: json.loads(bytes) decodes before parsing,
+            # so invalid UTF-8 raises it instead of JSONDecodeError — same
+            # corrupt-file class, same handling (Codex design review).
+            if strict:
+                raise KnownProjectsCorruptError(
+                    f"known_projects file at {self._path} is not valid JSON ({exc}); {hint}"
+                ) from exc
             logger.warning("known_projects: invalid JSON, ignoring file: %s", exc)
             return []
 
         if not isinstance(doc, dict) or doc.get("version") != _KNOWN_PROJECTS_VERSION:
-            logger.warning(
-                "known_projects: unexpected version %r, ignoring",
-                doc.get("version") if isinstance(doc, dict) else None,
-            )
+            version = doc.get("version") if isinstance(doc, dict) else None
+            if strict:
+                raise KnownProjectsCorruptError(
+                    f"known_projects file at {self._path} has unexpected version "
+                    f"{version!r} (this build writes version {_KNOWN_PROJECTS_VERSION}); {hint}"
+                )
+            logger.warning("known_projects: unexpected version %r, ignoring", version)
             return []
 
         entries: list[_KnownProjectEntry] = []
@@ -191,10 +232,13 @@ class KnownProjectsStore:
     def add(self, root: Path, label: str | None = None) -> _KnownProjectEntry:
         """Register *root*. Idempotent — re-registering an existing root is a no-op
         (returns the existing entry).
+
+        Raises :class:`KnownProjectsCorruptError` instead of re-baselining
+        the list to ``[new_entry]`` when the file exists but is corrupt.
         """
         normalized = Path(root).expanduser()
         with _file_lock(_lock_path_for(self._path)):
-            entries = self.load()
+            entries = self.load(strict=True)
             for existing in entries:
                 if _normalize_for_scope_id(existing.root) == _normalize_for_scope_id(normalized):
                     return existing
@@ -215,7 +259,7 @@ class KnownProjectsStore:
         existence-derived.
         """
         with _file_lock(_lock_path_for(self._path)):
-            entries = self.load()
+            entries = self.load(strict=True)
             kept = [e for e in entries if compute_scope_id(e.root) != scope_id]
             if len(kept) == len(entries):
                 return False
@@ -250,7 +294,7 @@ class KnownProjectsStore:
         ``add`` dedups by resolved path, so duplicates never arise via the API.
         """
         with _file_lock(_lock_path_for(self._path)):
-            entries = self.load()
+            entries = self.load(strict=True)
             first_updated: _KnownProjectEntry | None = None
             new_entries: list[_KnownProjectEntry] = []
             for e in entries:

--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -166,12 +166,13 @@ class KnownProjectsStore:
 
         Missing file → ``[]`` in both modes (the normal pre-registration
         state). For an *existing* file that is unreadable, invalid JSON,
-        not a dict, or an unknown ``version``: ``strict=False`` (default —
-        read-only discovery) logs a warning and degrades to ``[]``;
-        ``strict=True`` (mutators) raises
+        not a dict, an unknown ``version``, a non-list ``projects`` member,
+        or containing a row without a usable ``root``: ``strict=False``
+        (default — read-only discovery) logs a warning and degrades to
+        ``[]`` / skips the row; ``strict=True`` (mutators) raises
         :class:`KnownProjectsCorruptError` so the follow-up ``_write``
-        cannot persist the degraded empty list over the user's
-        registrations (#1247 id 16).
+        cannot persist the degraded list over the user's registrations
+        (#1247 id 16).
         """
         hint = "fix or remove it (e.g. restore it from version control), then retry"
         try:
@@ -209,12 +210,39 @@ class KnownProjectsStore:
             logger.warning("known_projects: unexpected version %r, ignoring", version)
             return []
 
+        # Shape guards below the version check: a row the parser drops here
+        # is *destroyed* by the next mutation — unlike the lockfile store,
+        # ``_write`` re-renders from parsed entries, so anything skipped does
+        # not round-trip. Strict mode therefore refuses any unrepresentable
+        # shape (Codex impl review: ``{"projects": {...}}`` was re-baselined
+        # to one entry). Designed legacy defaults (missing ``added_at`` /
+        # ``label`` / ``enabled``) are NOT corruption and parse normally.
+        projects_member = doc.get("projects", [])
+        if not isinstance(projects_member, list):
+            if strict:
+                raise KnownProjectsCorruptError(
+                    f"known_projects file at {self._path} has a non-list 'projects' "
+                    f"member ({type(projects_member).__name__}); {hint}"
+                )
+            logger.warning("known_projects: 'projects' is not a list, ignoring file")
+            return []
+
         entries: list[_KnownProjectEntry] = []
-        for item in doc.get("projects", []):
+        for item in projects_member:
             if not isinstance(item, dict):
+                if strict:
+                    raise KnownProjectsCorruptError(
+                        f"known_projects file at {self._path} has a non-object project "
+                        f"row ({type(item).__name__}); {hint}"
+                    )
                 continue
             root = item.get("root")
             if not isinstance(root, str) or not root:
+                if strict:
+                    raise KnownProjectsCorruptError(
+                        f"known_projects file at {self._path} has a project row without "
+                        f"a usable 'root'; {hint}"
+                    )
                 continue
             entries.append(
                 _KnownProjectEntry(

--- a/packages/memtomem/src/memtomem/context/status.py
+++ b/packages/memtomem/src/memtomem/context/status.py
@@ -34,7 +34,7 @@ from memtomem.context._names import is_internal_artifact_dir
 from memtomem.context.agents import AGENT_DIR_FILENAME
 from memtomem.context.commands import COMMAND_DIR_FILENAME
 from memtomem.context.dirty import is_asset_dirty
-from memtomem.context.lockfile import Lockfile, LockfileVersionError
+from memtomem.context.lockfile import Lockfile, LockfileError
 from memtomem.context.scope_resolver import canonical_artifact_dir
 from memtomem.context.skills import SKILL_MANIFEST
 from memtomem.wiki.store import WikiNotFoundError, WikiStore
@@ -322,34 +322,35 @@ def load_with_recovery(project_root: Path | str) -> tuple[dict, str | None]:
     """Read the lockfile in diagnostic mode, returning ``(doc, error_or_None)``.
 
     Used by ``status_cmd`` to surface a corrupt-lockfile error row at
-    the top of the output without crashing. Wraps
-    :meth:`Lockfile.load` with ``strict=False`` so a forward-compat
-    version mismatch returns the raw dict; outright JSON corruption
-    falls through to ``Lockfile.load``'s warning path which returns
-    a fresh ``{"version": LOCKFILE_VERSION}``.
+    the top of the output without crashing. Catches the
+    :class:`LockfileError` base so both a forward-compat version mismatch
+    (``strict=False`` then returns the raw dict) and outright corruption
+    (``strict=False`` degrades to a fresh ``{"version": LOCKFILE_VERSION}``)
+    render as an error message instead of a traceback.
     """
     lockfile = Lockfile.at(project_root)
     try:
         doc = lockfile.load(strict=True)
         return doc, None
-    except LockfileVersionError as exc:
+    except LockfileError as exc:
         return lockfile.load(strict=False), str(exc)
 
 
 def _tolerant_iter_entries(
     lockfile: Lockfile,
 ) -> Iterator[tuple[str, str, dict[str, Any]]]:
-    """Like :meth:`Lockfile.iter_entries` but tolerant of version mismatches.
+    """Like :meth:`Lockfile.iter_entries` but tolerant of unreadable lockfiles.
 
     Mirrors the alphabetical ``(asset_type, name)`` ordering contract.
     Used by :func:`classify_status` so a forward-compat lockfile (or a
-    user editing ``version`` by hand) still surfaces its entries —
+    user editing ``version`` by hand) still surfaces its entries, and an
+    outright corrupt lockfile yields zero entries instead of crashing —
     callers separately render a top-row error message via
     :func:`load_with_recovery`.
     """
     try:
         doc = lockfile.load(strict=True)
-    except LockfileVersionError:
+    except LockfileError:
         doc = lockfile.load(strict=False)
     for asset_type in sorted(doc):
         section = doc.get(asset_type)

--- a/packages/memtomem/src/memtomem/web/routes/context_projects.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_projects.py
@@ -34,6 +34,7 @@ from memtomem.context.commands import (
 )
 from memtomem.context.projects import (
     _MARKER_DIRS,
+    KnownProjectsCorruptError,
     KnownProjectsStore,
     ProjectScope,
     compute_scope_id,
@@ -449,7 +450,12 @@ async def add_known_project(body: AddProjectRequest, request: Request) -> dict:
     # precedence in discovery, an unnormalized "   " here would otherwise render
     # a blank project name.
     label = (body.label or "").strip() or None
-    entry = store.add(candidate, label=label)
+    try:
+        entry = store.add(candidate, label=label)
+    except KnownProjectsCorruptError as exc:
+        # Server-side state file is corrupt — 500, not 4xx: the request was
+        # valid, the store refused the write to avoid wiping registrations.
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
     project_scope_id = compute_scope_id(entry.root)
 
     response: dict = {
@@ -514,13 +520,17 @@ async def update_known_project(
     # Single atomic store write — applying label + enabled in one lock window so a
     # concurrent DELETE / PATCH can't interleave and partially apply the combined
     # update (Codex review). ``set_*`` flags gate which fields are touched.
-    updated = store.update_entry_by_scope_id(
-        scope_id,
-        label=(body.label or "").strip() or None,
-        set_label=label_present,
-        enabled=bool(body.enabled),
-        set_enabled=set_enabled,
-    )
+    try:
+        updated = store.update_entry_by_scope_id(
+            scope_id,
+            label=(body.label or "").strip() or None,
+            set_label=label_present,
+            enabled=bool(body.enabled),
+            set_enabled=set_enabled,
+        )
+    except KnownProjectsCorruptError as exc:
+        # Corrupt store must surface as a server error, not a misleading 404.
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
     if updated is None:
         raise HTTPException(status_code=404, detail=f"unknown scope_id: {scope_id!r}")
     return {
@@ -545,7 +555,12 @@ async def delete_known_project(scope_id: str, request: Request) -> dict:
     """
     cfg = _gateway_config(request)
     store = KnownProjectsStore(Path(cfg.known_projects_path).expanduser())
-    if not store.remove_by_scope_id(scope_id):
+    try:
+        removed = store.remove_by_scope_id(scope_id)
+    except KnownProjectsCorruptError as exc:
+        # Corrupt store must surface as a server error, not a misleading 404.
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    if not removed:
         raise HTTPException(status_code=404, detail=f"unknown scope_id: {scope_id!r}")
     return {"deleted": scope_id}
 

--- a/packages/memtomem/tests/test_context_install.py
+++ b/packages/memtomem/tests/test_context_install.py
@@ -26,7 +26,7 @@ from memtomem.context.install import (
     AssetNotFoundError,
     install_skill,
 )
-from memtomem.context.lockfile import LOCKFILE_VERSION, Lockfile
+from memtomem.context.lockfile import LOCKFILE_VERSION, Lockfile, LockfileCorruptError
 from memtomem.context.privacy_scan import PrivacyBlockedError
 from memtomem.wiki.store import WikiNotFoundError, WikiStore
 
@@ -315,6 +315,26 @@ def test_install_refuses_when_only_dest_present(wiki_root: Path, tmp_path: Path)
     assert "dest=yes" in msg
     # Hand-placed file must not be clobbered.
     assert (pre / "stray.txt").read_text() == "hand-placed"
+
+
+def test_install_over_corrupt_lockfile_names_the_lockfile(wiki_root: Path, tmp_path: Path) -> None:
+    """Corrupt lock.json + dest on disk used to wedge: install said
+    AlreadyInstalled ("run update"), update said NotInstalled ("run
+    install") — each pointing at the other while the tolerant reset was
+    one upsert away from wiping every sibling entry (#1247 id 16). The
+    strict read now names the real problem before either check runs."""
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
+    project = tmp_path
+
+    install_skill(project, "foo")
+    lock_json = project / ".memtomem" / "lock.json"
+    corrupt = b"not valid json {{"
+    lock_json.write_bytes(corrupt)
+
+    with pytest.raises(LockfileCorruptError, match="lock.json"):
+        install_skill(project, "foo")
+    assert lock_json.read_bytes() == corrupt  # refusal left the file untouched
 
 
 def test_install_invalid_name(wiki_root: Path, tmp_path: Path) -> None:

--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 
 from memtomem.context.projects import (
+    KnownProjectsCorruptError,
     KnownProjectsStore,
     ProjectHealth,
     ProjectScope,
@@ -329,6 +330,71 @@ def test_store_unknown_version_recovers_to_empty(tmp_path: Path) -> None:
     kp.write_text(json.dumps({"version": 999, "projects": []}))
     store = KnownProjectsStore(kp)
     assert store.load() == []
+
+
+# ── corrupt-file mutation refusal (#1247 id 16) ──────────────────────────
+
+
+def _seed_then_corrupt(tmp_path: Path, corrupt: bytes) -> tuple[KnownProjectsStore, Path, Path]:
+    """Register one real project, then overwrite the store file with
+    *corrupt* bytes. Returns ``(store, kp_path, registered_root)``."""
+    registered = tmp_path / "registered"
+    registered.mkdir()
+    kp = tmp_path / "kp.json"
+    store = KnownProjectsStore(kp)
+    store.add(registered)
+    kp.write_bytes(corrupt)
+    return store, kp, registered
+
+
+@pytest.mark.parametrize(
+    "corrupt",
+    [
+        pytest.param(b"not valid {json", id="invalid-json"),
+        pytest.param(b"\xff", id="invalid-utf8"),
+        pytest.param(b'{"version": 999, "projects": []}', id="future-version"),
+    ],
+)
+def test_store_add_over_corrupt_file_refuses_and_preserves_bytes(
+    tmp_path: Path, corrupt: bytes
+) -> None:
+    """``add()`` must refuse instead of re-baselining the registered-project
+    list to ``[new_entry]`` — pre-fix, the tolerant load returned ``[]`` and
+    ``_write`` persisted the wipe. Future-version is folded in: ``_write``
+    re-renders at the current version, so mutating a newer file is the same
+    clobber hazard."""
+    store, kp, _ = _seed_then_corrupt(tmp_path, corrupt)
+    newcomer = tmp_path / "newcomer"
+    newcomer.mkdir()
+
+    with pytest.raises(KnownProjectsCorruptError):
+        store.add(newcomer)
+    assert kp.read_bytes() == corrupt  # refusal left the file byte-identical
+
+
+def test_store_remove_over_corrupt_file_refuses(tmp_path: Path) -> None:
+    """Pre-fix this returned ``False`` ("not found") — a misleading no-op."""
+    store, kp, registered = _seed_then_corrupt(tmp_path, b"not valid {json")
+    with pytest.raises(KnownProjectsCorruptError):
+        store.remove_by_scope_id(compute_scope_id(registered))
+    assert kp.read_bytes() == b"not valid {json"
+
+
+def test_store_update_over_corrupt_file_refuses(tmp_path: Path) -> None:
+    """All three PATCH shapes (label-only, enabled-only, combined) go
+    through the same strict load — each must refuse, none may write."""
+    store, kp, registered = _seed_then_corrupt(tmp_path, b"not valid {json")
+    sid = compute_scope_id(registered)
+
+    with pytest.raises(KnownProjectsCorruptError):
+        store.update_entry_by_scope_id(sid, label="x", set_label=True)
+    with pytest.raises(KnownProjectsCorruptError):
+        store.update_entry_by_scope_id(sid, enabled=False, set_enabled=True)
+    with pytest.raises(KnownProjectsCorruptError):
+        store.update_entry_by_scope_id(
+            sid, label="x", set_label=True, enabled=False, set_enabled=True
+        )
+    assert kp.read_bytes() == b"not valid {json"
 
 
 # ── atomic-write race (real OS-level concurrency, RFC bar) ───────────────

--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -332,6 +332,19 @@ def test_store_unknown_version_recovers_to_empty(tmp_path: Path) -> None:
     assert store.load() == []
 
 
+def test_store_projects_not_list_recovers_to_empty(tmp_path: Path) -> None:
+    """Tolerant read degrades on a non-list ``projects`` member — including
+    a non-iterable, which used to crash the loop with TypeError."""
+    kp = tmp_path / "kp.json"
+    store = KnownProjectsStore(kp)
+
+    kp.write_text(json.dumps({"version": 1, "projects": {"root": "/old"}}))
+    assert store.load() == []
+
+    kp.write_text(json.dumps({"version": 1, "projects": 5}))
+    assert store.load() == []
+
+
 # ── corrupt-file mutation refusal (#1247 id 16) ──────────────────────────
 
 
@@ -353,6 +366,13 @@ def _seed_then_corrupt(tmp_path: Path, corrupt: bytes) -> tuple[KnownProjectsSto
         pytest.param(b"not valid {json", id="invalid-json"),
         pytest.param(b"\xff", id="invalid-utf8"),
         pytest.param(b'{"version": 999, "projects": []}', id="future-version"),
+        # Valid version-1 JSON whose shape the parser cannot represent —
+        # without the strict shape guard these silently re-baseline too
+        # (Codex impl review): _write re-renders from parsed entries, so a
+        # dropped member/row does not round-trip.
+        pytest.param(b'{"version": 1, "projects": {"root": "/old"}}', id="projects-not-list"),
+        pytest.param(b'{"version": 1, "projects": ["stray-string"]}', id="row-not-object"),
+        pytest.param(b'{"version": 1, "projects": [{"label": "no-root"}]}', id="row-without-root"),
     ],
 )
 def test_store_add_over_corrupt_file_refuses_and_preserves_bytes(

--- a/packages/memtomem/tests/test_context_status.py
+++ b/packages/memtomem/tests/test_context_status.py
@@ -358,6 +358,28 @@ def test_cli_status_corrupt_lockfile_exits_1(
     assert "lock.json" in result.output
 
 
+def test_cli_status_invalid_json_lockfile_exits_1_no_traceback(
+    wiki_root: Path,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Outright JSON corruption degrades the same way the version mismatch
+    does — error message + exit 1, never a traceback (#1247 id 16: status is
+    read-only, so it reports instead of refusing)."""
+    _initialized_wiki(wiki_root)
+    lockfile_path = tmp_path / ".memtomem" / "lock.json"
+    lockfile_path.parent.mkdir(parents=True)
+    lockfile_path.write_text("not valid json {{", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["status"])
+
+    assert result.exit_code == 1
+    assert "lock.json" in result.output
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
 def test_cli_status_wiki_absent_renders_with_annotation(
     wiki_root: Path,  # fixture sets MEMTOMEM_WIKI_PATH but we don't init
     tmp_path: Path,

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -35,6 +35,7 @@ from memtomem.context.install import (
     update_command,
     update_skill,
 )
+from memtomem.context.lockfile import LockfileCorruptError
 from memtomem.context.privacy_scan import PrivacyBlockedError
 from memtomem.wiki.store import WikiStore
 
@@ -202,6 +203,25 @@ def test_not_installed_raises(wiki_root: Path, tmp_path: Path) -> None:
     msg = str(excinfo.value)
     assert "no lockfile entry" in msg
     assert "mm context install skill foo" in msg
+
+
+def test_update_over_corrupt_lockfile_names_the_lockfile(wiki_root: Path, tmp_path: Path) -> None:
+    """A corrupt lock.json used to read as "no entry" → NotInstalledError
+    pointing at install, which then raised AlreadyInstalled (dest exists) —
+    the #1247 id 16 wedge. The strict read now names the real problem, and
+    the update's lockfile upsert can no longer persist a silent reset."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+
+    install_skill(project, "foo")
+    lock_json = project / ".memtomem" / "lock.json"
+    corrupt = b"not valid json {{"
+    lock_json.write_bytes(corrupt)
+
+    with pytest.raises(LockfileCorruptError, match="lock.json"):
+        update_skill(project, "foo")
+    assert lock_json.read_bytes() == corrupt  # refusal left the file untouched
 
 
 # ── no-op invariant pin (lockfile mtime + installed_at + flag) ──────────

--- a/packages/memtomem/tests/test_lockfile.py
+++ b/packages/memtomem/tests/test_lockfile.py
@@ -2,7 +2,9 @@
 
 Covers ADR-0008 lockfile schema invariants: dict round-trip preserves
 unknown fields, sidecar lock survives concurrent writers, recovery posture
-on missing/invalid/unknown-version files.
+on missing/invalid/unknown-version files — strict (default) reads refuse a
+corrupt file so write paths can never persist a silent reset (#1247 id 16);
+only ``strict=False`` diagnostic reads degrade to the empty default.
 """
 
 from __future__ import annotations
@@ -16,6 +18,8 @@ import pytest
 from memtomem.context.lockfile import (
     LOCKFILE_VERSION,
     Lockfile,
+    LockfileCorruptError,
+    LockfileError,
     LockfileVersionError,
 )
 
@@ -29,20 +33,54 @@ def test_load_missing_returns_default_v1(tmp_path: Path) -> None:
     assert doc == {"version": LOCKFILE_VERSION}
 
 
-def test_load_invalid_json_recovers_to_default(tmp_path: Path) -> None:
+def test_load_invalid_json_raises_when_strict(tmp_path: Path) -> None:
     project = tmp_path
     (project / ".memtomem").mkdir()
     (project / ".memtomem" / "lock.json").write_text("not valid json {{", encoding="utf-8")
     lock = Lockfile.at(project)
-    assert lock.load() == {"version": LOCKFILE_VERSION}
+    with pytest.raises(LockfileCorruptError, match="not valid JSON"):
+        lock.load()
 
 
-def test_load_top_level_not_object_recovers(tmp_path: Path) -> None:
+def test_load_invalid_utf8_raises_when_strict(tmp_path: Path) -> None:
+    """``json.loads(bytes)`` decodes before parsing — invalid UTF-8 raises
+    ``UnicodeDecodeError``, not ``JSONDecodeError``; both are the same
+    corrupt-file class (Codex design review)."""
+    project = tmp_path
+    (project / ".memtomem").mkdir()
+    (project / ".memtomem" / "lock.json").write_bytes(b"\xff")
+    lock = Lockfile.at(project)
+    with pytest.raises(LockfileCorruptError, match="not valid JSON"):
+        lock.load()
+    assert lock.load(strict=False) == {"version": LOCKFILE_VERSION}
+
+
+def test_load_top_level_not_object_raises_when_strict(tmp_path: Path) -> None:
     project = tmp_path
     (project / ".memtomem").mkdir()
     (project / ".memtomem" / "lock.json").write_text(json.dumps([1, 2, 3]), encoding="utf-8")
     lock = Lockfile.at(project)
-    assert lock.load() == {"version": LOCKFILE_VERSION}
+    with pytest.raises(LockfileCorruptError, match="not a JSON object"):
+        lock.load()
+
+
+def test_load_corrupt_recovers_to_default_when_not_strict(tmp_path: Path) -> None:
+    project = tmp_path
+    (project / ".memtomem").mkdir()
+    lock_json = project / ".memtomem" / "lock.json"
+    lock = Lockfile.at(project)
+
+    lock_json.write_text("not valid json {{", encoding="utf-8")
+    assert lock.load(strict=False) == {"version": LOCKFILE_VERSION}
+
+    lock_json.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    assert lock.load(strict=False) == {"version": LOCKFILE_VERSION}
+
+
+def test_corrupt_and_version_errors_share_lockfile_error_base() -> None:
+    """Degrading surfaces (status, CLI) catch the base in one clause."""
+    assert issubclass(LockfileCorruptError, LockfileError)
+    assert issubclass(LockfileVersionError, LockfileError)
 
 
 def test_load_unknown_version_raises_when_strict(tmp_path: Path) -> None:
@@ -307,3 +345,91 @@ def test_upsert_without_manifest_preserves_existing_manifest_keys(tmp_path: Path
     assert entry["files"] == ["SKILL.md"]
     assert entry["files_commit"] == "a" * 40  # now stale — guard ignores it
     assert entry["wiki_commit"] == "b" * 40
+
+
+# ── corrupt-file write refusal (#1247 id 16) ─────────────────────────────
+
+
+def test_upsert_over_corrupt_file_refuses_and_preserves_bytes(tmp_path: Path) -> None:
+    """A corrupt lockfile (e.g. git merge-conflict markers in a tracked
+    ``.memtomem/``) must refuse the upsert — pre-fix, the tolerant load
+    reset the doc and the write persisted it with ONLY the new entry,
+    wiping every sibling asset's install record."""
+    lock = Lockfile.at(tmp_path)
+    lock.upsert_entry(
+        "skills", "alpha", wiki_commit="a" * 40, installed_at="2026-01-01T00:00:00.000000Z"
+    )
+    lock.upsert_entry(
+        "agents", "beta", wiki_commit="b" * 40, installed_at="2026-01-02T00:00:00.000000Z"
+    )
+
+    corrupt = b'<<<<<<< HEAD\n{"version": 1}\n=======\n'
+    lock.path.write_bytes(corrupt)
+
+    with pytest.raises(LockfileCorruptError, match="not valid JSON"):
+        lock.upsert_entry(
+            "skills", "gamma", wiki_commit="c" * 40, installed_at="2026-01-03T00:00:00.000000Z"
+        )
+    assert lock.path.read_bytes() == corrupt  # refusal left the file byte-identical
+
+
+def test_upsert_transient_oserror_refuses_and_siblings_survive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One transient read failure (AV scanner / EACCES) during the in-lock
+    load must refuse the upsert — pre-fix it silently re-baselined and the
+    written file contained only the new entry."""
+    lock = Lockfile.at(tmp_path)
+    lock.upsert_entry(
+        "skills", "alpha", wiki_commit="a" * 40, installed_at="2026-01-01T00:00:00.000000Z"
+    )
+    lock.upsert_entry(
+        "skills", "beta", wiki_commit="b" * 40, installed_at="2026-01-02T00:00:00.000000Z"
+    )
+
+    real_read_bytes = Path.read_bytes
+    tripped = {"done": False}
+
+    def flaky_read_bytes(self: Path) -> bytes:
+        if self == lock.path and not tripped["done"]:
+            tripped["done"] = True
+            raise PermissionError(13, "transient access denied", str(self))
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", flaky_read_bytes)
+    with pytest.raises(LockfileCorruptError, match="unreadable"):
+        lock.upsert_entry(
+            "skills", "gamma", wiki_commit="c" * 40, installed_at="2026-01-03T00:00:00.000000Z"
+        )
+
+    doc = lock.load()
+    assert set(doc["skills"]) == {"alpha", "beta"}  # siblings survived the refusal
+
+
+def test_remove_entry_over_corrupt_file_refuses(tmp_path: Path) -> None:
+    project = tmp_path
+    (project / ".memtomem").mkdir()
+    corrupt = b"not valid json {{"
+    lock_json = project / ".memtomem" / "lock.json"
+    lock_json.write_bytes(corrupt)
+    lock = Lockfile.at(project)
+
+    with pytest.raises(LockfileCorruptError):
+        lock.remove_entry("skills", "anything")
+    assert lock_json.read_bytes() == corrupt
+
+
+def test_read_paths_raise_over_corrupt_file(tmp_path: Path) -> None:
+    """``read_entry`` feeds install's already-installed check and update's
+    not-installed check; a tolerant ``None`` there produced the
+    AlreadyInstalled/NotInstalled wedge where each command points at the
+    other. Raising names the real problem."""
+    project = tmp_path
+    (project / ".memtomem").mkdir()
+    (project / ".memtomem" / "lock.json").write_text("not valid json {{", encoding="utf-8")
+    lock = Lockfile.at(project)
+
+    with pytest.raises(LockfileCorruptError):
+        lock.read_entry("skills", "foo")
+    with pytest.raises(LockfileCorruptError):
+        list(lock.iter_entries())

--- a/packages/memtomem/tests/test_web_routes_context_projects.py
+++ b/packages/memtomem/tests/test_web_routes_context_projects.py
@@ -776,3 +776,61 @@ async def test_patch_label_and_enabled_together(client, tmp_path: Path) -> None:
     assert scope["label"] == "Both"
     assert scope["enabled"] is False
     assert scope["sync_eligible"] is False
+
+
+# ── corrupt known_projects.json → 500, never re-baselined (#1247 id 16) ──
+
+
+CORRUPT_STORE_VARIANTS = [
+    pytest.param(b"not valid {json", id="invalid-json"),
+    pytest.param(b'{"version": 999, "projects": []}', id="future-version"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("corrupt", CORRUPT_STORE_VARIANTS)
+async def test_post_over_corrupt_store_500_preserves_bytes(
+    client, known_projects_path: Path, tmp_path: Path, corrupt: bytes
+) -> None:
+    """Registering over a corrupt store must 500 and leave the file alone —
+    pre-fix, ``add()`` re-baselined the registered-project list to just the
+    new entry."""
+    await _register(client, tmp_path / "existing")
+    known_projects_path.write_bytes(corrupt)
+
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / ".claude").mkdir()
+    resp = await client.post("/api/context/known-projects", json={"root": str(other)})
+    assert resp.status_code == 500, resp.text
+    assert known_projects_path.read_bytes() == corrupt
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("corrupt", CORRUPT_STORE_VARIANTS)
+async def test_patch_over_corrupt_store_500_preserves_bytes(
+    client, known_projects_path: Path, tmp_path: Path, corrupt: bytes
+) -> None:
+    """All three PATCH shapes 500 over a corrupt store (not a misleading
+    404) and never write."""
+    sid = await _register(client, tmp_path / "proj")
+    known_projects_path.write_bytes(corrupt)
+
+    for payload in ({"label": "x"}, {"enabled": False}, {"label": "x", "enabled": False}):
+        resp = await client.patch(f"/api/context/known-projects/{sid}", json=payload)
+        assert resp.status_code == 500, f"{payload}: {resp.text}"
+    assert known_projects_path.read_bytes() == corrupt
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("corrupt", CORRUPT_STORE_VARIANTS)
+async def test_delete_over_corrupt_store_500_preserves_bytes(
+    client, known_projects_path: Path, tmp_path: Path, corrupt: bytes
+) -> None:
+    """DELETE over a corrupt store is a server error, not "already gone"."""
+    sid = await _register(client, tmp_path / "proj")
+    known_projects_path.write_bytes(corrupt)
+
+    resp = await client.delete(f"/api/context/known-projects/{sid}")
+    assert resp.status_code == 500, resp.text
+    assert known_projects_path.read_bytes() == corrupt

--- a/packages/memtomem/tests/test_web_routes_context_projects.py
+++ b/packages/memtomem/tests/test_web_routes_context_projects.py
@@ -784,6 +784,7 @@ async def test_patch_label_and_enabled_together(client, tmp_path: Path) -> None:
 CORRUPT_STORE_VARIANTS = [
     pytest.param(b"not valid {json", id="invalid-json"),
     pytest.param(b'{"version": 999, "projects": []}', id="future-version"),
+    pytest.param(b'{"version": 1, "projects": {"root": "/old"}}', id="projects-not-list"),
 ]
 
 


### PR DESCRIPTION
## Summary

#1247 backlog **B3 — id 16** (confirmed major): a corrupt or transiently unreadable `lock.json` / `known_projects.json` was silently re-baselined to an empty doc by the tolerant `load()`, and the very next mutation **persisted the reset** — wiping every sibling asset's install record (lockfile) or the whole registered-project list (known-projects). A corrupt lockfile also wedged the CLI: `mm context update` said *NotInstalled → run install*, `mm context install` said *AlreadyInstalled → run update*.

The codebase already raised on version mismatch for exactly this clobber hazard (`LockfileVersionError`, "silent reset would clobber a forward-compatible lockfile"); corrupt/unreadable was the one silent exception. This PR makes the posture consistent: **strict reads (every write path) refuse; diagnostic reads degrade; nothing re-baselines.**

## Changes

- **`context/lockfile.py`** — new `LockfileError` base + `LockfileCorruptError`. `load(strict=True)` (default) raises on unreadable (`OSError` ≠ missing), invalid JSON, invalid UTF-8 (`json.loads(bytes)` decodes before parsing — raises `UnicodeDecodeError`, not `JSONDecodeError`), and non-object top level. `strict=False` keeps the tolerant empty-doc fallback; a *missing* file stays the write-safe default in both modes. No rename-aside/quarantine — refuse + recovery hint only.
- **`context/status.py`** — `load_with_recovery` / `_tolerant_iter_entries` catch the `LockfileError` base: `mm context status` renders the error row + exits 1 on corrupt JSON the same way it already did for version mismatch (no traceback).
- **`cli/context_cmd.py`** — the three `except LockfileVersionError` arms widen to `LockfileError`: install/update/install `--all` produce a clean ClickException naming the lockfile, breaking the install/update wedge.
- **`context/install.py`** — the multi-project classify arm widens to `LockfileError` → per-project `state="error"` row; the install `--all` restore upsert can no longer wipe a corrupt project's lockfile.
- **`context/projects.py`** — new `KnownProjectsCorruptError`; `load(strict=True)` used by all three mutators (`add`, `remove_by_scope_id`, `update_entry_by_scope_id`). Version mismatch folds in: `_write` re-renders at the current version, so mutating a future-version file is the same hazard. Read-only discovery keeps the tolerant `[]`.
- **`web/routes/context_projects.py`** — known-projects POST/PATCH/DELETE catch the corrupt error → **500** with the hint (server-side state, not client error) instead of re-baselining (POST) or a misleading 404 (PATCH/DELETE).
- **`docs/adr/0008-wiki-layer.md`** — records the refuse-don't-rebaseline posture under "Lockfile schema".

Non-changes, verified: `remove_entry` / known-projects removers never persisted the reset (no write on no-match); `migrate.py`'s lockfile bookkeeping already wraps `remove_entry` in best-effort catch-and-warn; all in-tree `is_asset_dirty` callers pass `lock_entry=` explicitly.

## Tests

New tests across 6 files (parametrized; 28 new cases); **all pre-fix-fail validated by mutation** (strict branches reverted to tolerant → every strict-dependent test fails on its DID-NOT-RAISE / status-code / byte-preservation assertion, none on imports alone):

- `test_lockfile.py` — upsert over merge-conflict garbage refuses + bytes byte-identical; transient `PermissionError` during the in-lock read refuses + siblings survive; remove/read/iter raise; invalid-UTF-8; strict/tolerant load matrix; error-hierarchy pin.
- `test_context_projects.py` — `add` over invalid-JSON / invalid-UTF-8 / future-version / non-list-`projects` / non-object-row / row-without-root refuses + bytes preserved (parametrized); remove + all three update shapes refuse; tolerant degrade on non-list `projects` (the non-iterable case used to crash with TypeError).
- `test_web_routes_context_projects.py` — POST/PATCH(label-only, enabled-only, combined)/DELETE over corrupt + future-version + non-list-`projects` stores → 500, bytes preserved.
- `test_context_install.py` / `test_context_update.py` — the wedge pin: corrupt lockfile now raises `LockfileCorruptError` naming `lock.json` instead of `AlreadyInstalledError`/`NotInstalledError`.
- `test_context_status.py` — corrupt-JSON status degrades (error row, exit 1, no traceback), matching the existing version-mismatch behavior.

Full suite: 6276 passed; the only 4 failures are `test_session_tracing.py` items that fail identically on a clean origin/main tree (pre-existing #1249 isolation gap / known suite-combination flake — verified by stash + re-run). `ruff check` + `ruff format --check` clean; mypy advisory — 2 pre-existing arg-type errors in the route file, untouched by this change.

## Review

- Codex **design** round: NEEDS-FIX (no blockers) — both majors addressed: `update_entry_by_scope_id` made strict + PATCH route handling/tests; `UnicodeDecodeError` treated as corrupt in both stores. All five design open questions resolved as proposed (shared base class; folded version error for the projects store; HTTP 500; `read_entry` raises; migrate keeps catch-and-warn).
- Codex **implementation** round: NEEDS-FIX (no blockers) — prior majors confirmed closed; one new major (strict mode still re-baselined a version-1 doc whose `projects` member is not a list) fixed in the follow-up commit, extended to unrepresentable rows for the same persist-the-loss reason.

Refs #1247 (backlog id 16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
