### PR TITLE
fix(context): skills reverse-import sidecar lock + typed promote-race skips (#1247 B12)

### DIFF
--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -19,6 +19,7 @@ frontmatter rewriting without touching callers.
 
 from __future__ import annotations
 
+import errno
 import logging
 import os
 import secrets
@@ -306,8 +307,9 @@ def _reap_stale_internal_dirs(dst: Path) -> None:
     Safe ONLY while holding ``_lock_path_for(dst)``: every gateway writer
     for the same destination holds that lock across its stage→promote
     sequence, so no live staging tree for this dst can exist while we do.
-    The extract/copy_skill path holds no locks — canonical-root leftovers
-    are handled by discovery filtering only, never by GC.
+    Both the sync fan-out paths and the reverse-import path
+    (:func:`extract_skills_to_canonical`, #1247 id 18) hold that lock, so
+    runtime-side AND canonical-side leftovers get reaped.
     """
     parent = dst.parent
     if not parent.is_dir():
@@ -345,6 +347,29 @@ def _target_conflict(dst: Path) -> OSError | None:
     return None
 
 
+def _promote_race_conflict(exc: OSError) -> bool:
+    """Whether a :func:`_promote_staging` ``OSError`` is a destination race.
+
+    ``True`` only for the shapes a NON-gateway writer (manual shell, editor)
+    can produce by landing content at ``dst`` mid-swap — the
+    :func:`_target_conflict` refusal pair, and ENOTEMPTY/EEXIST from the
+    rename-in hitting a recreated destination. Callers convert those into a
+    typed ``target_conflict`` skip and keep going.
+
+    Everything else stays ``False`` so it RE-RAISES: ENOSPC, permission
+    errors, and — critically — the rollback-failure chain from #1123
+    (``raise promote_exc from rollback_exc``), where the only surviving copy
+    of the original tree is stranded in ``.old-*``. A non-``None``
+    ``__cause__`` is that chain's marker (promote errors are otherwise raised
+    bare), and demoting it to a skip would bury the operator breadcrumb.
+    """
+    if exc.__cause__ is not None:
+        return False
+    if isinstance(exc, (IsADirectoryError, NotADirectoryError)):
+        return True
+    return exc.errno in (errno.ENOTEMPTY, errno.EEXIST)
+
+
 def _promote_staging(staging: Path, dst: Path) -> None:
     """Atomic-replace ``dst`` with ``staging`` (same-fs precondition).
 
@@ -373,6 +398,8 @@ def _promote_staging(staging: Path, dst: Path) -> None:
             # orphaned without a trace. Log a breadcrumb naming ``old`` and
             # ``dst`` so an operator can recover the tree manually, then re-raise
             # the ORIGINAL error with the rollback failure chained (#1123 B3-4).
+            # The ``from`` chain is load-bearing: ``_promote_race_conflict``
+            # reads ``__cause__`` to refuse demoting THIS state to a skip.
             try:
                 os.replace(old, dst)
             except BaseException as rollback_exc:
@@ -392,10 +419,13 @@ def _promote_staging(staging: Path, dst: Path) -> None:
 def copy_skill(src: Path, dst: Path) -> None:
     """Mirror a skill directory from ``src`` to ``dst`` via staging-then-promote.
 
-    Thin wrapper kept for callers that don't care about the staging step
-    (no privacy scan, no override merge — pure file copy). E3
-    sync-side flow uses :func:`_stage_skill` + :func:`_promote_staging`
-    directly so it can scan + override-apply between the two halves.
+    Thin public wrapper (``__all__``) kept for external callers that don't
+    care about the staging step (no privacy scan, no override merge, no
+    destination lock — pure file copy). The gateway's own flows use
+    :func:`_stage_skill` + :func:`_promote_staging` directly: sync scans +
+    override-applies between the two halves, and the reverse import
+    (#1247 id 18) converts each half's failure into its own typed skip
+    while holding the destination sidecar lock.
 
     Individual files are written atomically via
     :func:`memtomem.context._atomic.atomic_write_bytes`. Directory-level
@@ -598,14 +628,19 @@ def generate_all_skills(
                 for target, staging, dst in staged:
                     try:
                         _promote_staging(staging, dst)
-                    except (IsADirectoryError, NotADirectoryError) as exc:
+                    except OSError as exc:
                         # Residual race: only a NON-gateway writer (manual
                         # shell, editor) can recreate conflicting content at
                         # dst after the preflight above — the sidecar lock
                         # held since before staging serializes every gateway
-                        # writer. Loud typed skip; the remaining destinations
-                        # still promote (the finally below reaps the
-                        # unconsumed staging tree).
+                        # writer. Loud typed skip for the verified race
+                        # shapes (refusal pair + ENOTEMPTY/EEXIST, #1247
+                        # id 18); the remaining destinations still promote
+                        # (the finally below reaps the unconsumed staging
+                        # tree). Anything else — ENOSPC, permissions, the
+                        # #1123 rollback-failure chain — re-raises loud.
+                        if not _promote_race_conflict(exc):
+                            raise
                         skipped.append((dst.name, str(exc), skip_codes.TARGET_CONFLICT))
                         continue
                     generated.append((target, dst))
@@ -744,13 +779,17 @@ def generate_all_skills(
                         skipped.append((skill_dir.name, reason, code))
                     else:
                         # 4. Promote — atomic os.replace into dst. The
-                        # conflict refusal can still fire here if a
+                        # conflict refusal (or a recreated-destination
+                        # ENOTEMPTY/EEXIST) can still fire here if a
                         # NON-gateway writer recreated content at dst after
                         # the preflight (the held sidecar lock serializes
                         # gateway writers only) — same typed-skip conversion.
+                        # Non-race OSErrors re-raise loud (#1247 id 18).
                         try:
                             _promote_staging(staging, dst)
-                        except (IsADirectoryError, NotADirectoryError) as exc:
+                        except OSError as exc:
+                            if not _promote_race_conflict(exc):
+                                raise
                             skipped.append((skill_dir.name, str(exc), skip_codes.TARGET_CONFLICT))
                         else:
                             promoted = True
@@ -788,9 +827,23 @@ def extract_skills_to_canonical(
     + Gate A privacy walk + cross-runtime dedup + canonical-exists check, then
     **skips only the directory copy**: the returned ``imported`` lists the
     destinations that *would* be written and ``skipped`` carries the same
-    reasons a real run would, but nothing touches disk. The skip decisions are
-    identical to a real run because both evaluate ``dst.exists()`` before any
-    write, so the preview is accurate (modulo the documented TOCTOU window).
+    reasons a real run would, but nothing touches disk — including the
+    destination sidecar lockfile, which only a real run creates. The skip
+    decisions are identical to a real run because both evaluate
+    ``dst.exists()`` before any write, so the preview is accurate (modulo
+    the documented TOCTOU window).
+
+    Concurrency (#1247 id 18): the write phase (reap → re-check → stage →
+    promote) runs inside the same per-destination sidecar flock the sync
+    paths hold (``_lock_path_for(dst)``), so parallel gateway writers cannot
+    interleave their ``dst → .old-* → staging → dst`` swaps and strand the
+    canonical tree in ``.old-*``. The Gate A scan stays OUTSIDE the lock
+    (it reads only the source tree); acquisition is bounded by one
+    whole-call ``_SKILLS_LOCK_BUDGET_S`` budget and a timed-out destination
+    becomes a typed ``lock_timeout`` skip. Only non-gateway writers (manual
+    shell, editor) can still race the promote — those surface as typed
+    ``target_conflict`` skips for the verified race shapes and re-raise
+    loud otherwise.
 
     ADR-0011 PR-E2: ``scope`` selects both the canonical destination
     (:func:`canonical_artifact_dir`) and the source runtime root
@@ -805,7 +858,7 @@ def extract_skills_to_canonical(
     ``project_shared`` destinations hard-abort via :class:`click.ClickException`
     on the first hit (with or without ``force_unsafe_import``).
 
-    Threat model — Gate A walks the source tree once and :func:`copy_skill`
+    Threat model — Gate A walks the source tree once and :func:`_stage_skill`
     re-reads the same files when the import proceeds; an adversarial
     filesystem could swap bytes between the two reads (a TOCTOU window).
     The current threat model is "accidental leak", not "adversarial
@@ -834,6 +887,15 @@ def extract_skills_to_canonical(
     imported: list[Path] = []
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = []
     seen: dict[str, str] = {}  # skill_name → first runtime label
+
+    # One shared deadline for ALL destination sidecar-lock waits — the whole
+    # call, not each destination, is bounded by ``_SKILLS_LOCK_BUDGET_S``
+    # (mirror of ``generate_all_skills``; #1145 shape — a thread-offloaded
+    # web/MCP caller must never be wedged by a stuck cross-process holder).
+    lock_deadline = time.monotonic() + _SKILLS_LOCK_BUDGET_S
+
+    def _lock_timeout() -> float:
+        return max(0.0, lock_deadline - time.monotonic())
 
     for runtime in ("claude", "gemini", "codex", "kimi"):
         try:
@@ -896,10 +958,10 @@ def extract_skills_to_canonical(
                 try:
                     content_text = src_file.read_text(encoding="utf-8", errors="replace")
                 except OSError:
-                    # Truly unreadable file — skip the scan; copy_skill
-                    # will surface the OSError during the actual copy if
-                    # it is real, otherwise the file passes through as
-                    # a binary asset.
+                    # Truly unreadable file — skip the scan; _stage_skill
+                    # will surface the OSError during the actual copy as a
+                    # typed ``parse_error`` skip if it is real, otherwise
+                    # the file passes through as a binary asset.
                     continue
                 outcome = apply_gate_a(
                     content_text=content_text,
@@ -936,20 +998,78 @@ def extract_skills_to_canonical(
 
             # All files clean — copy the whole tree (atomic at directory level).
             # ``dry_run`` records the would-import destination but skips the
-            # mkdir + copy so the preview never mutates disk (rank-10).
+            # mkdir + lock + copy so the preview never mutates disk (rank-10).
             if not dry_run:
                 dst.parent.mkdir(parents=True, exist_ok=True)
+                # Stage→promote runs inside the destination sidecar lock —
+                # mirror of the sync paths (#1247 id 18). Without it, two
+                # parallel importers interleave their dst→.old-*→staging→dst
+                # swaps and a racing promote can strand the only copy of the
+                # canonical tree in ``.old-*``.
+                dst_lock = ExitStack()
                 try:
-                    copy_skill(skill_dir, dst)
-                except (IsADirectoryError, NotADirectoryError) as exc:
-                    # Residual race: the import path holds no locks, so any
-                    # writer can land conflicting content at dst between the
-                    # preflight above and the promote — typed skip, the
-                    # remaining imports proceed.
-                    skipped.append((skill_name, str(exc), skip_codes.TARGET_CONFLICT))
-                    logger.warning("skip %s from %s: %s", skill_name, runtime_label, exc)
-                    seen[skill_name] = runtime_label
+                    dst_lock.enter_context(_file_lock(_lock_path_for(dst), timeout=_lock_timeout()))
+                except TimeoutError:
+                    reason = (
+                        "another process held the canonical destination lock "
+                        f"past the {_SKILLS_LOCK_BUDGET_S:g}s acquisition "
+                        "budget — re-run the import to retry"
+                    )
+                    # No ``seen`` mark: contention is transient and
+                    # destination-lock-specific, so a later runtime's copy of
+                    # the same name keeps its fallback chance (and, with the
+                    # per-call budget exhausted, fails fast into this same
+                    # skip rather than blocking).
+                    skipped.append((skill_name, reason, skip_codes.LOCK_TIMEOUT))
+                    logger.warning("skip %s from %s: %s", skill_name, runtime_label, reason)
                     continue
+                with dst_lock:
+                    # Lock held — safe point to reap crash leftovers for this
+                    # canonical dst (previously unreachable for the import
+                    # path, which relied on discovery filtering alone).
+                    _reap_stale_internal_dirs(dst)
+                    # Re-check the no-overwrite contract under the lock: a
+                    # parallel importer can land dst between the lock-free
+                    # preflight above and our acquisition, and replacing its
+                    # fresh import would violate ``overwrite=False``.
+                    if dst.exists() and not overwrite:
+                        reason = "canonical exists (use --overwrite)"
+                        skipped.append((skill_name, reason, skip_codes.CANONICAL_EXISTS))
+                        logger.warning("skip %s from %s: %s", skill_name, runtime_label, reason)
+                        seen[skill_name] = runtime_label
+                        continue
+                    # Inlined ``_stage_skill`` + ``_promote_staging`` (rather
+                    # than ``copy_skill``) so each half converts to its own
+                    # typed skip — sync-path parity. No ``seen`` mark on a
+                    # stage failure: unreadability is source-runtime-specific
+                    # (agents/commands parity), so a later runtime's clean
+                    # copy of the same name still imports.
+                    try:
+                        staging = _stage_skill(skill_dir, dst)
+                    except OSError as exc:
+                        skipped.append((skill_name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
+                        logger.warning("skip %s from %s: %s", skill_name, runtime_label, exc)
+                        continue
+                    try:
+                        _promote_staging(staging, dst)
+                    except OSError as exc:
+                        # Verified destination races (refusal pair +
+                        # ENOTEMPTY/EEXIST from a NON-gateway writer — the
+                        # held lock serializes gateway writers) become typed
+                        # skips; anything else, including the #1123
+                        # rollback-failure chain, re-raises loud.
+                        shutil.rmtree(staging, ignore_errors=True)
+                        if not _promote_race_conflict(exc):
+                            raise
+                        skipped.append((skill_name, str(exc), skip_codes.TARGET_CONFLICT))
+                        logger.warning("skip %s from %s: %s", skill_name, runtime_label, exc)
+                        seen[skill_name] = runtime_label
+                        continue
+                    except BaseException:
+                        # Non-OSError escape (KeyboardInterrupt, …): keep
+                        # ``copy_skill``'s staging hygiene before propagating.
+                        shutil.rmtree(staging, ignore_errors=True)
+                        raise
             imported.append(dst)
             seen[skill_name] = runtime_label
 

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -335,7 +335,11 @@ async def mem_context_init(
 
     if "skills" in inc:
         try:
-            skill_result = extract_skills_to_canonical(
+            # Thread offload (#1247 id 18): the skills import engine blocks
+            # on the destination sidecar flock (budget-bounded) — keep that
+            # wait off the event loop.
+            skill_result = await asyncio.to_thread(
+                extract_skills_to_canonical,
                 root,
                 overwrite=overwrite,
                 scope=artifact_scope,
@@ -610,8 +614,11 @@ async def mem_context_generate(
 
     if "skills" in inc:
         try:
-            skill_result = generate_all_skills(
-                root, scope=artifact_scope, surface="mcp_context_generate"
+            # Thread offload: ``generate_all_skills`` blocks on destination
+            # sidecar flocks since #1229 — keep the (budget-bounded) wait
+            # off the event loop (#1247 id 18 sweep).
+            skill_result = await asyncio.to_thread(
+                generate_all_skills, root, scope=artifact_scope, surface="mcp_context_generate"
             )
         except PrivacyScanError as exc:
             return f"privacy block: {exc.message}"
@@ -947,8 +954,9 @@ async def mem_context_sync(
 
     if "skills" in inc:
         try:
-            skill_result = generate_all_skills(
-                root, scope=artifact_scope, surface="mcp_context_sync"
+            # Thread offload: same rationale as mem_context_generate.
+            skill_result = await asyncio.to_thread(
+                generate_all_skills, root, scope=artifact_scope, surface="mcp_context_sync"
             )
         except PrivacyScanError as exc:
             return f"privacy block: {exc.message}"

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -545,7 +545,12 @@ async def import_skills(
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
-                result = extract_skills_to_canonical(
+                # Thread offload (#1247 id 18): the import engine now blocks
+                # on the destination sidecar flock (budget-bounded), and
+                # ``asyncio.timeout`` cannot fire while the loop thread
+                # itself is blocked — same shape as the sync route above.
+                result = await asyncio.to_thread(
+                    extract_skills_to_canonical,
                     project_root,
                     overwrite=overwrite,
                     dry_run=dry_run,
@@ -594,7 +599,9 @@ async def import_skill(
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
-                result = extract_skills_to_canonical(
+                # Thread offload (#1247 id 18): see import_skills above.
+                result = await asyncio.to_thread(
+                    extract_skills_to_canonical,
                     project_root,
                     overwrite=overwrite,
                     only_name=name,

--- a/packages/memtomem/tests/test_context_skills_staging.py
+++ b/packages/memtomem/tests/test_context_skills_staging.py
@@ -34,6 +34,7 @@ from memtomem.context.skills import (
     _stage_skill,
     canonical_skills_root,
     copy_skill,
+    extract_skills_to_canonical,
     generate_all_skills,
 )
 
@@ -735,3 +736,368 @@ class TestTargetConflict:
         assert "claude_skills" not in promoted
         assert promoted, result.skipped
         assert not list(claude_dst.parent.glob(".staging-*"))
+
+
+def _seed_runtime_skill(
+    project_root: Path,
+    runtime_dir: str = ".claude/skills",
+    name: str = "foo",
+    body: str = "---\nname: foo\n---\nbody\n",
+) -> Path:
+    """Seed a runtime-side skill for reverse-import tests."""
+    skill_dir = project_root / runtime_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / SKILL_MANIFEST).write_text(body, encoding="utf-8")
+    return skill_dir
+
+
+class TestExtractLock:
+    """#1247 id 18 — the reverse import promotes into canonical under the
+    same per-destination sidecar flock the sync paths hold. Without it, two
+    parallel importers could interleave their ``dst → .old-* → staging → dst``
+    swaps: the racing promote raised a plain ``OSError`` (ENOTEMPTY) that
+    escaped the refusal-pair catch and aborted the whole import, and a failed
+    rollback stranded the only copy of the canonical tree in ``.old-*``.
+    """
+
+    def test_held_lock_skips_only_contended_destination(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A foreign holder on one canonical destination lock produces a
+        typed ``lock_timeout`` skip for that skill only — the other skill
+        still imports, and the call stays bounded (never blocks forever)."""
+        import time as _time
+
+        import memtomem.context.skills as skills_mod
+        from memtomem.context._atomic import _file_lock, _lock_path_for
+
+        _seed_runtime_skill(tmp_path, name="foo")
+        _seed_runtime_skill(tmp_path, name="bar", body="---\nname: bar\n---\nbody\n")
+        canonical = canonical_skills_root(tmp_path)
+
+        monkeypatch.setattr(skills_mod, "_SKILLS_LOCK_BUDGET_S", 0.2)
+        start = _time.monotonic()
+        with _file_lock(_lock_path_for(canonical / "foo")):
+            result = extract_skills_to_canonical(tmp_path)
+        elapsed = _time.monotonic() - start
+
+        lock_skips = [s for s in result.skipped if s[2] == skip_codes.LOCK_TIMEOUT]
+        assert len(lock_skips) == 1, result.skipped
+        assert lock_skips[0][0] == "foo"
+        assert "acquisition budget" in lock_skips[0][1]
+        assert not (canonical / "foo").exists()
+        assert [p.name for p in result.imported] == ["bar"]
+        assert elapsed < 10, f"abort took {elapsed:.1f}s — budget not applied?"
+
+    def test_lock_timeout_leaves_no_seen_mark(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Contention is transient and destination-specific, so a timed-out
+        name is NOT marked ``seen``: the later runtime's copy gets its own
+        (fail-fast) attempt instead of a misleading ``already imported``
+        skip. Deterministic pin: with copies in two runtimes and the lock
+        held throughout, BOTH attempts surface as ``lock_timeout``."""
+        import memtomem.context.skills as skills_mod
+        from memtomem.context._atomic import _file_lock, _lock_path_for
+
+        _seed_runtime_skill(tmp_path, runtime_dir=".claude/skills", name="foo")
+        _seed_runtime_skill(tmp_path, runtime_dir=".gemini/skills", name="foo")
+        canonical = canonical_skills_root(tmp_path)
+
+        monkeypatch.setattr(skills_mod, "_SKILLS_LOCK_BUDGET_S", 0.2)
+        with _file_lock(_lock_path_for(canonical / "foo")):
+            result = extract_skills_to_canonical(tmp_path)
+
+        codes = [s[2] for s in result.skipped]
+        assert codes.count(skip_codes.LOCK_TIMEOUT) == 2, result.skipped
+        assert skip_codes.ALREADY_IMPORTED not in codes, result.skipped
+        assert result.imported == []
+
+    def test_promote_race_oserror_typed_skip_continues(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A racing promote's ENOTEMPTY (plain OSError — NOT the refusal
+        pair) becomes a typed ``target_conflict`` skip; the remaining imports
+        proceed and the orphaned staging tree is cleaned. Pre-fix this
+        escaped the loop and aborted the whole import."""
+        import errno as _errno
+
+        import memtomem.context.skills as skills_mod
+
+        _seed_runtime_skill(tmp_path, name="foo")
+        _seed_runtime_skill(tmp_path, name="bar", body="---\nname: bar\n---\nbody\n")
+        canonical = canonical_skills_root(tmp_path)
+
+        orig_promote = skills_mod._promote_staging
+
+        def racing_promote(staging: Path, dst: Path) -> None:
+            if dst.name == "foo":
+                raise OSError(_errno.ENOTEMPTY, "Directory not empty", str(dst))
+            orig_promote(staging, dst)
+
+        monkeypatch.setattr(skills_mod, "_promote_staging", racing_promote)
+        result = extract_skills_to_canonical(tmp_path)
+
+        conflicts = [s for s in result.skipped if s[2] == skip_codes.TARGET_CONFLICT]
+        assert len(conflicts) == 1, result.skipped
+        assert conflicts[0][0] == "foo"
+        assert [p.name for p in result.imported] == ["bar"]
+        assert not list(canonical.glob(".staging-*")), "orphaned staging tree left behind"
+
+    def test_promote_nonrace_oserror_reraises_loud(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-race promote failures (permissions, ENOSPC, …) must NOT be
+        demoted to a skip — they re-raise after staging cleanup."""
+        import errno as _errno
+
+        import memtomem.context.skills as skills_mod
+
+        _seed_runtime_skill(tmp_path, name="foo")
+        canonical = canonical_skills_root(tmp_path)
+
+        def failing_promote(staging: Path, dst: Path) -> None:
+            raise PermissionError(_errno.EACCES, "Permission denied", str(dst))
+
+        monkeypatch.setattr(skills_mod, "_promote_staging", failing_promote)
+        with pytest.raises(PermissionError):
+            extract_skills_to_canonical(tmp_path)
+        assert not list(canonical.glob(".staging-*")), "orphaned staging tree left behind"
+
+    def test_promote_rollback_failure_chain_reraises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The #1123 rollback-failure chain (``raise promote_exc from
+        rollback_exc``) means the original tree is stranded in ``.old-*`` —
+        even a race-shaped errno must stay loud, never a skip. The
+        ``__cause__`` marker is the classifier's contract."""
+        import errno as _errno
+
+        import memtomem.context.skills as skills_mod
+
+        _seed_runtime_skill(tmp_path, name="foo")
+
+        def stranding_promote(staging: Path, dst: Path) -> None:
+            try:
+                raise OSError(_errno.EACCES, "rollback rename failed")
+            except OSError as rollback_exc:
+                raise OSError(_errno.ENOTEMPTY, "Directory not empty", str(dst)) from rollback_exc
+
+        monkeypatch.setattr(skills_mod, "_promote_staging", stranding_promote)
+        with pytest.raises(OSError) as excinfo:
+            extract_skills_to_canonical(tmp_path)
+        assert excinfo.value.errno == _errno.ENOTEMPTY
+        assert excinfo.value.__cause__ is not None
+
+    def test_stage_oserror_parse_error_skip_allows_runtime_fallback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unreadable SOURCE is runtime-specific: typed ``parse_error``
+        skip with no ``seen`` mark, so a clean same-name copy in a later
+        runtime still imports (agents/commands parity). Pre-fix the OSError
+        crashed the whole import."""
+        import errno as _errno
+
+        import memtomem.context.skills as skills_mod
+
+        _seed_runtime_skill(tmp_path, runtime_dir=".claude/skills", name="foo")
+        _seed_runtime_skill(
+            tmp_path, runtime_dir=".gemini/skills", name="foo", body="---\nname: foo\n---\ngemini\n"
+        )
+        canonical = canonical_skills_root(tmp_path)
+
+        orig_stage = skills_mod._stage_skill
+
+        def failing_stage(src: Path, dst: Path, **kwargs):
+            if ".claude" in src.parts:
+                raise OSError(_errno.EIO, "Input/output error", str(src))
+            return orig_stage(src, dst, **kwargs)
+
+        monkeypatch.setattr(skills_mod, "_stage_skill", failing_stage)
+        result = extract_skills_to_canonical(tmp_path)
+
+        parse_skips = [s for s in result.skipped if s[2] == skip_codes.PARSE_ERROR]
+        assert len(parse_skips) == 1, result.skipped
+        assert parse_skips[0][0] == "foo"
+        assert "unreadable" in parse_skips[0][1]
+        # The gemini copy won the fallback — not an ``already imported`` skip.
+        assert [p.name for p in result.imported] == ["foo"]
+        text = (canonical / "foo" / SKILL_MANIFEST).read_text(encoding="utf-8")
+        assert text == "---\nname: foo\n---\ngemini\n"
+        codes = [s[2] for s in result.skipped]
+        assert skip_codes.ALREADY_IMPORTED not in codes, result.skipped
+
+    def test_reaps_canonical_crash_leftovers_under_lock(self, tmp_path: Path) -> None:
+        """Canonical-side ``.old-*``/``.staging-*`` crash leftovers were
+        previously never reaped (reaping is lock-gated and the import path
+        held no lock — only discovery filtering hid them). With the lock
+        held the import now GCs them; non-internal-shaped siblings survive."""
+        _seed_runtime_skill(tmp_path, name="foo")
+        canonical = canonical_skills_root(tmp_path)
+        stale = canonical / ".old-foo-99999-abc123.tmp"
+        stale.mkdir(parents=True)
+        (stale / SKILL_MANIFEST).write_text("stale", encoding="utf-8")
+        user_dir = canonical / ".old-foo-notes"
+        user_dir.mkdir(parents=True)
+        (user_dir / "keep.txt").write_text("keep", encoding="utf-8")
+
+        result = extract_skills_to_canonical(tmp_path)
+
+        assert [p.name for p in result.imported] == ["foo"]
+        assert not stale.exists(), "crash leftover not reaped"
+        assert (user_dir / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+    def test_overwrite_false_recheck_under_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A parallel importer landing ``dst`` between the lock-free
+        preflight and our lock acquisition must NOT be silently replaced
+        when ``overwrite=False`` — the contract is re-checked under the
+        lock. Simulated by planting dst from the Gate A hook (which runs
+        after the preflight, before the lock)."""
+        import memtomem.context.skills as skills_mod
+
+        _seed_runtime_skill(tmp_path, name="foo")
+        canonical = canonical_skills_root(tmp_path)
+        racer_dst = canonical / "foo"
+
+        orig_gate = skills_mod.apply_gate_a
+
+        def planting_gate(**kwargs):
+            out = orig_gate(**kwargs)
+            if not racer_dst.exists():
+                racer_dst.mkdir(parents=True)
+                (racer_dst / SKILL_MANIFEST).write_text("racer won\n", encoding="utf-8")
+            return out
+
+        monkeypatch.setattr(skills_mod, "apply_gate_a", planting_gate)
+        result = extract_skills_to_canonical(tmp_path)
+
+        exists_skips = [s for s in result.skipped if s[2] == skip_codes.CANONICAL_EXISTS]
+        assert len(exists_skips) == 1, result.skipped
+        assert exists_skips[0][0] == "foo"
+        assert result.imported == []
+        text = (racer_dst / SKILL_MANIFEST).read_text(encoding="utf-8")
+        assert text == "racer won\n", "racing importer's tree was replaced despite overwrite=False"
+
+    def test_promote_runs_under_destination_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Direct pin of the serialization property: at promote time the
+        destination sidecar lock is HELD (a non-blocking acquisition from
+        a second open-file-description fails)."""
+        import memtomem.context.skills as skills_mod
+        from memtomem.context._atomic import _file_lock, _lock_path_for
+
+        _seed_runtime_skill(tmp_path, name="foo")
+        contended: list[bool] = []
+
+        orig_promote = skills_mod._promote_staging
+
+        def probing_promote(staging: Path, dst: Path) -> None:
+            try:
+                with _file_lock(_lock_path_for(dst), timeout=0):
+                    contended.append(False)
+            except TimeoutError:
+                contended.append(True)
+            orig_promote(staging, dst)
+
+        monkeypatch.setattr(skills_mod, "_promote_staging", probing_promote)
+        result = extract_skills_to_canonical(tmp_path)
+
+        assert [p.name for p in result.imported] == ["foo"]
+        assert contended == [True], "promote ran without the destination sidecar lock held"
+
+    def test_dry_run_takes_no_lock_and_mutates_nothing(self, tmp_path: Path) -> None:
+        """rank-10 preview contract: dry_run must not create the canonical
+        root, the sidecar lockfile, or any staging artifact — the lock is
+        a disk mutation too."""
+        _seed_runtime_skill(tmp_path, name="foo")
+        canonical = canonical_skills_root(tmp_path)
+
+        result = extract_skills_to_canonical(tmp_path, dry_run=True)
+
+        assert [p.name for p in result.imported] == ["foo"]
+        assert not canonical.exists(), "dry_run touched disk"
+
+
+class TestSyncPromoteRaceClassification:
+    """#1247 id 18 same-shape sweep: the sync promote catches were limited to
+    the refusal pair, so a NON-gateway writer's mid-swap race (ENOTEMPTY)
+    crashed the fan-out mid-batch — same isolation break #1229 fixed for the
+    refusal types. Verified race shapes now convert to typed skips at all
+    three promote sites; everything else (ENOSPC, permissions, the #1123
+    rollback-failure chain) still re-raises."""
+
+    def test_project_shared_race_oserror_typed_skip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import errno as _errno
+
+        import memtomem.context.skills as skills_mod
+
+        _seed_canonical_skill(tmp_path, name="foo")
+        _seed_canonical_skill(tmp_path, name="bar", skill_md="---\nname: bar\n---\nbody\n")
+
+        orig_promote = skills_mod._promote_staging
+
+        def racing_promote(staging: Path, dst: Path) -> None:
+            if dst.name == "foo":
+                raise OSError(_errno.ENOTEMPTY, "Directory not empty", str(dst))
+            orig_promote(staging, dst)
+
+        monkeypatch.setattr(skills_mod, "_promote_staging", racing_promote)
+        result = generate_all_skills(tmp_path, runtimes=["claude_skills"])
+
+        conflicts = [s for s in result.skipped if s[2] == skip_codes.TARGET_CONFLICT]
+        assert len(conflicts) == 1, result.skipped
+        assert conflicts[0][0] == "foo"
+        generated_names = {p.name for _rt, p in result.generated}
+        assert generated_names == {"bar"}, result.generated
+
+    def test_project_shared_nonrace_oserror_reraises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import errno as _errno
+
+        import memtomem.context.skills as skills_mod
+
+        _seed_canonical_skill(tmp_path, name="foo")
+
+        def failing_promote(staging: Path, dst: Path) -> None:
+            raise PermissionError(_errno.EACCES, "Permission denied", str(dst))
+
+        monkeypatch.setattr(skills_mod, "_promote_staging", failing_promote)
+        with pytest.raises(PermissionError):
+            generate_all_skills(tmp_path, runtimes=["claude_skills"])
+
+    def test_user_scope_race_oserror_typed_skip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import errno as _errno
+
+        import memtomem.context.skills as skills_mod
+
+        home = tmp_path / "home"
+        home.mkdir()
+        set_home(monkeypatch, home)
+        _seed_canonical_skill(tmp_path, name="foo", scope="user")
+        claude_dst = SKILL_GENERATORS["claude_skills"].target_dir(tmp_path, "foo", scope="user")
+        assert claude_dst is not None
+
+        orig_promote = skills_mod._promote_staging
+
+        def racing_promote(staging: Path, dst: Path) -> None:
+            if dst == claude_dst:
+                raise OSError(_errno.ENOTEMPTY, "Directory not empty", str(dst))
+            orig_promote(staging, dst)
+
+        monkeypatch.setattr(skills_mod, "_promote_staging", racing_promote)
+        result = generate_all_skills(tmp_path, scope="user")  # must not raise
+
+        conflicts = [s for s in result.skipped if s[2] == skip_codes.TARGET_CONFLICT]
+        assert len(conflicts) == 1, result.skipped
+        assert conflicts[0][0] == "foo"
+        promoted = {rt for rt, _p in result.generated}
+        assert "claude_skills" not in promoted
+        assert promoted, result.skipped


### PR DESCRIPTION
## Summary

#1247 backlog **id 18** (B12, final code batch): the skills reverse import
(`extract_skills_to_canonical`) promoted into the canonical tree **without
the destination sidecar lock** that both sync fan-out paths hold (#1229),
and its promote error handling only caught the `IsADirectoryError` /
`NotADirectoryError` refusal pair.

Consequences on main:

- Two parallel importers (CLI `mm context init`, web Import CTA, MCP
  `mem_context_init`) could interleave their `dst → .old-* → staging → dst`
  swaps inside `_promote_staging`. The racing promote raises ENOTEMPTY — a
  **plain `OSError`** that escaped the catch and **aborted the whole
  import**; if the rollback rename also failed, the only copy of the
  canonical tree was stranded in `.old-*` (#1123 leaves a breadcrumb, but
  the tree is still orphaned).
- Canonical-side `.staging-*` / `.old-*` crash leftovers were **never
  reaped**: `_reap_stale_internal_dirs` is lock-gated by contract, and the
  import path held no lock (discovery filtering from #1240 only hides them).

## Fix

- **Lock the import write phase** (reap → overwrite re-check → stage →
  promote) with `_file_lock(_lock_path_for(dst))`, bounded by one whole-call
  `_SKILLS_LOCK_BUDGET_S` deadline (mirror of `generate_all_skills`, #1145
  shape). Timed-out destination → typed `lock_timeout` skip. The Gate A scan
  stays **outside** the lock — it reads only the source tree.
- **Inline `copy_skill`'s two halves** so each converts to its own typed
  skip with exact sync-path parity: stage `OSError` → `parse_error`
  ("unreadable"), promote `OSError` → `target_conflict` for verified race
  shapes. `copy_skill` stays exported for external callers.
- **Narrow race classification** (`_promote_race_conflict`, design-gate
  fold): refusal pair + ENOTEMPTY/EEXIST with no `__cause__`. The #1123
  rollback-failure chain (`raise promote_exc from rollback_exc`) and any
  other `OSError` (ENOSPC, permissions) **re-raise loud** — demoting a
  stranded-canonical state to a skip would bury the operator breadcrumb.
  The `from` chain in `_promote_staging` is now documented as load-bearing.
- **`seen` marking policy** (design-gate fold): `lock_timeout` and stage
  `parse_error` do **not** mark `seen` — contention is transient and
  unreadability is source-runtime-specific (agents/commands parity), so a
  later runtime's same-name copy keeps its fallback attempt. Destination-
  invariant skips (`canonical_exists`, `target_conflict`) keep marking.
- **Under-lock overwrite re-check**: a parallel importer landing `dst`
  between the lock-free preflight and our acquisition is no longer silently
  replaced when `overwrite=False` — typed `canonical_exists` skip.
- **Reap canonical-side crash leftovers** under the held lock (closes the
  "never reaped" gap; non-internal-shaped siblings untouched).
- **`dry_run` mutates nothing**, still: the lockfile itself is a disk
  mutation, so preview runs take no lock and do no reap (rank-10 contract).

## Same-shape sweep (disclosed scope)

- Both **sync** promote sites had the identical plain-`OSError` escape (a
  non-gateway writer's mid-swap race crashed the fan-out mid-batch — the
  same isolation break #1229 fixed for the refusal types). Both now use the
  same narrow classifier: verified races → typed skip, everything else
  re-raises.
- **Async-context offload**: the import engine now blocks on a flock, and
  `asyncio.timeout` cannot fire while the loop thread itself is blocked
  (#1145). The two web import routes and MCP `mem_context_init` now call it
  via `asyncio.to_thread` (mirror of the web sync route).
  `mem_context_generate` / `mem_context_sync` get the same wrap for
  `generate_all_skills`, which has blocked on these locks **since #1229** —
  a pre-existing same-family gap folded in here per design review (2-line
  wraps, same file).

## Not fixed here (adjacent, known)

- `migrate.py` lock posture (different surface; B5 #1258 shipped its own
  divergence guards).
- Single-read TOCTOU hardening for Gate A vs copy (documented out of scope
  in the extract docstring; threat model is accidental leak).
- Gate-A-blocked skips still mark `seen` (existing conservative behavior —
  a privacy-blocked name is not retried from later runtimes).
- agents/commands extracts hold no locks by design (single-file
  `atomic_write_bytes`, no directory swap window).

## Tests

13 new in `test_context_skills_staging.py`:

- `TestExtractLock` (10): held-lock typed skip + bounded abort; lock-timeout
  leaves no `seen` mark (deterministic 2-skip pin); promote ENOTEMPTY typed
  skip + remaining imports proceed + staging cleaned; non-race `OSError`
  re-raises; #1123 rollback-failure chain re-raises; stage `OSError` →
  `parse_error` + later-runtime fallback import; canonical crash-leftover
  reap (+ non-internal sibling survives); under-lock `overwrite=False`
  re-check; lock-held-at-promote probe (second-OFD non-blocking acquire must
  fail); dry-run takes no lock and creates nothing.
- `TestSyncPromoteRaceClassification` (3): project_shared race typed skip +
  batch isolation; project_shared non-race re-raise; user-scope race typed
  skip.

Verification discipline:

- **9 pre-fix-fail vs main** (source stashed, tests run, all 9 red for the
  pinned reasons; 4 negative pins pass pre-fix as expected).
- **Mutation-validated negative pins**: classifier mutated to always-True →
  3 loud-path pins go red; `dry_run` guard bypassed → preview pin goes red.
- Full suite + ruff green (see checks).
- Pre-existing suite-combination flake reproduced identically on clean main
  (16 fails in one specific multi-file invocation; single-file and full-suite
  runs green) — unrelated to this change.

Closes #1247 backlog id 18 (issue checklist updated on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
