### PR TITLE
fix(context): migrate fan-out divergence guard + EXDEV symlink parity (#1247 B5)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -2261,6 +2261,15 @@ def _print_migrate_scope_result(result: MigrateScopeResult, *, apply_: bool) -> 
     click.echo(f"  to   {result.to_scope}: {result.dst_path}")
 
     if not apply_:
+        if result.fanout_planned:
+            click.echo(
+                f"  will remove {len(result.fanout_planned)} stale runtime "
+                f"fan-out target(s) at scope='{result.from_scope}' (content "
+                f"that diverges from the canonical render is snapshotted to "
+                f"a .bak first):"
+            )
+            for path in result.fanout_planned:
+                click.echo(f"    - {path}")
         click.echo("\nRun with --apply to execute.")
         click.echo(
             f"After apply, run `mm context sync --scope {result.to_scope}` "
@@ -2278,6 +2287,15 @@ def _print_migrate_scope_result(result: MigrateScopeResult, *, apply_: bool) -> 
             f"target(s) at scope='{result.from_scope}':"
         )
         for path in result.fanout_cleaned:
+            click.echo(f"    - {path}")
+    if result.fanout_backed_up:
+        click.secho(
+            f"  {len(result.fanout_backed_up)} target(s) diverged from the "
+            f"canonical render — snapshotted before removal (review and "
+            f"delete manually):",
+            fg="yellow",
+        )
+        for path in result.fanout_backed_up:
             click.echo(f"    - {path}")
     click.echo(
         f"\nNext: run `mm context sync --scope {result.to_scope}` to "

--- a/packages/memtomem/src/memtomem/context/migrate.py
+++ b/packages/memtomem/src/memtomem/context/migrate.py
@@ -43,18 +43,25 @@ from typing import Any, Iterator, Literal
 import click
 
 from memtomem.config import TargetScope
+from memtomem.context import override as _override
 from memtomem.context._atomic import _file_lock, _lock_path_for
-from memtomem.context._names import InvalidNameError, validate_name
+from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, validate_name
 from memtomem.context._runtime_targets import runtime_fanout_root
 from memtomem.context.agents import (
     AGENT_DIR_FILENAME,
+    AGENT_GENERATORS,
     CANONICAL_AGENT_ROOT,
+    AgentParseError,
     list_canonical_agents,
+    parse_canonical_agent,
 )
 from memtomem.context.commands import (
     CANONICAL_COMMAND_ROOT,
     COMMAND_DIR_FILENAME,
+    COMMAND_GENERATORS,
+    CommandParseError,
     list_canonical_commands,
+    parse_canonical_command,
 )
 from memtomem.context.lockfile import Lockfile
 from memtomem.context.privacy_scan import (
@@ -66,7 +73,11 @@ from memtomem.context.scope_resolver import (
     ContextScopeError,
     canonical_artifact_dir,
 )
-from memtomem.context.skills import SKILL_MANIFEST
+from memtomem.context.skills import (
+    SKILL_GENERATORS,
+    SKILL_MANIFEST,
+    _skill_effective_equal,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -654,6 +665,14 @@ class MigrateScopeResult:
     layout: Literal["dir", "flat"]
     moved: bool
     fanout_cleaned: list[Path] = field(default_factory=list)
+    # Diverged-target snapshots taken before removal (apply only) — see
+    # ``_backup_fanout_target``. Independent of ``fanout_cleaned``: a
+    # snapshot whose target then failed to delete still appears here.
+    fanout_backed_up: list[Path] = field(default_factory=list)
+    # Dry-run only (#1247 id 6): the runtime fan-out targets that exist
+    # now and would be removed by an apply — previously the deletion half
+    # of the move was invisible until after the fact.
+    fanout_planned: list[Path] = field(default_factory=list)
 
 
 @contextmanager
@@ -719,11 +738,19 @@ def _stage_move(src: Path, dst_parent: Path, name_hint: str) -> tuple[Path, bool
                         staging.unlink()
             raise
         # EXDEV fallback: copy bytes into staging without touching src.
+        # ``symlinks=True`` / ``follow_symlinks=False`` keep cross-FS
+        # semantics identical to the same-FS ``os.rename`` path above,
+        # which moves symlinks as links. The stdlib default would
+        # dereference them, materializing out-of-tree target bytes into
+        # staging — and from there into the (possibly git-tracked)
+        # destination tier — violating the package's no-deref mirror
+        # contract (``_atomic.copy_tree_atomic``). Preserving links also
+        # makes dangling ones non-fatal (#1247 id 7).
         try:
             if src.is_dir():
-                shutil.copytree(src, staging)
+                shutil.copytree(src, staging, symlinks=True)
             else:
-                shutil.copy2(src, staging)
+                shutil.copy2(src, staging, follow_symlinks=False)
         except BaseException:
             if staging.exists():
                 if staging.is_dir():
@@ -764,24 +791,48 @@ _NON_SKILL_FANOUT_SUFFIX: dict[ArtifactKind, dict[str, str]] = {
 }
 
 
-def _remove_runtime_fanout_for(
+# Generator registries by artifact kind, for the fan-out divergence check.
+# Keyed ``f"{runtime}_{kind}"`` (``claude_agents``, ``gemini_commands``, …)
+# — the registries' own ``gen.name`` convention. A missing key means sync
+# has no writer for that (kind, runtime) at all (today: codex commands —
+# the ``~/.codex/prompts`` table row is a reserved placeholder), so a file
+# found there is necessarily foreign.
+_FANOUT_GENERATORS: dict[ArtifactKind, dict[str, Any]] = {
+    "agents": AGENT_GENERATORS,
+    "commands": COMMAND_GENERATORS,
+    "skills": SKILL_GENERATORS,
+}
+
+
+def _existing_fanout_targets(
     kind: ArtifactKind,
     name: str,
     scope: TargetScope,
     project_root: Path | None,
-) -> list[Path]:
-    """Remove runtime fan-out targets for one artifact at one scope.
+) -> list[tuple[str, Path]]:
+    """``(runtime, target)`` pairs the fan-out cleanup would act on.
 
-    Best-effort cleanup invoked after a successful canonical move so the
-    pre-migration scope's runtime entries (``~/.claude/agents/foo.md``,
-    ``~/.gemini/commands/foo.toml``, ``~/.codex/agents/foo.toml`` etc.)
-    do not linger as orphans. Returns the list of removed paths for
-    telemetry / verification.
+    Shared by the dry-run preview (``MigrateScopeResult.fanout_planned``)
+    and the post-move cleanup so the two can never disagree about the
+    deletion half of a migrate (#1247 id 6; Codex design review — the
+    preview must not list paths apply intentionally leaves alone).
 
-    Walks every known runtime (claude / gemini / codex / kimi). Tuples that
-    :func:`runtime_fanout_root` reports as ``NO_FANOUT`` are skipped
-    (project_local entries, codex commands at project tiers, etc.).
-    KeyError surfaces a programming error in the table — fail-loud.
+    Walks every known runtime (claude / gemini / codex / kimi). Excluded,
+    with a warning where the exclusion is news:
+
+    * tuples :func:`runtime_fanout_root` reports as ``NO_FANOUT``
+      (project_local entries, codex commands at project tiers, etc.);
+    * unknown (kind, runtime, scope) tuples — table gap; skip rather
+      than fail the migration (the table is the contract source of
+      truth and a missing tuple should be caught by the unit tests on
+      ``_runtime_targets``, not here);
+    * targets that don't exist on disk;
+    * symlinked targets — never follow / deref / remove one (a symlink
+      in a runtime root is user hand-routing, not sync output: the
+      generators only ever ``os.replace`` regular files into place);
+    * (kind, runtime) pairs with no registered generator — sync can
+      never have written the file, so removing it would be pure
+      collateral on a hand-authored file. Leave it in place.
 
     Per-runtime suffix: agents/codex and commands/gemini write
     ``.toml``, the other non-skill pairs write ``.md``. The cleanup
@@ -789,16 +840,12 @@ def _remove_runtime_fanout_for(
     stale artifact survives and the runtime can still discover and
     invoke the moved-away command/agent (#895 P2 review #2).
     """
-    removed: list[Path] = []
+    targets: list[tuple[str, Path]] = []
+    generators = _FANOUT_GENERATORS[kind]
     for runtime in ("claude", "gemini", "codex", "kimi"):
         try:
             root = runtime_fanout_root(kind, runtime, scope, project_root)
         except KeyError:
-            # Unknown (kind, runtime, scope) tuple — table gap. Skip
-            # rather than fail the migration (canonical is already
-            # moved at this point); the table is the contract source-
-            # of-truth and a missing tuple should be caught by the
-            # unit tests on _runtime_targets, not here.
             logger.warning(
                 "fanout cleanup: no table entry for (%s, %s, %s); skipping",
                 kind,
@@ -810,26 +857,216 @@ def _remove_runtime_fanout_for(
             continue
         if kind == "skills":
             target = root / name
-            if target.is_symlink():
-                # Defensive: never follow / rmtree a symlink — could
-                # point outside the runtime root.
-                continue
-            if target.is_dir():
-                try:
-                    shutil.rmtree(target)
-                    removed.append(target)
-                except OSError as exc:
-                    logger.warning("fanout cleanup: failed to remove %s: %s", target, exc)
+            exists = target.is_dir()
         else:
             suffix = _NON_SKILL_FANOUT_SUFFIX[kind].get(runtime, ".md")
             target = root / f"{name}{suffix}"
-            if target.is_file():
-                try:
-                    target.unlink()
-                    removed.append(target)
-                except OSError as exc:
-                    logger.warning("fanout cleanup: failed to remove %s: %s", target, exc)
-    return removed
+            exists = target.is_file()
+        if target.is_symlink():
+            logger.warning(
+                "fanout cleanup: %s is a symlink; leaving it in place (never deref)",
+                target,
+            )
+            continue
+        if not exists:
+            continue
+        if generators.get(f"{runtime}_{kind}") is None:
+            logger.warning(
+                "fanout cleanup: no %s generator for runtime %s — sync never "
+                "wrote %s; leaving the foreign file in place",
+                kind,
+                runtime,
+                target,
+            )
+            continue
+        targets.append((runtime, target))
+    return targets
+
+
+def _fanout_target_matches(
+    kind: ArtifactKind,
+    name: str,
+    runtime: str,
+    target: Path,
+    parsed_item: Any | None,
+    dst_path: Path,
+    to_scope: TargetScope,
+    project_root: Path,
+) -> bool:
+    """True when *target* byte-matches what sync would write for this artifact.
+
+    Reconstructs the expected fan-out content from the canonical **at its
+    post-move location** (``dst_path``): the moved bytes are identical to
+    what sync last read at the source scope, and per-vendor overrides live
+    inside the artifact dir (``<name>/overrides/<vendor>.<ext>``) so they
+    moved with it. The expected-bytes rule mirrors ``_sync_atomic`` Phase 2
+    exactly — override bytes verbatim when one resolves, else the
+    generator render — the same comparison ``diff_agents`` /
+    ``diff_commands`` / ``_skill_effective_equal`` already pin.
+
+    Any read failure returns ``False`` — the same "report drift, never
+    mask it" posture as diff — so uncertainty routes to the backup path
+    rather than a silent delete.
+    """
+    gen = _FANOUT_GENERATORS[kind][f"{runtime}_{kind}"]
+    vendor = GENERATOR_VENDOR.get(gen.name)
+    override_bytes: bytes | None = None
+    if vendor is not None:
+        override_path = _override.resolve(project_root, kind, name, vendor, scope=to_scope)
+        if override_path is not None:
+            try:
+                override_bytes = override_path.read_bytes()
+            except OSError:
+                return False
+    if kind == "skills":
+        try:
+            return _skill_effective_equal(dst_path, target, override_bytes)
+        except OSError:
+            return False
+    if override_bytes is not None:
+        expected = override_bytes
+    elif parsed_item is None:
+        # Canonical unreadable/unparseable — sync would skip it, so the
+        # target's provenance is unknowable. Treat as diverged.
+        return False
+    else:
+        content, _dropped = gen.render(parsed_item)
+        expected = content.encode("utf-8")
+    try:
+        return expected == target.read_bytes()
+    except OSError:
+        return False
+
+
+def _backup_fanout_target(target: Path) -> Path | None:
+    """Snapshot a diverged runtime fan-out target before removal.
+
+    Files: sibling ``<name>.<ext>.bak`` via ``shutil.copy2`` (mirrors
+    ``_execute_cleanup_flat``; an older ``.bak`` is overwritten —
+    newest snapshot wins). Suffix-filtered discovery never lists it and
+    runtimes don't load ``.bak``.
+
+    Skill dirs: ``<runtime_root>/.bak/<name>/`` via
+    ``shutil.copytree(symlinks=True)`` — deliberately NOT a sibling
+    ``<name>.bak``: ``validate_name`` accepts dots, so a skill-shaped
+    sibling would surface as a phantom "missing canonical" diff row, be
+    re-imported into canonical by ``extract_skills_to_canonical``
+    (#1229's round-trip failure mode), and be discoverable by the real
+    runtimes. One level down under a manifest-less ``.bak/`` parent,
+    every single-level ``<root>/*/SKILL.md`` discovery (ours and the
+    runtimes') stays blind to it. Internal-pattern names
+    (``.old-…-<pid>-<hex>.tmp``) are off the table — the sync-time
+    reaper (``skills._reap_stale_internal_dirs``) deletes those.
+
+    Backups are never auto-deleted by memtomem; the warning at the call
+    site and the CLI/MCP move summary name them for manual review.
+
+    Returns the backup path, or ``None`` (with a loud warning) when the
+    snapshot could not be taken — the caller must then KEEP the target,
+    because deleting without a backup is exactly the loss this guard
+    exists to prevent.
+    """
+    try:
+        if target.is_dir():
+            bak = target.parent / ".bak" / target.name
+            if bak.is_dir():
+                shutil.rmtree(bak)
+            elif bak.exists():
+                bak.unlink()
+            bak.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(target, bak, symlinks=True)
+        else:
+            bak = target.with_name(target.name + ".bak")
+            shutil.copy2(target, bak)
+    except (OSError, shutil.Error) as exc:
+        logger.warning(
+            "fanout cleanup: failed to snapshot diverged %s (%s); leaving the target in place",
+            target,
+            exc,
+        )
+        return None
+    return bak
+
+
+def _remove_runtime_fanout_for(
+    kind: ArtifactKind,
+    name: str,
+    scope: TargetScope,
+    project_root: Path,
+    *,
+    dst_path: Path,
+    to_scope: TargetScope,
+    layout: Literal["dir", "flat"],
+) -> tuple[list[Path], list[Path]]:
+    """Remove runtime fan-out targets for one artifact at one scope.
+
+    Best-effort cleanup invoked after a successful canonical move so the
+    pre-migration scope's runtime entries (``~/.claude/agents/foo.md``,
+    ``~/.gemini/commands/foo.toml``, ``~/.codex/agents/foo.toml`` etc.)
+    do not linger as orphans (#895 P2). Target selection — including the
+    symlink / foreign-file exclusions — lives in
+    :func:`_existing_fanout_targets`, shared with the dry-run preview.
+
+    #1247 id 6: deletion is no longer unconditional. Each target is
+    byte-compared against what sync would write
+    (:func:`_fanout_target_matches`); a diverged or unverifiable target
+    is snapshotted (:func:`_backup_fanout_target`) before removal, and
+    KEPT if the snapshot fails. Runtime-side edits and hand-authored
+    name collisions stay recoverable while the moved-away name still
+    stops being discoverable (#895's original point).
+
+    Returns ``(removed, backed_up)`` for telemetry / verification —
+    independent lists: a snapshot whose target then failed to delete
+    still appears in ``backed_up``.
+    """
+    removed: list[Path] = []
+    backed_up: list[Path] = []
+    targets = _existing_fanout_targets(kind, name, scope, project_root)
+    if not targets:
+        return removed, backed_up
+
+    # Parse the canonical once (agents/commands; skills compare trees).
+    parsed_item: Any | None = None
+    if kind != "skills":
+        manifest = dst_path if layout == "flat" else dst_path / _DIR_MANIFEST[kind]
+        try:
+            if kind == "agents":
+                parsed_item = parse_canonical_agent(manifest, layout=layout)
+            else:
+                parsed_item = parse_canonical_command(manifest, layout=layout)
+        except (OSError, AgentParseError, CommandParseError) as exc:
+            logger.warning(
+                "fanout cleanup: canonical at %s unreadable/unparseable (%s); "
+                "treating every runtime target as diverged",
+                manifest,
+                exc,
+            )
+
+    for runtime, target in targets:
+        matches = _fanout_target_matches(
+            kind, name, runtime, target, parsed_item, dst_path, to_scope, project_root
+        )
+        if not matches:
+            bak = _backup_fanout_target(target)
+            if bak is None:
+                continue
+            backed_up.append(bak)
+            logger.warning(
+                "fanout cleanup: %s diverged from the canonical render; "
+                "snapshotted to %s before removal — review and delete the "
+                "backup manually",
+                target,
+                bak,
+            )
+        try:
+            if target.is_dir():
+                shutil.rmtree(target)
+            else:
+                target.unlink()
+            removed.append(target)
+        except OSError as exc:
+            logger.warning("fanout cleanup: failed to remove %s: %s", target, exc)
+    return removed, backed_up
 
 
 def _detect_source_scope(
@@ -935,6 +1172,10 @@ def migrate_scope(
     10. Best-effort cleanup of stale src runtime fan-out targets
         (``~/.claude/agents/<name>.md`` etc.) — outside the lock so a
         partial cleanup failure does not roll back the canonical move.
+        Targets that diverge from the canonical render (or whose
+        provenance can't be verified) are snapshotted to a ``.bak``
+        before removal; symlinks and files sync can't have written
+        (no generator) are left in place (#1247 id 6).
 
     Args:
         surface: Gate A audit identifier forwarded to the step-7
@@ -945,8 +1186,10 @@ def migrate_scope(
 
     Returns:
         :class:`MigrateScopeResult` with ``moved=True`` on apply
-        success, ``moved=False`` on dry-run, and ``fanout_cleaned``
-        listing every runtime path removed.
+        success, ``moved=False`` on dry-run. ``fanout_cleaned`` lists
+        every runtime path removed and ``fanout_backed_up`` every
+        ``.bak`` snapshot taken for diverged targets (apply);
+        ``fanout_planned`` previews the same target selection (dry-run).
     """
     if kind not in SCOPE_MIGRATABLE_KINDS:
         raise click.ClickException(
@@ -975,7 +1218,10 @@ def migrate_scope(
         )
 
     if not apply_:
-        # Dry-run: compute plan, no mutation.
+        # Dry-run: compute plan, no mutation. ``fanout_planned`` previews
+        # the deletion half of the move (#1247 id 6) — the same selection
+        # the apply-side cleanup uses, so preview and apply cannot
+        # disagree about what gets removed.
         return MigrateScopeResult(
             kind=kind,
             name=name,
@@ -985,6 +1231,12 @@ def migrate_scope(
             dst_path=dst_path,
             layout=layout,
             moved=False,
+            fanout_planned=[
+                target
+                for _runtime, target in _existing_fanout_targets(
+                    kind, name, src_scope, project_root
+                )
+            ],
         )
 
     # ── apply path ───────────────────────────────────────────────────
@@ -1141,7 +1393,15 @@ def migrate_scope(
             )
 
     # Cleanup stale src runtime fan-out (best-effort).
-    fanout_cleaned = _remove_runtime_fanout_for(kind, name, src_scope, project_root)
+    fanout_cleaned, fanout_backed_up = _remove_runtime_fanout_for(
+        kind,
+        name,
+        src_scope,
+        project_root,
+        dst_path=dst_path,
+        to_scope=to_scope,
+        layout=layout,
+    )
 
     return MigrateScopeResult(
         kind=kind,
@@ -1153,4 +1413,5 @@ def migrate_scope(
         layout=layout,
         moved=True,
         fanout_cleaned=fanout_cleaned,
+        fanout_backed_up=fanout_backed_up,
     )

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -1315,6 +1315,14 @@ def _format_artifact_scope_result(result: MigrateScopeResult, *, apply_: bool) -
         f"  to   {result.to_scope}: {result.dst_path}",
     ]
     if not apply_:
+        if result.fanout_planned:
+            lines.append(
+                f"  will remove {len(result.fanout_planned)} stale runtime "
+                f"fan-out target(s) at scope='{result.from_scope}' (content "
+                f"that diverges from the canonical render is snapshotted to "
+                f"a .bak first):"
+            )
+            lines.extend(f"    - {path}" for path in result.fanout_planned)
         lines.append("\nRe-call with apply=True to execute.")
         lines.append(
             f"After apply, run mem_context_sync(scope='{result.to_scope}') "
@@ -1326,6 +1334,13 @@ def _format_artifact_scope_result(result: MigrateScopeResult, *, apply_: bool) -
     if result.fanout_cleaned:
         lines.append(f"  cleaned {len(result.fanout_cleaned)} stale runtime fan-out target(s):")
         lines.extend(f"    - {path}" for path in result.fanout_cleaned)
+    if result.fanout_backed_up:
+        lines.append(
+            f"  {len(result.fanout_backed_up)} target(s) diverged from the "
+            f"canonical render — snapshotted before removal (review and "
+            f"delete manually):"
+        )
+        lines.extend(f"    - {path}" for path in result.fanout_backed_up)
     lines.append(
         f"\nNext: run mem_context_sync(scope='{result.to_scope}') "
         "to regenerate runtime fan-out at the new tier."

--- a/packages/memtomem/tests/test_context_migrate.py
+++ b/packages/memtomem/tests/test_context_migrate.py
@@ -741,7 +741,15 @@ _RUNTIME_REL = {
         # so the user-tier path can still seed for the codex regression.
         "codex": ".codex/prompts",
     },
-    "skills": {"claude": ".claude/skills", "gemini": ".gemini/skills"},
+    "skills": {
+        "claude": ".claude/skills",
+        "gemini": ".gemini/skills",
+        # Codex skills live under the vendor-neutral Agent Skills path,
+        # kimi under .kimi/ — mirrored from RUNTIME_FANOUT_TABLE so the
+        # divergence-guard tests can exercise non-claude skill runtimes.
+        "codex": ".agents/skills",
+        "kimi": ".kimi/skills",
+    },
 }
 _AGENT_BODY_CLEAN = "---\nname: foo\ndescription: a clean test agent\n---\n\nhello world\n"
 _COMMAND_BODY_CLEAN = "---\nname: foo\ndescription: a clean test command\n---\n\nhello $ARGUMENTS\n"
@@ -1983,6 +1991,382 @@ def test_e4_project_shared_blocked_override_leaves_no_partial_fanout_commands(sc
         "claude_commands — partial fan-out violates ADR §5 atomicity."
     )
     assert not gemini_fanout.exists()
+
+
+# ── #1247 id 7: EXDEV fallback must not dereference symlinks ─────────
+
+
+def _exdev_once(monkeypatch) -> dict[str, bool]:
+    """Make the first ``os.rename`` inside migrate raise EXDEV (Row-11 pattern)."""
+    import os as os_mod
+
+    real_rename = os_mod.rename
+    raised: dict[str, bool] = {"once": False}
+
+    def fake_rename(a, b):
+        if not raised["once"]:
+            raised["once"] = True
+            import errno as _errno
+
+            raise OSError(_errno.EXDEV, "Cross-device link", str(a))
+        return real_rename(a, b)
+
+    monkeypatch.setattr("memtomem.context.migrate.os.rename", fake_rename)
+    return raised
+
+
+@pytest.mark.requires_symlinks
+def test_exdev_symlink_in_skill_tree_stays_a_link(scope_layout, monkeypatch, tmp_path):
+    """#1247 id 7: cross-FS staging must mirror the same-FS rename semantics.
+
+    Pre-fix, the EXDEV fallback used ``shutil.copytree`` with the stdlib
+    default ``symlinks=False``, dereferencing a resolvable symlink and
+    materializing its out-of-tree target bytes into staging — and from
+    there into the git-shareable ``.memtomem/`` tier — while the same-FS
+    rename path moves the link as a link. This violates the package's own
+    no-deref mirror contract (``_atomic.copy_tree_atomic``).
+    """
+    marker = "OUT_OF_TREE_MARKER_1247_ID7"
+    out_of_tree = tmp_path / "outside" / "secret-notes.md"
+    out_of_tree.parent.mkdir(parents=True)
+    out_of_tree.write_text(marker + "\n", encoding="utf-8")
+
+    src_manifest = _write_canonical_dir(scope_layout, "skills", "user", "foo", _SKILL_BODY_CLEAN)
+    (src_manifest.parent / "link.md").symlink_to(out_of_tree)
+
+    raised = _exdev_once(monkeypatch)
+    result = _invoke_migrate(
+        _migrate_args(
+            "skills",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code == 0, result.output
+    assert raised["once"], "EXDEV path should have triggered"
+
+    dst_dir = _canonical_root_for(scope_layout, "skills", "project_shared") / "foo"
+    link = dst_dir / "link.md"
+    # POSITIVE: the link survived as a link, still pointing out of tree.
+    assert link.is_symlink(), "EXDEV staging dereferenced the symlink"
+    assert link.resolve() == out_of_tree.resolve()
+    # NEGATIVE: no regular file in the promoted tree carries the target bytes.
+    for p in dst_dir.rglob("*"):
+        if p.is_file() and not p.is_symlink():
+            assert marker not in p.read_text(encoding="utf-8"), (
+                f"out-of-tree bytes materialized into {p}"
+            )
+
+
+@pytest.mark.requires_symlinks
+def test_exdev_flat_symlink_canonical_stays_a_link(scope_layout, monkeypatch, tmp_path):
+    """Flat-artifact sibling of the tree case: ``shutil.copy2`` must not
+    follow a symlinked canonical on the EXDEV path (``follow_symlinks=False``
+    parity with the rename path, which moves the link itself)."""
+    target_body = "---\nname: foo\ndescription: linked agent\n---\n\nlinked body\n"
+    out_of_tree = tmp_path / "outside" / "real-agent.md"
+    out_of_tree.parent.mkdir(parents=True)
+    out_of_tree.write_text(target_body, encoding="utf-8")
+
+    flat_root = _canonical_root_for(scope_layout, "agents", "user")
+    flat_root.mkdir(parents=True, exist_ok=True)
+    flat = flat_root / "foo.md"
+    flat.symlink_to(out_of_tree)
+
+    raised = _exdev_once(monkeypatch)
+    result = _invoke_migrate(
+        _migrate_args("agents", "foo", from_scope="user", to_scope="project_local")
+    )
+    assert result.exit_code == 0, result.output
+    assert raised["once"], "EXDEV path should have triggered"
+
+    dst = _canonical_root_for(scope_layout, "agents", "project_local") / "foo.md"
+    # POSITIVE: the moved flat canonical is still a symlink to the same target.
+    assert dst.is_symlink(), "EXDEV copy2 materialized the symlinked flat canonical"
+    assert dst.resolve() == out_of_tree.resolve()
+    # The out-of-tree target itself is untouched.
+    assert out_of_tree.read_text(encoding="utf-8") == target_body
+    # EXDEV cleanup removed the src link, not the link target.
+    assert not flat.exists()
+
+
+# ── #1247 id 6: fan-out cleanup divergence guard + dry-run preview ───
+
+
+def _rendered_fanout_bytes(manifest: Path, kind: str, runtime: str) -> bytes:
+    """Exactly what sync would write for this canonical at this runtime."""
+    if kind == "agents":
+        from memtomem.context.agents import AGENT_GENERATORS, parse_canonical_agent
+
+        item = parse_canonical_agent(manifest, layout="dir")
+        content, _ = AGENT_GENERATORS[f"{runtime}_agents"].render(item)
+    else:
+        from memtomem.context.commands import COMMAND_GENERATORS, parse_canonical_command
+
+        item = parse_canonical_command(manifest, layout="dir")
+        content, _ = COMMAND_GENERATORS[f"{runtime}_commands"].render(item)
+    return content.encode("utf-8")
+
+
+def test_fanout_diverged_agent_snapshotted_to_bak(scope_layout):
+    """#1247 id 6: a runtime-side edit made after the last sync must survive
+    the migrate cleanup as a ``.bak`` sibling instead of being destroyed.
+
+    Pre-fix, ``_remove_runtime_fanout_for`` unlinked by name with no
+    content check and no backup — the diverged bytes existed nowhere else.
+    """
+    src = _write_canonical_dir(scope_layout, "agents", "project_shared", "foo", _AGENT_BODY_CLEAN)
+    target = _runtime_fanout_path(scope_layout, "agents", "claude", "project_shared", "foo")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    diverged = _rendered_fanout_bytes(src, "agents", "claude") + b"\n# local runtime edit\n"
+    target.write_bytes(diverged)
+    # Sibling negative pin: gemini holds EXACTLY what sync wrote — must be
+    # removed clean, with no backup.
+    in_sync = _runtime_fanout_path(scope_layout, "agents", "gemini", "project_shared", "foo")
+    in_sync.parent.mkdir(parents=True, exist_ok=True)
+    in_sync.write_bytes(_rendered_fanout_bytes(src, "agents", "gemini"))
+
+    result = _invoke_migrate(
+        _migrate_args("agents", "foo", from_scope="project_shared", to_scope="user")
+    )
+    assert result.exit_code == 0, result.output
+
+    # POSITIVE: both targets removed; the diverged one left a .bak with
+    # the edited bytes.
+    assert not target.exists()
+    assert not in_sync.exists()
+    bak = target.with_name(target.name + ".bak")
+    assert bak.is_file(), "diverged fan-out target deleted without a backup"
+    assert bak.read_bytes() == diverged
+    assert "snapshotted before removal" in result.output
+    assert str(bak) in result.output
+    # NEGATIVE (pin-and-invert): the in-sync target must NOT leave a .bak.
+    assert not in_sync.with_name(in_sync.name + ".bak").exists()
+
+
+def test_fanout_override_carrying_agent_in_sync_no_bak(scope_layout):
+    """A per-vendor override REPLACES the rendered file at sync time
+    (ADR-0008 Invariant 4); the divergence check must compare against the
+    override bytes — overrides moved with the artifact dir — or every
+    override-carrying artifact would false-positive a .bak on migrate."""
+    src = _write_canonical_dir(scope_layout, "agents", "project_shared", "foo", _AGENT_BODY_CLEAN)
+    override = src.parent / "overrides" / "claude.md"
+    override.parent.mkdir(parents=True)
+    override_body = b"override body: claude-specific\n"
+    override.write_bytes(override_body)
+    target = _runtime_fanout_path(scope_layout, "agents", "claude", "project_shared", "foo")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(override_body)
+
+    result = _invoke_migrate(
+        _migrate_args("agents", "foo", from_scope="project_shared", to_scope="user")
+    )
+    assert result.exit_code == 0, result.output
+
+    assert not target.exists()
+    # POSITIVE: clean delete — no backup, no divergence warning.
+    assert not target.with_name(target.name + ".bak").exists()
+    assert "snapshotted before removal" not in result.output
+
+
+def test_fanout_hand_authored_skill_content_snapshotted(scope_layout):
+    """The heaviest id-6 loss path: ``rmtree`` of a skill dir holding files
+    sync never wrote. The extra bytes must survive under
+    ``<runtime_root>/.bak/<name>/`` — one level down so neither our
+    discovery loops (diff/extract: ``<root>/*/SKILL.md``) nor the real
+    runtimes can rediscover the stale skill, and extract cannot round-trip
+    it back into canonical (#1229's failure mode with a sibling name).
+    """
+    _write_canonical_dir(scope_layout, "skills", "user", "foo", _SKILL_BODY_CLEAN)
+    target = _runtime_fanout_path(scope_layout, "skills", "claude", "user", "foo")
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text(_SKILL_BODY_CLEAN, encoding="utf-8")
+    notes = "hand-authored runtime-only notes\n"
+    (target / "notes.txt").write_text(notes, encoding="utf-8")
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "skills",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code == 0, result.output
+
+    assert not target.exists(), "stale runtime skill dir must still be removed"
+    bak = target.parent / ".bak" / "foo"
+    assert (bak / "notes.txt").read_text(encoding="utf-8") == notes
+    assert (bak / "SKILL.md").read_text(encoding="utf-8") == _SKILL_BODY_CLEAN
+    # The backup parent holds no SKILL.md itself — single-level discovery
+    # (diff, extract, real runtimes) cannot see the snapshot as a skill.
+    assert not (target.parent / ".bak" / "SKILL.md").exists()
+
+
+def test_fanout_diverged_kimi_skill_snapshotted(scope_layout):
+    """Non-claude skill runtime coverage (Codex design review): the same
+    guard must hold for the kimi fan-out tree."""
+    _write_canonical_dir(scope_layout, "skills", "user", "foo", _SKILL_BODY_CLEAN)
+    target = _runtime_fanout_path(scope_layout, "skills", "kimi", "user", "foo")
+    target.mkdir(parents=True)
+    edited = _SKILL_BODY_CLEAN + "\nkimi-side local edit\n"
+    (target / "SKILL.md").write_text(edited, encoding="utf-8")
+
+    result = _invoke_migrate(
+        _migrate_args("skills", "foo", from_scope="user", to_scope="project_local")
+    )
+    assert result.exit_code == 0, result.output
+
+    assert not target.exists()
+    bak = target.parent / ".bak" / "foo"
+    assert (bak / "SKILL.md").read_text(encoding="utf-8") == edited
+
+
+def test_fanout_exact_skill_copy_removed_without_bak(scope_layout):
+    """Negative pin (pin-and-invert): a runtime skill tree that byte-matches
+    the canonical is removed with NO backup — the .bak valve is for
+    diverged content only, not a tombstone for every migrate."""
+    _write_canonical_dir(scope_layout, "skills", "user", "foo", _SKILL_BODY_CLEAN)
+    target = _runtime_fanout_path(scope_layout, "skills", "claude", "user", "foo")
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text(_SKILL_BODY_CLEAN, encoding="utf-8")
+
+    result = _invoke_migrate(
+        _migrate_args("skills", "foo", from_scope="user", to_scope="project_local")
+    )
+    assert result.exit_code == 0, result.output
+
+    assert not target.exists()
+    assert not (target.parent / ".bak").exists()
+    assert "snapshotted before removal" not in result.output
+
+
+def test_fanout_foreign_codex_prompt_left_in_place(scope_layout):
+    """``~/.codex/prompts`` is a reserved table row with NO generator —
+    sync can never have written there, so a hand-authored prompt that
+    happens to share the command's name must survive the migrate, and the
+    dry-run preview must not claim it as planned cleanup (Codex design
+    review: preview/apply parity). Pre-fix, both halves were wrong: the
+    file was deleted, invisibly."""
+    _write_canonical_dir(scope_layout, "commands", "user", "foo", _COMMAND_BODY_CLEAN)
+    prompt = scope_layout["user_home"] / ".codex" / "prompts" / "foo.md"
+    prompt.parent.mkdir(parents=True)
+    hand_authored = "# my hand-written codex prompt — not memtomem's\n"
+    prompt.write_text(hand_authored, encoding="utf-8")
+
+    preview = _invoke_migrate(
+        _migrate_args(
+            "commands", "foo", from_scope="user", to_scope="project_local", apply_=False, yes=False
+        )
+    )
+    assert preview.exit_code == 0, preview.output
+    # NEGATIVE: not in the planned-cleanup preview.
+    assert str(prompt) not in preview.output
+
+    result = _invoke_migrate(
+        _migrate_args("commands", "foo", from_scope="user", to_scope="project_local")
+    )
+    assert result.exit_code == 0, result.output
+    # POSITIVE: the foreign file survived, byte-identical, no .bak churn.
+    assert prompt.read_text(encoding="utf-8") == hand_authored
+    assert not prompt.with_name("foo.md.bak").exists()
+
+
+@pytest.mark.requires_symlinks
+def test_fanout_symlink_target_left_in_place(scope_layout, tmp_path):
+    """A symlinked runtime target is user hand-routing, not sync output
+    (generators only ever ``os.replace`` regular files): never deref,
+    back up, or remove it. Pre-fix it was unlinked."""
+    src = _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+    referent = tmp_path / "outside" / "routed-agent.md"
+    referent.parent.mkdir(parents=True)
+    referent.write_bytes(_rendered_fanout_bytes(src, "agents", "claude"))
+    target = _runtime_fanout_path(scope_layout, "agents", "claude", "user", "foo")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.symlink_to(referent)
+
+    result = _invoke_migrate(
+        _migrate_args("agents", "foo", from_scope="user", to_scope="project_local")
+    )
+    assert result.exit_code == 0, result.output
+
+    assert target.is_symlink(), "symlinked fan-out target must be left in place"
+    assert referent.is_file()
+    assert str(target) not in result.output
+
+
+def test_fanout_dry_run_previews_deletion_half(scope_layout):
+    """#1247 id 6: the dry-run plan must show the deletion half of the
+    move — pre-fix the fan-out paths were only reported AFTER apply."""
+    _write_canonical_dir(scope_layout, "agents", "project_shared", "foo", _AGENT_BODY_CLEAN)
+    seeded = _seed_runtime_fanout(
+        scope_layout, "agents", "project_shared", "foo", _AGENT_BODY_CLEAN
+    )
+
+    preview = _invoke_migrate(
+        _migrate_args(
+            "agents", "foo", from_scope="project_shared", to_scope="user", apply_=False, yes=False
+        )
+    )
+    assert preview.exit_code == 0, preview.output
+    assert "will remove 2 stale runtime fan-out target(s)" in preview.output
+    for path in seeded:
+        assert str(path) in preview.output
+        assert path.exists(), "dry-run must not delete anything"
+
+
+def test_fanout_backup_failure_keeps_file_target(scope_layout, monkeypatch):
+    """When the .bak snapshot of a diverged FILE target fails, the target
+    must be KEPT — deleting without a backup is exactly the loss the
+    guard exists to prevent."""
+    src = _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+    target = _runtime_fanout_path(scope_layout, "agents", "claude", "user", "foo")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    diverged = _rendered_fanout_bytes(src, "agents", "claude") + b"\n# edit\n"
+    target.write_bytes(diverged)
+
+    def boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("memtomem.context.migrate.shutil.copy2", boom)
+
+    result = _invoke_migrate(
+        _migrate_args("agents", "foo", from_scope="user", to_scope="project_local")
+    )
+    assert result.exit_code == 0, result.output  # cleanup stays best-effort
+
+    assert target.read_bytes() == diverged, "target deleted despite failed backup"
+    assert not target.with_name(target.name + ".bak").exists()
+
+
+def test_fanout_backup_failure_keeps_skill_dir(scope_layout, monkeypatch):
+    """Skill-tree sibling of the file case (Codex design review): a failed
+    ``copytree`` snapshot must keep the whole runtime skill dir — the
+    heaviest id-6 loss path is the dir ``rmtree``."""
+    _write_canonical_dir(scope_layout, "skills", "user", "foo", _SKILL_BODY_CLEAN)
+    target = _runtime_fanout_path(scope_layout, "skills", "claude", "user", "foo")
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text(_SKILL_BODY_CLEAN, encoding="utf-8")
+    notes = "runtime-only bytes\n"
+    (target / "notes.txt").write_text(notes, encoding="utf-8")
+
+    def boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("memtomem.context.migrate.shutil.copytree", boom)
+
+    result = _invoke_migrate(
+        _migrate_args("skills", "foo", from_scope="user", to_scope="project_local")
+    )
+    assert result.exit_code == 0, result.output
+
+    assert (target / "notes.txt").read_text(encoding="utf-8") == notes, (
+        "skill dir rmtree'd despite failed backup"
+    )
+    assert not (target.parent / ".bak" / "foo" / "notes.txt").exists()
 
 
 # ── adopt_flat_to_dir (ADR-0022 rank 6) ──────────────────────────────────


### PR DESCRIPTION
Part of the #1247 unverified-backlog fix campaign — **B5: migrate hardening** (backlog ids **6**, **7**; both confirmed against main in the 2026-06-11 re-triage).

## id 6 (major) — fan-out cleanup deleted runtime files with no divergence check or backup

`_remove_runtime_fanout_for` ran after every applied `mm context migrate <kind> <name> --to <scope>` and deleted `<runtime_root>/<name><suffix>` (agents/commands) or rmtree'd `<runtime_root>/<name>` (skills) across all four runtimes at the source scope, keyed by name only. Two unrecoverable loss paths:

1. **Runtime-side edits** made after the last sync (a state the dashboard explicitly models as "out of sync") — the divergence delta existed nowhere else.
2. **Hand-authored name collisions** — a file or hand-installed skill dir sync never wrote, deleted as a side effect of moving the canonical away. Heaviest case: the skill-dir rmtree. Always-foreign case: `~/.codex/prompts/<name>.md`, a reserved table row with **no** registered generator.

The dry-run preview never showed the deletion half; paths were reported only after apply.

### Fix

- **Divergence check before delete.** Each target is byte-compared against what sync would write, reconstructed from the canonical at its **post-move** location (the moved bytes are identical to what sync last read at the source scope; per-vendor overrides live inside the artifact dir, so they moved with it). Expected-bytes rule mirrors `_sync_atomic` Phase 2 exactly — override bytes verbatim when one resolves, else the generator render — i.e. the same comparison `diff_agents` / `diff_commands` / `_skill_effective_equal` already pin.
- **Snapshot-then-delete for diverged/unverifiable targets.** Files → sibling `<name>.<ext>.bak` (mirrors `_execute_cleanup_flat`; invisible to suffix-filtered discovery). Skill dirs → `<runtime_root>/.bak/<name>/` — deliberately *not* a skill-shaped sibling: `validate_name` accepts dots, so `<name>.bak` would surface as a phantom diff row, be **re-imported into canonical by extract** (#1229's round-trip failure mode), and be discoverable by the real runtimes; one level under a manifest-less `.bak/` parent, every single-level `<root>/*/SKILL.md` walk stays blind to it. Internal-pattern names were ruled out — the sync-time reaper deletes those.
- **Failed snapshot keeps the target** — deleting without a backup is exactly the loss this guard exists to prevent.
- **Left in place entirely:** symlinked targets (user hand-routing; generators only ever `os.replace` regular files — never deref/back-up/remove) and generator-less (kind, runtime) pairs (`~/.codex/prompts`: sync can never have written there, deletion was pure collateral).
- **Dry-run previews the deletion half** via `MigrateScopeResult.fanout_planned`, computed by the same `_existing_fanout_targets` selection the apply path consumes — preview and apply cannot disagree (Codex design-review fold). Apply surfaces snapshots via `fanout_backed_up` in both CLI and MCP output (hint-prose parity).

## id 7 (minor) — `_stage_move` EXDEV fallback dereferenced symlinks

The cross-FS staging fallback used stdlib-default `shutil.copytree` / `shutil.copy2`, dereferencing resolvable symlinks and materializing out-of-tree target bytes into staging — and from there into the (possibly git-tracked) destination tier — while the same-FS `os.rename` path moves links intact, violating the package's own no-deref mirror contract (`_atomic.copy_tree_atomic`). Gate A still blocks secret-class content behind links on both paths; the exposure was non-secret out-of-tree bytes landing in `.memtomem/`.

Fixed with `symlinks=True` / `follow_symlinks=False` — cross-FS now matches same-FS semantics; dangling links become non-fatal as a side effect.

## Review & tests

- **Codex design review** (pre-implementation): NEEDS-FIX → all folded — dry-run/apply parity for foreign/symlink skips, a skill-tree (`copytree`) backup-failure test alongside the file one, non-claude skill-runtime coverage. All five design questions (backup semantics, skills backup location, foreign-file policy, symlink policy, preview scope) resolved in line with the design.
- **Codex impl review**: SHIP, zero findings (round 1; reviewer independently re-ran the migrate suite and ruff on the changed files).
- **12 new tests**, pre-fix-fail verified: 10 fail on unfixed source; the 2 deliberate negative pins (in-sync targets must NOT produce `.bak` churn) validated by mutation — forcing the divergence check to always-match fails the diverged set, forcing always-diverged fails the negative pins. New symlink-creating tests carry `@pytest.mark.requires_symlinks`.
- Existing 81 migrate tests unchanged and green; full suite green except the known pre-existing `test_session_tracing` failures (#1249, reproduced on clean main).

Backlog bookkeeping: checks off ids 6 and 7 in #1247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
