### PR TITLE
fix(context): install/status hardening — flat-layout guard, untracked status rows, degraded-wiki probe (#1247 B6-7)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -1680,7 +1680,8 @@ def _run_update_all(
     if needs_force and not force:
         click.secho(
             f"\n{len(needs_force)} project(s) have local edits; "
-            f"pass --force to overwrite (each dirty file gets a .bak sibling). "
+            f"pass --force to proceed (modified files in the dest tree get a .bak "
+            f"sibling; flat-layout files are kept on disk but stop being served). "
             f"Refusing to write any project — re-run with --force or resolve manually.",
             fg="red",
             err=True,
@@ -1796,6 +1797,7 @@ _STATUS_GLYPH: dict[str, tuple[str, str]] = {
     "missing": ("!", "red"),
     "stale-pin": ("⚠", "red"),
     "local-draft": ("·", "magenta"),
+    "untracked": ("○", "yellow"),
 }
 
 # ADR-0011 §3 / ADR-0016 §7: project_local agents / commands / skills never
@@ -1844,25 +1846,38 @@ def status_cmd(scope_flag: TargetScope) -> None:
     if lockfile_error is not None:
         click.secho(f"  ✗ lock.json: {lockfile_error}", fg="red", err=True)
 
-    # Header — counts + wiki HEAD (or "wiki not present" annotation).
+    # Header — counts + wiki HEAD (or wiki absent/unusable annotation).
     # Lockfile-tracked installs (project_shared) drive the "installed"
-    # count; project_local rows are surfaced separately so the header
-    # word ("installed") stays accurate for both groups.
-    installed_count = sum(1 for r in rows if r.state != "local-draft")
+    # count; local-draft and untracked rows are surfaced separately so the
+    # header word ("installed") stays accurate for every group (#1247).
+    installed_count = sum(1 for r in rows if r.state not in ("local-draft", "untracked"))
     draft_count = sum(1 for r in rows if r.state == "local-draft")
-    draft_suffix = (
-        f" (+ {draft_count} local draft{'s' if draft_count != 1 else ''})" if draft_count else ""
-    )
+    untracked_count = sum(1 for r in rows if r.state == "untracked")
+    extra_parts: list[str] = []
+    if draft_count:
+        extra_parts.append(f"{draft_count} local draft{'s' if draft_count != 1 else ''}")
+    if untracked_count:
+        extra_parts.append(f"{untracked_count} untracked")
+    extra_suffix = f" (+ {', '.join(extra_parts)})" if extra_parts else ""
     scope_suffix = f" — scope {scope_flag}"
     if wiki_head is None:
         wiki_root = wiki.root
+        # Absent vs present-but-unusable (#1247 id 9): exists() is a pure
+        # stat probe — classify_status already degraded the row reasons;
+        # this only keeps the header from claiming "not present" about a
+        # wiki that IS on disk (e.g. a clone of an empty remote, no HEAD).
+        wiki_note = (
+            f"wiki at {wiki_root} is present but unusable"
+            if wiki.exists()
+            else f"wiki not present at {wiki_root}"
+        )
         click.echo(
-            f".memtomem/ — {installed_count} asset(s) installed{draft_suffix} — "
-            f"wiki not present at {wiki_root}; pin reachability not checked{scope_suffix}"
+            f".memtomem/ — {installed_count} asset(s) installed{extra_suffix} — "
+            f"{wiki_note}; pin reachability not checked{scope_suffix}"
         )
     else:
         click.echo(
-            f".memtomem/ — {installed_count} asset(s) installed{draft_suffix} — "
+            f".memtomem/ — {installed_count} asset(s) installed{extra_suffix} — "
             f"wiki HEAD {wiki_head[:12]}{scope_suffix}"
         )
 
@@ -1872,7 +1887,10 @@ def status_cmd(scope_flag: TargetScope) -> None:
         elif scope_flag == "user":
             click.echo("\nNo user-scope assets found under ~/.memtomem/.")
         else:
-            click.echo(f"\nNo wiki assets installed in this project for scope {scope_flag}.")
+            click.echo(
+                f"\nNo wiki assets installed and no untracked canonicals "
+                f"in this project for scope {scope_flag}."
+            )
         return
 
     # Sectioned by asset type, preserving classify_status() order
@@ -1885,6 +1903,7 @@ def status_cmd(scope_flag: TargetScope) -> None:
         "dirty": 0,
         "missing": 0,
         "stale-pin": 0,
+        "untracked": 0,
         "local-draft": 0,
     }
     for row in rows:
@@ -1892,12 +1911,12 @@ def status_cmd(scope_flag: TargetScope) -> None:
             click.secho(f"\n{row.asset_type}", fg="cyan")
             last_type = row.asset_type
         glyph, color = _STATUS_GLYPH[row.state]
-        # Local-draft rows have no lockfile metadata — render the
-        # pin and installed-at columns as dashes rather than the
-        # "?"/"—" placeholders the lockfile-tracked branches use, so
+        # Local-draft and untracked rows have no lockfile metadata —
+        # render the pin and installed-at columns as dashes rather than
+        # the "?"/"—" placeholders the lockfile-tracked branches use, so
         # the visual distinction is obvious to a reader scanning the
         # column.
-        if row.state == "local-draft":
+        if row.state in ("local-draft", "untracked"):
             line = f"  {glyph}  {row.name:24s}  {'—':<12}  {'(no install record)':<23}"
         else:
             installed_date = row.installed_at[:10] if row.installed_at else "—"
@@ -1915,7 +1934,7 @@ def status_cmd(scope_flag: TargetScope) -> None:
     if rows:
         parts = [
             f"{summary[k]} {k}"
-            for k in ("ok", "behind", "dirty", "missing", "stale-pin", "local-draft")
+            for k in ("ok", "behind", "dirty", "missing", "stale-pin", "untracked", "local-draft")
             if summary[k] > 0
         ]
         if parts:
@@ -1987,7 +2006,8 @@ def _run_install_all(
     if needs_force and not force:
         click.secho(
             f"\n{len(needs_force)} entry(ies) have local edits; "
-            f"pass --force to overwrite (each dirty file gets a .bak sibling). "
+            f"pass --force to proceed (modified files in the dest tree get a .bak "
+            f"sibling; flat-layout files are kept on disk but stop being served). "
             f"Refusing to write any entry — re-run with --force or resolve manually.",
             fg="red",
             err=True,

--- a/packages/memtomem/src/memtomem/context/dirty.py
+++ b/packages/memtomem/src/memtomem/context/dirty.py
@@ -28,6 +28,7 @@ the dest tree separately.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -35,6 +36,8 @@ from typing import Any, Literal
 
 from memtomem.context._atomic import iter_installed_files
 from memtomem.context.lockfile import Lockfile, manifest_from_entry
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "DirtyReason",
@@ -58,9 +61,11 @@ class DirtyReport:
       ``missing_files``) — a user deletion is a local edit too (#1247).
     - ``reason="never_installed"`` — no usable lockfile entry;
       ``installed_at`` is ``None`` and ``dirty_files`` / ``checked_files``
-      are empty. Returned for both "no entry at all" and "entry exists
-      but missing/non-string ``installed_at``" — both are unrecoverable
-      states for a strict mtime compare.
+      are empty. Returned for "no entry at all" and "entry exists but
+      missing / non-string / unparseable ``installed_at``" — all are
+      unrecoverable states for a strict mtime compare (#1247: an
+      unparseable ISO string previously crashed with ``ValueError``
+      instead of degrading like its non-string siblings).
     - ``reason="missing_dest"`` — lockfile entry exists but
       ``<project>/.memtomem/<type>/<name>/`` was deleted; ``installed_at``
       is the lockfile value, ``dirty_files`` empty.
@@ -121,8 +126,23 @@ def is_asset_dirty(
             checked_files=0,
         )
 
+    # Parse before the dest probe so a malformed string degrades to
+    # never_installed in EVERY branch, exactly like its non-string
+    # siblings — previously a malformed string returned missing_dest when
+    # the dest was gone but crashed with ValueError when it existed (#1247).
     installed_at = lock_entry.get("installed_at")
-    if not isinstance(installed_at, str):
+    installed_at_epoch: float | None = None
+    if isinstance(installed_at, str):
+        try:
+            installed_at_epoch = datetime.fromisoformat(installed_at).timestamp()
+        except ValueError:
+            logger.warning(
+                "%s/%s: lockfile installed_at %r is not ISO-8601; treating as never installed",
+                asset_type,
+                name,
+                installed_at,
+            )
+    if installed_at_epoch is None:
         return DirtyReport(
             reason="never_installed",
             installed_at=None,
@@ -138,8 +158,6 @@ def is_asset_dirty(
             dirty_files=(),
             checked_files=0,
         )
-
-    installed_at_epoch = datetime.fromisoformat(installed_at).timestamp()
 
     dirty: list[Path] = []
     checked = 0

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -155,8 +155,11 @@ class ProjectClassification:
       copy wiki bytes when the user confirms.
     - ``"unchanged"`` — wiki HEAD == lockfile pin. No-op; ``dirty_report``
       stays ``None`` because the dirty walk was skipped (cheap by design).
-    - ``"refuse"`` — wiki HEAD ≠ lockfile pin AND dest has local edits.
-      Without ``--force`` the entire batch refuses.
+    - ``"refuse"`` — wiki HEAD ≠ lockfile pin AND the write can't be
+      proven safe: dest has local edits, a live flat-layout sibling
+      would be shadowed, or the entry's ``installed_at`` is unusable
+      over an existing dest (#1247). Without ``--force`` the entire
+      batch refuses.
     - ``"error"`` — the project's lockfile is corrupt or unreadable;
       ``reason`` carries the detail. Propagates as a row-level failure
       in the execute summary.
@@ -706,9 +709,13 @@ def _apply_update(
     Refuses with :class:`StaleInstallError` when ``dirty_report.reason ==
     "dirty"`` and ``force=False``. With ``force=True`` and a dirty tree,
     each dirty file is preserved alongside the wiki bytes as
-    ``<file>.bak`` before the copy. ``shutil.copy2`` is used so the
-    user's edit-mtime survives onto the ``.bak`` (atomic_write_bytes
-    would lose it). After the copy, dest files absent from the wiki
+    ``<file>.bak`` before the copy. An existing dest whose entry has an
+    unusable ``installed_at`` (``reason == "never_installed"``) refuses
+    the same way — nothing is provably clean — and ``--force`` preserves
+    EVERY current dest file as ``.bak`` (#1247). ``shutil.copy2`` is used
+    so the user's edit-mtime survives onto the ``.bak``
+    (atomic_write_bytes would lose it). After the copy, dest files absent
+    from the wiki
     source are reconciled away (:func:`_reconcile_removed_files`,
     #1247) so the refreshed tree mirrors the wiki instead of growing
     additively. ``installed_at`` is captured *after* copy + reconcile,
@@ -721,6 +728,22 @@ def _apply_update(
             f"since install at {dirty_report.installed_at}; "
             f"pass --force to overwrite "
             f"(each modified file gets a .bak sibling; deleted files are restored)"
+        )
+
+    # Unprovable install record (#1247 impl gate): the entry exists but its
+    # installed_at is missing/non-string/unparseable, so NO file in an
+    # EXISTING dest tree can be proven clean — refusing is the only
+    # non-destructive default. (Pre-#1247 a malformed string crashed with a
+    # ValueError here; degrading that crash to never_installed must not
+    # degrade it into a silent overwrite.) --force proceeds with EVERY
+    # current dest file preserved as .bak, not just a dirty subset — there
+    # is no epoch to subset by.
+    unprovable = dirty_report.reason == "never_installed" and dest.is_dir()
+    if unprovable and not force:
+        raise StaleInstallError(
+            f"{asset_type}/{name}: install record unusable (missing or malformed "
+            f"installed_at) — local edits cannot be ruled out; pass --force to "
+            f"overwrite (every current file gets a .bak sibling)"
         )
 
     # Flat-layout guard (#1247 id 0): a flat file + lockfile entry with no
@@ -762,9 +785,14 @@ def _apply_update(
         asset_type=asset_type,
         name=name,
     )
+    files_to_bak: tuple[Path, ...] = ()
     if force and dirty_report.reason == "dirty":
+        files_to_bak = dirty_report.dirty_files
+    elif force and unprovable:
+        files_to_bak = tuple(iter_installed_files(dest))
+    if files_to_bak:
         _gate_a_scan_dirty_files(
-            dirty_report.dirty_files,
+            files_to_bak,
             surface=surface,
             project_root=project_root,
             asset_type=asset_type,
@@ -772,15 +800,14 @@ def _apply_update(
         )
 
     bak_paths: list[Path] = []
-    if force and dirty_report.reason == "dirty":
-        for f in dirty_report.dirty_files:
-            bak = f.with_suffix(f.suffix + ".bak")
-            # shutil.copy2 preserves user edit's mtime — atomic_write_bytes
-            # would lose it. Race window between copy2 and copy_tree_atomic
-            # is sub-ms; acceptable for v1. Overwrite-if-exists policy
-            # (prior .bak from earlier --force gets replaced).
-            shutil.copy2(f, bak)
-            bak_paths.append(bak)
+    for f in files_to_bak:
+        bak = f.with_suffix(f.suffix + ".bak")
+        # shutil.copy2 preserves user edit's mtime — atomic_write_bytes
+        # would lose it. Race window between copy2 and copy_tree_atomic
+        # is sub-ms; acceptable for v1. Overwrite-if-exists policy
+        # (prior .bak from earlier --force gets replaced).
+        shutil.copy2(f, bak)
+        bak_paths.append(bak)
 
     dest.parent.mkdir(parents=True, exist_ok=True)
     files_written = copy_tree_atomic(src, dest, skip_suffixes=DIRTY_SKIP_SUFFIXES)
@@ -798,11 +825,7 @@ def _apply_update(
         dest,
         src_has=lambda rel: rel in src_files,
         old_installed_at_epoch=_installed_at_epoch(lock_entry),
-        baked=(
-            frozenset(dirty_report.dirty_files)
-            if force and dirty_report.reason == "dirty"
-            else frozenset()
-        ),
+        baked=frozenset(files_to_bak),
         manifest=manifest_from_entry(lock_entry),
     )
 
@@ -937,13 +960,9 @@ def _classify_for_all_update(
 
         # Wiki advanced — classify dirty/clean for this project.
         report = is_asset_dirty(project_root, asset_type, name, lock_entry=lock_entry)
+        dest = project_root / ".memtomem" / asset_type / name
         flat_path, flat_dirty = (
-            _flat_layout_probe(
-                project_root / ".memtomem" / asset_type / name,
-                asset_type,
-                name,
-                lock_entry,
-            )
+            _flat_layout_probe(dest, asset_type, name, lock_entry)
             if report.reason in ("missing_dest", "never_installed")
             else (None, False)
         )
@@ -958,6 +977,15 @@ def _classify_for_all_update(
             reason = (
                 f"flat layout with local edits; run "
                 f"`mm context migrate {asset_type.removesuffix('s')} {name}` first"
+            )
+        elif report.reason == "never_installed" and dest.is_dir():
+            # Unprovable install record over an existing dest — preview
+            # parity with _apply_update's unprovable gate (#1247 impl
+            # gate): nothing is provably clean, so the batch must refuse
+            # rather than silently overwrite.
+            state = "refuse"
+            reason = (
+                "install record unusable (malformed installed_at); local edits cannot be ruled out"
             )
         else:
             state = "update"
@@ -997,9 +1025,13 @@ class ProjectInstallClassification:
     - ``"skip"`` — dest exists and is clean. Default behavior is no-op;
       ``--force`` re-extracts at the pin (no ``.bak`` since there's
       nothing to preserve).
-    - ``"refuse"`` — dest exists and has local edits. Without ``--force``
-      the entire batch refuses (no writes). With ``--force`` each dirty
-      file is preserved as ``<file>.bak`` then the pin is re-extracted.
+    - ``"refuse"`` — the restore can't be proven safe: dest exists with
+      local edits, the entry's ``installed_at`` is unusable over an
+      existing dest, or a live flat-layout sibling would be shadowed
+      (#1247). Without ``--force`` the entire batch refuses (no writes).
+      With ``--force`` the at-risk dest files (dirty subset, or every
+      current file when unprovable) are preserved as ``<file>.bak`` then
+      the pin is re-extracted; flat siblings are kept in place.
     - ``"orphan"`` — the pinned ``wiki_commit`` is not reachable in the
       wiki repo (history rewrite, force-push past the pin). Per-entry
       skip with a yellow warning row; the batch continues so the user
@@ -1173,11 +1205,19 @@ def _classify_for_install_all(
         if report.reason == "dirty":
             state: Literal["install", "skip", "refuse", "orphan", "error"] = "refuse"
             reason: str | None = report.summary()
+        elif report.reason == "never_installed":
+            # Dest exists here, so this is exactly "entry present but
+            # unusable installed_at" — unprovable. Collapsing it to "skip"
+            # would let --force re-extract over possible local edits with
+            # no .bak (#1247 impl gate); mirror _apply_update's refuse.
+            state = "refuse"
+            reason = (
+                "install record unusable (malformed installed_at); local edits cannot be ruled out"
+            )
         else:
-            # clean / missing_dest / never_installed all collapse to "skip" here:
-            # missing_dest is impossible (we already saw dest.exists()), and
-            # never_installed shouldn't happen (we read the entry above), so
-            # this is effectively the clean path.
+            # clean / missing_dest collapse to "skip" here: missing_dest is
+            # impossible (we already saw dest.exists()), so this is
+            # effectively the clean path.
             state = "skip"
             reason = "already installed"
 
@@ -1226,9 +1266,11 @@ def _apply_pinned_install(
     - ``state="refuse"`` + ``force=False``: raise
       :class:`StaleInstallError` (caller already aborted batch; defense
       in depth).
-    - ``state="refuse"`` + ``force=True``: ``shutil.copy2`` each dirty
-      file to ``<file>.bak`` (mirroring ``_apply_update``), then extract
-      at pin.
+    - ``state="refuse"`` + ``force=True``: ``shutil.copy2`` the at-risk
+      dest files to ``<file>.bak`` (the dirty subset, or EVERY current
+      file when the install record is unusable — mirroring
+      ``_apply_update``, #1247), then extract at pin. Flat-layout refuse
+      rows have no dest to preserve; the flat file stays in place.
     """
     pin = classification.pin_commit
     asset_type = classification.asset_type
@@ -1260,11 +1302,23 @@ def _apply_pinned_install(
         surface=surface,
         project_root=project_root,
     )
+    files_to_bak: tuple[Path, ...] = ()
     if classification.state == "refuse" and force:
         report = classification.dirty_report
         assert report is not None  # state=refuse always carries a report
+        if report.reason == "dirty":
+            files_to_bak = report.dirty_files
+        elif report.reason == "never_installed" and dest.is_dir():
+            # Unprovable install record over an existing dest (#1247 impl
+            # gate): no epoch to subset by, so preserve EVERY current file
+            # before the pin re-extraction — mirrors _apply_update. (The
+            # flat-refuse rows also carry never_installed/missing_dest
+            # reports, but their dest is absent → no bak set, the flat
+            # file is preserved in place.)
+            files_to_bak = tuple(iter_installed_files(dest))
+    if files_to_bak:
         _gate_a_scan_dirty_files(
-            report.dirty_files,
+            files_to_bak,
             surface=surface,
             project_root=project_root,
             asset_type=asset_type,
@@ -1272,13 +1326,10 @@ def _apply_pinned_install(
         )
 
     bak_paths: list[Path] = []
-    if classification.state == "refuse" and force:
-        report = classification.dirty_report
-        assert report is not None  # state=refuse always carries a report
-        for f in report.dirty_files:
-            bak = f.with_suffix(f.suffix + ".bak")
-            shutil.copy2(f, bak)
-            bak_paths.append(bak)
+    for f in files_to_bak:
+        bak = f.with_suffix(f.suffix + ".bak")
+        shutil.copy2(f, bak)
+        bak_paths.append(bak)
 
     files_written = wiki.copy_asset_at_commit(pin, asset_type, name, dest)
 
@@ -1295,11 +1346,7 @@ def _apply_pinned_install(
             dest,
             src_has=lambda rel: rel in expected,
             old_installed_at_epoch=_installed_at_epoch(entry),
-            baked=(
-                frozenset(classification.dirty_report.dirty_files)
-                if classification.state == "refuse" and classification.dirty_report is not None
-                else frozenset()
-            ),
+            baked=frozenset(files_to_bak),
             manifest=manifest_from_entry(entry),
         )
 

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -225,6 +225,44 @@ def _installed_at_epoch(lock_entry: dict[str, Any]) -> float | None:
         return None
 
 
+def _flat_layout_probe(
+    dest: Path,
+    asset_type: str,
+    name: str,
+    lock_entry: dict[str, Any] | None,
+) -> tuple[Path | None, bool]:
+    """Probe the legacy flat-layout sibling of a dir-layout dest (#1247).
+
+    Returns ``(flat_path, dirty_or_unprovable)``. ``flat_path`` is
+    ``<dest_parent>/<name>.md`` when it exists as a file AND ``dest`` itself
+    is not a directory, else ``None``. Writing the dir layout next to a live
+    flat file flips fan-out serving from the flat bytes to the wiki bytes
+    (dir wins in ``list_canonical_agents``/``commands``), so callers must
+    refuse when the flat file can't be proven clean. The ``dest.is_dir()``
+    short-circuit scopes the guard to that serving FLIP: when the dir
+    already exists, dir-wins already happened and this write isn't what
+    shadows the flat file.
+
+    The dirty rule matches ``migrate._is_flat_file_dirty`` — strict
+    ``mtime > installed_at_epoch`` — with one addition: an entry whose
+    ``installed_at`` is missing/non-string/unparseable
+    (:func:`_installed_at_epoch` → ``None``) counts as dirty-or-unprovable.
+    "Can't prove clean" must protect, not proceed — without this, a
+    malformed timestamp (classified ``never_installed``) would skip the
+    guard entirely (#1247 design gate M1). Skills have no flat layout;
+    other asset types return ``(None, False)``.
+    """
+    if asset_type not in ("agents", "commands") or dest.is_dir():
+        return None, False
+    flat = dest.parent / f"{name}.md"
+    if not flat.is_file():
+        return None, False
+    epoch = _installed_at_epoch(lock_entry or {})
+    if epoch is None:
+        return flat, True
+    return flat, flat.stat().st_mtime > epoch
+
+
 def _manifest_relpaths(dest: Path) -> list[str]:
     """The asset's installed file set as sorted POSIX relpaths.
 
@@ -457,12 +495,30 @@ def _install_asset(
     has_dest = dest.exists()
     if has_lock or has_dest:
         asset_type_singular = asset_type.removesuffix("s")
+        if has_dest and not has_lock:
+            # Half-install leftovers (copy succeeded, lockfile write failed
+            # or interrupted) and hand-placed trees both land here. The
+            # update hint would dead-end (`mm context update` raises
+            # NotInstalledError without an entry and points back at
+            # install — a circle, #1247 id 4). No auto-adopt either:
+            # install can't tell a leftover from hand-placed content it
+            # must not clobber.
+            hint = (
+                f"dest exists with no lockfile entry — hand-placed files or an "
+                f"install interrupted before its lockfile write; inspect {dest}, "
+                f"remove the directory if it's disposable, then re-run "
+                f"`mm context install {asset_type_singular} {validated}`"
+            )
+        else:
+            hint = (
+                f"run `mm context update {asset_type_singular} {validated}` "
+                f"to refresh from wiki HEAD"
+            )
         raise AlreadyInstalledError(
             f"{asset_type}/{validated}: "
             f"lockfile_entry={'yes' if has_lock else 'no'}, "
             f"dest={'yes' if has_dest else 'no'}; "
-            f"run `mm context update {asset_type_singular} {validated}` "
-            f"to refresh from wiki HEAD"
+            f"{hint}"
         )
 
     # Gate A (ADR-0011 §5, #1247): wiki bytes are user-tier — secrets are
@@ -667,6 +723,35 @@ def _apply_update(
             f"(each modified file gets a .bak sibling; deleted files are restored)"
         )
 
+    # Flat-layout guard (#1247 id 0): a flat file + lockfile entry with no
+    # dest dir classifies missing_dest (or never_installed when the entry's
+    # installed_at is unusable), which sails past the dirty gate above —
+    # yet writing the dir layout silently stops the flat file being served.
+    # Refuse like migrate's refuse_dirty unless --force. No .bak and no
+    # deletion under --force: nothing overwrites the flat file (it stays on
+    # disk, merely shadowed) and consolidation is `mm context migrate`'s job.
+    if dirty_report.reason in ("missing_dest", "never_installed"):
+        flat_path, flat_dirty = _flat_layout_probe(dest, asset_type, name, lock_entry)
+        if flat_path is not None:
+            kind = asset_type.removesuffix("s")
+            if flat_dirty and not force:
+                raise StaleInstallError(
+                    f"{asset_type}/{name}: flat-layout file {flat_path.name} has local "
+                    f"edits (or no provable install time) and the dir-layout install "
+                    f"would stop it being served; run `mm context migrate {kind} {name}` "
+                    f"first, or pass --force to write the dir layout anyway (the flat "
+                    f"file is kept on disk but stops being served)"
+                )
+            logger.warning(
+                "%s/%s: dir layout will shadow flat file %s (dir wins at fan-out); "
+                "run `mm context migrate %s %s` to consolidate",
+                asset_type,
+                name,
+                flat_path,
+                kind,
+                name,
+            )
+
     # Gate A (ADR-0011 §5, #1247): both scans precede the .bak loop — the
     # first dest mutation with no rollback — so a privacy refusal leaves
     # no .bak, no copied bytes, and (upserts trail copies) no lockfile drift.
@@ -852,9 +937,28 @@ def _classify_for_all_update(
 
         # Wiki advanced — classify dirty/clean for this project.
         report = is_asset_dirty(project_root, asset_type, name, lock_entry=lock_entry)
+        flat_path, flat_dirty = (
+            _flat_layout_probe(
+                project_root / ".memtomem" / asset_type / name,
+                asset_type,
+                name,
+                lock_entry,
+            )
+            if report.reason in ("missing_dest", "never_installed")
+            else (None, False)
+        )
         if report.reason == "dirty":
             state: Literal["update", "unchanged", "refuse", "error"] = "refuse"
             reason: str | None = f"{report.summary()} since install"
+        elif flat_path is not None and flat_dirty:
+            # Preview parity with _apply_update's flat-layout guard
+            # (#1247 id 0): the batch table must show the refusal the
+            # execute phase would raise.
+            state = "refuse"
+            reason = (
+                f"flat layout with local edits; run "
+                f"`mm context migrate {asset_type.removesuffix('s')} {name}` first"
+            )
         else:
             state = "update"
             reason = None
@@ -931,9 +1035,17 @@ def _classify_for_install_all(
     1. Read pin from the entry; missing/empty → state=``error``.
     2. Reachability via :meth:`WikiStore.commit_is_reachable`; missing →
        state=``orphan``.
-    3. Dest existence check:
+    3. Asset-path presence at the pin via
+       :meth:`WikiStore.asset_files_at_commit` (the extractor's own
+       ls-tree shape); absent → state=``error`` (#1247 id 5 —
+       preview/execute parity with the extract phase's
+       ``AssetNotFoundError``).
+    4. Dest existence check:
 
-       - missing → state=``install`` (no dirty walk needed).
+       - missing → probe the flat-layout sibling
+         (:func:`_flat_layout_probe`, #1247 id 0): dirty/unprovable flat
+         → state=``refuse``; else state=``install`` (no dirty walk
+         needed).
        - present → run :func:`is_asset_dirty` against the cached entry:
          clean → state=``skip``, dirty → state=``refuse``.
 
@@ -979,8 +1091,71 @@ def _classify_for_install_all(
             )
             continue
 
+        # Preview/execute parity (#1247 id 5): the state="error" docstring
+        # promises "asset path missing at the pinned commit", but nothing
+        # probed it — such rows previewed green as install/skip and only the
+        # execute phase hit AssetNotFoundError from the extractor. Probe with
+        # the extractor's own ls-tree helper so the two can't drift. Sits
+        # before the dest check: a skip/refuse row at an unrestorable pin is
+        # just as unrestorable (--force re-extracts at the pin).
+        try:
+            wiki.asset_files_at_commit(pin, asset_type, name)
+        except AssetNotFoundError:
+            out.append(
+                ProjectInstallClassification(
+                    asset_type=asset_type,  # type: ignore[arg-type]
+                    name=name,
+                    pin_commit=pin,
+                    state="error",
+                    reason=f"{asset_type}/{name} not present at pin {pin[:12]}",
+                    lock_entry=entry,
+                    dirty_report=None,
+                )
+            )
+            continue
+        except CommitNotFoundError:
+            # Race: reachable in the check above, gone by the ls-tree probe.
+            out.append(
+                ProjectInstallClassification(
+                    asset_type=asset_type,  # type: ignore[arg-type]
+                    name=name,
+                    pin_commit=pin,
+                    state="orphan",
+                    reason=f"pin {pin[:12]} not reachable",
+                    lock_entry=entry,
+                    dirty_report=None,
+                )
+            )
+            continue
+
         dest = project_root / ".memtomem" / asset_type / name
         if not dest.exists():
+            flat_path, flat_dirty = _flat_layout_probe(dest, asset_type, name, entry)
+            if flat_path is not None and flat_dirty:
+                # Flat-layout guard (#1247 id 0): extracting the dir layout
+                # next to a dirty (or unprovable) flat file would silently
+                # stop the user's flat bytes being served. dirty_report is
+                # attached (a missing_dest/never_installed report) so
+                # _apply_pinned_install's refuse-state invariants hold; its
+                # --force .bak loop iterates dirty_files=() — nothing is
+                # overwritten, the flat file stays on disk.
+                out.append(
+                    ProjectInstallClassification(
+                        asset_type=asset_type,  # type: ignore[arg-type]
+                        name=name,
+                        pin_commit=pin,
+                        state="refuse",
+                        reason=(
+                            f"flat layout with local edits; run `mm context migrate "
+                            f"{asset_type.removesuffix('s')} {name}` first"
+                        ),
+                        lock_entry=entry,
+                        dirty_report=is_asset_dirty(
+                            project_root, asset_type, name, lock_entry=entry
+                        ),
+                    )
+                )
+                continue
             out.append(
                 ProjectInstallClassification(
                     asset_type=asset_type,  # type: ignore[arg-type]

--- a/packages/memtomem/src/memtomem/context/migrate.py
+++ b/packages/memtomem/src/memtomem/context/migrate.py
@@ -214,12 +214,30 @@ def _is_flat_file_dirty(flat_path: Path, lock_entry: dict[str, Any]) -> bool:
     Timezone handling matches ``dirty.py`` — ``datetime.fromisoformat``
     on the ISO-8601Z string. Python 3.11+ accepts the ``Z`` suffix
     natively, so no manual replacement is needed.
+
+    Callers must pre-validate ``installed_at`` with
+    :func:`_installed_at_parseable` (``_classify_row`` demotes unusable
+    entries to ``lock_entry=None`` before reaching here). Deliberately NOT
+    catching ``ValueError`` here — returning ``False`` would mean "clean"
+    and approve overwriting user edits on a corrupt entry (#1247 id 1).
     """
     installed_at = lock_entry.get("installed_at")
     if not isinstance(installed_at, str):
         return False
     installed_at_epoch = datetime.fromisoformat(installed_at).timestamp()
     return flat_path.stat().st_mtime > installed_at_epoch
+
+
+def _installed_at_parseable(lock_entry: dict[str, Any]) -> bool:
+    """``True`` when the entry's ``installed_at`` is a parseable ISO-8601 string."""
+    installed_at = lock_entry.get("installed_at")
+    if not isinstance(installed_at, str):
+        return False
+    try:
+        datetime.fromisoformat(installed_at)
+    except ValueError:
+        return False
+    return True
 
 
 def _flat_path_for(project_root: Path, asset_type: str, name: str) -> Path:
@@ -250,11 +268,14 @@ def _classify_row(
 
     # Treat a lockfile entry without a usable ``installed_at`` as "no
     # entry" — mirrors :func:`memtomem.context.dirty.is_asset_dirty`,
-    # which collapses both "no entry" and "entry but missing/non-string
-    # installed_at" into ``never_installed``. Otherwise migrate would
-    # silently proceed against a corrupt entry (no dirty check possible)
-    # and could overwrite user edits.
-    if lock_entry is not None and not isinstance(lock_entry.get("installed_at"), str):
+    # which collapses "no entry", "entry but missing/non-string
+    # installed_at" and "unparseable installed_at string" into
+    # ``never_installed``. Otherwise migrate would silently proceed
+    # against a corrupt entry (no dirty check possible) and could
+    # overwrite user edits. The parse probe (not just isinstance) keeps
+    # an unparseable string from reaching ``_is_flat_file_dirty``'s
+    # deliberately-unguarded ``fromisoformat`` (#1247 id 1).
+    if lock_entry is not None and not _installed_at_parseable(lock_entry):
         logger.warning(
             "migrate: %s/%s lockfile entry missing or invalid installed_at; "
             "treating as never installed",

--- a/packages/memtomem/src/memtomem/context/status.py
+++ b/packages/memtomem/src/memtomem/context/status.py
@@ -198,6 +198,11 @@ def classify_status(
                 reason = (
                     f"flat layout; run `mm context migrate {asset_type.removesuffix('s')} {name}`"
                 )
+            elif report.reason == "never_installed" and dest.is_dir():
+                # Entry present but unusable installed_at over an existing
+                # dest — "dest missing" would be flatly wrong. Mirrors the
+                # update/install-all "unprovable" refuse reason (#1247).
+                reason = "install record unusable (malformed installed_at)"
         elif report.reason == "dirty":
             state = "dirty"
             dirty_count = len(report.dirty_files) + len(report.missing_files)

--- a/packages/memtomem/src/memtomem/context/status.py
+++ b/packages/memtomem/src/memtomem/context/status.py
@@ -13,19 +13,27 @@ State semantics for each lockfile entry:
 - ``dirty`` — dest has local edits since ``installed_at``
 - ``missing`` — lockfile entry exists but ``<project>/.memtomem/<type>/<name>/``
   is gone (collapses :data:`memtomem.context.dirty.DirtyReport.reason`
-  values ``missing_dest`` and ``never_installed``)
-- ``stale-pin`` — wiki absent OR pin not reachable in the wiki repo
-  (history rewrite, force-push past the pin, etc.)
+  values ``missing_dest`` and ``never_installed``); when a legacy
+  flat-layout sibling (``<type>/<name>.md``) is what actually serves the
+  asset, the row's reason points at ``mm context migrate`` instead of
+  claiming "dest missing" (#1247)
+- ``stale-pin`` — wiki absent or unusable, OR pin not reachable in the
+  wiki repo (history rewrite, force-push past the pin, etc.)
+- ``untracked`` — project_shared canonical on disk with no lockfile entry
+  (reverse-imported via ``mm context init`` or moved in via ``mm context
+  migrate --to project_shared``); actively served by sync fan-out, just
+  not a wiki install (#1247)
 
-The wiki-absent case still renders rows: status is read-only and the
-lockfile is local; we just can't compute ``behind``/``stale-pin``
-without a wiki to compare against.
+The wiki-absent (or present-but-unusable, e.g. a clone of an empty
+remote with no HEAD) case still renders rows: status is read-only and
+the lockfile is local; we just can't compute ``behind``/``stale-pin``
+without a usable wiki to compare against.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Literal
 
@@ -47,7 +55,7 @@ __all__ = [
 ]
 
 
-StatusState = Literal["ok", "behind", "dirty", "missing", "stale-pin", "local-draft"]
+StatusState = Literal["ok", "behind", "dirty", "missing", "stale-pin", "local-draft", "untracked"]
 
 _LOCAL_DRAFT_MANIFEST: dict[str, str] = {
     "agents": AGENT_DIR_FILENAME,
@@ -75,7 +83,9 @@ class StatusRow:
 
     ``tier`` distinguishes lockfile-tracked installs (``project_shared``)
     from author-managed drafts. :func:`classify_status` walks the
-    project-rooted tiers — lockfile installs plus
+    project-rooted tiers — lockfile installs, non-lockfile project_shared
+    canonicals (``state="untracked"``: reverse-imported / migrated-in
+    artifacts with no wiki pin, #1247), plus
     ``<proj>/.memtomem/<artifact>.local/`` (``project_local``) drafts. The
     global ``~/.memtomem/<artifact>/`` (``user``) tier is enumerated
     separately by :func:`scan_user_artifacts`, which the CLI surfaces for
@@ -129,6 +139,7 @@ def classify_status(
 
     wiki_head: str | None = None
     wiki_present = False
+    wiki_unavailable_reason = "wiki not present"
     if wiki is None:
         wiki = WikiStore.at_default()
     try:
@@ -137,9 +148,25 @@ def classify_status(
     except WikiNotFoundError:
         wiki_head = None
         wiki_present = False
+    except (RuntimeError, OSError) as exc:
+        # Degraded wiki (#1247 id 9): present but unusable — a clone of an
+        # empty remote has .git but no HEAD (`rev-parse HEAD` fails as a
+        # bare RuntimeError from WikiStore._git), the object store may be
+        # corrupt, or git itself is missing from PATH (OSError). status is
+        # the read-only diagnostic verb a user would run to investigate, so
+        # it must degrade like the absent-wiki case instead of escaping as
+        # a traceback. WikiNotFoundError subclasses RuntimeError — its arm
+        # above must stay first.
+        wiki_head = None
+        wiki_present = False
+        detail_lines = str(exc).strip().splitlines()
+        detail = detail_lines[0] if detail_lines else exc.__class__.__name__
+        wiki_unavailable_reason = f"wiki unusable: {detail}"
 
     rows: list[StatusRow] = []
+    tracked: set[tuple[str, str]] = set()
     for asset_type, name, entry in _tolerant_iter_entries(lockfile):
+        tracked.add((asset_type, name))
         if asset_type not in ("skills", "agents", "commands"):
             # Unknown asset_type — forward-compat shape is preserved
             # by iter_entries, but we can only render the three known
@@ -159,6 +186,18 @@ def classify_status(
         if report.reason in ("missing_dest", "never_installed"):
             state = "missing"
             reason = "dest missing"
+            # Flat-layout population (#1247 id 0): the dir-layout dest is
+            # missing but a legacy flat sibling exists and is what fan-out
+            # actually serves — "dest missing" would misreport a live
+            # asset. Point at the migrate verb instead. Mirrors
+            # install._flat_layout_probe's scope (agents/commands only;
+            # dest dir absent).
+            dest = project_root_path / ".memtomem" / asset_type / name
+            flat = project_root_path / ".memtomem" / asset_type / f"{name}.md"
+            if asset_type in ("agents", "commands") and not dest.is_dir() and flat.is_file():
+                reason = (
+                    f"flat layout; run `mm context migrate {asset_type.removesuffix('s')} {name}`"
+                )
         elif report.reason == "dirty":
             state = "dirty"
             dirty_count = len(report.dirty_files) + len(report.missing_files)
@@ -166,7 +205,7 @@ def classify_status(
         else:  # report.reason == "clean"
             if not wiki_present:
                 state = "stale-pin"
-                reason = "wiki not present"
+                reason = wiki_unavailable_reason
             elif not pin_commit:
                 state = "stale-pin"
                 reason = "lockfile entry missing wiki_commit"
@@ -193,6 +232,7 @@ def classify_status(
         )
 
     rows.extend(_scan_project_local_drafts(project_root_path))
+    rows.extend(_scan_project_shared_untracked(project_root_path, tracked))
 
     # Final order: alphabetical by (asset_type, name); within a name,
     # project_shared (lockfile-tracked install) renders before
@@ -289,6 +329,36 @@ def _scan_draft_tier(scope: TargetScope, project_root: Path | None) -> Iterator[
                 reason=None,
                 tier=scope,
             )
+
+
+def _scan_project_shared_untracked(
+    project_root: Path,
+    tracked: set[tuple[str, str]],
+) -> Iterator[StatusRow]:
+    """Yield ``untracked`` rows for project_shared canonicals with no lockfile entry.
+
+    ``mm context init --include ...`` (reverse import) and ``mm context
+    migrate <kind> <name> --to project_shared`` both write the project_shared
+    canonical tier without a lockfile entry — they are not wiki installs, so
+    there is no pin to record. Those artifacts are actively served (sync fans
+    them out from disk via ``list_canonical_*``), and ADR-0016 §6 names
+    ``mm context status --scope <tier>`` as the per-tier inspection surface,
+    so omitting them misreported a populated tier as "0 asset(s) installed"
+    (#1247 id 8).
+
+    Reuses :func:`_scan_draft_tier`'s walk (dir-with-manifest + flat layouts,
+    internal-dir skip, dir-wins-on-collision) and rewrites the rows:
+    ``state="untracked"`` — deliberately NOT ``local-draft``, because
+    project_shared canonicals fan out while drafts don't — with a fixed
+    reason. *tracked* carries the lockfile-tracked ``(asset_type, name)``
+    pairs to drop: those names already render as lockfile rows (including
+    the flat-layout ``missing`` hint, #1247 id 0), so emitting them here
+    would double-report.
+    """
+    for row in _scan_draft_tier("project_shared", project_root):
+        if (row.asset_type, row.name) in tracked:
+            continue
+        yield replace(row, state="untracked", reason="not lockfile-tracked; no wiki pin")
 
 
 def _scan_project_local_drafts(project_root: Path) -> Iterator[StatusRow]:

--- a/packages/memtomem/tests/test_context_install.py
+++ b/packages/memtomem/tests/test_context_install.py
@@ -550,3 +550,51 @@ def test_cli_install_privacy_block_exit_and_message(
     assert "Gate A" in result.output
     assert "AKIA1234567890ABCDEF" not in result.output
     assert "Traceback" not in result.output
+
+
+# ── interrupted-install hint (#1247 id 4) ────────────────────────────────
+
+
+def test_install_interrupted_before_lockfile_hint_breaks_circle(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """#1247 id 4: the dest-only state must not point at `mm context update`.
+
+    A copy that succeeds but whose lockfile upsert fails (disk full,
+    Ctrl-C) leaves dest with no entry. Pre-fix, install's refusal said
+    "run `mm context update`" unconditionally, and update raised
+    NotInstalledError saying "run `mm context install` first" — a closed
+    circle with no in-product exit."""
+    from memtomem.context.install import NotInstalledError, update_skill
+
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
+    project = tmp_path
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise OSError("disk full")
+
+    with pytest.MonkeyPatch.context() as patch_ctx:
+        patch_ctx.setattr(Lockfile, "upsert_entry", _boom)
+        with pytest.raises(OSError):
+            install_skill(project, "foo")
+
+    dest = project / ".memtomem" / "skills" / "foo"
+    assert dest.is_dir()  # half-installed: copy landed, lockfile write failed
+
+    with pytest.raises(AlreadyInstalledError) as excinfo:
+        install_skill(project, "foo")
+    msg = str(excinfo.value)
+    # Pin-and-invert: the old circular hint must be gone for dest-only...
+    assert "mm context update" not in msg
+    assert "lockfile_entry=no" in msg
+    assert "dest=yes" in msg
+    assert "interrupted" in msg
+    assert "mm context install skill foo" in msg
+    assert str(dest) in msg
+
+    # ...and the other half of the old circle still dead-ends by design:
+    # update without an entry refuses toward install. Proves the pre-fix
+    # hint pair really was a closed loop.
+    with pytest.raises(NotInstalledError):
+        update_skill(project, "foo")

--- a/packages/memtomem/tests/test_context_install_all.py
+++ b/packages/memtomem/tests/test_context_install_all.py
@@ -793,3 +793,119 @@ class TestPrivacyGateBatchIngress:
         by_tool = privacy.snapshot()["by_tool"]
         assert by_tool["cli_context_update_all"]["blocked"] >= 1
         assert "cli_context_update" not in by_tool
+
+
+# ── asset missing at reachable pin (#1247 id 5) ──────────────────────────
+
+
+def _retarget_pin(project: Path, asset_type: str, name: str, pin: str) -> None:
+    lock_path = project / ".memtomem" / "lock.json"
+    doc = json.loads(lock_path.read_text(encoding="utf-8"))
+    doc[asset_type][name]["wiki_commit"] = pin
+    lock_path.write_text(json.dumps(doc), encoding="utf-8")
+
+
+def test_classify_error_when_asset_missing_at_pin(wiki_root: Path, tmp_path: Path) -> None:
+    """#1247 id 5: a reachable pin lacking the asset path must preview as
+    state="error", not green "install".
+
+    Pre-fix the classifier checked only pin presence + reachability +
+    dest existence, so the row previewed as install and the user found
+    out via the execute phase's AssetNotFoundError — a preview/execute
+    contract mismatch against ProjectInstallClassification's docstring."""
+    from memtomem.context.install import _classify_for_install_all
+
+    _initialized_wiki(wiki_root)
+    c1 = _seed_wiki_asset(wiki_root, "skills", "alpha", {"SKILL.md": b"a\n"})
+    install_skill(tmp_path, "alpha")
+    _seed_wiki_asset(wiki_root, "skills", "beta", {"SKILL.md": b"b\n"})
+    install_skill(tmp_path, "beta")
+
+    # beta pinned to c1 — reachable, but skills/beta has no tree entry there.
+    _retarget_pin(tmp_path, "skills", "beta", c1)
+    shutil.rmtree(tmp_path / ".memtomem" / "skills" / "beta")
+
+    rows = _classify_for_install_all(tmp_path, wiki=WikiStore.at_default())
+
+    by_name = {(r.asset_type, r.name): r for r in rows}
+    beta = by_name[("skills", "beta")]
+    assert beta.state == "error"
+    assert "not present at pin" in (beta.reason or "")
+    assert beta.pin_commit == c1
+    alpha = by_name[("skills", "alpha")]
+    assert alpha.state == "skip"
+
+
+def test_cli_install_all_error_row_in_preview_not_execute(
+    wiki_root: Path, tmp_path: Path, monkeypatch
+) -> None:
+    """The preview table itself must carry the red error row; the execute
+    phase must not be the first place the bad pin surfaces."""
+    _initialized_wiki(wiki_root)
+    c1 = _seed_wiki_asset(wiki_root, "skills", "alpha", {"SKILL.md": b"a\n"})
+    install_skill(tmp_path, "alpha")
+    _seed_wiki_asset(wiki_root, "skills", "beta", {"SKILL.md": b"b\n"})
+    install_skill(tmp_path, "beta")
+    _retarget_pin(tmp_path, "skills", "beta", c1)
+    shutil.rmtree(tmp_path / ".memtomem" / "skills" / "beta")
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["install", "--all", "--yes"])
+
+    # alpha=skip + beta=error → nothing actionable; the error row exits 1.
+    assert "error" in result.output
+    assert "not present at pin" in result.output
+    assert "Nothing to install" in result.output
+    assert result.exit_code == 1
+
+
+# ── flat-layout guard (#1247 id 0, install --all) ────────────────────────
+
+
+def test_install_all_refuses_dirty_flat_sibling(wiki_root: Path, tmp_path: Path) -> None:
+    """Restoring the dir layout next to a dirty flat file must classify
+    refuse — extraction would silently stop the flat bytes being served."""
+    from memtomem.context.install import _classify_for_install_all
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "agents", "foo", {"agent.md": b"wiki\n"})
+    install_agent(tmp_path, "foo")
+
+    # Convert to the flat population: dir gone, flat present, entry kept.
+    shutil.rmtree(tmp_path / ".memtomem" / "agents" / "foo")
+    flat = tmp_path / ".memtomem" / "agents" / "foo.md"
+    flat.write_bytes(b"# local flat\n")
+    _bump_mtime(flat)
+
+    rows = _classify_for_install_all(tmp_path, wiki=WikiStore.at_default())
+
+    [row] = rows
+    assert row.state == "refuse"
+    assert "flat layout" in (row.reason or "")
+    assert "migrate" in (row.reason or "")
+    assert row.dirty_report is not None
+
+
+def test_install_all_force_extracts_dir_and_preserves_flat(wiki_root: Path, tmp_path: Path) -> None:
+    """--force on the flat-refuse row extracts the dir; the flat file stays
+    on disk with no .bak (nothing was overwritten)."""
+    from memtomem.context.install import _apply_pinned_install, _classify_for_install_all
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "agents", "foo", {"agent.md": b"wiki\n"})
+    install_agent(tmp_path, "foo")
+    shutil.rmtree(tmp_path / ".memtomem" / "agents" / "foo")
+    flat = tmp_path / ".memtomem" / "agents" / "foo.md"
+    flat.write_bytes(b"# local flat\n")
+    _bump_mtime(flat)
+
+    [row] = _classify_for_install_all(tmp_path, wiki=WikiStore.at_default())
+    assert row.state == "refuse"
+
+    result = _apply_pinned_install(tmp_path, row, wiki=WikiStore.at_default(), force=True)
+
+    assert result.files_written >= 1
+    assert (tmp_path / ".memtomem" / "agents" / "foo" / "agent.md").read_bytes() == b"wiki\n"
+    assert flat.read_bytes() == b"# local flat\n"
+    assert not flat.with_suffix(".md.bak").exists()

--- a/packages/memtomem/tests/test_context_install_all.py
+++ b/packages/memtomem/tests/test_context_install_all.py
@@ -909,3 +909,37 @@ def test_install_all_force_extracts_dir_and_preserves_flat(wiki_root: Path, tmp_
     assert (tmp_path / ".memtomem" / "agents" / "foo" / "agent.md").read_bytes() == b"wiki\n"
     assert flat.read_bytes() == b"# local flat\n"
     assert not flat.with_suffix(".md.bak").exists()
+
+
+# ── unprovable install record (#1247 impl gate) ──────────────────────────
+
+
+def test_install_all_unusable_record_refuses_then_force_baks_all(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """Malformed installed_at over an existing dest must classify refuse —
+    not skip — and --force must preserve every current file before the pin
+    re-extraction. Pre-fix the row collapsed to skip, so --force re-extracted
+    over possible local edits with no .bak."""
+    from memtomem.context.install import _apply_pinned_install, _classify_for_install_all
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "agents", "foo", {"agent.md": b"wiki\n"})
+    install_agent(tmp_path, "foo")
+    edited = tmp_path / ".memtomem" / "agents" / "foo" / "agent.md"
+    edited.write_bytes(b"local edit\n")
+    _bump_mtime(edited)
+    lock_path = tmp_path / ".memtomem" / "lock.json"
+    doc = json.loads(lock_path.read_text(encoding="utf-8"))
+    doc["agents"]["foo"]["installed_at"] = "yesterday"
+    lock_path.write_text(json.dumps(doc), encoding="utf-8")
+
+    [row] = _classify_for_install_all(tmp_path, wiki=WikiStore.at_default())
+    assert row.state == "refuse"
+    assert "install record unusable" in (row.reason or "")
+
+    result = _apply_pinned_install(tmp_path, row, wiki=WikiStore.at_default(), force=True)
+
+    assert result.files_written >= 1
+    assert edited.read_bytes() == b"wiki\n"  # pin bytes restored
+    assert edited.with_suffix(".md.bak").read_bytes() == b"local edit\n"

--- a/packages/memtomem/tests/test_context_migrate.py
+++ b/packages/memtomem/tests/test_context_migrate.py
@@ -2433,3 +2433,34 @@ def test_adopt_flat_to_dir_unknown_type_raises(tmp_path: Path) -> None:
     flat = _write_flat(tmp_path, "agents", "foo", b"x\n")
     with pytest.raises(ValueError):
         adopt_flat_to_dir("skills", flat, tmp_path / ".memtomem" / "skills" / "foo")
+
+
+def test_classify_lockfile_entry_unparseable_installed_at(tmp_path: Path) -> None:
+    """A malformed installed_at STRING demotes to skip_manual, not a crash
+    and not "clean" (#1247 id 1).
+
+    Pre-fix the isinstance-only guard let the string through to
+    ``_is_flat_file_dirty``'s unguarded ``fromisoformat`` → ValueError.
+    Returning False there instead would be worse — False means clean,
+    which would let migrate remove/overwrite a possibly-edited flat file
+    on a corrupt entry."""
+    import json
+
+    _write_flat(tmp_path, "agents", "foo", b"v1\n")
+    lock_path = tmp_path / ".memtomem" / "lock.json"
+    lock_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "agents": {"foo": {"wiki_commit": "0" * 40, "installed_at": "yesterday"}},
+            }
+        )
+    )
+
+    rows = classify_migrate(tmp_path)
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.state == "skip_manual"
+    assert row.has_lock_entry is False
+    assert row.flat_dirty is None

--- a/packages/memtomem/tests/test_context_status.py
+++ b/packages/memtomem/tests/test_context_status.py
@@ -820,3 +820,210 @@ def test_cli_status_user_scope_empty_message(monkeypatch, tmp_path: Path) -> Non
 
     assert result.exit_code == 0
     assert "No user-scope assets found" in result.output
+
+
+# ── flat-layout reason (#1247 id 0) ──────────────────────────────────────
+
+
+def _seed_flat_installed(project: Path, asset_type: str, name: str, pin: str) -> Path:
+    """Seed the #1247 id 0 population: flat ``<type>/<name>.md`` + lock entry, no dir."""
+    flat = project / ".memtomem" / asset_type / f"{name}.md"
+    flat.parent.mkdir(parents=True, exist_ok=True)
+    flat.write_bytes(b"# flat\n")
+    installed_at = datetime.fromtimestamp(flat.stat().st_mtime, tz=timezone.utc).isoformat()
+    Lockfile.at(project).upsert_entry(asset_type, name, wiki_commit=pin, installed_at=installed_at)
+    return flat
+
+
+def test_status_flat_layout_row_points_at_migrate(wiki_root: Path, tmp_path: Path) -> None:
+    """#1247 id 0: a flat-layout install must not render as "dest missing" —
+    the flat file exists and is what fan-out actually serves. The reason
+    points at the migrate verb instead."""
+    _initialized_wiki(wiki_root)
+    pin = _seed_wiki_skill(wiki_root, "anchor", {"SKILL.md": b"x\n"})
+    _seed_flat_installed(tmp_path, "agents", "foo", pin)
+
+    _wiki_head, rows = classify_status(tmp_path)
+
+    [row] = [r for r in rows if r.asset_type == "agents" and r.name == "foo"]
+    assert row.state == "missing"
+    assert row.tier == "project_shared"
+    assert "migrate agent foo" in (row.reason or "")
+    assert "dest missing" not in (row.reason or "")
+
+
+def test_status_missing_without_flat_keeps_dest_missing_reason(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """Negative pin for the flat hint: no flat sibling → reason unchanged."""
+    _initialized_wiki(wiki_root)
+    pin = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"x\n"})
+    _setup_installed_at_pin(tmp_path, "agents", "bar", {"agent.md": b"x\n"}, pin)
+    shutil.rmtree(tmp_path / ".memtomem" / "agents" / "bar")
+
+    _wiki_head, rows = classify_status(tmp_path)
+
+    [row] = [r for r in rows if r.name == "bar"]
+    assert row.state == "missing"
+    assert row.reason == "dest missing"
+
+
+# ── malformed installed_at end-to-end (#1247 id 1) ───────────────────────
+
+
+def test_classify_status_survives_malformed_installed_at(wiki_root: Path, tmp_path: Path) -> None:
+    """One corrupt entry must not crash the whole status walk — the healthy
+    sibling still classifies and the corrupt row degrades to missing."""
+    _initialized_wiki(wiki_root)
+    pin_a = _seed_wiki_skill(wiki_root, "alpha", {"SKILL.md": b"a\n"})
+    _setup_installed_at_pin(tmp_path, "skills", "alpha", {"SKILL.md": b"a\n"}, pin_a)
+    pin_b = _seed_wiki_skill(wiki_root, "beta", {"SKILL.md": b"b\n"})
+    _setup_installed_at_pin(tmp_path, "skills", "beta", {"SKILL.md": b"b\n"}, pin_b)
+
+    lock_path = tmp_path / ".memtomem" / "lock.json"
+    doc = json.loads(lock_path.read_text(encoding="utf-8"))
+    doc["skills"]["alpha"]["installed_at"] = "yesterday"
+    lock_path.write_text(json.dumps(doc), encoding="utf-8")
+
+    _wiki_head, rows = classify_status(tmp_path)  # pre-fix: ValueError escaped
+
+    by_name = {r.name: r for r in rows}
+    assert by_name["beta"].state == "ok"
+    assert by_name["alpha"].state == "missing"
+
+
+# ── untracked project_shared canonicals (#1247 id 8) ─────────────────────
+
+
+def test_classify_status_lists_untracked_project_shared_canonicals(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """init-imported / migrate-moved-in canonicals (no lockfile entry) must
+    surface as state="untracked" — they are actively served by sync fan-out,
+    and ADR-0016 §6 names status as the per-tier inspection surface."""
+    _initialized_wiki(wiki_root)
+    agent_dir = tmp_path / ".memtomem" / "agents" / "foo"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "agent.md").write_text("# foo\n", encoding="utf-8")
+    flat_cmd = tmp_path / ".memtomem" / "commands" / "bar.md"
+    flat_cmd.parent.mkdir(parents=True)
+    flat_cmd.write_text("# bar\n", encoding="utf-8")
+
+    _wiki_head, rows = classify_status(tmp_path)  # pre-fix: zero rows
+
+    by_key = {(r.asset_type, r.name): r for r in rows}
+    foo = by_key[("agents", "foo")]
+    assert foo.state == "untracked"
+    assert foo.tier == "project_shared"
+    assert foo.pin_commit == "" and foo.installed_at == ""
+    assert "not lockfile-tracked" in (foo.reason or "")
+    bar = by_key[("commands", "bar")]
+    assert bar.state == "untracked"
+
+
+def test_untracked_scan_skips_lockfile_tracked_names(wiki_root: Path, tmp_path: Path) -> None:
+    """A lockfile-tracked install renders exactly one row — the untracked
+    scan must not double-report it."""
+    _initialized_wiki(wiki_root)
+    pin = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"x\n"})
+    _setup_installed_at_pin(tmp_path, "skills", "foo", {"SKILL.md": b"x\n"}, pin)
+
+    _wiki_head, rows = classify_status(tmp_path)
+
+    rows_for_foo = [r for r in rows if r.name == "foo"]
+    assert len(rows_for_foo) == 1
+    assert rows_for_foo[0].state != "untracked"
+
+
+def test_untracked_scan_skips_tracked_flat_population(wiki_root: Path, tmp_path: Path) -> None:
+    """The id 0 population (flat + entry) renders as the lockfile "missing"
+    row with the migrate hint — not additionally as untracked."""
+    _initialized_wiki(wiki_root)
+    pin = _seed_wiki_skill(wiki_root, "anchor", {"SKILL.md": b"x\n"})
+    _seed_flat_installed(tmp_path, "agents", "foo", pin)
+
+    _wiki_head, rows = classify_status(tmp_path)
+
+    rows_for_foo = [r for r in rows if r.name == "foo"]
+    assert len(rows_for_foo) == 1
+    assert rows_for_foo[0].state == "missing"
+
+
+def test_cli_status_renders_untracked_rows(wiki_root: Path, tmp_path: Path, monkeypatch) -> None:
+    _initialized_wiki(wiki_root)
+    agent_dir = tmp_path / ".memtomem" / "agents" / "foo"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "agent.md").write_text("# foo\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["status"])
+
+    assert result.exit_code == 0
+    assert "foo" in result.output
+    assert "0 asset(s) installed (+ 1 untracked)" in result.output
+    assert "1 untracked" in result.output
+    assert "No wiki assets installed" not in result.output
+
+
+# ── degraded wiki (#1247 id 9) ───────────────────────────────────────────
+
+
+def test_classify_status_degrades_when_wiki_has_no_head(wiki_root: Path, tmp_path: Path) -> None:
+    """A wiki with .git but no HEAD (clone of an empty remote) must degrade
+    like the absent-wiki case, not escape as a RuntimeError traceback."""
+    wiki_root.mkdir(parents=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root), "init", "-b", "main"], check=True, capture_output=True
+    )
+    _setup_installed_at_pin(tmp_path, "skills", "foo", {"SKILL.md": b"x\n"}, "0" * 40)
+
+    wiki_head, rows = classify_status(tmp_path)  # pre-fix: RuntimeError escaped
+
+    assert wiki_head is None
+    [row] = rows
+    assert row.state == "stale-pin"
+    assert "wiki unusable" in (row.reason or "")
+
+
+def test_classify_status_degrades_when_git_binary_missing(
+    wiki_root: Path, tmp_path: Path, monkeypatch
+) -> None:
+    """git vanishing from PATH surfaces as OSError from subprocess — same
+    degrade path (the probe's OSError arm)."""
+    _initialized_wiki(wiki_root)
+    pin = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"x\n"})
+    _setup_installed_at_pin(tmp_path, "skills", "foo", {"SKILL.md": b"x\n"}, pin)
+
+    def _no_git(*args: object, **kwargs: object) -> None:
+        raise FileNotFoundError("git not found")
+
+    monkeypatch.setattr("memtomem.wiki.store.subprocess.run", _no_git)
+
+    wiki_head, rows = classify_status(tmp_path)
+
+    assert wiki_head is None
+    [row] = rows
+    assert row.state == "stale-pin"
+    assert "wiki unusable" in (row.reason or "")
+
+
+def test_cli_status_degraded_wiki_exits_zero(wiki_root: Path, tmp_path: Path, monkeypatch) -> None:
+    """Exit-0 contract: status is the diagnostic verb; a degraded wiki must
+    render an annotated header, not a traceback (pre-fix: exit 1 + raw
+    RuntimeError). The header must say unusable, not "not present" — the
+    wiki IS on disk."""
+    wiki_root.mkdir(parents=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root), "init", "-b", "main"], check=True, capture_output=True
+    )
+    _setup_installed_at_pin(tmp_path, "skills", "foo", {"SKILL.md": b"x\n"}, "0" * 40)
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["status"])
+
+    assert result.exit_code == 0, result.output
+    assert "present but unusable" in result.output
+    assert "wiki not present" not in result.output
+    assert "stale-pin" in result.output

--- a/packages/memtomem/tests/test_context_status.py
+++ b/packages/memtomem/tests/test_context_status.py
@@ -890,6 +890,9 @@ def test_classify_status_survives_malformed_installed_at(wiki_root: Path, tmp_pa
     by_name = {r.name: r for r in rows}
     assert by_name["beta"].state == "ok"
     assert by_name["alpha"].state == "missing"
+    # The dest dir EXISTS here — "dest missing" would be flatly wrong;
+    # the reason mirrors the update/install-all unprovable refusal.
+    assert "install record unusable" in (by_name["alpha"].reason or "")
 
 
 # ── untracked project_shared canonicals (#1247 id 8) ─────────────────────

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -1398,3 +1398,152 @@ class TestUpdatePrivacyGate:
         # contract: path + hit count only).
         assert "AKIA1234567890ABCDEF" not in result.output
         assert "Traceback" not in result.output
+
+
+# ── flat-layout guard (#1247 id 0) ───────────────────────────────────────
+
+
+def _seed_wiki_agent(wiki_root_path: Path, name: str, files: dict[str, bytes]) -> str:
+    """Add ``agents/<name>/`` to wiki + commit. Returns the commit SHA."""
+    agent_dir = wiki_root_path / "agents" / name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    for relpath, data in files.items():
+        target = agent_dir / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    subprocess.run(["git", "-C", str(wiki_root_path), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root_path), "commit", "-m", f"agents/{name}"],
+        check=True,
+        capture_output=True,
+    )
+    return WikiStore.at_default().current_commit()
+
+
+def _seed_flat_installed_agent(
+    project: Path, name: str, pin: str, *, installed_at: str | None = None
+) -> Path:
+    """Seed the #1247 id 0 population: flat ``agents/<name>.md`` + lock entry, no dir.
+
+    By default the flat file's mtime is backdated 10s before
+    ``installed_at`` so the strict ``>`` rule lands deterministically on
+    the clean side (float↔ns mtime round-trips make exact equality
+    unreliable). Pass an explicit ``installed_at`` to simulate corrupt
+    entries (mtime is left alone — the unprovable arm doesn't compare).
+    """
+    from memtomem.context.lockfile import Lockfile
+
+    flat = project / ".memtomem" / "agents" / f"{name}.md"
+    flat.parent.mkdir(parents=True, exist_ok=True)
+    flat.write_bytes(b"# flat agent\n")
+    if installed_at is None:
+        installed_at = datetime.now(timezone.utc).isoformat()
+        past = datetime.now(timezone.utc).timestamp() - 10.0
+        os.utime(flat, (past, past))
+    Lockfile.at(project).upsert_entry("agents", name, wiki_commit=pin, installed_at=installed_at)
+    return flat
+
+
+def test_update_refuses_dirty_flat_layout(wiki_root: Path, tmp_path: Path) -> None:
+    """#1247 id 0: flat file + lock entry + local edit → refuse, not silent shadow.
+
+    Pre-fix: the flat population classified ``missing_dest``, sailed past
+    the dirty gate, the dir layout landed next to the flat file, and
+    dir-wins fan-out silently stopped serving the user's edited bytes —
+    no refusal, no --force, no .bak."""
+    _initialized_wiki(wiki_root)
+    pin = _seed_wiki_agent(wiki_root, "foo", {"agent.md": b"wiki v1\n"})
+    flat = _seed_flat_installed_agent(tmp_path, "foo", pin)
+    flat.write_bytes(b"# local edit\n")
+    _bump_mtime(flat)
+    _seed_wiki_agent(wiki_root, "foo", {"agent.md": b"wiki v2\n"})  # HEAD advances
+
+    with pytest.raises(StaleInstallError) as excinfo:
+        update_agent(tmp_path, "foo")
+
+    msg = str(excinfo.value)
+    assert "flat-layout" in msg
+    assert "mm context migrate agent foo" in msg
+    assert "--force" in msg
+    # Refusal left zero residue: no dir layout, flat bytes untouched.
+    assert not (tmp_path / ".memtomem" / "agents" / "foo").exists()
+    assert flat.read_bytes() == b"# local edit\n"
+
+
+def test_update_force_shadows_flat_but_preserves_it(wiki_root: Path, tmp_path: Path) -> None:
+    """--force writes the dir layout; the flat file stays on disk, no .bak.
+
+    Nothing overwrites the flat bytes (they are merely shadowed by
+    dir-wins), so a .bak would be a redundant copy — design-gate Q1."""
+    _initialized_wiki(wiki_root)
+    pin = _seed_wiki_agent(wiki_root, "foo", {"agent.md": b"wiki v1\n"})
+    flat = _seed_flat_installed_agent(tmp_path, "foo", pin)
+    flat.write_bytes(b"# local edit\n")
+    _bump_mtime(flat)
+    _seed_wiki_agent(wiki_root, "foo", {"agent.md": b"wiki v2\n"})
+
+    result = update_agent(tmp_path, "foo", force=True)
+
+    assert result.was_no_op is False
+    dir_file = tmp_path / ".memtomem" / "agents" / "foo" / "agent.md"
+    assert dir_file.read_bytes() == b"wiki v2\n"
+    assert flat.read_bytes() == b"# local edit\n"
+    assert not flat.with_suffix(".md.bak").exists()
+    assert result.bak_files_written == ()
+
+
+def test_update_clean_flat_proceeds_and_warns(
+    wiki_root: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A provably-clean flat file doesn't block (no user-authored bytes at
+    risk) — but the shadowing is logged with a migrate hint."""
+    _initialized_wiki(wiki_root)
+    pin = _seed_wiki_agent(wiki_root, "foo", {"agent.md": b"wiki v1\n"})
+    flat = _seed_flat_installed_agent(tmp_path, "foo", pin)
+    _seed_wiki_agent(wiki_root, "foo", {"agent.md": b"wiki v2\n"})
+
+    with caplog.at_level("WARNING", logger="memtomem.context.install"):
+        result = update_agent(tmp_path, "foo")
+
+    assert result.was_no_op is False
+    assert (tmp_path / ".memtomem" / "agents" / "foo" / "agent.md").read_bytes() == b"wiki v2\n"
+    assert flat.is_file()
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any("shadow" in m for m in messages)
+    assert any("mm context migrate" in m for m in messages)
+
+
+def test_update_refuses_flat_with_unprovable_installed_at(wiki_root: Path, tmp_path: Path) -> None:
+    """Design-gate M1: a malformed installed_at classifies never_installed
+    and must NOT skip the flat guard — unprovable counts as dirty."""
+    _initialized_wiki(wiki_root)
+    pin = _seed_wiki_agent(wiki_root, "foo", {"agent.md": b"wiki v1\n"})
+    flat = _seed_flat_installed_agent(tmp_path, "foo", pin, installed_at="yesterday")
+    _seed_wiki_agent(wiki_root, "foo", {"agent.md": b"wiki v2\n"})
+
+    with pytest.raises(StaleInstallError) as excinfo:
+        update_agent(tmp_path, "foo")
+
+    assert "flat-layout" in str(excinfo.value)
+    assert not (tmp_path / ".memtomem" / "agents" / "foo").exists()
+    assert flat.is_file()
+
+
+def test_classify_for_all_update_flat_dirty_is_refuse(wiki_root: Path, tmp_path: Path) -> None:
+    """The --all preview shows the same refusal the execute gate raises
+    (#1247 id 0 preview/execute parity)."""
+    _initialized_wiki(wiki_root)
+    pin = _seed_wiki_agent(wiki_root, "foo", {"agent.md": b"wiki v1\n"})
+    flat = _seed_flat_installed_agent(tmp_path, "foo", pin)
+    flat.write_bytes(b"# local edit\n")
+    _bump_mtime(flat)
+    _seed_wiki_agent(wiki_root, "foo", {"agent.md": b"wiki v2\n"})
+
+    _new_commit, classifications = _classify_for_all_update(
+        "agents", "foo", wiki=WikiStore.at_default(), projects=[tmp_path]
+    )
+
+    [c] = classifications
+    assert c.state == "refuse"
+    assert "flat layout" in (c.reason or "")
+    assert "migrate" in (c.reason or "")

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -1547,3 +1547,77 @@ def test_classify_for_all_update_flat_dirty_is_refuse(wiki_root: Path, tmp_path:
     assert c.state == "refuse"
     assert "flat layout" in (c.reason or "")
     assert "migrate" in (c.reason or "")
+
+
+# ── unprovable install record (#1247 impl gate) ──────────────────────────
+
+
+def _corrupt_installed_at(project: Path, asset_type: str, name: str, value: str) -> None:
+    lock_path = project / ".memtomem" / "lock.json"
+    doc = json.loads(lock_path.read_text(encoding="utf-8"))
+    doc[asset_type][name]["installed_at"] = value
+    lock_path.write_text(json.dumps(doc), encoding="utf-8")
+
+
+def test_update_refuses_unusable_install_record_over_existing_dest(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """Impl-gate: malformed installed_at over an EXISTING dest must refuse,
+    not silently overwrite. Pre-#1247 this crashed with a ValueError; the
+    id-1 degrade (crash → never_installed) must not turn the crash into
+    data loss by sailing past the dirty gate."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(tmp_path, "foo")
+    edited = tmp_path / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    edited.write_bytes(b"local edit\n")
+    _bump_mtime(edited)
+    _corrupt_installed_at(tmp_path, "skills", "foo", "yesterday")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    with pytest.raises(StaleInstallError) as excinfo:
+        update_skill(tmp_path, "foo")
+
+    msg = str(excinfo.value)
+    assert "install record unusable" in msg
+    assert "--force" in msg
+    assert edited.read_bytes() == b"local edit\n"  # nothing overwritten
+    assert not edited.with_suffix(".md.bak").exists()  # refusal leaves zero residue
+
+
+def test_update_force_unusable_record_baks_every_file(wiki_root: Path, tmp_path: Path) -> None:
+    """--force over an unprovable record preserves EVERY current dest file
+    as .bak — with no epoch there is no dirty subset to limit to."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n", "extra.md": b"e1\n"})
+    install_skill(tmp_path, "foo")
+    edited = tmp_path / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    edited.write_bytes(b"local edit\n")
+    _bump_mtime(edited)
+    _corrupt_installed_at(tmp_path, "skills", "foo", "yesterday")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    result = update_skill(tmp_path, "foo", force=True)
+
+    dest = tmp_path / ".memtomem" / "skills" / "foo"
+    assert (dest / "SKILL.md").read_bytes() == b"v2\n"
+    assert (dest / "SKILL.md.bak").read_bytes() == b"local edit\n"
+    assert (dest / "extra.md.bak").read_bytes() == b"e1\n"
+    assert len(result.bak_files_written) == 2
+
+
+def test_classify_for_all_update_unusable_record_is_refuse(wiki_root: Path, tmp_path: Path) -> None:
+    """Batch preview parity for the unprovable gate."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(tmp_path, "foo")
+    _corrupt_installed_at(tmp_path, "skills", "foo", "yesterday")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    _new_commit, classifications = _classify_for_all_update(
+        "skills", "foo", wiki=WikiStore.at_default(), projects=[tmp_path]
+    )
+
+    [c] = classifications
+    assert c.state == "refuse"
+    assert "install record unusable" in (c.reason or "")

--- a/packages/memtomem/tests/test_dirty.py
+++ b/packages/memtomem/tests/test_dirty.py
@@ -470,3 +470,44 @@ def test_malformed_or_stale_manifest_ignored(
     report = is_asset_dirty(tmp_path, "skills", "web")
     assert report.reason == "clean"
     assert report.missing_files == ()
+
+
+# ── malformed installed_at degrades, never crashes (#1247 id 1) ──────────
+
+
+def _corrupt_installed_at(project: Path, asset_type: str, name: str, value: str) -> None:
+    lock_path = project / ".memtomem" / "lock.json"
+    doc = json.loads(lock_path.read_text(encoding="utf-8"))
+    doc[asset_type][name]["installed_at"] = value
+    lock_path.write_text(json.dumps(doc), encoding="utf-8")
+
+
+@pytest.mark.parametrize("malformed", ["yesterday", "2026-05-1", ""])
+def test_malformed_installed_at_degrades_to_never_installed(tmp_path: Path, malformed: str) -> None:
+    """An unparseable installed_at STRING degrades exactly like its
+    missing/non-string siblings (#1247 id 1) — previously
+    ``datetime.fromisoformat`` raised an uncaught ValueError whenever the
+    dest dir existed, crashing status/update/install-all classification."""
+    _setup_installed(tmp_path, "skills", "web", {"SKILL.md": b"v1\n"})
+    _corrupt_installed_at(tmp_path, "skills", "web", malformed)
+
+    report = is_asset_dirty(tmp_path, "skills", "web")
+
+    assert report.reason == "never_installed"
+    assert report.installed_at is None
+    assert report.dirty_files == ()
+    assert report.checked_files == 0
+
+
+def test_malformed_installed_at_with_missing_dest_degrades_too(tmp_path: Path) -> None:
+    """Consistency half of #1247 id 1: malformed + dest gone is also
+    never_installed (it used to return missing_dest because the dest probe
+    ran before the parse) — malformed ≡ non-string in EVERY branch."""
+    _setup_installed(tmp_path, "skills", "web", {"SKILL.md": b"v1\n"})
+    shutil.rmtree(tmp_path / ".memtomem" / "skills" / "web")
+    _corrupt_installed_at(tmp_path, "skills", "web", "yesterday")
+
+    report = is_asset_dirty(tmp_path, "skills", "web")
+
+    assert report.reason == "never_installed"
+    assert report.installed_at is None


### PR DESCRIPTION
## Summary

Sixth fix batch for #1247 (**B6-7 — install/status small fixes**), closing backlog ids **0, 1, 4, 5, 8, 9**: two majors (flat-layout silent shadow, status blind to non-lockfile project_shared canonicals) and four minors (malformed `installed_at` crash, circular half-install hints, `install --all` preview/execute mismatch, status traceback on a degraded wiki).

### id 0 (major) — flat-layout installs: update silently shadowed, status misreported

The flat population (`.memtomem/<agents|commands>/<name>.md` + lock entry, no dir — legacy reverse-imports, or a user resolving a flat+dir collision by deleting the dir) is first-class in `migrate`'s truth table and ADR-0008 Invariant 2, but `update`/`status` bypassed it: `is_asset_dirty` probes dir-only → `missing_dest` sailed past the dirty refuse gate, the dir layout landed next to the flat file, and dir-wins fan-out silently stopped serving the (possibly edited) flat bytes. `status` called the row `missing` / "dest missing" while the flat file was being actively served.

- New `install._flat_layout_probe`: flat sibling present + dest dir absent → dirty-or-unprovable check (strict `mtime > installed_at`; missing/unparseable `installed_at` counts as dirty — *can't prove clean must protect*, design-gate M1). Skills excluded (no flat layout).
- `_apply_update` (single + `--all` execute) refuses dirty/unprovable flat without `--force`, pointing at `mm context migrate`; with `--force` (or a provably clean flat) it proceeds with a shadow warning. **No flat `.bak`, no flat deletion**: nothing overwrites the flat file (it stays on disk, merely shadowed) and consolidation stays `migrate`'s job.
- `_classify_for_all_update` / `_classify_for_install_all` emit matching `refuse` rows so batch previews show the same refusal the execute gate raises.
- `classify_status` missing-branch reason becomes ``flat layout; run `mm context migrate <kind> <name>` `` when the flat sibling exists.

The gate covers both `missing_dest` **and** `never_installed`-with-entry reports — without the latter, id 1's degrade (below) would have reopened the bypass for corrupt entries (Codex design gate M1).

### id 1 (minor) — malformed `installed_at` crashed classification

`dirty.py` guarded only `isinstance(str)` and then ran `datetime.fromisoformat` unguarded — a hand-edited `"yesterday"` crashed `status` / `update` / `update --all` / `install --all` / `migrate` with a raw ValueError traceback, defeating the tolerant-read posture. Now an unparseable string degrades to `never_installed` in **every** branch (parse moved before the dest probe, so malformed ≡ non-string), with a warning log. `migrate._classify_row` extends its guard with the same parse probe, demoting corrupt entries to the `skip_manual` path — deliberately **not** `except ValueError: return False` inside `_is_flat_file_dirty`, since `False` means *clean* and would approve overwriting user edits.

### id 4 (minor) — circular remediation hints on half-installs

Copy-succeeded-then-lockfile-write-failed leaves dest with no entry; install's refusal said "run `mm context update`" unconditionally, and update said "run `mm context install` first" — a closed circle with no in-product exit. The `AlreadyInstalledError` message now branches on `(has_lock, has_dest)`: the dest-only state explains the likely causes (interrupted install / hand-placed files) and the actual recovery (inspect dest, remove if disposable, re-run install). No auto-adopt — install can't tell a leftover from hand-placed content it must not clobber (pinned by `test_install_refuses_when_only_dest_present`).

### id 5 (minor) — `install --all` preview missed asset-missing-at-pin

`ProjectInstallClassification`'s docstring promises a state=`error` row for "asset path missing at the pinned commit", but the classifier never probed it — such rows previewed green as `install` and the user found out from the execute phase's `AssetNotFoundError`. The classifier now probes `wiki.asset_files_at_commit(pin, …)` (the extractor's own ls-tree helper, so the two can't drift) right after the reachability check; absence → `error` row, classify-time `CommitNotFoundError` race → `orphan`. The execute-side catch stays as race defense.

### id 8 (major) — status blind to non-lockfile project_shared canonicals

`mm context init --include …` and `mm context migrate --to project_shared` write the project_shared canonical with **no** lockfile entry, and `classify_status` sourced project_shared rows from lock.json only — so the default status view reported "0 asset(s) installed" while sync actively fanned those artifacts out. ADR-0016 §6 names `mm context status --scope <tier>` as the per-tier inspection surface; this aligns the code to the ADR. New `untracked` state (deliberately not `local-draft`: project_shared canonicals fan out, drafts don't), produced by a thin wrapper over the existing `_scan_draft_tier` walk with the lockfile-tracked names dropped (no double rows; the id-0 flat population stays a single `missing` row with the migrate hint). CLI gains the `○` glyph, an accurate header (`N asset(s) installed (+ M untracked)`), and summary/empty-state coverage.

### id 9 (minor) — status traceback on a degraded wiki

`classify_status`'s probe caught only `WikiNotFoundError`, but `WikiStore._git` wraps any git failure in a bare `RuntimeError` — a wiki cloned from an empty remote (`.git` present, no HEAD) or git missing from PATH escaped as a traceback from the read-only diagnostic verb, violating its own "always exits 0 for normal runs" contract. The probe now degrades on `(RuntimeError, OSError)` with a `wiki unusable: <detail>` row reason, and the CLI header distinguishes present-but-unusable (via the pure-stat `exists()`) from not-present. `classify_status`'s public signature is unchanged.

Known adjacent gap, deliberately out of scope (not in the #1247 backlog): `mm context update`'s `wiki.is_dirty()` still raises on a degraded wiki.

## Copy fixes

The aggregate `--all` refusal lines promised "each dirty file gets a .bak sibling", which is false for flat-refuse rows — reworded to cover both classes (dest-tree files get `.bak`; flat files are kept on disk but stop being served). (Codex design gate m2.)

## Codex impl gate: unprovable install records (2nd commit)

The impl review caught a hole the id-1 degrade would have opened: malformed `installed_at` + **existing** dest went from a ValueError crash to a silent overwrite (no dirty proof, no `.bak`) in `_apply_update`, both `--all` classifiers, and `install --all`'s skip-collapse (whose `--force` re-extracted with no preservation). The follow-up commit adds the "unprovable install record" gate: `never_installed` + `dest.is_dir()` (entry present, timestamp unusable) refuses everywhere a write could clobber, and `--force` preserves **every** current dest file as `.bak` — with no epoch there is no dirty subset to limit to. Gate A scans the full bak set; reconcile's `baked=` follows. dest-absent entries keep classifying `update`/`install` (fresh creation clobbers nothing). status's missing-row reason says `install record unusable (malformed installed_at)` when the dest exists.

## Verification

- Codex design gate: 1 round (NEEDS-FIX → M1 + m2 folded, all 5 design questions answered). Codex implementation gate: round 1 NEEDS-FIX (the unprovable-record hole above) → round 2 **SHIP, zero findings** (reviewer independently ran the six touched test files: 236 passed).
- 27 new test functions (+1 strengthened): 19 verified pre-fix-fail against `origin/main` (src reverted, tests kept), 5 verified pre-fix-fail against the first commit for the impl-gate fold, 4 negative/behavior-preservation pins — the force-path pin holds by design pre/post, and the two untracked-dedup pins were mutation-validated (tracked-set filter removed → both fail).
- `ruff check` + `ruff format --check` clean; `mypy` on the touched context modules clean.
- Full suite local: **6325 passed**, 11 skipped (`test_session_tracing` excluded — pre-existing #1249).

Part of #1247 (B6-7). Ids 15 (installed_at race) and the toast/frontend residuals remain with their assigned batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
