### PR TITLE
fix(web): per-item diff render parity + delete/resolve hardening (#1247 B9)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -34,7 +34,12 @@ from memtomem.context.agents import (
 )
 from memtomem.context.detector import AGENT_DIRS
 from memtomem.context.privacy_scan import PrivacyScanError
-from memtomem.web.routes.context_gateway import read_text_lenient, sanitize_diff_reason
+from memtomem.web.routes.context_gateway import (
+    delete_skip_entry,
+    expected_vs_runtime_row,
+    read_text_lenient,
+    sanitize_diff_reason,
+)
 from memtomem.web.routes.context_projects import (
     resolve_scope_root,
     resolve_scope_root_cascade_gated,
@@ -443,9 +448,7 @@ async def delete_agent(
                         agent_path.unlink()
                         removed.append(_safe_rel(agent_path, project_root))
                     except OSError as e:
-                        skipped.append(
-                            {"path": _safe_rel(agent_path, project_root), "reason": str(e)}
-                        )
+                        skipped.append(delete_skip_entry(agent_path, e, project_root))
 
                 if cascade:
                     for gen in AGENT_GENERATORS.values():
@@ -458,9 +461,7 @@ async def delete_agent(
                             target.unlink()
                             removed.append(_safe_rel(target, project_root))
                         except OSError as e:
-                            skipped.append(
-                                {"path": _safe_rel(target, project_root), "reason": str(e)}
-                            )
+                            skipped.append(delete_skip_entry(target, e, project_root))
     except TimeoutError:
         raise HTTPException(503, "Agent delete timed out — another sync may be in progress")
 
@@ -484,6 +485,7 @@ async def diff_agent(
     canonical_content = None
     canonical_path = None
     parse_error_reason = None
+    parsed = None
     if resolved is not None:
         agent_path, layout = resolved
         canonical_path = _safe_rel(agent_path, project_root)
@@ -500,7 +502,9 @@ async def diff_agent(
             parse_error_reason = sanitize_diff_reason(f"unreadable: {agent_path}", project_root)
         else:
             try:
-                _parse_canonical_agent_text(canonical_content, source=agent_path, layout=layout)
+                parsed = _parse_canonical_agent_text(
+                    canonical_content, source=agent_path, layout=layout
+                )
             except AgentParseError as exc:
                 parse_error_reason = sanitize_diff_reason(str(exc), project_root)
 
@@ -536,15 +540,22 @@ async def diff_agent(
                 }
             )
         else:
-            # Unreadable runtime ≡ parity can't be asserted — report drift,
-            # never mask it (the engine diff contract).
-            runtime_content = read_text_lenient(target)
+            # Compare on the engine's basis — vendor override bytes, else
+            # rendered output — NOT the raw canonical text: codex/kimi targets
+            # are TOML/YAML, so a raw compare pinned this pane to a permanent
+            # "out of sync" under an "in sync" list badge (#1247 id 30).
+            assert parsed is not None  # parse failures took the branch above
+            agent = parsed
             runtimes.append(
-                {
-                    "runtime": gen_name,
-                    "status": "out of sync" if runtime_content != canonical_content else "in sync",
-                    "runtime_content": runtime_content,
-                }
+                expected_vs_runtime_row(
+                    kind="agents",
+                    gen_name=gen_name,
+                    render=lambda gen=gen, agent=agent: gen.render(agent)[0],
+                    target=target,
+                    name=name,
+                    project_root=project_root,
+                    scope=target_scope,
+                )
             )
 
     return {

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -33,7 +33,12 @@ from memtomem.context.commands import (
 )
 from memtomem.context.detector import COMMAND_DIRS
 from memtomem.context.privacy_scan import PrivacyScanError
-from memtomem.web.routes.context_gateway import read_text_lenient, sanitize_diff_reason
+from memtomem.web.routes.context_gateway import (
+    delete_skip_entry,
+    expected_vs_runtime_row,
+    read_text_lenient,
+    sanitize_diff_reason,
+)
 from memtomem.web.routes.context_projects import (
     resolve_scope_root,
     resolve_scope_root_cascade_gated,
@@ -436,24 +441,24 @@ async def delete_command(
                         cmd_path.unlink()
                         removed.append(_safe_rel(cmd_path, project_root))
                     except OSError as e:
-                        skipped.append(
-                            {"path": _safe_rel(cmd_path, project_root), "reason": str(e)}
-                        )
+                        skipped.append(delete_skip_entry(cmd_path, e, project_root))
 
-                    if cascade:
-                        for gen in COMMAND_GENERATORS.values():
-                            target = gen.target_file(project_root, name)
-                            if target is None:
-                                continue
-                            if not target.is_file():
-                                continue
-                            try:
-                                target.unlink()
-                                removed.append(_safe_rel(target, project_root))
-                            except OSError as e:
-                                skipped.append(
-                                    {"path": _safe_rel(target, project_root), "reason": str(e)}
-                                )
+                # Sibling of the canonical branch, not nested inside it — a
+                # runtime-only command (no canonical) + cascade=true must still
+                # remove the runtime copies; the nested shape silently no-opped
+                # (#1247 id 46). Matches delete_agent / delete_skill.
+                if cascade:
+                    for gen in COMMAND_GENERATORS.values():
+                        target = gen.target_file(project_root, name)
+                        if target is None:
+                            continue
+                        if not target.is_file():
+                            continue
+                        try:
+                            target.unlink()
+                            removed.append(_safe_rel(target, project_root))
+                        except OSError as e:
+                            skipped.append(delete_skip_entry(target, e, project_root))
     except TimeoutError:
         raise HTTPException(503, "Command delete timed out — another sync may be in progress")
 
@@ -477,6 +482,7 @@ async def diff_command(
     canonical_content = None
     canonical_path = None
     parse_error_reason = None
+    parsed = None
     if resolved is not None:
         cmd_path, layout = resolved
         canonical_path = _safe_rel(cmd_path, project_root)
@@ -491,7 +497,9 @@ async def diff_command(
             parse_error_reason = sanitize_diff_reason(f"unreadable: {cmd_path}", project_root)
         else:
             try:
-                _parse_canonical_command_text(canonical_content, source=cmd_path, layout=layout)
+                parsed = _parse_canonical_command_text(
+                    canonical_content, source=cmd_path, layout=layout
+                )
             except CommandParseError as exc:
                 parse_error_reason = sanitize_diff_reason(str(exc), project_root)
 
@@ -527,17 +535,22 @@ async def diff_command(
                 }
             )
         else:
-            # Unreadable runtime ≡ parity can't be asserted — report drift,
-            # never mask it (the engine diff contract).
-            runtime_content = read_text_lenient(target)
-            # For commands, content won't be byte-identical (placeholder rewrites)
-            # so we always provide the runtime content for diff view.
+            # Compare on the engine's basis — vendor override bytes, else
+            # rendered output — NOT the raw canonical text: gemini targets
+            # are TOML, so a raw compare pinned this pane to a permanent
+            # "out of sync" under an "in sync" list badge (#1247 id 30).
+            assert parsed is not None  # parse failures took the branch above
+            cmd = parsed
             runtimes.append(
-                {
-                    "runtime": gen_name,
-                    "status": "out of sync" if runtime_content != canonical_content else "in sync",
-                    "runtime_content": runtime_content,
-                }
+                expected_vs_runtime_row(
+                    kind="commands",
+                    gen_name=gen_name,
+                    render=lambda gen=gen, cmd=cmd: gen.render(cmd)[0],
+                    target=target,
+                    name=name,
+                    project_root=project_root,
+                    scope=target_scope,
+                )
             )
 
     return {

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import json
 import logging
 import os
+from collections.abc import Callable
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, Query
 
 from memtomem.privacy import scan as _privacy_scan
 from memtomem.config import TargetScope
+from memtomem.context import override as _override
+from memtomem.context._names import GENERATOR_VENDOR
 from memtomem.web.routes.context_projects import resolve_scope_root
 
 try:
@@ -144,6 +147,84 @@ def read_text_lenient(path: Path) -> str | None:
         return path.read_bytes().decode("utf-8", errors="replace")
     except OSError:
         return None
+
+
+def expected_vs_runtime_row(
+    *,
+    kind: str,
+    gen_name: str,
+    render: Callable[[], str],
+    target: Path,
+    name: str,
+    project_root: Path,
+    scope: TargetScope,
+) -> dict[str, object]:
+    """Both-sides-exist diff row on the engine's comparison basis (#1247 id 30).
+
+    The per-item diff panes used to compare the RAW canonical text against the
+    runtime file, while the list badge (engine ``diff_commands`` /
+    ``diff_agents``) compares **vendor override bytes → else rendered output**
+    — so a TOML/YAML-rendering runtime (gemini commands, codex/kimi agents)
+    showed a permanent "out of sync" pane under an "in sync" badge. Shared by
+    the commands and agents per-name diff routes so the comparison basis
+    cannot drift per kind (same rationale as ``sanitize_diff_reason``).
+
+    ``render`` is lazy so an override-carrying runtime never pays for (or
+    crashes on) a render it doesn't use. Error parity with the engine: an
+    unreadable override or runtime file means parity can't be asserted —
+    report drift, never mask it; the unreadable side's content key is omitted.
+    ``expected_content`` is what sync would write — the pane's diff baseline.
+    """
+    vendor = GENERATOR_VENDOR.get(gen_name)
+    override_path = (
+        _override.resolve(project_root, kind, name, vendor, scope=scope)
+        if vendor is not None
+        else None
+    )
+    expected_bytes: bytes | None
+    if override_path is not None:
+        try:
+            expected_bytes = override_path.read_bytes()
+        except OSError:
+            expected_bytes = None
+    else:
+        expected_bytes = render().encode("utf-8")
+
+    runtime_bytes: bytes | None
+    try:
+        runtime_bytes = target.read_bytes()
+    except OSError:
+        runtime_bytes = None
+
+    entry: dict[str, object] = {"runtime": gen_name}
+    if expected_bytes is None or runtime_bytes is None:
+        entry["status"] = "out of sync"
+    else:
+        entry["status"] = "in sync" if expected_bytes == runtime_bytes else "out of sync"
+    if expected_bytes is not None:
+        entry["expected_content"] = expected_bytes.decode("utf-8", errors="replace")
+    if runtime_bytes is not None:
+        entry["runtime_content"] = runtime_bytes.decode("utf-8", errors="replace")
+    return entry
+
+
+def delete_skip_entry(path: Path, exc: OSError, project_root: Path) -> dict[str, str]:
+    """``skipped[]`` row for a failed delete leg (#1247 id 49).
+
+    ``str(OSError)`` embeds absolute paths — including ``$HOME``-rooted
+    cascade targets — so the reason crosses the wire through
+    ``sanitize_diff_reason`` like every other route-surfaced exception text.
+    Shared by the skills/commands/agents delete routes (6 call sites) so the
+    sanitization boundary cannot drift per kind.
+    """
+    try:
+        rel = str(path.relative_to(project_root))
+    except ValueError:
+        rel = str(path)
+    return {
+        "path": rel,
+        "reason": sanitize_diff_reason(str(exc), project_root) or "",
+    }
 
 
 def _compute_last_synced_at(project_root: Path, target_scope: TargetScope) -> str | None:

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -28,7 +28,7 @@ from memtomem.context.skills import (
 )
 from memtomem.config import TargetScope
 from memtomem.web.routes._locks import _gateway_lock
-from memtomem.web.routes.context_gateway import sanitize_diff_reason
+from memtomem.web.routes.context_gateway import delete_skip_entry, sanitize_diff_reason
 from memtomem.web.routes.context_projects import (
     resolve_scope_root,
     resolve_scope_root_cascade_gated,
@@ -382,9 +382,7 @@ async def delete_skill(
                         shutil.rmtree(skill_dir)
                         removed.append(_safe_rel(skill_dir, project_root))
                     except OSError as e:
-                        skipped.append(
-                            {"path": _safe_rel(skill_dir, project_root), "reason": str(e)}
-                        )
+                        skipped.append(delete_skip_entry(skill_dir, e, project_root))
 
                 if cascade:
                     for gen in SKILL_GENERATORS.values():
@@ -397,9 +395,7 @@ async def delete_skill(
                             shutil.rmtree(target)
                             removed.append(_safe_rel(target, project_root))
                         except OSError as e:
-                            skipped.append(
-                                {"path": _safe_rel(target, project_root), "reason": str(e)}
-                            )
+                            skipped.append(delete_skip_entry(target, e, project_root))
     except TimeoutError:
         raise HTTPException(503, "Skill delete timed out — another sync may be in progress")
 

--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -527,8 +527,18 @@ async def resolve_conflict(
                 # canonical; otherwise we keep the first-match-by-matcher
                 # behavior for old label-only clients.
                 proposed = None
-                canonical_hooks: dict = canonical.get("hooks", {})
-                for rule in canonical_hooks.get(body.event, []):
+                # Shape guards mirroring the target side below (and the promote
+                # route): array-form hooks / a non-list event value in valid
+                # JSON escaped as an AttributeError 500 while the GET diff
+                # reports a structured error (#1247 id 51). ``create=True``
+                # only inserts into the local dict — this path never writes
+                # the canonical file, so a missing ``hooks`` key stays the
+                # legacy "rule not found" 404, not a 422.
+                canonical_hooks = _hooks_record(canonical, label="Canonical", create=True)
+                canonical_event_rules = canonical_hooks.get(body.event, [])
+                if not isinstance(canonical_event_rules, list):
+                    raise HTTPException(422, detail="Canonical hook event is not a list")
+                for rule in canonical_event_rules:
                     if not (isinstance(rule, dict) and rule.get("matcher", "") == body.matcher):
                         continue
                     stamped = _stamp_status_markers({"hooks": {body.event: [rule]}})["hooks"][

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -4141,7 +4141,24 @@ async function loadCtxDetail(type, name, opts = {}) {
           return;
         }
         const data = await r.json();
-        if (data.deleted) {
+        // Branch on lengths, not truthiness — ``deleted``/``skipped`` are
+        // always arrays and ``[]`` is truthy, so a fully-failed delete
+        // (every unlink skipped) used to show the success toast and hide
+        // the detail (#1247 id 33). Reasons are sanitized server-side.
+        const skipped = Array.isArray(data.skipped) ? data.skipped : [];
+        if (skipped.length) {
+          // Partial/failed delete: name the first failure, keep the detail
+          // open (the artifact may still exist — matches the error path
+          // above), and reload so list badges repaint to on-disk truth.
+          showToast(t('settings.ctx.delete_partial', {
+            count: skipped.length,
+            path: (skipped[0] && skipped[0].path) || '',
+            reason: (skipped[0] && skipped[0].reason) || '',
+          }), 'warning');
+          loadCtxList(type);
+        } else {
+          // Includes the zero-deleted idempotent no-op: nothing existed,
+          // which is the state the user asked for.
           showToast(t('settings.ctx.delete_success').replace('{name}', name));
           detailEl.hidden = true;
           loadCtxList(type);
@@ -4254,8 +4271,14 @@ async function _ctxLoadDiff(type, name, detailEl) {
         if (rt.dropped_fields && rt.dropped_fields.length) {
           html += `<div style="margin-top:4px">${renderDroppedChips(rt.dropped_fields)}</div>`;
         }
-        if (rt.status === 'out of sync' && data.canonical_content != null && rt.runtime_content != null) {
-          const ops = diffLines(data.canonical_content, rt.runtime_content);
+        // ``expected_content`` (commands/agents, #1247 id 30) is what sync
+        // would actually write — vendor override or rendered output — so the
+        // diff shows the real pending change instead of a raw canonical-vs-
+        // runtime compare (permanently red for TOML/YAML-rendering runtimes).
+        // Skills/mcp-servers responses don't send it; fall back to canonical.
+        const expected = rt.expected_content != null ? rt.expected_content : data.canonical_content;
+        if (rt.status === 'out of sync' && expected != null && rt.runtime_content != null) {
+          const ops = diffLines(expected, rt.runtime_content);
           html += `<div class="diff-view" style="margin-top:6px">${renderDiff(ops)}</div>`;
         } else if (rt.runtime_content) {
           html += `<pre class="ctx-content-pre" style="margin-top:6px">${escapeHtml(rt.runtime_content)}</pre>`;

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1468,7 +1468,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=17"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=69"></script>
+  <script src="/context-gateway.js?v=70"></script>
   <script src="/context-portal.js?v=2"></script>
   <script src="/path-picker.js?v=3"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -421,6 +421,7 @@
   "settings.ctx.import_result": "{imported} imported, {skipped} skipped",
   "settings.ctx.import_success": "Import completed",
   "settings.ctx.delete_success": "\"{name}\" deleted",
+  "settings.ctx.delete_partial": "Delete incomplete — {count} path(s) not removed. {path}: {reason}",
   "settings.ctx.save_success": "\"{name}\" saved",
   "settings.ctx.create_success": "\"{name}\" created",
   "settings.ctx.mtime_conflict": "File was modified externally. Reloading...",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -421,6 +421,7 @@
   "settings.ctx.import_result": "{imported}개 가져옴, {skipped}개 건너뜀",
   "settings.ctx.import_success": "가져오기 완료",
   "settings.ctx.delete_success": "\"{name}\" 삭제됨",
+  "settings.ctx.delete_partial": "삭제 미완료 — 경로 {count}개를 제거하지 못했습니다. {path}: {reason}",
   "settings.ctx.save_success": "\"{name}\" 저장됨",
   "settings.ctx.create_success": "\"{name}\" 생성됨",
   "settings.ctx.mtime_conflict": "파일이 외부에서 수정되었습니다. 다시 불러오는 중...",

--- a/packages/memtomem/tests-js/ctx-diff-expected-delete-toast.test.mjs
+++ b/packages/memtomem/tests-js/ctx-diff-expected-delete-toast.test.mjs
@@ -1,0 +1,146 @@
+/* #1247 B9 — two JS contract fixes on the artifact detail panel.
+ *
+ * id 30: the diff pane diffs ``expected_content`` (what sync would write —
+ * vendor override or rendered output) against the runtime file when the
+ * response provides it, falling back to ``canonical_content`` for response
+ * shapes that don't send it (skills, mcp-servers). The raw canonical diff
+ * showed md-vs-toml noise for rendering runtimes.
+ *
+ * id 33: the delete handler branches on ``skipped.length`` instead of
+ * ``if (data.deleted)`` — ``[]`` is truthy, so a fully-failed delete
+ * ({deleted: [], skipped: [{path, reason}]}) used to show the success toast
+ * and hide the detail panel.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+function fetchResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+describe('diff pane expected-content baseline (_ctxLoadDiff)', () => {
+  async function bootDiff(type, diffBody) {
+    const dom = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+    const { window } = dom;
+    await window.I18N.init();
+    const realFetch = window.fetch;
+    window.fetch = async (input) => {
+      const url = typeof input === 'string' ? input : input?.url;
+      if (url && url.includes(`/diff`)) return fetchResponse(200, diffBody);
+      if (url && url.includes(`/rendered`)) return fetchResponse(200, {});
+      return realFetch(input);
+    };
+    const detailEl = window.document.createElement('div');
+    detailEl.innerHTML = `<div id="ctx-pane-${type}-diff"></div>`;
+    window.document.body.appendChild(detailEl);
+    await window._ctxLoadDiff(type, 'x', detailEl);
+    return detailEl.querySelector(`#ctx-pane-${type}-diff`).innerHTML;
+  }
+
+  it('diffs expected_content (not canonical) when the row provides it', async () => {
+    const html = await bootDiff('commands', {
+      name: 'x',
+      canonical_content: 'CANONICAL-LINE\n',
+      canonical_path: '.memtomem/commands/x.md',
+      runtimes: [{
+        runtime: 'gemini_commands',
+        status: 'out of sync',
+        expected_content: 'EXPECTED-LINE\n',
+        runtime_content: 'RUNTIME-LINE\n',
+      }],
+    });
+    expect(html).toContain('EXPECTED-LINE');
+    expect(html).toContain('RUNTIME-LINE');
+    // The raw canonical text must NOT be the diff baseline anymore.
+    expect(html).not.toContain('CANONICAL-LINE');
+  });
+
+  it('falls back to canonical_content for rows without expected_content (skills shape)', async () => {
+    const html = await bootDiff('skills', {
+      name: 'x',
+      canonical_content: 'CANONICAL-LINE\n',
+      runtimes: [{
+        runtime: 'claude_skills',
+        status: 'out of sync',
+        runtime_content: 'RUNTIME-LINE\n',
+      }],
+    });
+    expect(html).toContain('CANONICAL-LINE');
+    expect(html).toContain('RUNTIME-LINE');
+  });
+});
+
+describe('delete toast branches on skipped, not array truthiness', () => {
+  async function bootDelete(deleteBody) {
+    const dom = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+    const { window } = dom;
+    await window.I18N.init();
+
+    const toasts = [];
+    window.showToast = (message, kind = 'success') => toasts.push({ message, kind });
+    window.showConfirm = async () => ({ ok: true, extras: {} });
+    window.ensureCsrfToken = async () => 'test-token';
+    const listReloads = [];
+    window.loadCtxList = (type) => listReloads.push(type);
+
+    const realFetch = window.fetch;
+    window.fetch = async (input, init = {}) => {
+      const url = typeof input === 'string' ? input : input?.url;
+      const pathname = (url || '').split('?')[0];
+      if (init.method === 'DELETE') return fetchResponse(200, deleteBody);
+      if (pathname === '/api/context/commands/x') {
+        // Detail GET — minimal payload the detail renderer needs.
+        return fetchResponse(200, {
+          name: 'x',
+          content: 'body\n',
+          mtime_ns: '1',
+          fields: {},
+          target_scope: 'project_shared',
+          layout: 'flat',
+        });
+      }
+      return realFetch(input, init);
+    };
+
+    await window.loadCtxDetail('commands', 'x');
+    const detailEl = window.document.getElementById('ctx-commands-detail');
+    const btn = detailEl.querySelector('.ctx-detail-delete-btn');
+    expect(btn).toBeTruthy();
+    btn.click();
+    // The click handler is async (confirm → fetch → toast); drain it.
+    for (let i = 0; i < 5; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    return { toasts, listReloads, detailEl };
+  }
+
+  it('shows a warning naming the failure when every leg was skipped', async () => {
+    const { toasts, listReloads, detailEl } = await bootDelete({
+      deleted: [],
+      skipped: [{ path: '.claude/commands/x.md', reason: 'Permission denied' }],
+    });
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].kind).toBe('warning');
+    expect(toasts[0].message).toContain('.claude/commands/x.md');
+    expect(toasts[0].message).toContain('Permission denied');
+    // The artifact may still exist — detail stays open, list repaints.
+    expect(detailEl.hidden).toBe(false);
+    expect(listReloads).toContain('commands');
+  });
+
+  it('keeps the success toast for a clean delete', async () => {
+    const { toasts, detailEl } = await bootDelete({
+      deleted: ['.memtomem/commands/x/command.md'],
+      skipped: [],
+    });
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].kind).toBe('success');
+    expect(detailEl.hidden).toBe(true);
+  });
+});

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -1871,6 +1871,36 @@ class TestSettingsHttpLayer:
         canonical = json.loads((tmp_path / CANONICAL_SETTINGS_FILE).read_text(encoding="utf-8"))
         assert canonical["hooks"]["PostToolUse"] == [_rule("Write", "echo canonical")]
 
+    async def test_promote_non_list_canonical_event_returns_422(self, client, tmp_path):
+        """Route-local contract pin (#1247 id 51 sibling): promote refuses to
+        append into a non-list canonical event value with a structured 422.
+        The guard predates the resolve-side fix — pinned while aligning
+        resolve so the two canonical-side guards can't drift apart."""
+        _make_canonical_settings(tmp_path, {"hooks": {"PreToolUse": 42}})
+        (tmp_path / ".claude").mkdir()
+        target = tmp_path / ".claude" / "settings.json"
+        target.write_text(
+            json.dumps({"hooks": {"PreToolUse": [_rule("Bash", "echo target")]}}),
+            encoding="utf-8",
+        )
+
+        diff = await client.get("/api/context/settings?target_scope=project_shared")
+        assert diff.status_code == 200
+        row = diff.json()["target_hooks"]["configured"][0]
+        resp = await client.post(
+            "/api/context/settings/rules/promote?target_scope=project_shared",
+            json={
+                "event": row["event"],
+                "matcher": row["matcher"],
+                "rule_index": row["rule_index"],
+                "rule_hash": row["rule_hash"],
+                "target_mtime_ns": diff.json()["target_mtime_ns"],
+                "canonical_mtime_ns": diff.json()["canonical_mtime_ns"],
+            },
+        )
+        assert resp.status_code == 422
+        assert "Canonical hook event is not a list" in resp.json()["detail"]
+
     async def test_delete_target_rule_uses_index_and_hash_for_duplicate_matchers(
         self, client, claude_home
     ):

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -9,6 +9,12 @@ from unittest.mock import AsyncMock
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from memtomem.context.agents import AGENT_GENERATORS, parse_canonical_agent
+from memtomem.context.commands import (
+    COMMAND_GENERATORS,
+    diff_commands,
+    parse_canonical_command,
+)
 from memtomem.context.skills import SKILL_MANIFEST
 from memtomem.web.app import create_app
 
@@ -1284,10 +1290,17 @@ class TestDiffCommand:
         set_home(monkeypatch, home)
         cmd_dir = home / ".memtomem" / "commands"
         cmd_dir.mkdir(parents=True)
-        (cmd_dir / "scoped.md").write_text(_CMD_CONTENT, encoding="utf-8")
+        cmd_file = cmd_dir / "scoped.md"
+        cmd_file.write_text(_CMD_CONTENT, encoding="utf-8")
         rt_dir = home / ".claude" / "commands"
         rt_dir.mkdir(parents=True)
-        (rt_dir / "scoped.md").write_text(_CMD_CONTENT, encoding="utf-8")
+        # The runtime side holds what sync would write (rendered output) —
+        # the pane compares on the engine's basis, not raw canonical text
+        # (#1247 id 30), and claude's render is near- but not byte-identity.
+        rendered, _ = COMMAND_GENERATORS["claude_commands"].render(
+            parse_canonical_command(cmd_file, layout="flat")
+        )
+        (rt_dir / "scoped.md").write_text(rendered, encoding="utf-8")
 
         r = await client.get("/api/context/commands/scoped/diff", params={"target_scope": "user"})
         assert r.status_code == 200
@@ -1312,6 +1325,159 @@ class TestDiffCommand:
         data = r.json()
         assert data["canonical_content"] == _CMD_CONTENT
         assert data["runtimes"] == []
+
+    @pytest.mark.anyio
+    async def test_diff_gemini_compares_rendered_not_raw(self, client: AsyncClient, tmp_path: Path):
+        """The pane must compare on the engine's basis — rendered output —
+        not the raw canonical text: gemini targets are TOML, so the raw
+        compare pinned this pane to a permanent "out of sync" under an
+        "in sync" list badge (#1247 id 30)."""
+        path = _make_command(tmp_path, "review")
+        rendered, _ = COMMAND_GENERATORS["gemini_commands"].render(
+            parse_canonical_command(path, layout="flat")
+        )
+        _make_runtime_command(tmp_path, ".gemini/commands", "review", ".toml", rendered)
+
+        r = await client.get("/api/context/commands/review/diff")
+        assert r.status_code == 200
+        gem = [rt for rt in r.json()["runtimes"] if rt["runtime"] == "gemini_commands"][0]
+        assert gem["status"] == "in sync"
+        assert gem["expected_content"] == rendered
+
+    @pytest.mark.anyio
+    async def test_diff_out_of_sync_expected_is_rendered(self, client: AsyncClient, tmp_path: Path):
+        """``expected_content`` is what sync would write — the pane's diff
+        baseline — so a drifted runtime diffs against the rendered output
+        instead of md-vs-toml noise (#1247 id 30)."""
+        path = _make_command(tmp_path, "review")
+        rendered, _ = COMMAND_GENERATORS["gemini_commands"].render(
+            parse_canonical_command(path, layout="flat")
+        )
+        stale = 'description = "stale"\n'
+        _make_runtime_command(tmp_path, ".gemini/commands", "review", ".toml", stale)
+
+        r = await client.get("/api/context/commands/review/diff")
+        data = r.json()
+        gem = [rt for rt in data["runtimes"] if rt["runtime"] == "gemini_commands"][0]
+        assert gem["status"] == "out of sync"
+        assert gem["expected_content"] == rendered
+        assert gem["expected_content"] != data["canonical_content"]
+        assert gem["runtime_content"] == stale
+
+    @pytest.mark.anyio
+    async def test_diff_override_carrying_command_in_sync(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """A vendor override replaces the rendered output at sync time
+        (ADR-0008 Invariant 4) — the pane must compare against the override
+        bytes like the engine, or override-carrying commands read permanently
+        "out of sync" (#1247 id 30)."""
+        art = tmp_path / ".memtomem" / "commands" / "ov"
+        (art / "overrides").mkdir(parents=True)
+        (art / "command.md").write_text(_CMD_CONTENT, encoding="utf-8")
+        override = "# claude-specific replacement\n"
+        (art / "overrides" / "claude.md").write_text(override, encoding="utf-8")
+        _make_runtime_command(tmp_path, ".claude/commands", "ov", ".md", override)
+
+        r = await client.get("/api/context/commands/ov/diff")
+        claude_rt = [rt for rt in r.json()["runtimes"] if rt["runtime"] == "claude_commands"][0]
+        assert claude_rt["status"] == "in sync"
+        assert claude_rt["expected_content"] == override
+
+    @pytest.mark.anyio
+    async def test_diff_pane_status_matches_engine_badge(self, client: AsyncClient, tmp_path: Path):
+        """Parity pin — the invariant #1247 id 30 is actually about: for the
+        same rows, the per-item pane status equals the engine diff status
+        that feeds the list badge."""
+        path = _make_command(tmp_path, "parity")
+        parsed = parse_canonical_command(path, layout="flat")
+        claude_rendered, _ = COMMAND_GENERATORS["claude_commands"].render(parsed)
+        _make_runtime_command(tmp_path, ".claude/commands", "parity", ".md", claude_rendered)
+        _make_runtime_command(
+            tmp_path, ".gemini/commands", "parity", ".toml", 'description = "stale"\n'
+        )
+
+        r = await client.get("/api/context/commands/parity/diff")
+        pane = {rt["runtime"]: rt["status"] for rt in r.json()["runtimes"]}
+        engine = {rt: status for rt, n, status in diff_commands(tmp_path) if n == "parity"}
+        assert pane == engine
+        assert engine == {"claude_commands": "in sync", "gemini_commands": "out of sync"}
+
+
+class TestDeleteCommandCascade:
+    @pytest.mark.anyio
+    async def test_cascade_deletes_runtime_only_command(self, client: AsyncClient, tmp_path: Path):
+        """``if cascade:`` was nested under ``resolved is not None`` — a
+        runtime-only command + cascade=true silently no-opped with
+        ``{deleted: [], skipped: []}`` (#1247 id 46; agents and skills run
+        cascade as a sibling branch)."""
+        rt = _make_runtime_command(tmp_path, ".claude/commands", "ghost", ".md", _CMD_CONTENT)
+        r = await client.delete("/api/context/commands/ghost?cascade=true")
+        assert r.status_code == 200
+        data = r.json()
+        assert str(Path(".claude/commands/ghost.md")) in data["deleted"]
+        assert data["skipped"] == []
+        assert not rt.exists()
+
+
+class TestDeleteSkipReasonSanitized:
+    """A failed delete leg's ``skipped[].reason`` crosses the wire through
+    ``sanitize_diff_reason`` — ``str(OSError)`` embeds the absolute target
+    path, which used to ship raw (#1247 id 49; all three artifact types)."""
+
+    @staticmethod
+    def _refuse_unlink(self_path: Path, *args, **kwargs):
+        raise OSError(13, "Permission denied", str(self_path))
+
+    @pytest.mark.anyio
+    async def test_command_unlink_failure_reason_sanitized(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        cmd_path = _make_command(tmp_path, "stuck")
+        monkeypatch.setattr(Path, "unlink", self._refuse_unlink)
+        r = await client.delete("/api/context/commands/stuck")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["deleted"] == []
+        [skip] = data["skipped"]
+        assert str(tmp_path) not in skip["reason"]
+        assert "Permission denied" in skip["reason"]
+        assert cmd_path.exists()
+
+    @pytest.mark.anyio
+    async def test_agent_cascade_failure_reasons_sanitized(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _make_agent(tmp_path, "stuck")
+        _make_runtime_agent(tmp_path, ".claude/agents", "stuck")
+        monkeypatch.setattr(Path, "unlink", self._refuse_unlink)
+        r = await client.delete("/api/context/agents/stuck?cascade=true")
+        assert r.status_code == 200
+        skipped = r.json()["skipped"]
+        # Canonical leg + at least the claude cascade leg both failed.
+        assert len(skipped) >= 2
+        for skip in skipped:
+            assert str(tmp_path) not in skip["reason"]
+            assert "Permission denied" in skip["reason"]
+
+    @pytest.mark.anyio
+    async def test_skill_rmtree_failure_reason_sanitized(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        skill_dir = _make_skill(tmp_path, "stuck")
+
+        def _refuse_rmtree(path, *args, **kwargs):
+            raise OSError(13, "Permission denied", str(path))
+
+        import memtomem.web.routes.context_skills as skills_routes
+
+        monkeypatch.setattr(skills_routes.shutil, "rmtree", _refuse_rmtree)
+        r = await client.delete("/api/context/skills/stuck")
+        assert r.status_code == 200
+        [skip] = r.json()["skipped"]
+        assert str(tmp_path) not in skip["reason"]
+        assert "Permission denied" in skip["reason"]
+        assert skill_dir.exists()
 
 
 class TestSyncCommands:
@@ -1634,10 +1800,17 @@ class TestDiffAgent:
         set_home(monkeypatch, home)
         agent_dir = home / ".memtomem" / "agents"
         agent_dir.mkdir(parents=True)
-        (agent_dir / "scoped.md").write_text(_AGENT_CONTENT, encoding="utf-8")
+        agent_file = agent_dir / "scoped.md"
+        agent_file.write_text(_AGENT_CONTENT, encoding="utf-8")
         rt_dir = home / ".claude" / "agents"
         rt_dir.mkdir(parents=True)
-        (rt_dir / "scoped.md").write_text(_AGENT_CONTENT, encoding="utf-8")
+        # The runtime side holds what sync would write (rendered output) —
+        # the pane compares on the engine's basis, not raw canonical text
+        # (#1247 id 30), and claude's render is near- but not byte-identity.
+        rendered, _ = AGENT_GENERATORS["claude_agents"].render(
+            parse_canonical_agent(agent_file, layout="flat")
+        )
+        (rt_dir / "scoped.md").write_text(rendered, encoding="utf-8")
 
         r = await client.get("/api/context/agents/scoped/diff", params={"target_scope": "user"})
         assert r.status_code == 200
@@ -1662,6 +1835,46 @@ class TestDiffAgent:
         data = r.json()
         assert data["canonical_content"] == _AGENT_CONTENT
         assert data["runtimes"] == []
+
+    @pytest.mark.anyio
+    async def test_diff_codex_kimi_compare_rendered_not_raw(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """Commands #1247 id 30 mirror: codex renders TOML and kimi renders
+        YAML, so the raw canonical-vs-runtime compare pinned both panes to a
+        permanent "out of sync" under an "in sync" list badge."""
+        path = _make_agent(tmp_path, "shaped")
+        parsed = parse_canonical_agent(path, layout="flat")
+        for gen_name, runtime_dir, ext in (
+            ("codex_agents", ".codex/agents", ".toml"),
+            ("kimi_agents", ".kimi/agents", ".yaml"),
+        ):
+            rendered, _ = AGENT_GENERATORS[gen_name].render(parsed)
+            rt_dir = tmp_path / runtime_dir
+            rt_dir.mkdir(parents=True, exist_ok=True)
+            (rt_dir / f"shaped{ext}").write_text(rendered, encoding="utf-8")
+
+        r = await client.get("/api/context/agents/shaped/diff")
+        assert r.status_code == 200
+        rows = {rt["runtime"]: rt for rt in r.json()["runtimes"]}
+        assert rows["codex_agents"]["status"] == "in sync"
+        assert rows["kimi_agents"]["status"] == "in sync"
+
+    @pytest.mark.anyio
+    async def test_diff_override_carrying_agent_in_sync(self, client: AsyncClient, tmp_path: Path):
+        """Override bytes are the expected side when present — engine parity
+        (#1247 id 30; same contract as the commands sibling test)."""
+        art = tmp_path / ".memtomem" / "agents" / "ov"
+        (art / "overrides").mkdir(parents=True)
+        (art / "agent.md").write_text(_AGENT_CONTENT, encoding="utf-8")
+        override = "# claude-specific replacement\n"
+        (art / "overrides" / "claude.md").write_text(override, encoding="utf-8")
+        _make_runtime_agent(tmp_path, ".claude/agents", "ov", override)
+
+        r = await client.get("/api/context/agents/ov/diff")
+        claude_rt = [rt for rt in r.json()["runtimes"] if rt["runtime"] == "claude_agents"][0]
+        assert claude_rt["status"] == "in sync"
+        assert claude_rt["expected_content"] == override
 
 
 class TestSyncAgents:

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -907,6 +907,60 @@ class TestSettingsSync:
             elif target.is_file():
                 target.unlink()
 
+    async def test_resolve_array_form_canonical_hooks_returns_422(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        """Array-form canonical hooks (valid JSON, wrong shape) escaped the
+        canonical-side read as an AttributeError 500 while the GET diff
+        reports a structured shape error — mirror the target-side guard
+        instead (#1247 id 51). Fires before the target file is touched, so
+        no target fixture is needed."""
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(json.dumps({"hooks": [self._rule("Write")]}), encoding="utf-8")
+        app.state.project_root = tmp_path
+
+        resp = await client.post(
+            "/api/settings-sync/resolve?target_scope=user",
+            json={"event": "PostToolUse", "matcher": "Write", "action": "use_proposed"},
+        )
+        assert resp.status_code == 422
+        assert "Canonical hooks is not a record" in resp.json()["detail"]
+
+    async def test_resolve_non_list_canonical_event_returns_422(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        """A non-list canonical event value must 422 like the target-side
+        guard, not crash mid-iteration (#1247 id 51)."""
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(json.dumps({"hooks": {"PostToolUse": 42}}), encoding="utf-8")
+        app.state.project_root = tmp_path
+
+        resp = await client.post(
+            "/api/settings-sync/resolve?target_scope=user",
+            json={"event": "PostToolUse", "matcher": "Write", "action": "use_proposed"},
+        )
+        assert resp.status_code == 422
+        assert "Canonical hook event is not a list" in resp.json()["detail"]
+
+    async def test_resolve_missing_hooks_key_stays_404(self, app, client: AsyncClient, tmp_path):
+        """Regression guard for the shape fix (#1247 id 51, Codex design
+        round): a canonical with NO hooks key keeps the legacy "rule not
+        found" 404 — the record guard must not turn the missing-key case
+        into a 422."""
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(json.dumps({"editor": "vim"}), encoding="utf-8")
+        app.state.project_root = tmp_path
+
+        resp = await client.post(
+            "/api/settings-sync/resolve?target_scope=user",
+            json={"event": "PostToolUse", "matcher": "Write", "action": "use_proposed"},
+        )
+        assert resp.status_code == 404
+        assert "not in canonical source" in resp.json()["detail"]
+
     async def test_conflict_payload_carries_rule_identity(self, app, client: AsyncClient, tmp_path):
         """Issue #1112: each conflict row exposes a stable identity for both
         the target row (``target_rule_index`` + ``target_rule_hash``) and the


### PR DESCRIPTION
Fixes five confirmed findings from the #1247 unverified-backlog triage (batch B9 — routes/JS): ids 30, 33, 46, 49, 51.

## What changed

### id 30 (major) — per-item diff panes compared raw canonical text; the list badge compares rendered output
The commands and agents per-item diff routes raw-compared the canonical text against the runtime file, while the list badge (engine `diff_commands` / `diff_agents`) compares **vendor-override bytes → else `gen.render(parsed)` bytes**. TOML/YAML-rendering runtimes (gemini commands, codex/kimi agents) were pinned to a permanent "out of sync" pane under an "in sync" badge, and override-carrying artifacts likewise. The triage claim named commands; the agents route had the identical shape (full-tree grep), so both are fixed.

- New shared helper `expected_vs_runtime_row` in `context_gateway.py` (same shared-boundary rationale as `sanitize_diff_reason`): resolves the vendor override, else lazily renders the parsed canonical; byte-exact status compare matching the engine; unreadable override/runtime legs report drift and never mask it.
- The row now carries `expected_content` — what sync would actually write — and `_ctxLoadDiff` diffs that against the runtime, falling back to `canonical_content` for response shapes that don't send it (skills, mcp-servers). The two existing tier-resolution tests now write rendered bytes to the runtime side (their fixture relied on the raw compare).
- Deliberately NOT added: `dropped_fields` on `/diff` rows — triage #35 (B10) concluded the diff-pane chips are dead code to be removed; the field-map matrix already covers that UX.

### id 33 (major) — delete success toast on fully-failed deletes
`if (data.deleted)` — `[]` is truthy, so `{deleted: [], skipped: [{path, reason}]}` showed the success toast, hid the detail, and never surfaced the reasons. Now branches on `skipped.length`: warning toast naming the first failed path/reason + count (new i18n key `settings.ctx.delete_partial`, en+ko), detail stays open, list reloads to repaint on-disk truth. The zero-deleted/zero-skipped idempotent no-op keeps the success path. `?v=69 → ?v=70` cache-bust.

### id 46 (minor) — `delete_command` nested `if cascade:` under `resolved is not None`
Runtime-only command + `cascade=true` silently no-opped (and the id-33 bug turned that into a success toast). Dedented to the sibling shape `delete_agent` / `delete_skill` use.

### id 49 (minor) — raw `str(OSError)` in `skipped[].reason` at all six delete sites
`str(OSError)` embeds absolute target paths. All six sites (skills/commands/agents × canonical/cascade legs) now route through new shared `delete_skip_entry` → `sanitize_diff_reason`, the boundary #1229 established for exactly this route surface.

### id 51 (minor) — `resolve_conflict` 500s on array-form canonical hooks
The target side guards record-shape and event-value list-shape; the canonical side didn't — array-form hooks (valid JSON) escaped as an `AttributeError` 500, a non-list event value as a `TypeError` 500. Mirrored via `_hooks_record(canonical, label="Canonical", create=True)` (local-dict-only insert on this read-only path; per Codex design round, the no-create call would have broken the legacy missing-hooks → 404 semantics, now pinned by a regression test) + the event-value list guard. A sibling test pins the promote route's pre-existing event-value guard so the two canonical-side guards can't drift.

## Verification

- **Pre-fix-fail**: all 14 new/updated pytest cases fail against main (`git checkout HEAD~1 -- src` → 14 failed / 35 neighbors green → restore); the 2 positive vitest cases fail against main JS, the 2 negative pins pass both sides.
- Full pytest: 6380 passed; 4 failures = the resident `test_session_tracing` set (#1249, pre-existing on clean main). `TestConfigPatch::test_save_config` fails locally on clean main too (reads the real `~/.memtomem/config.json`) and passes in the full run.
- vitest: 163 passed (159 + 4 new). `ruff check` + `ruff format --check` clean.
- Codex design gate: NEEDS-FIX → folded (the `_hooks_record` create-semantics catch above). Codex impl review of `d5393fd6..51d41286`: **SHIP, zero findings**.

## Known adjacent gaps (not fixed here, disclosed)

- **Skills per-item diff pane** still raw-compares the `SKILL.md` manifest while the engine badge uses `_skill_effective_equal` (tree-wide + override-aware) — same divergence family as id 30 but a different fix shape (a text pane can't show a tree diff; needs an effective-manifest compare + "files beyond the manifest differ" note). Follow-up candidate.
- Sync-toast skip-class masking (#1247 id 21) and Delete-button in-flight disable (id 27) are B10 scope; the delete handler keeps its shape so B10 can layer on.

Part of #1247 (B9). Batches B1-B8: #1250, #1253, #1254, #1257, #1258, #1259, #1260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
