### PR TITLE
fix(context): harden sync engine — name dedupe, atomic project-memory writes, on_drop surface (#1247 B4)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import click
 
 from memtomem.context import versioning
+from memtomem.context._atomic import atomic_write_text
 from memtomem.context.agents import (
     AGENT_DIR_FILENAME,
     ON_DROP_LEVELS,
@@ -869,7 +870,11 @@ def init_cmd(
                         sections[key] = val
 
         ctx_path.parent.mkdir(parents=True, exist_ok=True)
-        ctx_path.write_text(sections_to_markdown(sections), encoding="utf-8")
+        # Atomic write (#1247 id 19): a crash mid-write must not truncate the
+        # canonical context.md — unlike the runtime fan-out targets it is NOT
+        # regenerable. 0o644: project file meant to be read (and committed)
+        # by other tools, not a 0o600 state file.
+        atomic_write_text(ctx_path, sections_to_markdown(sections), 0o644)
         click.secho(f"Created {CONTEXT_FILENAME}", fg="green")
         click.echo(f"  Sections: {', '.join(sections.keys())}")
         click.echo("  Edit this file, then run 'mm context generate' to sync.")
@@ -1005,7 +1010,9 @@ def generate_cmd(
                 content = gen.generate(sections)
                 out_path = root / gen.output_path
                 out_path.parent.mkdir(parents=True, exist_ok=True)
-                out_path.write_text(content, encoding="utf-8")
+                # Atomic write (#1247 id 19): crash mid-write must not
+                # truncate the user's CLAUDE.md / GEMINI.md / etc.
+                atomic_write_text(out_path, content, 0o644)
                 click.echo(f"  {name:10s}  {gen.output_path}")
     elif not inc:
         click.secho(f"{CONTEXT_FILENAME} not found. Run 'mm context init' first.", fg="red")
@@ -1187,7 +1194,9 @@ def sync_cmd(
 
                     content = gen.generate(sections)
                     out_path = root / gen.output_path
-                    out_path.write_text(content, encoding="utf-8")
+                    # Atomic write (#1247 id 19): crash mid-write must not
+                    # truncate the user's CLAUDE.md / GEMINI.md / etc.
+                    atomic_write_text(out_path, content, 0o644)
                     click.echo(f"  {agent_name:10s}  {gen.output_path}")
             else:
                 click.echo(

--- a/packages/memtomem/src/memtomem/context/_skip_reasons.py
+++ b/packages/memtomem/src/memtomem/context/_skip_reasons.py
@@ -39,6 +39,15 @@ LOCK_TIMEOUT: Final = "lock_timeout"
 # conflicting path so the user can remove it (or add a SKILL.md) and re-run.
 TARGET_CONFLICT: Final = "target_conflict"
 
+# Two canonical files (different stems) declare the same frontmatter ``name:``.
+# ``out_path`` is a pure function of (target, name), so both would land on the
+# SAME runtime file — last-writer-wins with both writes reported as generated
+# (#1247). ``sync_atomic_artifact`` keeps the first-seen canonical (sorted
+# order, deterministic) and emits this typed skip for every later claimant.
+# The human reason names both source paths so the user can rename one.
+# Loud emit, not silent — feedback_defensive_noise.md.
+DUPLICATE_NAME: Final = "duplicate_name"
+
 # Import (runtime → canonical) skip codes.
 INVALID_NAME: Final = "invalid_name"
 ALREADY_IMPORTED: Final = "already_imported"
@@ -75,6 +84,7 @@ SkipCode = Literal[
     "no_project_fanout_for_runtime",
     "lock_timeout",
     "target_conflict",
+    "duplicate_name",
     "invalid_name",
     "already_imported",
     "canonical_exists",

--- a/packages/memtomem/src/memtomem/context/_sync_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_sync_atomic.py
@@ -62,7 +62,23 @@ class StrictDropError(ValueError):
     — an ``except agents.StrictDropError`` block does NOT catch a commands
     raise. The engine raises ``adapter.strict_drop_error_type`` which each
     adapter sets to its own subclass.
+
+    ``generated`` carries the ``(runtime, target_file)`` writes that landed
+    BEFORE the raise — the #908 partial-write boundary fires mid-Phase-2, so
+    surfaces (web 422, #1247 id 47) can report which runtime files already
+    changed instead of an opaque error. Keyword-optional with a ``None``
+    default: the class is public API (re-exported by both artifact modules)
+    and one-arg construction must keep working.
     """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        generated: list[tuple[str, Path]] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.generated: list[tuple[str, Path]] = list(generated or [])
 
 
 # Valid severity levels for the ``on_drop`` parameter.
@@ -249,6 +265,21 @@ def sync_atomic_artifact(
     # disk and the scan→write TOCTOU window stays closed.
     pending: list[tuple[str, str, AtomicGenerator[T], T, Path, bytes | None]] = []
 
+    # Frontmatter-name dedupe (#1247): ``out_path`` is a pure function of
+    # (target, name), so two canonicals (different stems) declaring the same
+    # ``name:`` would both queue for the SAME runtime file — silent
+    # last-writer-wins, with both writes reported in ``generated`` and the
+    # loser invisible on every surface (diff keys canonicals by parsed name
+    # too). Track the first canonical to claim each name across the whole
+    # fan-out; later claimants from a *different* source path get a typed
+    # ``DUPLICATE_NAME`` skip per target (matching the per-(target, item)
+    # convention of the parse/privacy skips above) plus a once-per-loser
+    # warning. First-seen wins: ``list_canonical`` returns sorted order, so
+    # the winner is deterministic. Same-name flat-vs-dir pairs never reach
+    # here — ``list_canonical`` already collapses those (dir wins).
+    name_owner: dict[str, Path] = {}
+    duplicates_warned: set[Path] = set()
+
     for target in targets:
         gen = adapter.generators.get(target)
         if gen is None:
@@ -350,6 +381,34 @@ def sync_atomic_artifact(
                 )
                 skipped.append((name, reason, code))
                 continue
+            # Frontmatter-name dedupe (#1247) — deliberately AFTER the Gate A
+            # scan, so a secret-bearing duplicate loser still trips the
+            # project_shared all-or-nothing raise (the dedupe must not become
+            # a privacy bypass for canonical bytes), and AFTER the no-fanout
+            # check, so that contract's skip rows are unchanged for duplicate
+            # losers too. BEFORE override resolution — the loser never
+            # writes, and the colliding name resolves the SAME override file
+            # the winner's pass already scans, so no scan surface is lost.
+            owner = name_owner.setdefault(name, item_path)
+            if owner != item_path:
+                if item_path not in duplicates_warned:
+                    duplicates_warned.add(item_path)
+                    adapter.logger.warning(
+                        "duplicate %s name %r: %s already provides it; skipping %s",
+                        adapter.kind,
+                        name,
+                        owner,
+                        item_path,
+                    )
+                skipped.append(
+                    (
+                        name,
+                        f"duplicate name {name!r}: already provided by {owner}; "
+                        f"skipping {item_path}",
+                        skip_codes.DUPLICATE_NAME,
+                    )
+                )
+                continue
             # Resolve per-vendor override and scan its bytes — read once,
             # scan once, hand the bytes to Phase 2. Same TOCTOU close as
             # canonical above.
@@ -412,14 +471,18 @@ def sync_atomic_artifact(
     # which raises before any write; (b) user / project_local partial writes are
     # an intentional contract pinned by ``test_strict_drop_preserves_earlier_writes``
     # (#908); and (c) each ``out_path`` is written exactly once via a single
-    # atomic ``os.replace`` (below), so per-file writes are idempotent /
-    # last-writer-wins with no torn cross-file state to protect (#1123 B3-1).
+    # atomic ``os.replace`` (below), so per-file writes are idempotent with
+    # no torn cross-file state to protect (#1123 B3-1). The exactly-once
+    # part is enforced by the Phase 1 duplicate-name dedupe (#1247) — before
+    # it, two canonicals sharing a frontmatter name queued the same
+    # ``out_path`` twice.
     for target, name, gen, item, out_path, override_bytes in pending:
         content, dropped_fields = gen.render(item)
         if dropped_fields:
             if effective_drop == "error":
                 raise adapter.strict_drop_error_type(
-                    f"strict mode: {target} would drop {dropped_fields} from '{name}'"
+                    f"strict mode: {target} would drop {dropped_fields} from '{name}'",
+                    generated=generated,
                 )
             if effective_drop == "warn":
                 adapter.logger.warning("%s dropped %s from '%s'", target, dropped_fields, name)

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -1038,7 +1038,22 @@ def diff_agents(
             parse_failures[fallback_name] = str(exc)
             logger.warning("canonical agent %s failed to parse: %s", path, exc)
         else:
-            canonical_index[parsed.name] = parsed
+            # First-parsed-wins on a frontmatter-name collision, matching the
+            # sync engine's duplicate-name dedupe (#1247) — last-wins here
+            # would diff the runtime file against the canonical sync never
+            # wrote, reporting permanent phantom drift. The loser surfaces in
+            # the sync result as a ``duplicate_name`` skip, not as a diff row
+            # (flat-vs-dir precedent: log-only in diff). A ``None`` entry
+            # (parse-failure fallback name) stays overwritable — pre-existing
+            # interplay, unchanged.
+            if canonical_index.get(parsed.name) is not None:
+                logger.warning(
+                    "duplicate agent name %r: keeping first-seen canonical, ignoring %s",
+                    parsed.name,
+                    path,
+                )
+            else:
+                canonical_index[parsed.name] = parsed
     canonical_names = set(canonical_index)
 
     for gen_name, gen in AGENT_GENERATORS.items():

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -1030,12 +1030,21 @@ def diff_agents(
             text = path.read_bytes().decode("utf-8", errors="replace")
             parsed = _parse_canonical_agent_text(text, source=path, layout=layout)
         except OSError as exc:
-            canonical_index[fallback_name] = None
-            parse_failures[fallback_name] = f"unreadable: {exc}"
+            # Same first-parsed-wins precedence as below (#1247 Codex impl
+            # round): a fallback-name entry must not SHADOW an earlier
+            # successfully parsed canonical that claimed the same effective
+            # name — sync writes that name fine (the unreadable file never
+            # claims a name there), so a None overwrite here would report
+            # permanent phantom "parse error" drift no sync can clear. The
+            # warning below still fires, so the broken file stays loud.
+            if canonical_index.get(fallback_name) is None:
+                canonical_index[fallback_name] = None
+                parse_failures[fallback_name] = f"unreadable: {exc}"
             logger.warning("canonical agent %s unreadable: %s", path, exc)
         except AgentParseError as exc:
-            canonical_index[fallback_name] = None
-            parse_failures[fallback_name] = str(exc)
+            if canonical_index.get(fallback_name) is None:
+                canonical_index[fallback_name] = None
+                parse_failures[fallback_name] = str(exc)
             logger.warning("canonical agent %s failed to parse: %s", path, exc)
         else:
             # First-parsed-wins on a frontmatter-name collision, matching the

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -50,6 +50,7 @@ from memtomem.context._runtime_targets import (
     runtime_fanout_root,
 )
 from memtomem.context._sync_atomic import (
+    ON_DROP_LEVELS,
     AtomicSyncAdapter,
     AtomicSyncResult,
     StrictDropError as _EngineStrictDropError,
@@ -811,7 +812,16 @@ def diff_commands(
             parse_failures[fallback_name] = str(exc)
             logger.warning("canonical command %s failed to parse: %s", path, exc)
         else:
-            canonical_index[parsed.name] = parsed
+            # First-parsed-wins on a frontmatter-name collision, matching the
+            # sync engine's duplicate-name dedupe (#1247) — see diff_agents.
+            if canonical_index.get(parsed.name) is not None:
+                logger.warning(
+                    "duplicate command name %r: keeping first-seen canonical, ignoring %s",
+                    parsed.name,
+                    path,
+                )
+            else:
+                canonical_index[parsed.name] = parsed
     canonical_names = set(canonical_index)
 
     for gen_name, gen in COMMAND_GENERATORS.items():
@@ -917,6 +927,7 @@ __all__ = [
     "CommandSyncResult",
     "ExtractResult",
     "GeminiCommandsGenerator",
+    "ON_DROP_LEVELS",
     "SlashCommand",
     "StrictDropError",
     "canonical_command_name",

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -804,12 +804,17 @@ def diff_commands(
             text = path.read_bytes().decode("utf-8", errors="replace")
             parsed = _parse_canonical_command_text(text, source=path, layout=layout)
         except OSError as exc:
-            canonical_index[fallback_name] = None
-            parse_failures[fallback_name] = f"unreadable: {exc}"
+            # First-parsed-wins guard — see diff_agents (#1247 Codex impl
+            # round): a fallback-name entry must not shadow an earlier
+            # successfully parsed canonical claiming the same name.
+            if canonical_index.get(fallback_name) is None:
+                canonical_index[fallback_name] = None
+                parse_failures[fallback_name] = f"unreadable: {exc}"
             logger.warning("canonical command %s unreadable: %s", path, exc)
         except CommandParseError as exc:
-            canonical_index[fallback_name] = None
-            parse_failures[fallback_name] = str(exc)
+            if canonical_index.get(fallback_name) is None:
+                canonical_index[fallback_name] = None
+                parse_failures[fallback_name] = str(exc)
             logger.warning("canonical command %s failed to parse: %s", path, exc)
         else:
             # First-parsed-wins on a frontmatter-name collision, matching the

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -201,6 +201,7 @@ async def mem_context_init(
             hard-refuses unsafe imports.
     """
     from memtomem.context import _skip_reasons as skip_codes
+    from memtomem.context._atomic import atomic_write_text
     from memtomem.context.agents import (
         canonical_agent_name,
         extract_agents_to_canonical,
@@ -288,10 +289,15 @@ async def mem_context_init(
                         sections[key] = val
 
         ctx_path.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic write (#1247 id 19): a crash mid-write must not truncate
+        # the canonical context.md — unlike the runtime fan-out targets it
+        # is NOT regenerable. 0o644: project file meant to be read (and
+        # committed) by other tools, not a 0o600 state file.
         await asyncio.to_thread(
-            ctx_path.write_text,
+            atomic_write_text,
+            ctx_path,
             sections_to_markdown(sections),
-            encoding="utf-8",
+            0o644,
         )
         results.append(f"Created {CONTEXT_FILENAME}")
         results.append(f"  Sections: {', '.join(sections.keys())}")
@@ -557,6 +563,7 @@ async def mem_context_generate(
             with ``allow_host_writes=True`` after surfacing the host
             paths to the user.
     """
+    from memtomem.context._atomic import atomic_write_text
     from memtomem.context.agents import StrictDropError, generate_all_agents
     from memtomem.context.commands import (
         StrictDropError as CommandStrictDropError,
@@ -588,7 +595,9 @@ async def mem_context_generate(
                 content = gen.generate(sections)
                 out_path = root / gen.output_path
                 out_path.parent.mkdir(parents=True, exist_ok=True)
-                await asyncio.to_thread(out_path.write_text, content, encoding="utf-8")
+                # Atomic write (#1247 id 19): crash mid-write must not
+                # truncate the user's CLAUDE.md / GEMINI.md / etc.
+                await asyncio.to_thread(atomic_write_text, out_path, content, 0o644)
                 results.append(f"{name}: {gen.output_path}")
         else:
             results.append(f"{CONTEXT_FILENAME} is empty.")
@@ -877,6 +886,7 @@ async def mem_context_sync(
     flat-layout artifact is isolated as a per-artifact ``skipped`` row, never a
     whole-run error. Mirrors the CLI ``mm context sync --label``.
     """
+    from memtomem.context._atomic import atomic_write_text
     from memtomem.context.agents import StrictDropError, generate_all_agents
     from memtomem.context.commands import (
         StrictDropError as CommandStrictDropError,
@@ -918,7 +928,9 @@ async def mem_context_sync(
                         continue
                     content = gen.generate(sections)
                     out_path = root / gen.output_path
-                    await asyncio.to_thread(out_path.write_text, content, encoding="utf-8")
+                    # Atomic write (#1247 id 19): crash mid-write must not
+                    # truncate the user's CLAUDE.md / GEMINI.md / etc.
+                    await asyncio.to_thread(atomic_write_text, out_path, content, 0o644)
                     results.append(f"{f.agent}: {gen.output_path}")
                     agents_synced.add(f.agent)
             elif not inc:

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from memtomem.config import TargetScope
 from memtomem.context import versioning
@@ -19,7 +19,9 @@ from memtomem.context.agents import (
     AGENT_DIR_FILENAME,
     AGENT_GENERATORS,
     CANONICAL_AGENT_ROOT,
+    ON_DROP_LEVELS,
     AgentParseError,
+    StrictDropError,
     SubAgent,
     _parse_canonical_agent_text,
     canonical_agent_name,
@@ -559,6 +561,19 @@ async def diff_agent(
 class SyncRequest(BaseModel):
     on_drop: str = "warn"
 
+    # An out-of-vocabulary value used to slip through to the engine, where it
+    # silently behaved as "ignore" (#1247 id 47) — reject at the boundary
+    # instead (FastAPI renders the ValueError as a native 422). Validates
+    # against the engine's ON_DROP_LEVELS so the vocabulary has one owner
+    # (no Literal duplication; CLI click.Choice and MCP _validate_on_drop
+    # already gate the same way).
+    @field_validator("on_drop")
+    @classmethod
+    def _check_on_drop(cls, value: str) -> str:
+        if value not in ON_DROP_LEVELS:
+            raise ValueError(f"on_drop must be one of {ON_DROP_LEVELS}, got {value!r}")
+        return value
+
 
 @router.post("/context/agents/sync")
 async def sync_agents(
@@ -585,6 +600,23 @@ async def sync_agents(
         # bypass valve, so the user must remove the secret or migrate the
         # artifact to a writable tier (the message body explains how).
         raise HTTPException(422, exc.message) from exc
+    except StrictDropError as exc:
+        # on_drop="error" aborts mid-Phase-2 with earlier writes persisted
+        # (the #908 partial-write boundary). Surface the partial fan-out
+        # instead of an opaque 500 (#1247 id 47): the detail dict follows
+        # the #1210 ``{reason_code, message}`` shape the JS error path
+        # already renders, plus the writes that landed before the abort.
+        # API-only reachability — the UI never sends on_drop="error".
+        raise HTTPException(
+            422,
+            detail={
+                "reason_code": "strict_drop",
+                "message": str(exc),
+                "generated": [
+                    {"runtime": rt, "path": _safe_rel(p, project_root)} for rt, p in exc.generated
+                ],
+            },
+        ) from exc
 
     return {
         "generated": [

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from memtomem.config import TargetScope
 from memtomem.context import versioning
@@ -20,7 +20,9 @@ from memtomem.context.commands import (
     CANONICAL_COMMAND_ROOT,
     COMMAND_DIR_FILENAME,
     COMMAND_GENERATORS,
+    ON_DROP_LEVELS,
     CommandParseError,
+    StrictDropError,
     canonical_command_name,
     diff_commands,
     extract_commands_to_canonical,
@@ -552,6 +554,19 @@ async def diff_command(
 class SyncRequest(BaseModel):
     on_drop: str = "warn"
 
+    # An out-of-vocabulary value used to slip through to the engine, where it
+    # silently behaved as "ignore" (#1247 id 47) — reject at the boundary
+    # instead (FastAPI renders the ValueError as a native 422). Validates
+    # against the engine's ON_DROP_LEVELS so the vocabulary has one owner
+    # (no Literal duplication; CLI click.Choice and MCP _validate_on_drop
+    # already gate the same way).
+    @field_validator("on_drop")
+    @classmethod
+    def _check_on_drop(cls, value: str) -> str:
+        if value not in ON_DROP_LEVELS:
+            raise ValueError(f"on_drop must be one of {ON_DROP_LEVELS}, got {value!r}")
+        return value
+
 
 @router.post("/context/commands/sync")
 async def sync_commands(
@@ -574,6 +589,23 @@ async def sync_commands(
         raise HTTPException(503, "Commands sync timed out — another sync may be in progress")
     except PrivacyScanError as exc:
         raise HTTPException(422, exc.message) from exc
+    except StrictDropError as exc:
+        # on_drop="error" aborts mid-Phase-2 with earlier writes persisted
+        # (the #908 partial-write boundary). Surface the partial fan-out
+        # instead of an opaque 500 (#1247 id 47): the detail dict follows
+        # the #1210 ``{reason_code, message}`` shape the JS error path
+        # already renders, plus the writes that landed before the abort.
+        # API-only reachability — the UI never sends on_drop="error".
+        raise HTTPException(
+            422,
+            detail={
+                "reason_code": "strict_drop",
+                "message": str(exc),
+                "generated": [
+                    {"runtime": rt, "path": _safe_rel(p, project_root)} for rt, p in exc.generated
+                ],
+            },
+        ) from exc
     return {
         "generated": [
             {"runtime": rt, "path": _safe_rel(p, project_root)} for rt, p in result.generated

--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -355,6 +355,36 @@ class TestDuplicateAgentName:
         assert rows, "expected diff rows for the colliding name"
         assert {r[2] for r in rows} == {"in sync"}
 
+    def test_parse_failure_does_not_shadow_parsed_name_in_diff(self, tmp_path, codex_home):
+        """Codex impl round (#1247 B4): a later malformed canonical whose
+        FALLBACK name (stem) collides with an earlier parsed ``name:`` must
+        not overwrite the parsed entry with a parse-error row. Sync writes
+        that name fine — the malformed file never claims a name there — so
+        the shadowed row would be permanent phantom "parse error" drift no
+        sync can clear. The malformed file stays loud via the warning log."""
+        _make_canonical_agent(tmp_path, "aaa", SAMPLE_MINIMAL_AGENT.replace("helper", "shared"))
+        _make_canonical_agent(tmp_path, "shared", "no frontmatter at all\n")
+        generate_all_agents(tmp_path)
+
+        rows = [r for r in diff_agents(tmp_path) if r[1] == "shared"]
+        assert rows, "expected diff rows for the shared name"
+        assert {r[2] for r in rows} == {"in sync"}
+
+    def test_parsed_name_recovers_parse_failure_fallback_in_diff(self, tmp_path, codex_home):
+        """Reverse order of the shadow case: the malformed file registers its
+        fallback name FIRST, then a later canonical parses to the same name.
+        The parsed entry wins (pre-existing overwrite-None behavior, now
+        load-bearing for the sync alignment): sync writes the name from the
+        parsed file, so diff must compare against it — not report a stale
+        parse-error row."""
+        _make_canonical_agent(tmp_path, "shared", "no frontmatter at all\n")
+        _make_canonical_agent(tmp_path, "zzz", SAMPLE_MINIMAL_AGENT.replace("helper", "shared"))
+        generate_all_agents(tmp_path)
+
+        rows = [r for r in diff_agents(tmp_path) if r[1] == "shared"]
+        assert rows, "expected diff rows for the shared name"
+        assert {r[2] for r in rows} == {"in sync"}
+
 
 class TestExtractAgentsToCanonical:
     def test_imports_claude_agent(self, tmp_path):

--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -308,6 +308,54 @@ class TestStrictMode:
         assert list(runtime_dir.glob(".beta-full.md.*.tmp")) == []
 
 
+class TestDuplicateAgentName:
+    """Two canonicals (different stems) declaring the same frontmatter
+    ``name:`` (#1247): the engine keeps the first-seen canonical (sorted
+    order) and emits a typed ``duplicate_name`` skip for the later claimant
+    instead of silently last-writer-winning the shared runtime file.
+    """
+
+    def _seed_collision(self, project_root):
+        body = SAMPLE_MINIMAL_AGENT.replace("helper", "code-reviewer")
+        winner = _make_canonical_agent(
+            project_root, "a-reviewer", body.replace("Help with things.", "Body from A.")
+        )
+        loser = _make_canonical_agent(
+            project_root, "b-reviewer", body.replace("Help with things.", "Body from B.")
+        )
+        return winner, loser
+
+    def test_first_seen_wins_single_write(self, tmp_path):
+        self._seed_collision(tmp_path)
+        result = generate_all_agents(tmp_path, runtimes=["claude_agents"])
+
+        out = tmp_path / ".claude/agents/code-reviewer.md"
+        # Exactly one generated tuple — pre-fix both canonicals queued the
+        # same out_path and both writes were reported.
+        assert result.generated == [("claude_agents", out)]
+        text = out.read_text(encoding="utf-8")
+        assert "Body from A." in text
+        assert "Body from B." not in text
+
+        dup_rows = [row for row in result.skipped if row[2] == "duplicate_name"]
+        assert len(dup_rows) == 1
+        name, reason, _code = dup_rows[0]
+        assert name == "code-reviewer"
+        assert "a-reviewer.md" in reason and "b-reviewer.md" in reason
+
+    def test_post_sync_diff_reports_in_sync(self, tmp_path, codex_home):
+        """diff keys canonicals by parsed name with the SAME first-seen
+        precedence as sync — last-wins there would diff the runtime file
+        against the canonical sync never wrote, reporting permanent
+        phantom drift the user cannot clear."""
+        self._seed_collision(tmp_path)
+        generate_all_agents(tmp_path)
+
+        rows = [r for r in diff_agents(tmp_path) if r[1] == "code-reviewer"]
+        assert rows, "expected diff rows for the colliding name"
+        assert {r[2] for r in rows} == {"in sync"}
+
+
 class TestExtractAgentsToCanonical:
     def test_imports_claude_agent(self, tmp_path):
         claude_dir = tmp_path / ".claude/agents"

--- a/packages/memtomem/tests/test_context_atomic_write_guard.py
+++ b/packages/memtomem/tests/test_context_atomic_write_guard.py
@@ -1,0 +1,93 @@
+"""Architectural guard for the context-gateway atomic-write invariant.
+
+``context/_atomic.py`` states: "Every gateway write site funnels through the
+helpers in this module" — a crash between truncate and flush of a bare
+``Path.write_text`` leaves the target empty or half-written. The artifact
+fan-out families (agents, commands, skills, settings, MCP servers, web
+mutators) were converted in #283, but the invariant was docstring-only: the
+project-memory fan-out and the canonical ``context.md`` writes shipped six
+bare ``write_text`` sites that survived until the #1247 triage (id 19).
+
+This file makes the contract enforced rather than aspirational (an
+unenforced policy is no policy): AST-scan every gateway write surface for
+bare ``.write_text(`` / ``.write_bytes(`` calls. A future write site must
+either use ``atomic_write_text`` / ``atomic_write_bytes`` or be added to
+:data:`ALLOWED_BARE_WRITES` with an inline rationale — a silent gap stops
+being representable.
+
+Scope note: only production gateway write surfaces are scanned. Tests freely
+use bare writes to SEED fixtures — that is reading-side setup, not the
+crash-safety surface this guards.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+_SRC = pathlib.Path(__file__).resolve().parents[1] / "src" / "memtomem"
+
+# Methods whose bare use on a Path-like target re-opens the truncate/flush
+# crash window the atomic helpers exist to close.
+_BARE_WRITE_ATTRS = frozenset({"write_text", "write_bytes"})
+
+# ``(path relative to src/memtomem, line_function)`` pairs explicitly allowed
+# to use a bare write. Empty as of #1247 B4 — every gateway write site goes
+# through the helpers. Add an entry ONLY with an inline why (e.g. a target
+# whose partial loss is provably harmless), mirroring the DEFERRED registry
+# convention in test_validate_namespace_architectural_guard.py.
+ALLOWED_BARE_WRITES: frozenset[tuple[str, str]] = frozenset()
+
+
+def _gateway_write_files() -> list[pathlib.Path]:
+    """Every production module that writes context-gateway artifacts.
+
+    * ``context/*.py`` — the engine + per-artifact fan-out/import modules.
+    * ``cli/context_cmd.py`` / ``server/tools/context.py`` — the CLI and MCP
+      surfaces carrying the inline project-memory fan-out (#1247 id 19).
+    * ``web/routes/context_*.py`` — the web mutators.
+    """
+    files = sorted((_SRC / "context").glob("*.py"))
+    files.append(_SRC / "cli" / "context_cmd.py")
+    files.append(_SRC / "server" / "tools" / "context.py")
+    files.extend(sorted((_SRC / "web" / "routes").glob("context_*.py")))
+    return files
+
+
+def _enclosing_function(tree: ast.AST, lineno: int) -> str:
+    """Best-effort name of the function containing *lineno* (for the report)."""
+    best = "<module>"
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            end = getattr(node, "end_lineno", node.lineno)
+            if node.lineno <= lineno <= end:
+                best = node.name
+    return best
+
+
+def test_gateway_files_exist() -> None:
+    """The scan list must not silently go stale on a rename/move."""
+    for f in _gateway_write_files():
+        assert f.is_file(), f"guard scan list references a missing file: {f}"
+
+
+def test_no_bare_writes_on_gateway_surfaces() -> None:
+    # Flag ATTRIBUTE REFERENCES, not just direct calls: three of the six
+    # #1247 id-19 sites were ``asyncio.to_thread(out_path.write_text, ...)``,
+    # where ``.write_text`` is an uncalled attribute handed to the executor —
+    # a Call-only scan walks right past the exact shape being guarded.
+    offenders: list[str] = []
+    for f in _gateway_write_files():
+        tree = ast.parse(f.read_text(encoding="utf-8"))
+        rel = str(f.relative_to(_SRC))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr in _BARE_WRITE_ATTRS:
+                fn = _enclosing_function(tree, node.lineno)
+                if (rel, fn) in ALLOWED_BARE_WRITES:
+                    continue
+                offenders.append(f"{rel}:{node.lineno} ({fn}) .{node.attr}")
+    assert not offenders, (
+        "bare write on a gateway surface — use context._atomic.atomic_write_text/"
+        "atomic_write_bytes (crash mid-write must not truncate the target), or add "
+        "an ALLOWED_BARE_WRITES entry with a rationale:\n  " + "\n  ".join(offenders)
+    )

--- a/packages/memtomem/tests/test_context_commands.py
+++ b/packages/memtomem/tests/test_context_commands.py
@@ -279,6 +279,42 @@ class TestDuplicateCommandName:
         assert rows, "expected diff rows for the colliding name"
         assert {r[2] for r in rows} == {"in sync"}
 
+    # Command parse failures are narrower than agents': frontmatter-less
+    # files are tolerated (stem-named prompt body), so the only
+    # ``CommandParseError`` shape is an INVALID effective name. The shadow
+    # fixture is a file whose stem is the colliding name but whose
+    # frontmatter ``name: -bad`` fails validation.
+    _MALFORMED = "---\nname: -bad\ndescription: broken\n---\n\nBody.\n"
+
+    def test_parse_failure_does_not_shadow_parsed_name_in_diff(self, tmp_path):
+        """Sibling of the agents shadow pin (#1247 B4 Codex impl round): a
+        later malformed canonical whose stem collides with an earlier parsed
+        ``name:`` must not flip diff to a permanent parse-error row."""
+        _make_canonical_command(
+            tmp_path,
+            "aaa",
+            "---\nname: review\ndescription: Parsed claimant\n---\n\nBody from A.\n",
+        )
+        _make_canonical_command(tmp_path, "review", self._MALFORMED)
+        generate_all_commands(tmp_path)
+
+        rows = [r for r in diff_commands(tmp_path) if r[1] == "review"]
+        assert rows, "expected diff rows for the shared name"
+        assert {r[2] for r in rows} == {"in sync"}
+
+    def test_parsed_name_recovers_parse_failure_fallback_in_diff(self, tmp_path):
+        _make_canonical_command(tmp_path, "review", self._MALFORMED)
+        _make_canonical_command(
+            tmp_path,
+            "zzz",
+            "---\nname: review\ndescription: Parsed claimant\n---\n\nBody from Z.\n",
+        )
+        generate_all_commands(tmp_path)
+
+        rows = [r for r in diff_commands(tmp_path) if r[1] == "review"]
+        assert rows, "expected diff rows for the shared name"
+        assert {r[2] for r in rows} == {"in sync"}
+
 
 class TestExtractCommandsToCanonical:
     def test_imports_claude_command(self, tmp_path):

--- a/packages/memtomem/tests/test_context_commands.py
+++ b/packages/memtomem/tests/test_context_commands.py
@@ -237,6 +237,49 @@ class TestStrictMode:
         assert list(runtime_dir.glob(".beta-full.toml.*.tmp")) == []
 
 
+class TestDuplicateCommandName:
+    """Sibling of ``TestDuplicateAgentName`` (#1247) — same engine, same
+    contract: first-seen canonical wins the colliding frontmatter ``name:``,
+    later claimants get a typed ``duplicate_name`` skip.
+    """
+
+    def _seed_collision(self, project_root):
+        _make_canonical_command(
+            project_root,
+            "a-review",
+            "---\nname: review\ndescription: First claimant\n---\n\nBody from A.\n",
+        )
+        _make_canonical_command(
+            project_root,
+            "b-review",
+            "---\nname: review\ndescription: Second claimant\n---\n\nBody from B.\n",
+        )
+
+    def test_first_seen_wins_single_write(self, tmp_path):
+        self._seed_collision(tmp_path)
+        result = generate_all_commands(tmp_path, runtimes=["claude_commands"])
+
+        out = tmp_path / ".claude/commands/review.md"
+        assert result.generated == [("claude_commands", out)]
+        text = out.read_text(encoding="utf-8")
+        assert "Body from A." in text
+        assert "Body from B." not in text
+
+        dup_rows = [row for row in result.skipped if row[2] == "duplicate_name"]
+        assert len(dup_rows) == 1
+        name, reason, _code = dup_rows[0]
+        assert name == "review"
+        assert "a-review.md" in reason and "b-review.md" in reason
+
+    def test_post_sync_diff_reports_in_sync(self, tmp_path):
+        self._seed_collision(tmp_path)
+        generate_all_commands(tmp_path)
+
+        rows = [r for r in diff_commands(tmp_path) if r[1] == "review"]
+        assert rows, "expected diff rows for the colliding name"
+        assert {r[2] for r in rows} == {"in sync"}
+
+
 class TestExtractCommandsToCanonical:
     def test_imports_claude_command(self, tmp_path):
         d = tmp_path / ".claude/commands"

--- a/packages/memtomem/tests/test_context_project_memory_atomic.py
+++ b/packages/memtomem/tests/test_context_project_memory_atomic.py
@@ -1,0 +1,194 @@
+"""Mechanism pins for #1247 id 19 — project-memory writes are atomic.
+
+``context/_atomic.py`` states the invariant "Every gateway write site funnels
+through the helpers in this module", and every artifact fan-out family
+(agents, commands, skills, settings, MCP servers, web mutators) honors it —
+but the project-memory fan-out (CLAUDE.md / GEMINI.md / ...) and the canonical
+``.memtomem/context.md`` writes used bare ``Path.write_text`` on the CLI and
+MCP surfaces. A crash mid-write truncates the target; for ``context.md`` the
+loss is not even regenerable.
+
+These tests pin the MECHANISM (the write goes through ``atomic_write_text``
+with mode ``0o644``) rather than simulating a crash at the command level —
+the helper's own crash semantics are already pinned by
+``test_context_atomic.py``; patching ``os.write`` here would be global and
+brittle.
+
+Patch-site note: ``cli.context_cmd`` binds the helper at module import time
+(patch the bound name); the MCP tools import it function-locally at call time
+(patch the source module attribute). The spy fixture patches both.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+from memtomem.context._atomic import atomic_write_text as _real_atomic_write_text
+from memtomem.context.parser import CONTEXT_FILENAME
+
+from .helpers import set_home
+
+
+@pytest.fixture
+def atomic_spy(monkeypatch):
+    """Wrap-spy on ``atomic_write_text`` recording ``(path, mode)`` calls."""
+    calls: list[tuple[Path, int]] = []
+
+    def spy(path, text, mode=0o600, encoding="utf-8"):
+        calls.append((Path(path), mode))
+        _real_atomic_write_text(path, text, mode=mode, encoding=encoding)
+
+    import memtomem.cli.context_cmd as ctx_cmd
+    import memtomem.context._atomic as atomic_mod
+
+    monkeypatch.setattr(ctx_cmd, "atomic_write_text", spy)
+    monkeypatch.setattr(atomic_mod, "atomic_write_text", spy)
+    return calls
+
+
+def _spied_paths(calls: list[tuple[Path, int]]) -> list[Path]:
+    return [p for p, _mode in calls]
+
+
+def _assert_mode_644(calls: list[tuple[Path, int]], target: Path) -> None:
+    modes = {mode for p, mode in calls if p == target}
+    assert modes == {0o644}, (
+        f"{target} should be written 0o644 (readable project file), got {modes}"
+    )
+
+
+# ── CLI surface ───────────────────────────────────────────────────────
+
+
+def _runner_in_project(tmp_path, monkeypatch):
+    """Hermetic CliRunner in a seeded project (test_context_cli_exit_scope idiom)."""
+    from memtomem.cli import _bootstrap
+
+    home = tmp_path / "home"
+    home.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "pyproject.toml").write_text(
+        '[project]\nname = "atomic-pin"\nversion = "0"\n', encoding="utf-8"
+    )
+    set_home(monkeypatch, home)
+    monkeypatch.delenv("MEMTOMEM_HOOKS__TARGET_SCOPE", raising=False)
+    monkeypatch.setattr(_bootstrap, "_CONFIG_PATH", home / ".memtomem" / "config.json")
+    monkeypatch.chdir(project)
+    return CliRunner(), project
+
+
+def _ctx_with_sections(root: Path) -> None:
+    ctx = root / ".memtomem" / "context.md"
+    ctx.parent.mkdir(parents=True, exist_ok=True)
+    ctx.write_text(
+        "# Project Context\n\n## Project\n- Name: atomic-pin\n\n## Rules\n- keep\n",
+        encoding="utf-8",
+    )
+
+
+class TestCliProjectMemoryAtomic:
+    def test_init_writes_context_md_atomically(self, tmp_path, monkeypatch, atomic_spy):
+        runner, project = _runner_in_project(tmp_path, monkeypatch)
+
+        r = runner.invoke(cli, ["context", "init"])
+
+        assert r.exit_code == 0, r.output
+        ctx_path = project / ".memtomem" / "context.md"
+        assert ctx_path.is_file()
+        assert ctx_path in _spied_paths(atomic_spy)
+        _assert_mode_644(atomic_spy, ctx_path)
+
+    def test_generate_writes_project_memory_atomically(self, tmp_path, monkeypatch, atomic_spy):
+        runner, project = _runner_in_project(tmp_path, monkeypatch)
+        _ctx_with_sections(project)
+
+        r = runner.invoke(cli, ["context", "generate", "--agent", "claude"])
+
+        assert r.exit_code == 0, r.output
+        claude_md = project / "CLAUDE.md"
+        assert claude_md.is_file()
+        assert "atomic-pin" in claude_md.read_text(encoding="utf-8")
+        assert claude_md in _spied_paths(atomic_spy)
+        _assert_mode_644(atomic_spy, claude_md)
+
+    def test_sync_writes_project_memory_atomically(self, tmp_path, monkeypatch, atomic_spy):
+        runner, project = _runner_in_project(tmp_path, monkeypatch)
+        _ctx_with_sections(project)
+        # sync only refreshes DETECTED agent files — seed a stale one.
+        (project / "CLAUDE.md").write_text("stale sentinel\n", encoding="utf-8")
+
+        r = runner.invoke(cli, ["context", "sync"])
+
+        assert r.exit_code == 0, r.output
+        claude_md = project / "CLAUDE.md"
+        text = claude_md.read_text(encoding="utf-8")
+        assert "stale sentinel" not in text
+        assert "atomic-pin" in text
+        assert claude_md in _spied_paths(atomic_spy)
+        _assert_mode_644(atomic_spy, claude_md)
+
+
+# ── MCP surface ───────────────────────────────────────────────────────
+
+
+class TestMcpProjectMemoryAtomic:
+    def _setup_project(self, tmp_path, monkeypatch) -> Path:
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".git").mkdir()
+        set_home(monkeypatch, tmp_path / "home")
+        monkeypatch.chdir(project)
+        return project
+
+    @pytest.mark.anyio
+    async def test_init_writes_context_md_atomically(self, tmp_path, monkeypatch, atomic_spy):
+        from memtomem.server.tools.context import mem_context_init
+
+        project = self._setup_project(tmp_path, monkeypatch)
+
+        out = await mem_context_init()
+
+        assert f"Created {CONTEXT_FILENAME}" in out
+        ctx_path = project / ".memtomem" / "context.md"
+        assert ctx_path.is_file()
+        assert ctx_path in _spied_paths(atomic_spy)
+        _assert_mode_644(atomic_spy, ctx_path)
+
+    @pytest.mark.anyio
+    async def test_generate_writes_project_memory_atomically(
+        self, tmp_path, monkeypatch, atomic_spy
+    ):
+        from memtomem.server.tools.context import mem_context_generate
+
+        project = self._setup_project(tmp_path, monkeypatch)
+        _ctx_with_sections(project)
+
+        out = await mem_context_generate(agent="claude")
+
+        assert "claude" in out
+        claude_md = project / "CLAUDE.md"
+        assert claude_md.is_file()
+        assert claude_md in _spied_paths(atomic_spy)
+        _assert_mode_644(atomic_spy, claude_md)
+
+    @pytest.mark.anyio
+    async def test_sync_writes_project_memory_atomically(self, tmp_path, monkeypatch, atomic_spy):
+        from memtomem.server.tools.context import mem_context_sync
+
+        project = self._setup_project(tmp_path, monkeypatch)
+        _ctx_with_sections(project)
+        (project / "CLAUDE.md").write_text("stale sentinel\n", encoding="utf-8")
+
+        out = await mem_context_sync()
+
+        assert "claude" in out
+        claude_md = project / "CLAUDE.md"
+        text = claude_md.read_text(encoding="utf-8")
+        assert "stale sentinel" not in text
+        assert claude_md in _spied_paths(atomic_spy)
+        _assert_mode_644(atomic_spy, claude_md)

--- a/packages/memtomem/tests/test_sync_atomic_engine.py
+++ b/packages/memtomem/tests/test_sync_atomic_engine.py
@@ -486,3 +486,111 @@ def test_strict_drop_errors_are_sister_subclasses() -> None:
     assert AgentsStrictDrop is not CommandsStrictDrop
     assert not issubclass(AgentsStrictDrop, CommandsStrictDrop)
     assert not issubclass(CommandsStrictDrop, AgentsStrictDrop)
+
+
+# ── 7. Duplicate frontmatter names (#1247) ────────────────────────────
+
+
+def _parse_inline_name(text: str, *, source: Path, layout: Any = "flat") -> StubItem:
+    """Stub parse variant whose name can DIFFER from the file stem.
+
+    ``_stub_parse_text`` derives the name from ``source.stem``, which makes a
+    cross-file name collision impossible — the very case the dedupe exists
+    for. A leading ``NAME: <name>`` line plays the role of the frontmatter
+    ``name:`` key.
+    """
+    first, _, rest = text.partition("\n")
+    if first.startswith("NAME:"):
+        return StubItem(name=first.split(":", 1)[1].strip(), body=rest)
+    return _stub_parse_text(text, source=source, layout=layout)
+
+
+def _make_inline_name_adapter(
+    generators: dict[str, StubGenerator],
+) -> AtomicSyncAdapter[StubItem]:
+    return AtomicSyncAdapter(
+        kind="agent",
+        artifact_label="agents",
+        list_canonical=_stub_list_canonical,
+        parse_canonical_text=_parse_inline_name,
+        parse_error_type=StubParseError,
+        name_of=lambda item: item.name,
+        generators=generators,
+    )
+
+
+class TestDuplicateNameDedupe:
+    """Two canonicals (different stems) declaring the same name (#1247).
+
+    ``out_path`` is a pure function of (target, name), so pre-dedupe both
+    queued the SAME runtime file — silent last-writer-wins with both writes
+    reported in ``generated``.
+    """
+
+    def test_later_claimant_skipped_first_seen_wins(self, tmp_path: Path) -> None:
+        _seed_canonical(tmp_path, "aaa", "NAME: shared\nbody A")
+        _seed_canonical(tmp_path, "bbb", "NAME: shared\nbody B")
+        adapter = _make_inline_name_adapter({"t1": StubGenerator("out")})
+
+        result = sync_atomic_artifact(adapter, tmp_path)
+
+        out = tmp_path / "out" / "shared.txt"
+        # Exactly one write — pre-fix this was [("t1", out), ("t1", out)].
+        assert result.generated == [("t1", out)]
+        assert out.read_text(encoding="utf-8") == "body A"
+        assert [row[2] for row in result.skipped] == [skip_codes.DUPLICATE_NAME]
+        name, reason, _code = result.skipped[0]
+        assert name == "shared"
+        # The reason names both source paths so the user can rename one.
+        assert "aaa.txt" in reason and "bbb.txt" in reason
+
+    def test_winner_reclaims_name_on_every_target(self, tmp_path: Path) -> None:
+        """The SAME canonical claiming its name on a second target is not a
+        duplicate; the loser is skipped once per target (matching the
+        per-(target, item) convention of the parse/privacy skips)."""
+        _seed_canonical(tmp_path, "aaa", "NAME: shared\nbody A")
+        _seed_canonical(tmp_path, "bbb", "NAME: shared\nbody B")
+        adapter = _make_inline_name_adapter(
+            {"t1": StubGenerator("out1"), "t2": StubGenerator("out2")}
+        )
+
+        result = sync_atomic_artifact(adapter, tmp_path)
+
+        assert sorted(result.generated) == [
+            ("t1", tmp_path / "out1" / "shared.txt"),
+            ("t2", tmp_path / "out2" / "shared.txt"),
+        ]
+        assert [row[2] for row in result.skipped] == [
+            skip_codes.DUPLICATE_NAME,
+            skip_codes.DUPLICATE_NAME,
+        ]
+
+    def test_no_fanout_skip_precedes_duplicate(self, tmp_path: Path) -> None:
+        """Dedupe sits AFTER the no-fanout check: a duplicate loser on a
+        runtime with no fan-out keeps its pinned ``NO_PROJECT_FANOUT`` row
+        (Codex design review on #1247 B4)."""
+        _seed_canonical(tmp_path, "aaa", "NAME: shared\nbody A")
+        _seed_canonical(tmp_path, "bbb", "NAME: shared\nbody B")
+        adapter = _make_inline_name_adapter({"t1": StubGenerator("out", no_fanout=True)})
+
+        result = sync_atomic_artifact(adapter, tmp_path)
+
+        assert result.generated == []
+        assert [row[2] for row in result.skipped] == [
+            skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME,
+            skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME,
+        ]
+
+    def test_secret_bearing_loser_still_trips_gate_a(self, tmp_path: Path) -> None:
+        """Dedupe sits AFTER Gate A: a duplicate loser carrying a secret must
+        still abort the ``project_shared`` fan-out (all-or-nothing) — the
+        duplicate skip must not become a privacy bypass for canonical bytes."""
+        _seed_canonical(tmp_path, "aaa", "NAME: shared\nclean body")
+        _seed_canonical(tmp_path, "bbb", f"NAME: shared\n{SECRET}")
+        adapter = _make_inline_name_adapter({"t1": StubGenerator("out")})
+
+        with pytest.raises(PrivacyBlockedError):
+            sync_atomic_artifact(adapter, tmp_path, scope="project_shared")
+
+        # Phase 1 raise — nothing landed on disk.
+        assert not (tmp_path / "out").exists()

--- a/packages/memtomem/tests/test_web_sync_on_drop.py
+++ b/packages/memtomem/tests/test_web_sync_on_drop.py
@@ -1,0 +1,190 @@
+"""Web sync routes — ``on_drop`` vocabulary + ``StrictDropError`` surface (#1247 id 47).
+
+Pre-fix, ``SyncRequest.on_drop`` accepted any string: out-of-vocabulary values
+slipped through to the engine where they silently behaved as ``"ignore"``
+(neither the ``"error"`` nor the ``"warn"`` branch matched), and an explicit
+``on_drop="error"`` raised ``StrictDropError`` mid-Phase-2 — earlier runtime
+writes persisted (the #908 partial-write boundary) — which neither route
+caught, surfacing as an opaque 500 with zero partial-write info.
+
+These tests pin:
+
+* unknown ``on_drop`` → FastAPI-native 422 (field_validator against the
+  engine's ``ON_DROP_LEVELS`` — one vocabulary owner, mirroring CLI
+  ``click.Choice`` and MCP ``_validate_on_drop``);
+* ``on_drop="error"`` with a dropping canonical → 422 with a structured
+  ``{reason_code: "strict_drop", message, generated}`` detail naming the
+  writes that landed before the abort, which remain on disk;
+* ``on_drop="warn"`` still syncs and reports ``dropped``.
+
+App shape mirrors ``test_sync_privacy_block_surfaces.py`` — minimal FastAPI
+app + ``get_project_root`` dependency override; the routes run the real
+engine against a real tmp project.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from memtomem.context.agents import CANONICAL_AGENT_ROOT
+from memtomem.context.commands import CANONICAL_COMMAND_ROOT
+
+from .helpers import set_home
+
+# Carries Gemini-only AND Claude-only fields so some field drops for every
+# runtime (same shape as test_server_tools_context_on_drop.py).
+_FULL_AGENT = """---
+name: beta-full
+description: Reviews staged code for quality
+tools: [Read, Grep, Glob]
+model: sonnet
+skills: [code-review]
+isolation: worktree
+kind: reviewer
+temperature: 0.2
+---
+
+You are a meticulous code reviewer.
+"""
+
+_MINIMAL_AGENT = """---
+name: alpha-minimal
+description: Generic helper
+---
+
+Help with things.
+"""
+
+# gemini_commands drops argument-hint/allowed-tools; claude_commands supports
+# the full schema and never drops (see test_context_commands.py strict tests).
+_FULL_COMMAND = """---
+description: Review a file for issues
+argument-hint: [file-path]
+allowed-tools: [Read, Grep]
+model: sonnet
+---
+
+Review the file at $ARGUMENTS for issues.
+"""
+
+_MINIMAL_COMMAND = """---
+description: Simple prompt
+---
+
+Say hi to $ARGUMENTS.
+"""
+
+
+def _client_for(router, project_root: Path) -> TestClient:
+    from memtomem.web.deps import get_project_root
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_project_root] = lambda: project_root
+    return TestClient(app)
+
+
+def _seed(project_root: Path, canonical_root: str, files: dict[str, str]) -> None:
+    root = project_root / canonical_root
+    root.mkdir(parents=True, exist_ok=True)
+    for name, body in files.items():
+        (root / name).write_text(body, encoding="utf-8")
+
+
+@pytest.fixture
+def agents_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    from memtomem.web.routes import context_agents
+
+    set_home(monkeypatch, tmp_path / "home")
+    return _client_for(context_agents.router, tmp_path)
+
+
+@pytest.fixture
+def commands_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    from memtomem.web.routes import context_commands
+
+    set_home(monkeypatch, tmp_path / "home")
+    return _client_for(context_commands.router, tmp_path)
+
+
+class TestOnDropVocabulary:
+    def test_agents_sync_rejects_unknown_on_drop(self, agents_client: TestClient) -> None:
+        res = agents_client.post("/context/agents/sync", json={"on_drop": "bogus"})
+        assert res.status_code == 422, res.text
+        assert "on_drop" in res.text
+
+    def test_commands_sync_rejects_unknown_on_drop(self, commands_client: TestClient) -> None:
+        res = commands_client.post("/context/commands/sync", json={"on_drop": "bogus"})
+        assert res.status_code == 422, res.text
+        assert "on_drop" in res.text
+
+    def test_agents_sync_accepts_full_vocabulary(
+        self, agents_client: TestClient, tmp_path: Path
+    ) -> None:
+        _seed(tmp_path, CANONICAL_AGENT_ROOT, {"alpha-minimal.md": _MINIMAL_AGENT})
+        for level in ("ignore", "warn", "error"):
+            res = agents_client.post("/context/agents/sync", json={"on_drop": level})
+            assert res.status_code == 200, f"{level}: {res.text}"
+
+
+class TestStrictDropSurfaces:
+    def test_agents_sync_error_returns_422_with_partial_writes(
+        self, agents_client: TestClient, tmp_path: Path
+    ) -> None:
+        _seed(
+            tmp_path,
+            CANONICAL_AGENT_ROOT,
+            {"alpha-minimal.md": _MINIMAL_AGENT, "beta-full.md": _FULL_AGENT},
+        )
+
+        res = agents_client.post("/context/agents/sync", json={"on_drop": "error"})
+
+        assert res.status_code == 422, res.text
+        detail = res.json()["detail"]
+        assert detail["reason_code"] == "strict_drop"
+        assert "beta-full" in detail["message"]
+        # alpha-minimal sorted first → written before the abort; the response
+        # must name it AND it must still exist on disk (#908 boundary).
+        generated_paths = [g["path"] for g in detail["generated"]]
+        assert any("alpha-minimal" in p for p in generated_paths)
+        assert (tmp_path / ".claude/agents/alpha-minimal.md").is_file()
+        assert not (tmp_path / ".claude/agents/beta-full.md").exists()
+
+    def test_commands_sync_error_returns_422_with_partial_writes(
+        self, commands_client: TestClient, tmp_path: Path
+    ) -> None:
+        _seed(
+            tmp_path,
+            CANONICAL_COMMAND_ROOT,
+            {"alpha-minimal.md": _MINIMAL_COMMAND, "beta-full.md": _FULL_COMMAND},
+        )
+
+        res = commands_client.post("/context/commands/sync", json={"on_drop": "error"})
+
+        assert res.status_code == 422, res.text
+        detail = res.json()["detail"]
+        assert detail["reason_code"] == "strict_drop"
+        assert detail["generated"], "expected at least one pre-abort write reported"
+        # claude_commands never drops — gemini's beta-full render aborts.
+        assert (tmp_path / ".claude/commands/alpha-minimal.md").is_file()
+        assert not (tmp_path / ".gemini/commands/beta-full.toml").exists()
+
+    def test_agents_sync_warn_still_writes_and_reports_dropped(
+        self, agents_client: TestClient, tmp_path: Path
+    ) -> None:
+        _seed(
+            tmp_path,
+            CANONICAL_AGENT_ROOT,
+            {"alpha-minimal.md": _MINIMAL_AGENT, "beta-full.md": _FULL_AGENT},
+        )
+
+        res = agents_client.post("/context/agents/sync", json={"on_drop": "warn"})
+
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert body["dropped"], "full agent must report dropped fields under warn"
+        assert (tmp_path / ".claude/agents/beta-full.md").is_file()


### PR DESCRIPTION
## Summary

#1247 B4 (sync-engine batch) — fixes confirmed backlog findings **11** (major), **19** (major), **47** (minor) from the triage on #1247.

### id 11 — duplicate frontmatter names silently last-writer-win

`out_path` is a pure function of `(target, name)`, so two canonicals with different stems but the same `name:` both queued the same runtime file: the loser was silently overwritten, **both** writes were reported in `result.generated` (contradicting the in-code #1123 B3-1 "written exactly once" invariant), and `diff` masked the drop by indexing canonicals with the same last-wins order — the dropped artifact was invisible on every surface.

- Phase 1 now tracks the first canonical to claim each name; later claimants from a different source path get a typed **`duplicate_name`** skip (new `SkipCode`) naming both paths, plus a once-per-loser warning.
- Placement (per Codex design review): **after** the Gate A scan — a secret-bearing duplicate loser must still trip the `project_shared` all-or-nothing raise — and **after** the no-fanout check, so those pinned skip rows are unchanged. Before override resolution (the colliding name resolves the same override file via the winner, so no scan surface is lost).
- `diff_agents` / `diff_commands` switch to the matching **first-parsed-wins** precedence; last-wins there would report permanent phantom drift against the file sync now writes.
- Codex impl round caught the adjacent shadow case: a parse-failure **fallback-name** entry (unreadable/unparseable file) overwrote an earlier parsed entry with the same effective name — sync writes that name fine, so diff showed permanent phantom "parse error" drift. The fallback row now registers only when no parsed entry holds the name (warning log still fires); the reverse order keeps its parsed-wins recovery, now pinned as load-bearing. Both shadow pins mutation-validated (guard reverted → fail).

### id 19 — project-memory writes were not crash-safe

The CLAUDE.md/GEMINI.md/… fan-out and the **not-regenerable** canonical `.memtomem/context.md` write used bare `Path.write_text` on all six CLI/MCP sites (`cli/context_cmd.py` init/generate/sync, `server/tools/context.py` init/generate/sync), violating the `_atomic.py` invariant every other fan-out family already honors. All six now use `atomic_write_text` with explicit `0o644` (the helper's `0o600` default would turn a git-tracked CLAUDE.md user-private).

Scope disclosure: the two `context.md` sites are same-family adjacents of the reported fan-out sites — included here because a truncated `context.md` is strictly worse (not regenerable).

New **AST architectural guard** (`test_context_atomic_write_guard.py`) makes the docstring invariant enforced: it scans every gateway write surface for bare `.write_text`/`.write_bytes` **attribute references** (not just calls — three of the six sites passed the method uncalled to `asyncio.to_thread`, which a call-only scan walks right past). Future bare writes must use the helpers or register an `ALLOWED_BARE_WRITES` entry with a rationale.

### id 47 — web sync `on_drop` surface

`SyncRequest.on_drop` accepted any string (out-of-vocabulary values silently degraded to `"ignore"` in the engine), and `on_drop="error"`'s `StrictDropError` escaped as an opaque 500 even though earlier fan-out writes had already landed (the intentional #908 partial-write boundary).

- `on_drop` is validated against the engine's `ON_DROP_LEVELS` via a pydantic `field_validator` → FastAPI-native 422. Single vocabulary owner (CLI `click.Choice` and MCP `_validate_on_drop` already gate the same way); `commands.py` gains the `ON_DROP_LEVELS` re-export for sibling parity with `agents.py`.
- `StrictDropError` now carries `generated` (keyword-optional, default `None`, defensive copy — one-arg construction stays valid), and both sync routes translate it to **422** with a structured `{reason_code: "strict_drop", message, generated}` detail in the #1210 shape, so the client sees exactly which runtime files already changed. API-only reachability — the UI never sends `on_drop`.

## Known residual (routed to B10)

The web sync toast falls through to `sync_success` when `skipped` contains `duplicate_name` — same shape #1229 fixed for `target_conflict`. Needs a JS branch + en/ko i18n keys + `?v` bump; deliberately out of scope for this backend batch.

No ADR contract touched: ADR-0008 Invariant 4 unchanged; no ADR prescribes same-scope name uniqueness (ADR-0011 §419 covers the cross-scope story).

## Testing

- Engine: first-seen winner + per-target `duplicate_name` rows; winner re-claims across targets; **no-fanout precedence** and **Gate A precedence** (secret-bearing loser still aborts `project_shared`) pinned per Codex design round.
- Module mirrors (agents + commands): single generated tuple, winner content survives, skip row names both paths; post-sync `diff` reports `in sync` (no phantom drift).
- Mechanism-spy pins for all six atomic write sites (incl. mode `0o644`), CLI via `CliRunner` + MCP handlers.
- Routes: unknown `on_drop` → 422 (both routes), `error` → 422 with partial-write disclosure matching on-disk state, `warn` → 200 + `dropped`.
- **Pre-fix-fail verified** (src stashed): 8 failed + 6 errors + guard naming all six bare-write sites; surviving passes are contract-preservation pins.
- Full suite: **6303 passed**, 4 failed = `test_session_tracing` pre-existing (#1249; reproduced on clean main during B3).
- `ruff check` + `ruff format --check` green; `mypy` clean on touched modules.
- Codex: design round NEEDS-FIX → applied (dedupe placement vs Gate A/no-fanout, `StrictDropError` API compat); impl round NEEDS-FIX → applied (diff fallback shadow guard); verify-fix round **SHIP** (0 findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
