### PR TITLE
fix(context): duplicate-tier banner + runtime-chip settings probe + ADR riders (#1247 B11)

### DIFF
--- a/docs/adr/0001-context-gateway-sync-policies.md
+++ b/docs/adr/0001-context-gateway-sync-policies.md
@@ -120,6 +120,18 @@ removes its `STATE.uiMode === 'dev'` UI gate(s) when **all four** hold:
    that the conflict semantics are pinned by a test, not the specific
    status code.
 
+> **2026-06 (#1247):** Criterion 2's "no reverse-import API by design"
+> parenthetical for Settings is now narrower than reality: ADR-0019's
+> ownership markers made memtomem-authored rules distinguishable from
+> user-authored ones, which enabled a **consent-gated, per-rule**
+> reverse-import — `POST /context/settings/rules/promote` (web hooks
+> panel; Gate-A-scanned per the ADR-0011 §5 note). The original rationale
+> still holds for the bulk path: there is still no
+> `extract_settings_to_canonical`, because outside marked rules the
+> additive merge cannot attribute authorship. Settings remains a
+> unidirectional *phase* for this section's round-trip criteria. See the
+> matching ADR-0009 §2 note.
+
 **Why these four:** the round-trip test catches lossy serialization
 (the most common context-gateway regression class); the i18n parity
 test catches missing translations (the most common prod-only UX gap);

--- a/docs/adr/0009-context-gateway-dashboard-info-surface.md
+++ b/docs/adr/0009-context-gateway-dashboard-info-surface.md
@@ -130,6 +130,15 @@ authored from user-authored entries (ADR-0001 §5 unidirectional
 readiness contract). Its inline pointer reduces to the first and third
 rules above.
 
+> **2026-06 (#1247):** Narrowed since: the per-rule, consent-gated
+> `rules/promote` endpoint (enabled by ADR-0019 ownership markers;
+> Gate-A-scanned per the ADR-0011 §5 note) is a settings reverse-import
+> path on the hooks **leaf**. The tile contract above is unchanged — the
+> settings tile still never renders `missing canonical` (promote operates
+> on conflict/diff rows, not the count envelope), and the dashboard stays
+> push-only with leaf-only pull per this section. See the matching
+> ADR-0001 §5 note.
+
 **Why not add `Import All`:** bidirectional bulk actions create a class
 of UX-traps where the user clicks the wrong direction and silently
 overwrites local edits or canonical content. ADR-0001's `extract_*` is
@@ -210,6 +219,16 @@ the client's perspective:
 **Why additive:** preserves the Q-PR3 envelope clients (Web UI v0.1.36+)
 already understand. Older clients ignore unknown fields. The four
 existing tile envelopes are unchanged.
+
+> **2026-06 (#1247):** `/api/context/overview` has since gained a **fifth**
+> tile envelope — `mcp_servers` (#1165, `context_gateway.py`) — with the
+> same count shape, plus a matching dashboard tile and Sync All phase. The
+> "four tile envelopes" wording above is historical; this section's
+> additive-fields contract is unchanged. MCP servers are a
+> project_shared-only artifact (canonical
+> `.memtomem/mcp-servers/<name>.json` fanning out to the project
+> `.mcp.json` `mcpServers` object) — see the ADR-0011 §1 table row and the
+> ADR-0016 §3 note.
 
 **Direction signal source for §2.** The four-status core shared by
 `diff_skills` / `diff_commands` / `diff_agents` (`in sync`,

--- a/docs/adr/0011-canonical-artifact-scope-hierarchy.md
+++ b/docs/adr/0011-canonical-artifact-scope-hierarchy.md
@@ -119,6 +119,7 @@ The canonical / runtime layout per scope per artifact type:
 | **skills**   | `~/.memtomem/skills/<name>/SKILL.md`          | `<proj>/.memtomem/skills/<name>/SKILL.md`        | `<proj>/.memtomem/skills.local/<name>/SKILL.md`          | user → `~/.claude/skills/<name>/`; project_shared → `<proj>/.claude/skills/<name>/`; project_local → no fan-out |
 | **commands** | `~/.memtomem/commands/<name>.md`              | `<proj>/.memtomem/commands/<name>.md`            | `<proj>/.memtomem/commands.local/<name>.md`              | user → `~/.claude/commands/`; project_shared → `<proj>/.claude/commands/`; project_local → no fan-out |
 | **settings** (ADR-0010, special case per ADR-0016 §2) | `<proj>/.memtomem/settings.json` (canonical is single regardless of tier) | ↑ same | ↑ same | `user` → `~/.claude/settings.json`; `project_shared` → `<proj>/.claude/settings.json`; `project_local` → `<proj>/.claude/settings.local.json` |
+| **mcp_servers** (#1165, single-tier — see note below) | — (no user tier) | `<proj>/.memtomem/mcp-servers/<name>.json` | — (no local tier) | project_shared → `<proj>/.mcp.json` (`mcpServers` object); no user / project_local fan-out |
 
 Settings inverts the tier ↔ residency mapping the other rows share: per
 ADR-0016 §2, the `target_scope` axis on settings hooks selects the
@@ -127,6 +128,15 @@ is `<proj>/.memtomem/settings.json` by ADR-0010 §Background, regardless
 of the configured `target_scope`). The other four artifacts in this
 table couple canonical residency and runtime fan-out through
 `RUNTIME_FANOUT_TABLE`; settings is the documented exception.
+
+> **2026-06 (#1247):** The `mcp_servers` row was added when that surface
+> shipped (#1165, post-dating this ADR). It is the only single-tier
+> artifact: canonical exists at `project_shared` only, and the fan-out
+> target is a *shared* file (`.mcp.json`) merged additively per server
+> name rather than a per-artifact file/dir. Web write routes reject
+> non-`project_shared` tiers for it like every sibling (see the ADR-0015
+> §4c note); the dashboard's fifth tile envelope is recorded in the
+> ADR-0009 §5 note.
 
 ### 2. v1 defaults preserve current behavior, zero behavior change for existing installs
 

--- a/docs/adr/0015-context-gateway-scope-vocabulary.md
+++ b/docs/adr/0015-context-gateway-scope-vocabulary.md
@@ -250,6 +250,17 @@ Affects: sync routes per §2d. The artifact sync service in #900
 inherits this contract — one pair per invocation, no cross-product
 batch.
 
+> **2026-06 (#1247):** v1 web routes implement a narrower slice of Option B
+> than this section implies: every artifact **write** route (create /
+> update / delete / import / sync, across skills / commands / agents /
+> mcp-servers) rejects `target_scope != project_shared` with 400
+> (`_reject_non_shared_write` — "intentionally deferred" in its
+> docstring). `target_scope` is resolved per-request exactly as decided
+> here, but only the `project_shared` value is accepted on writes;
+> list/read routes accept the full tier set. The engine already supports
+> user-tier sync (ADR-0011 PR-E3); exposing it through the web write
+> routes is tracked in #1263.
+
 #### 4d. Mutator routes accepting `project_scope_id` — Option C (sync only)
 
 Sync routes accept `?project_scope_id=` (and `?target_scope=` per §4c).

--- a/docs/adr/0016-three-tier-canonical-context-store.md
+++ b/docs/adr/0016-three-tier-canonical-context-store.md
@@ -182,6 +182,12 @@ three values of `target_scope` index the runtime side. For
 memory / agents / skills / commands, the canonical and runtime
 sides are coupled via `RUNTIME_FANOUT_TABLE` per ADR-0011 §1.
 
+> **2026-06 (#1247):** `mcp_servers` (shipped #1165, post-dating this ADR)
+> joins neither table: it is the one single-tier artifact — canonical exists
+> at `project_shared` only (`<proj>/.memtomem/mcp-servers/<name>.json`) and
+> fans out to the project `.mcp.json` `mcpServers` object. See the ADR-0011
+> §1 table row and the ADR-0009 §5 note.
+
 v1 defaults preserved unchanged from ADR-0010 §2 (settings:
 `target_scope=user` → runtime at `~/.claude/settings.json`) and
 ADR-0011 §2 (memory canonical: `user`; agents / skills / commands
@@ -295,6 +301,15 @@ entries remain visible by inspecting each tier (`mm context status
 --scope <tier>`, or the Web overview's per-tier views). ADR-0011 §"Open
 questions" item 2 owns the user-facing warning copy for the
 cross-tier collision case.
+
+> **2026-06 (#1247):** "Refuses to overwrite without `--force`" shipped
+> differently: ADR-0011 PR-E4 (Row 15) deliberately made `mm context migrate
+> --to <tier>` refuse destination overwrite **even with `--force`**
+> (`context/migrate.py` — "force does not overwrite scope-tier targets;
+> replace verb is a follow-up"). Within-tier name conflicts therefore always
+> refuse today; an explicit `replace`-style verb is the named follow-up
+> rather than a `--force` valve. (`--force` keeps its other migrate
+> meanings, e.g. proceeding past a dirty flat-layout source.)
 
 For settings, ADR-0010's documented Claude Code tier-merge handles
 duplicate keys additively (one hook entry per tier fires per tier);

--- a/docs/adr/0018-multi-runtime-hook-fanout.md
+++ b/docs/adr/0018-multi-runtime-hook-fanout.md
@@ -24,6 +24,17 @@ Accepted ADR; ADR-0007 / ADR-0008 layer onto ADR-0001 the same way).
    | Codex  | `~/.codex/hooks.json` | `<proj>/.codex/hooks.json` | — (none) |
    | Gemini | `~/.gemini/settings.json` | `<proj>/.gemini/settings.json` | — (none) |
 
+   > **2026-06 (#1247):** A fourth runtime shipped after this ADR: **Kimi
+   > CLI** (`KimiSettingsGenerator`, `context/settings.py`). Targets: user →
+   > `~/.kimi/config.toml`, project_shared → `<proj>/.kimi/config.toml`,
+   > project_local → none (the same `target_file() → None` skip contract as
+   > Codex/Gemini, decision 4). Kimi's config is TOML, not JSON: instead of
+   > the additive JSON merge, sync preserves the user's file verbatim and
+   > replaces only a memtomem-managed block delimited by
+   > `# BEGIN memtomem managed hooks` / `# END memtomem managed hooks`.
+   > Ownership is block-scoped, not per-rule — see the companion note on
+   > ADR-0019.
+
 2. **Codex is near-identical.** Codex shares Claude's event names and accepts
    `Bash` / `Edit` / `Write` matchers natively, so it reuses the same
    `_merge_hooks_record` additive merge as Claude. Events Codex lacks

--- a/docs/adr/0019-hook-rule-ownership-marker.md
+++ b/docs/adr/0019-hook-rule-ownership-marker.md
@@ -38,6 +38,17 @@ an Accepted ADR).
    memtomem-owned and will be overwritten on re-sync. Hand-editing such a rule
    while keeping the prefix loses the edit — to take ownership, drop the marker.
 
+   > **2026-06 (#1247):** Kimi (the fourth runtime — see the ADR-0018 note)
+   > uses a different ownership mechanism than the per-rule markers above:
+   > its TOML config carries one memtomem-managed block
+   > (`# BEGIN memtomem managed hooks` / `# END memtomem managed hooks`)
+   > that re-sync replaces wholesale. The block delimiters are the ownership
+   > marker; rules inside the block are memtomem-owned by position, user
+   > TOML outside it is never touched, and a hand-edit inside the block is
+   > lost on the next sync (this ADR's per-rule "user rules win" merge does
+   > not apply inside the block). The per-rule marker contract applies to
+   > the JSON runtimes (Claude / Codex / Gemini) only.
+
 2. **Stamping is idempotent and preserves author text.** `statusMessage` is set
    to `"memtomem · {event}"` when absent, prefixed (`"memtomem · {text}"`) when
    the canonical handler already supplies text, and left untouched when already

--- a/packages/memtomem/src/memtomem/context/runtime_coverage.py
+++ b/packages/memtomem/src/memtomem/context/runtime_coverage.py
@@ -17,7 +17,15 @@ def compute_runtime_coverage(project_root: Path) -> list[dict[str, object]]:
       * non-import runtime marker file (for example Kimi ``.kimi/config.toml``),
       * project-scope skill dir (``.claude/skills`` etc.),
       * project-scope sub-agent dir (``.claude/agents`` etc.),
-      * project-scope command dir (``.claude/commands`` etc., Codex omitted).
+      * project-scope command dir (``.claude/commands`` etc., Codex omitted),
+      * settings-generator availability (ADR-0009 §1: settings is the one
+        ``is_available()``-probed surface because its targets are not
+        project-scoped).
+
+    The settings probe is home-OR-project (ADR-0010 §3), so ``available`` can
+    be true from machine-level runtime presence alone (``~/.codex`` exists,
+    project untouched); ``installed`` stays the registry's separate
+    machine-axis signal.
     """
     from memtomem.context._runtime_targets import KNOWN_RUNTIMES
     from memtomem.context.detector import (
@@ -28,6 +36,7 @@ def compute_runtime_coverage(project_root: Path) -> list[dict[str, object]]:
         SKILL_DIRS,
     )
     from memtomem.context.runtime_registry import RUNTIME_TO_CLIENT, probe_all_runtimes
+    from memtomem.context.settings import SETTINGS_GENERATORS
 
     try:
         statuses = {s.name: s for s in probe_all_runtimes(project_root)}
@@ -49,6 +58,9 @@ def compute_runtime_coverage(project_root: Path) -> list[dict[str, object]]:
         cmd = COMMAND_DIRS.get(f"{rt}_commands")
         if cmd is not None:
             probes.append((project_root / cmd[0]).is_dir())
+        settings_gen = SETTINGS_GENERATORS.get(f"{rt}_settings")
+        if settings_gen is not None:
+            probes.append(settings_gen.is_available(project_root))
         entry: dict[str, object] = {"name": rt, "available": any(probes)}
         st = statuses.get(RUNTIME_TO_CLIENT.get(rt, ""))
         if st is not None:

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=104" />
+  <link rel="stylesheet" href="/style.css?v=105" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -665,6 +665,10 @@
                     data-i18n-aria-label="settings.hooks.sync_now_aria">Sync Now</button>
           </div>
           <div id="hooks-sync-status"></div>
+          <!-- ADR-0010 §3 read-only signal: memtomem-managed hooks duplicated
+               across tiers (filled from the GET /api/settings-sync payload's
+               duplicate_tier_warnings; #1247 id 32). -->
+          <div id="hooks-duplicate-banner" class="hooks-duplicate-banner" hidden></div>
           <div id="hooks-sync-content"></div>
         </div>
 
@@ -1473,7 +1477,7 @@
   <script src="/settings-maintenance.js?v=4"></script>
   <script src="/settings-namespaces.js?v=9"></script>
   <script src="/settings-harness.js?v=2"></script>
-  <script src="/settings-hooks-watchdog.js?v=17"></script>
+  <script src="/settings-hooks-watchdog.js?v=18"></script>
   <script src="/timeline.js?v=3"></script>
   <script src="/context-gateway.js?v=71"></script>
   <script src="/context-portal.js?v=2"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -721,6 +721,8 @@
   "settings.hooks.target_label_project_local": "Project (local) target:",
   "settings.hooks.needs_confirmation_title": "Host write requires confirmation",
   "settings.hooks.needs_confirmation_body": "Server refused the write for the following target(s):\n{targets}\nReview via `mm settings sync` for details.",
+  "settings.hooks.duplicate_banner_one": "1 memtomem-managed hook entry already exists in the {tier} tier ({path}) — run {cmd} to move it. Active scope: {active}.",
+  "settings.hooks.duplicate_banner_many": "{count} memtomem-managed hook entries already exist in the {tier} tier ({path}) — run {cmd} to move them. Active scope: {active}.",
   "settings.hooks.badge_in_sync": "in sync",
   "settings.hooks.badge_out_of_sync": "out of sync",
   "settings.hooks.badge_error": "error",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -721,6 +721,8 @@
   "settings.hooks.target_label_project_local": "프로젝트(로컬) 대상:",
   "settings.hooks.needs_confirmation_title": "호스트 쓰기 확인이 필요합니다",
   "settings.hooks.needs_confirmation_body": "서버가 다음 대상에 대해 쓰기를 거부했습니다:\n{targets}\n자세한 내용은 `mm settings sync` 로 확인하세요.",
+  "settings.hooks.duplicate_banner_one": "{tier} tier({path})에 memtomem 관리 훅 항목 1개가 이미 있습니다 — {cmd} 로 이동하세요. 활성 스코프: {active}.",
+  "settings.hooks.duplicate_banner_many": "{tier} tier({path})에 memtomem 관리 훅 항목 {count}개가 이미 있습니다 — {cmd} 로 이동하세요. 활성 스코프: {active}.",
   "settings.hooks.badge_in_sync": "동기화됨",
   "settings.hooks.badge_out_of_sync": "불일치",
   "settings.hooks.badge_error": "오류",

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -370,11 +370,62 @@ async function _handleHooksPromoteAll(btn) {
   }
 }
 
+// ADR-0010 §3/§4 read-only banner: memtomem-managed hook entries duplicated
+// across non-active tiers (#1247 id 32). Renders ONLY from GET
+// /api/settings-sync payloads — the POST response also carries
+// ``duplicate_tier_warnings`` but lacks ``target_scope`` (the ``--to=`` hint
+// source), and every POST success path already re-runs loadHooksSync(),
+// whose GET repaints this. Wording mirrors the CLI's ``format_warning``
+// (context/settings_doctor.py) per the sibling hint-parity convention.
+function _renderHooksDuplicateBanner(data) {
+  const el = qs('hooks-duplicate-banner');
+  if (!el) return;
+  const dups = Array.isArray(data && data.duplicate_tier_warnings)
+    ? data.duplicate_tier_warnings
+    : [];
+  if (!dups.length) {
+    el.innerHTML = '';
+    el.hidden = true;
+    return;
+  }
+  const active = escapeHtml(typeof data.target_scope === 'string' ? data.target_scope : '');
+  const rows = dups.map(dup => {
+    const tier = escapeHtml(dup.tier || '');
+    const path = escapeHtml(dup.path || '');
+    const count = Array.isArray(dup.entries) ? dup.entries.length : 0;
+    const cmd = `<code>mm context settings-migrate --from=${tier} --to=${active}</code>`;
+    const key = count === 1
+      ? 'settings.hooks.duplicate_banner_one'
+      : 'settings.hooks.duplicate_banner_many';
+    let text = t(key, { count: String(count), tier, path, cmd, active });
+    if (text === key) {
+      // Cold-boot fallback: the locale fetch may still be in flight, in which
+      // case t() echoes the key — render the EN literal instead (same shape
+      // as the B10 fan-out annotation fix).
+      text = count === 1
+        ? `1 memtomem-managed hook entry already exists in the ${tier} tier (${path}) — run ${cmd} to move it. Active scope: ${active}.`
+        : `${count} memtomem-managed hook entries already exist in the ${tier} tier (${path}) — run ${cmd} to move them. Active scope: ${active}.`;
+    }
+    return `<div class="hooks-duplicate-banner-row">${text}</div>`;
+  }).join('');
+  el.innerHTML = rows;
+  el.hidden = false;
+}
+
 async function loadHooksSync() {
   const seq = ++_hooksSyncSeq;
   const statusEl = qs('hooks-sync-status');
   const contentEl = qs('hooks-sync-content');
   panelLoading(contentEl);
+  // Clear the duplicate-tier banner before ANY await: a tier/project switch
+  // whose reload then fails must not leave the previous scope's banner (and
+  // its now-wrong ``--to=`` hint) on screen (Codex impl-gate catch). The
+  // success path repaints it from the fresh GET payload below. Deliberately
+  // does NOT null ``_hooksLastSyncData`` — that cache also feeds the rule
+  // actions' mtime staleness tokens (``_hooksRuleActionPayload``), and
+  // nulling it mid-reload would let a concurrent rule click bypass the
+  // stale-write gate.
+  _renderHooksDuplicateBanner(null);
   const requestedScope = _hooksCurrentTargetScope();
   let requestedProjectScope = _hooksCurrentProjectScope();
   if (typeof _ctxFetchProjectsData === 'function') {
@@ -460,6 +511,7 @@ async function loadHooksSync() {
       + (showTarget
         ? `<div class="hooks-status-target" data-target-scope="${escapeHtml(scope || '')}">${escapeHtml(targetLabel)} <code>${escapeHtml(data.target_path)}</code></div>`
         : '');
+    _renderHooksDuplicateBanner(data);
 
     // Sync Now is only meaningful when a canonical source exists and has
     // at least one hook rule. Disable the button for empty sources so a
@@ -976,3 +1028,18 @@ async function runWatchdogNow() {
 
 qs('health-watchdog-refresh-btn')?.addEventListener('click', loadWatchdogStatus);
 qs('health-watchdog-run-btn')?.addEventListener('click', runWatchdogNow);
+
+// Re-render the duplicate-tier banner in the new locale from the cached GET
+// payload (the emb-mismatch banner pattern — see
+// feedback_i18n_init_order_race). The rest of the hooks panel repaints on
+// its next load; the banner is the only piece whose copy is otherwise
+// invisible until then. Guarded on the banner being VISIBLE: after a failed
+// reload the banner is cleared while ``_hooksLastSyncData`` still holds the
+// previous scope's payload — re-rendering from that cache would resurrect
+// the stale ``--to=`` hint the reload-start clear just removed.
+window.addEventListener('langchange', () => {
+  const el = qs('hooks-duplicate-banner');
+  if (el && !el.hidden && _hooksLastSyncData) {
+    _renderHooksDuplicateBanner(_hooksLastSyncData);
+  }
+});

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -2549,6 +2549,27 @@ select:focus-visible {
   white-space: pre-line;
   overflow-wrap: anywhere;
 }
+/* ADR-0010 §3 duplicate-tier banner: read-only warning that memtomem-managed
+ * hook entries also live in a non-active tier (#1247 id 32). Same warning
+ * tokens as .hooks-sync-needs-confirmation; hidden attr toggled by JS. */
+.hooks-duplicate-banner {
+  margin-top: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--warning, #b58900);
+  border-radius: var(--radius);
+  background: rgba(181, 137, 0, 0.08);
+  font-size: 0.78rem;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.hooks-duplicate-banner[hidden] { display: none; }
+.hooks-duplicate-banner-row { overflow-wrap: anywhere; }
+.hooks-duplicate-banner-row code {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  overflow-wrap: anywhere;
+}
 .hooks-sync-card {
   border: 1px solid var(--border); border-radius: var(--radius);
   padding: 12px; margin-bottom: 12px; background: var(--surface);

--- a/packages/memtomem/tests-js/settings-hooks-duplicate-banner.test.mjs
+++ b/packages/memtomem/tests-js/settings-hooks-duplicate-banner.test.mjs
@@ -1,0 +1,185 @@
+/* Duplicate-tier warning banner in the hooks panel (#1247 id 32).
+ *
+ * GET /api/settings-sync has carried ``duplicate_tier_warnings`` since the
+ * settings-doctor shipped (ADR-0010 §4), but no web surface consumed it —
+ * the ADR-0010 §3 "banner when duplicate-tier memtomem-managed hooks are
+ * detected" was missing. These tests pin the banner render:
+ *
+ *  - rows render from the GET payload only (the POST response lacks
+ *    ``target_scope``, the ``--to=`` hint source; every POST success path
+ *    re-runs loadHooksSync, so the GET repaint covers apply — design-gate
+ *    fold, codex-20260611-234932),
+ *  - the migrate hint reflects the payload's ``target_scope`` (non-default
+ *    scopes get the right ``--to=``),
+ *  - a clean re-fetch clears the banner,
+ *  - tier/path values are HTML-escaped.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+const BASE_SYNC = {
+  status: 'in_sync',
+  target_scope: 'project_shared',
+  target_path: '/proj/.claude/settings.json',
+  hooks: { pending: [], conflicts: [], synced: [] },
+};
+
+function dup(tier, path, entryCount) {
+  return {
+    tier,
+    path,
+    entries: Array.from({ length: entryCount }, (_, i) => ({
+      event: 'Stop',
+      matcher: '',
+      command_preview: `echo hook-${i}`,
+    })),
+  };
+}
+
+async function bootHooksPanel(syncPayload) {
+  const dom = await bootApp({
+    scripts: ['i18n.js', 'app.js', 'settings-hooks-watchdog.js'],
+    apiResponses: { '/api/settings-sync': syncPayload },
+  });
+  const { window } = dom;
+  await window.loadHooksSync();
+  return window;
+}
+
+describe('hooks duplicate-tier banner (#1247 id 32)', () => {
+  it('renders one row per duplicate tier with count, path, and migrate hint', async () => {
+    const window = await bootHooksPanel({
+      ...BASE_SYNC,
+      duplicate_tier_warnings: [
+        dup('user', '/home/u/.claude/settings.json', 2),
+        dup('project_local', '/proj/.claude/settings.local.json', 1),
+      ],
+    });
+    const el = window.document.getElementById('hooks-duplicate-banner');
+    expect(el).toBeTruthy();
+    // The container styling (and the [hidden] display override) is
+    // class-scoped — an id-only element would render unstyled (Codex
+    // impl-gate round-2 catch).
+    expect(el.classList.contains('hooks-duplicate-banner')).toBe(true);
+    expect(el.hidden).toBe(false);
+    const rows = el.querySelectorAll('.hooks-duplicate-banner-row');
+    expect(rows.length).toBe(2);
+    expect(rows[0].textContent).toContain('2');
+    expect(rows[0].textContent).toContain('user');
+    expect(rows[0].textContent).toContain('/home/u/.claude/settings.json');
+    expect(rows[0].textContent).toContain(
+      'mm context settings-migrate --from=user --to=project_shared',
+    );
+    expect(rows[1].textContent).toContain(
+      'mm context settings-migrate --from=project_local --to=project_shared',
+    );
+  });
+
+  it('builds the --to= hint from the payload target_scope (non-default scope)', async () => {
+    const window = await bootHooksPanel({
+      ...BASE_SYNC,
+      target_scope: 'user',
+      duplicate_tier_warnings: [dup('project_shared', '/proj/.claude/settings.json', 1)],
+    });
+    const el = window.document.getElementById('hooks-duplicate-banner');
+    expect(el.textContent).toContain(
+      'mm context settings-migrate --from=project_shared --to=user',
+    );
+  });
+
+  it('stays hidden with no duplicates and clears after a clean re-fetch', async () => {
+    const window = await bootHooksPanel({
+      ...BASE_SYNC,
+      duplicate_tier_warnings: [dup('user', '/home/u/.claude/settings.json', 1)],
+    });
+    const el = window.document.getElementById('hooks-duplicate-banner');
+    expect(el.hidden).toBe(false);
+
+    // Post-apply repaint path: every POST success handler re-runs
+    // loadHooksSync(); a now-clean GET must clear the banner rather than
+    // leave a stale warning behind.
+    window.fetch = async (input) => {
+      const url = typeof input === 'string' ? input : input?.url;
+      if (url && url.split('?')[0] === '/api/settings-sync') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ ...BASE_SYNC, duplicate_tier_warnings: [] }),
+          text: async () => '',
+        };
+      }
+      return { ok: true, status: 200, json: async () => ({}), text: async () => '{}' };
+    };
+    await window.loadHooksSync();
+    expect(el.hidden).toBe(true);
+    expect(el.innerHTML).toBe('');
+  });
+
+  it('clears the banner when a scoped refetch fails (no stale --to hint)', async () => {
+    const window = await bootHooksPanel({
+      ...BASE_SYNC,
+      duplicate_tier_warnings: [dup('user', '/home/u/.claude/settings.json', 1)],
+    });
+    const el = window.document.getElementById('hooks-duplicate-banner');
+    expect(el.hidden).toBe(false);
+
+    // Tier/project switch whose reload fails: the banner must be cleared at
+    // reload start, not left showing the previous scope's migrate hint
+    // (Codex impl-gate catch).
+    window.fetch = async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: 'boom' }),
+      text: async () => '{}',
+    });
+    await window.loadHooksSync();
+    expect(el.hidden).toBe(true);
+    expect(el.innerHTML).toBe('');
+  });
+
+  it('langchange does not resurrect a cleared banner from the stale cache', async () => {
+    const window = await bootHooksPanel({
+      ...BASE_SYNC,
+      duplicate_tier_warnings: [dup('user', '/home/u/.claude/settings.json', 1)],
+    });
+    const el = window.document.getElementById('hooks-duplicate-banner');
+    expect(el.hidden).toBe(false);
+
+    window.fetch = async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: 'boom' }),
+      text: async () => '{}',
+    });
+    await window.loadHooksSync();
+    expect(el.hidden).toBe(true);
+
+    // _hooksLastSyncData still holds the pre-failure payload; the langchange
+    // re-render must not repaint from it while the banner is cleared.
+    window.dispatchEvent(new window.CustomEvent('langchange', { detail: { lang: 'ko' } }));
+    expect(el.hidden).toBe(true);
+    expect(el.innerHTML).toBe('');
+  });
+
+  it('treats a payload without the field as no duplicates', async () => {
+    const window = await bootHooksPanel({ ...BASE_SYNC });
+    const el = window.document.getElementById('hooks-duplicate-banner');
+    expect(el.hidden).toBe(true);
+    expect(el.innerHTML).toBe('');
+  });
+
+  it('escapes HTML in tier and path values', async () => {
+    const window = await bootHooksPanel({
+      ...BASE_SYNC,
+      duplicate_tier_warnings: [
+        dup('<img src=x onerror=alert(1)>', '/tmp/<script>boom</script>.json', 1),
+      ],
+    });
+    const el = window.document.getElementById('hooks-duplicate-banner');
+    expect(el.hidden).toBe(false);
+    expect(el.querySelector('img')).toBeNull();
+    expect(el.querySelector('script')).toBeNull();
+    expect(el.innerHTML).toContain('&lt;script&gt;');
+  });
+});

--- a/packages/memtomem/tests/test_context_runtime_coverage.py
+++ b/packages/memtomem/tests/test_context_runtime_coverage.py
@@ -4,12 +4,32 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from memtomem.context.runtime_coverage import compute_runtime_coverage
 
+from .helpers import set_home
 
-def test_compute_runtime_coverage_empty_dir(tmp_path: Path) -> None:
-    """An empty directory has no available runtimes."""
-    coverage = compute_runtime_coverage(tmp_path)
+
+@pytest.fixture()
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Empty fake home so machine-level runtime dirs can't leak into probes.
+
+    The settings-availability probe (ADR-0009 §1) reads ``Path.home()``
+    directly — without this, a dev machine's real ``~/.claude`` would flip
+    every ``available`` assertion below.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    set_home(monkeypatch, fake_home)
+    return fake_home
+
+
+def test_compute_runtime_coverage_empty_dir(tmp_path: Path, isolated_home: Path) -> None:
+    """An empty directory (and empty home) has no available runtimes."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    coverage = compute_runtime_coverage(project)
     assert len(coverage) == 4
     names = {c["name"] for c in coverage}
     assert names == {"claude", "gemini", "codex", "kimi"}
@@ -17,18 +37,70 @@ def test_compute_runtime_coverage_empty_dir(tmp_path: Path) -> None:
         assert item["available"] is False
 
 
-def test_compute_runtime_coverage_with_markers(tmp_path: Path) -> None:
+def test_compute_runtime_coverage_with_markers(tmp_path: Path, isolated_home: Path) -> None:
     """Markers trigger available=True for targeted runtimes."""
+    project = tmp_path / "proj"
     # Claude marker directory
-    (tmp_path / ".claude" / "skills").mkdir(parents=True)
+    (project / ".claude" / "skills").mkdir(parents=True)
     # Kimi config file marker
-    (tmp_path / ".kimi").mkdir()
-    (tmp_path / ".kimi" / "config.toml").touch()
+    (project / ".kimi").mkdir()
+    (project / ".kimi" / "config.toml").touch()
 
-    coverage = compute_runtime_coverage(tmp_path)
+    coverage = compute_runtime_coverage(project)
     coverage_dict = {c["name"]: c for c in coverage}
 
     assert coverage_dict["claude"]["available"] is True
     assert coverage_dict["kimi"]["available"] is True
     assert coverage_dict["gemini"]["available"] is False
     assert coverage_dict["codex"]["available"] is False
+
+
+def test_settings_home_dir_counts_as_available(tmp_path: Path, isolated_home: Path) -> None:
+    """ADR-0009 §1: the settings surface joins the availability OR.
+
+    A machine-level runtime home (``~/.codex``) with a completely untouched
+    project must light the chip — the settings generators' ``is_available``
+    is home-OR-project per ADR-0010 §3.
+    """
+    (isolated_home / ".codex").mkdir()
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    coverage = {c["name"]: c for c in compute_runtime_coverage(project)}
+
+    assert coverage["codex"]["available"] is True
+    assert coverage["claude"]["available"] is False
+    assert coverage["gemini"]["available"] is False
+    assert coverage["kimi"]["available"] is False
+
+
+def test_settings_project_dir_counts_as_available(tmp_path: Path, isolated_home: Path) -> None:
+    """Project-side runtime dir without any marker file is enough.
+
+    ``<proj>/.kimi/`` (no ``config.toml``) is invisible to the
+    RUNTIME_MARKER_FILES probe but satisfies ``KimiSettingsGenerator.
+    is_available`` — pins that the settings probe is a distinct OR leg,
+    not a restatement of the marker-file probe.
+    """
+    project = tmp_path / "proj"
+    (project / ".kimi").mkdir(parents=True)
+
+    coverage = {c["name"]: c for c in compute_runtime_coverage(project)}
+
+    assert coverage["kimi"]["available"] is True
+    assert coverage["claude"]["available"] is False
+
+
+def test_home_isolation_negative_pin(tmp_path: Path, isolated_home: Path) -> None:
+    """Empty home + empty project stays all-False even with home dirs nearby.
+
+    Negative pin for the settings probe: creating an unrelated dir in the
+    fake home must not light any chip (guards against an over-broad probe
+    that keys on home existence rather than the runtime dir).
+    """
+    (isolated_home / ".not-a-runtime").mkdir()
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    coverage = {c["name"]: c for c in compute_runtime_coverage(project)}
+    assert all(c["available"] is False for c in coverage.values())

--- a/packages/memtomem/tests/test_settings_doctor.py
+++ b/packages/memtomem/tests/test_settings_doctor.py
@@ -420,8 +420,9 @@ class TestSyncWarning:
 class TestWebDuplicateTierWarnings:
     """``GET /api/settings-sync`` and ``POST /api/settings-sync`` both
     expose ``duplicate_tier_warnings`` (ADR-0010 §4 data surface). The
-    frontend banner that consumes this is gated for a follow-up PR;
-    these tests pin the data layer."""
+    consuming frontend banner ships alongside (#1247 id 32,
+    ``settings-hooks-watchdog.js`` + vitest pins); these tests pin the
+    data layer."""
 
     @pytest.fixture
     def app(self, project_root, fake_home, monkeypatch):

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -118,8 +118,14 @@ class TestOverview:
 
     @pytest.mark.anyio
     async def test_overview_detected_runtimes_flags_present_surfaces(
-        self, client: AsyncClient, tmp_path: Path
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
+        # Isolated home: the settings-availability probe (ADR-0009 §1,
+        # #1247 id 54) reads Path.home(), so a dev machine's real ~/.codex
+        # would otherwise flip the exact-flag assertion below.
+        home = tmp_path / "home"
+        home.mkdir()
+        set_home(monkeypatch, home)
         # CLAUDE.md (top-level agent file) → claude detected
         (tmp_path / "CLAUDE.md").write_text("# x\n", encoding="utf-8")
         # .gemini/skills/foo/SKILL.md → gemini detected via skill dir
@@ -129,12 +135,17 @@ class TestOverview:
 
         r = await client.get("/api/context/overview")
         runtimes = {r["name"]: r["available"] for r in r.json()["detected_runtimes"]}
+        # gemini is True via BOTH the skill dir and the settings probe
+        # (project .gemini/ dir); claude via CLAUDE.md only.
         assert runtimes == {"claude": True, "gemini": True, "codex": False, "kimi": False}
 
     @pytest.mark.anyio
     async def test_overview_detects_kimi_runtime_config_without_importing_as_context(
-        self, client: AsyncClient, tmp_path: Path
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
+        home = tmp_path / "home"
+        home.mkdir()
+        set_home(monkeypatch, home)
         kimi_dir = tmp_path / ".kimi"
         kimi_dir.mkdir()
         (kimi_dir / "config.toml").write_text("[hooks]\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

#1247 backlog batch **B11** — the adr-conformance family plus the two code
fixes the ADRs prescribe. Backlog ids **32, 52, 53, 54, 55, 56, 57** (7 of the
11 remaining unchecked items; B12 `#18` extract-lock is the last code batch).

### Commit 1 — code (ids 32, 54)

- **id 32 · duplicate-tier hooks banner.** `duplicate_tier_warnings` has been
  emitted on both settings endpoints since the settings-doctor shipped
  (ADR-0010 §4) — the serializer docstring even promised a web banner — but
  no web surface consumed it. The hooks panel now renders a read-only warning
  row per duplicate tier (count, tier, path, and the CLI-parity
  `mm context settings-migrate --from=… --to=…` hint), en+ko, with a
  langchange re-render from the cached GET payload.
  - **GET-only by design** (Codex design-gate catch): the POST response also
    carries the field but lacks `target_scope` (the `--to=` hint source), and
    every POST success path already re-runs `loadHooksSync()` — so a
    POST-side render could emit a wrong migrate hint for non-default scopes.
  - Deliberately **not** surfaced on the dashboard Sync All path (it has
    phase rows; the panel GET re-surfaces the warning on the next visit).
- **id 54 · settings probe in the detected-runtimes chips.** ADR-0009 §1
  prescribes the chip availability OR across surfaces *including* the
  settings generators' `is_available()`; the probe was missing since the chip
  shipped (#947), so a runtime reachable only through settings fan-out
  rendered gray "undetected". `compute_runtime_coverage` now ORs it in.
  - **User-visible semantics change (disclosed):** `is_available` is
    home-OR-project (ADR-0010 §3), so a chip can now be green from
    machine-level presence alone (`~/.codex` exists, project untouched).
    This is what ADR-0009 §1 prescribes; the chip strip is the only live
    consumer (the per-project coverage matrix consumer was removed —
    `context-gateway.js` "rank 2" note), and `installed` remains the
    registry's separate machine-axis field.
  - The pre-existing coverage tests asserted all-False on an empty dir
    **without isolating HOME** — environment-flaky post-fix — so they now run
    under an isolated fake home (`tests/helpers.set_home`). The full-suite
    run surfaced the same leak one layer up: the two
    `TestOverview.detected_runtimes` route tests in
    `test_web_routes_context.py` asserted exact flags against the real home
    (`~/.codex` flipped `codex` to True) and are now isolated the same way.

### Commit 2 — docs (ids 52, 53, 55, 56, 57)

Dated rider notes (the B2 ADR-0011 §5 blockquote shape) recording shipped
reality in Accepted ADRs:

- **id 52** ADR-0016 §6 — migrate refuses scope-tier overwrite even with
  `--force` (ADR-0011 PR-E4 Row 15; replace verb is the named follow-up).
- **id 53** ADR-0018 — Kimi 4th-runtime row (TOML targets); ADR-0019 — Kimi
  ownership is a managed block, not per-rule markers (JSON runtimes only).
- **id 55** ADR-0009 §5 — fifth `mcp_servers` tile envelope (#1165);
  ADR-0011 §1 — `mcp_servers` table row (the only single-tier artifact);
  ADR-0016 §3 — matching note.
- **id 56** ADR-0015 §4c — v1 web write routes 400-reject non-project_shared
  tiers (`_reject_non_shared_write`); implementing user-tier web writes is
  tracked in **#1263** (filed first so no placeholder lands).
- **id 57** ADR-0001 §5 + ADR-0009 §2 — the marker-enabled, consent-gated
  per-rule `rules/promote` reverse-import narrows "no reverse-import by
  design"; the bulk extract path remains absent by design.

## Verification

- Codex gates: design ×1 (NEEDS-FIX → GET-only banner fold + issue-first
  ordering) → impl ×2 (R1 Major: stale banner / langchange resurrect after a
  failed scoped reload → folded as reload-start clear + visible-only
  langchange re-render, deliberately WITHOUT nulling `_hooksLastSyncData` —
  that cache feeds the rule actions' mtime staleness tokens, and nulling it
  mid-reload would let a concurrent rule click bypass the stale-write gate).
- Pre-fix-fail: pytest 2 new cases fail at HEAD (settings-probe legs);
  vitest 5/5 fail at HEAD (banner spec). Fold cases mutation-validated
  against the pre-fold JS (2 fail / 5 pass). All green post-fix.
- New tests: pytest 3 (+4 pre-existing hardened with home isolation), vitest
  7 (render / non-default-scope `--to=` hint / clear-on-clean-refetch /
  failed-refetch clear / langchange no-resurrect / absent-field / XSS
  escape).
- Full suites: pytest 6356 passed (`-m "not ollama"`, `test_session_tracing`
  excluded = #1249 pre-existing); vitest 177 passed (34 files).
- `ruff check` + `ruff format --check` clean. i18n parity auto-covered by
  `test_i18n.py`.
- `?v` bumps: style.css 105, settings-hooks-watchdog.js 18.

Refs #1247. Closes nothing; #1263 stays open as the id 56 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
