### PR TITLE
fix(context): apply-time dirty re-walk for --all + agent-specific alias + copilot Architecture (#1247 B13)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -1610,16 +1610,21 @@ def _run_update_all(
        correction; the design's earlier ``list_entries()`` reference does
        not exist in the actual API).
     2. Classify across all roots in one pass — ``current_commit`` and
-       ``is_asset_dirty`` each run at most once per project, all cached
-       on :class:`ProjectClassification` for the execute phase.
+       ``is_asset_dirty`` each run at most once per project during
+       classification; ``lock_entry`` is cached on
+       :class:`ProjectClassification` for the execute phase (the dirty
+       walk is preview-only — see step 7).
     3. Print a 4-state preview table.
     4. Empty store / "no projects have asset" exit 0 informationally —
        cron/CI safety so a first-run before any registration succeeds.
     5. ``refuse`` without ``--force`` aborts the entire batch (no partial
        writes).
     6. ``--yes --force`` prints WARNING + skips prompt + executes.
-    7. Serial execute consumes cached ``dirty_report`` / ``lock_entry``;
-       no second walk per project.
+    7. Serial execute consumes the cached ``lock_entry``; the dest tree
+       is re-classified inside ``_apply_update`` (#1247 id 13 — the
+       classify-phase ``dirty_report`` only renders the preview table,
+       because the confirm prompt between classify and execute is
+       unbounded).
     """
     cfg = ContextGatewayConfig()
     store = KnownProjectsStore(Path(cfg.known_projects_path).expanduser())
@@ -1711,9 +1716,11 @@ def _run_update_all(
             continue
 
         # state in {"update", "refuse"} — execute via _apply_update with
-        # cached dirty_report + lock_entry (no re-walk).
+        # the cached lock_entry; the dest tree is re-classified at apply
+        # time (#1247 id 13 — the classify-phase dirty_report is
+        # preview-only; an edit made during the confirm prompt must still
+        # refuse / get its .bak).
         assert c.lock_entry is not None
-        assert c.dirty_report is not None
         src = wiki.root / asset_type_plural / name
         dest = c.project_root / ".memtomem" / asset_type_plural / name
         try:
@@ -1725,7 +1732,6 @@ def _run_update_all(
                 dest=dest,
                 wiki_commit=new_commit,
                 lock_entry=c.lock_entry,
-                dirty_report=c.dirty_report,
                 force=force,
                 surface="cli_context_update_all",
             )
@@ -1964,8 +1970,10 @@ def _run_install_all(
        irrelevant — intentionally diverges from ``update --all`` which
        does warn (it cares about HEAD).
     3. Classify every entry in ``<project>/.memtomem/lock.json`` once
-       via ``_classify_for_install_all`` (cached lock_entry +
-       dirty_report passed through to execute).
+       via ``_classify_for_install_all``. ``lock_entry`` is cached for
+       execute; the classify-phase ``dirty_report`` is preview-only —
+       ``_apply_pinned_install`` re-classifies before its gates
+       (#1247 id 13).
     4. Empty lockfile → "No entries..." stderr, exit 0.
     5. Print 5-state preview table.
     6. If only skip/orphan/error rows (no install/refuse) → exit 0.

--- a/packages/memtomem/src/memtomem/context/generator.py
+++ b/packages/memtomem/src/memtomem/context/generator.py
@@ -6,7 +6,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
-from memtomem.context.parser import iter_markdown_sections, split_preamble
+from memtomem.context.parser import (
+    AGENT_SPECIFIC_ALIASES,
+    iter_markdown_sections,
+    split_preamble,
+)
 
 
 class AgentGenerator(Protocol):
@@ -54,13 +58,11 @@ _RESERVED_SECTION_KEYS = {
     "Copilot",
 }
 
-_RESERVED_SECTION_KEYS_CASEFOLD = {
-    "claude-specific",
-    "cursor-specific",
-    "gemini-specific",
-    "codex-specific",
-    "copilot-specific",
-}
+# The "<agent>-specific" headings the generators emit; parse_context folds
+# these into the short keys above (#1247 id 38), and this suppression set
+# keeps any that still reach a sections dict (e.g. hand-built) out of the
+# unknown passthrough. Derived from the same map so the two can't drift.
+_RESERVED_SECTION_KEYS_CASEFOLD = frozenset(AGENT_SPECIFIC_ALIASES)
 
 
 def _append_unknown_sections(lines: list[str], sections: dict[str, str]) -> None:
@@ -249,6 +251,10 @@ class CopilotGenerator:
             lines.append("## Commands\n")
             lines.append(sections["Commands"])
             lines.append("")
+        if "Architecture" in sections:
+            lines.append("## Architecture\n")
+            lines.append(sections["Architecture"])
+            lines.append("")
         if "Copilot" in sections:
             lines.append("## Copilot-Specific\n")
             lines.append(sections["Copilot"])
@@ -371,12 +377,10 @@ def extract_sections_from_agent_file(content: str, source: str | None = None) ->
         "rules": "Rules",
         "style": "Style",
         # Agent-specific override sections — must round-trip through
-        # generate() which emits "## <Agent>-Specific" headings.
-        "claude-specific": "Claude",
-        "cursor-specific": "Cursor",
-        "gemini-specific": "Gemini",
-        "codex-specific": "Codex",
-        "copilot-specific": "Copilot",
+        # generate() which emits "## <Agent>-Specific" headings. Shared with
+        # parse_context, which folds the same headings on the canonical side
+        # (#1247 id 38).
+        **AGENT_SPECIFIC_ALIASES,
     }
 
     # Every ## heading starts a section; the text before the first one is the

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -145,9 +145,11 @@ class UpdateResult:
 class ProjectClassification:
     """Per-project classification produced by :func:`_classify_for_all_update`.
 
-    The dataclass *caches* the per-project lockfile read and the dirty walk
-    so the execute phase can reuse them — the same expensive operations
-    must not run twice between preview and write.
+    The dataclass caches the per-project lockfile read (``lock_entry``) for
+    the execute phase. ``dirty_report`` is **preview-only** (#1247 id 13):
+    it renders the table the user confirms against, and
+    :func:`_apply_update` re-classifies the dest tree at apply time because
+    the confirm prompt between preview and write is unbounded.
 
     State semantics:
 
@@ -618,12 +620,13 @@ def _update_asset(
     5. **True no-op short-circuit**: when ``new_commit`` matches the lockfile
        pin, return early *without touching the lockfile*. ``installed_at``
        is echoed from the existing entry; ``was_no_op=True``.
-    6. Classify the dest tree via :func:`is_asset_dirty` (using the lock
-       entry we already loaded — no second lockfile read).
-    7. Delegate to :func:`_apply_update` for the refuse-or-write step.
+    6. Delegate to :func:`_apply_update`, which classifies the dest tree
+       via :func:`is_asset_dirty` immediately before its gates (#1247
+       id 13) and then refuses or writes.
 
-    The split lets ``mm context update --all`` (commit 4) reuse step 7
-    after performing classification across all known projects up front.
+    The split lets ``mm context update --all`` (commit 4) reuse step 6
+    after rendering a preview classification across all known projects
+    up front.
     """
     validated = validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
     project_root = Path(project_root).expanduser()
@@ -666,8 +669,6 @@ def _update_asset(
             files_written=0,
         )
 
-    dirty_report = is_asset_dirty(project_root, asset_type, validated, lock_entry=lock_entry)
-
     return _apply_update(
         project_root,
         asset_type,
@@ -676,7 +677,6 @@ def _update_asset(
         dest=dest,
         wiki_commit=new_commit,
         lock_entry=lock_entry,
-        dirty_report=dirty_report,
         force=force,
     )
 
@@ -690,11 +690,10 @@ def _apply_update(
     dest: Path,
     wiki_commit: str,
     lock_entry: dict[str, Any],
-    dirty_report: DirtyReport,
     force: bool,
     surface: str = "cli_context_update",
 ) -> UpdateResult:
-    """Execute an already-classified update.
+    """Execute an update against apply-time dirty evidence.
 
     Pre-conditions enforced by callers (``_update_asset`` for the single-
     asset path, ``mm context update --all`` orchestration for the batch
@@ -703,8 +702,16 @@ def _apply_update(
     - ``lock_entry`` is non-None (``NotInstalledError`` is raised earlier).
     - The no-op case (``lock_entry["wiki_commit"] == wiki_commit``) was
       already short-circuited; this helper unconditionally writes.
-    - ``dirty_report`` was already computed; this helper does **not**
-      re-walk the dest tree.
+
+    The dest tree is classified HERE, immediately before the gates. A
+    report computed earlier — in particular before ``--all``'s unbounded
+    confirm prompt — is preview-only and must never gate writes: a
+    stale-clean report would silently clobber an edit made while the user
+    sat on the prompt, and a stale dirty set would ``.bak`` too few files
+    under ``--force`` (#1247 id 13; same plan-time-trust bug as #1135
+    B4-3). The single-asset path pays no extra walk (it no longer
+    pre-computes); ``--all`` walks twice per actionable project — once for
+    the preview table, once here for the gate.
 
     Refuses with :class:`StaleInstallError` when ``dirty_report.reason ==
     "dirty"`` and ``force=False``. With ``force=True`` and a dirty tree,
@@ -722,6 +729,8 @@ def _apply_update(
     mirroring the C2a (#630) install invariant so a follow-up dirty
     check can't false-positive on this update's own writes.
     """
+    dirty_report = is_asset_dirty(project_root, asset_type, name, lock_entry=lock_entry)
+
     if dirty_report.reason == "dirty" and not force:
         raise StaleInstallError(
             f"{asset_type}/{name}: {dirty_report.summary()} "
@@ -886,7 +895,11 @@ def _classify_for_all_update(
       (only populated when ``state in {"update", "refuse"}``; the
       ``unchanged`` short-circuit skips the walk entirely since the
       lockfile pin matches HEAD and the dest tree is, by definition,
-      what was installed at that pin).
+      what was installed at that pin). **Preview-only** (#1247 id 13):
+      it renders the table the user confirms against, but the execute
+      phase re-classifies inside :func:`_apply_update` — an unbounded
+      confirm prompt sits between the two, so apply-time gates must not
+      trust this snapshot.
 
     Projects without a lockfile entry for this asset are silently
     skipped (no result row): they were never in scope for this
@@ -1043,7 +1056,9 @@ class ProjectInstallClassification:
 
     ``lock_entry`` carries the live entry (``wiki_commit`` + ``installed_at``);
     ``dirty_report`` is populated only when the dirty walk actually
-    ran (state ∈ {``skip``, ``refuse``}).
+    ran (state ∈ {``skip``, ``refuse``}) and is **preview-only** (#1247
+    id 13): :func:`_apply_pinned_install` re-classifies at apply time
+    because ``--all``'s confirm prompt sits between classify and execute.
     """
 
     asset_type: Literal["skills", "agents", "commands"]
@@ -1261,16 +1276,23 @@ def _apply_pinned_install(
       preserved, ``installed_at`` refreshed).
     - ``state="skip"`` + ``force=False``: caller skips; this helper
       shouldn't be reached (defense in depth — raises if it is).
-    - ``state="skip"`` + ``force=True``: re-extract at pin, no ``.bak``
-      (clean dest had nothing to preserve).
     - ``state="refuse"`` + ``force=False``: raise
       :class:`StaleInstallError` (caller already aborted batch; defense
       in depth).
-    - ``state="refuse"`` + ``force=True``: ``shutil.copy2`` the at-risk
-      dest files to ``<file>.bak`` (the dirty subset, or EVERY current
-      file when the install record is unusable — mirroring
-      ``_apply_update``, #1247), then extract at pin. Flat-layout refuse
-      rows have no dest to preserve; the flat file stays in place.
+    - The dest tree is then **re-classified here** (#1247 id 13): the
+      classify-phase ``dirty_report`` predates ``--all``'s unbounded
+      confirm prompt and is preview-only. Fresh ``dirty`` — or an
+      unusable install record over an existing dest — without ``force``
+      raises :class:`StaleInstallError` (covers install/skip rows that
+      went dirty during the prompt; the CLI loop degrades it to a red
+      row). With ``force`` the FRESH at-risk set (dirty subset, or
+      EVERY current file when unprovable — mirroring ``_apply_update``)
+      is ``shutil.copy2``'d to ``<file>.bak`` before extraction, so a
+      clean-at-classify row edited mid-prompt still gets its ``.bak``.
+    - A dirty flat-layout sibling is re-probed the same way (design-gate
+      fold): one that APPEARED during the prompt refuses without
+      ``force``; with ``force`` the flat file stays on disk (shadowed,
+      no ``.bak``) exactly like the classify-time flat-refuse rows.
     """
     pin = classification.pin_commit
     asset_type = classification.asset_type
@@ -1291,6 +1313,55 @@ def _apply_pinned_install(
             f"pass --force to overwrite (each modified file gets a .bak sibling)"
         )
 
+    # Apply-time re-classification (#1247 id 13): the classify-phase report
+    # predates --all's unbounded confirm prompt, so every gate and the .bak
+    # set below use FRESH evidence — mirroring _apply_update. A row that
+    # classified install/skip and went dirty during the prompt refuses loud
+    # here (the CLI loop catches → red row, file intact).
+    report = is_asset_dirty(project_root, asset_type, name, lock_entry=classification.lock_entry)
+    unprovable = report.reason == "never_installed" and dest.is_dir()
+    if report.reason == "dirty" and not force:
+        raise StaleInstallError(
+            f"{asset_type}/{name}: {report.summary()} since classification; "
+            f"pass --force to overwrite (each modified file gets a .bak sibling)"
+        )
+    if unprovable and not force:
+        raise StaleInstallError(
+            f"{asset_type}/{name}: install record unusable (missing or malformed "
+            f"installed_at) — local edits cannot be ruled out; pass --force to "
+            f"overwrite (every current file gets a .bak sibling)"
+        )
+
+    # Flat-layout re-probe (#1247 id 13 design gate): a dirty flat sibling
+    # that appeared during the prompt while dest is absent would be silently
+    # shadowed by the extraction below — classify probed too early to see
+    # it. The probe self-short-circuits when dest is a dir or the asset
+    # type has no flat layout, so classify-time flat-refuse rows re-probe
+    # to the same verdict here.
+    if report.reason in ("missing_dest", "never_installed"):
+        flat_path, flat_dirty = _flat_layout_probe(
+            dest, asset_type, name, classification.lock_entry
+        )
+        if flat_path is not None:
+            kind = asset_type.removesuffix("s")
+            if flat_dirty and not force:
+                raise StaleInstallError(
+                    f"{asset_type}/{name}: flat-layout file {flat_path.name} has local "
+                    f"edits (or no provable install time) and the dir-layout install "
+                    f"would stop it being served; run `mm context migrate {kind} {name}` "
+                    f"first, or pass --force to write the dir layout anyway (the flat "
+                    f"file is kept on disk but stops being served)"
+                )
+            logger.warning(
+                "%s/%s: dir layout will shadow flat file %s (dir wins at fan-out); "
+                "run `mm context migrate %s %s` to consolidate",
+                asset_type,
+                name,
+                flat_path,
+                kind,
+                name,
+            )
+
     # Gate A (ADR-0011 §5, #1247): scan the pin's git objects (the exact
     # bytes the extractor would write) plus any dirty files a --force run
     # would .bak — both BEFORE the .bak loop, the first dest mutation.
@@ -1303,19 +1374,16 @@ def _apply_pinned_install(
         project_root=project_root,
     )
     files_to_bak: tuple[Path, ...] = ()
-    if classification.state == "refuse" and force:
-        report = classification.dirty_report
-        assert report is not None  # state=refuse always carries a report
-        if report.reason == "dirty":
-            files_to_bak = report.dirty_files
-        elif report.reason == "never_installed" and dest.is_dir():
-            # Unprovable install record over an existing dest (#1247 impl
-            # gate): no epoch to subset by, so preserve EVERY current file
-            # before the pin re-extraction — mirrors _apply_update. (The
-            # flat-refuse rows also carry never_installed/missing_dest
-            # reports, but their dest is absent → no bak set, the flat
-            # file is preserved in place.)
-            files_to_bak = tuple(iter_installed_files(dest))
+    if force and report.reason == "dirty":
+        files_to_bak = report.dirty_files
+    elif force and unprovable:
+        # Unprovable install record over an existing dest (#1247 impl
+        # gate): no epoch to subset by, so preserve EVERY current file
+        # before the pin re-extraction — mirrors _apply_update. (The
+        # flat-refuse rows carry never_installed/missing_dest reports,
+        # but their dest is absent → no bak set, the flat file is
+        # preserved in place.)
+        files_to_bak = tuple(iter_installed_files(dest))
     if files_to_bak:
         _gate_a_scan_dirty_files(
             files_to_bak,

--- a/packages/memtomem/src/memtomem/context/parser.py
+++ b/packages/memtomem/src/memtomem/context/parser.py
@@ -11,6 +11,20 @@ CONTEXT_FILENAME = ".memtomem/context.md"
 # Known section names (case-insensitive matching)
 KNOWN_SECTIONS = {"project", "commands", "architecture", "rules", "style"}
 
+# Canonical short keys for the per-agent override sections, keyed by the
+# casefolded "<agent>-specific" heading the generators *emit*. Shared by
+# :func:`parse_context` and the reverse-import alias map in
+# :func:`memtomem.context.generator.extract_sections_from_agent_file`, and
+# the source for the generator module's unknown-section suppression set —
+# single source of truth so the three can't drift (#1247 id 38).
+AGENT_SPECIFIC_ALIASES: dict[str, str] = {
+    "claude-specific": "Claude",
+    "cursor-specific": "Cursor",
+    "gemini-specific": "Gemini",
+    "codex-specific": "Codex",
+    "copilot-specific": "Copilot",
+}
+
 _HEADING_RE = re.compile(r"^##\s+(.+)$")
 # A Markdown code fence: 3+ backticks or tildes, indented up to 3 spaces
 # (CommonMark). group(1) is the fence run — its marker char and length
@@ -126,6 +140,15 @@ def parse_context(path: Path) -> dict[str, str]:
     Unknown sections are preserved as-is. Repeated headings are merged
     (content concatenated) rather than the earlier copy being overwritten.
 
+    A `## <Agent>-Specific` heading (any case) folds into the canonical short
+    key (`Claude`, `Cursor`, …) via :data:`AGENT_SPECIFIC_ALIASES` — the
+    generators look up the short key and suppress the literal `-specific`
+    headings from unknown-section passthrough, so without the fold a
+    canonical-authored override section (copied from a generated file, which
+    *displays* `## Claude-Specific`) was silently dropped from every output
+    (#1247 id 38). A folded heading merges with an existing short-key section
+    exactly like a repeated heading.
+
     Text before the first `## SectionName` heading is not a section and is
     not preserved — put project description under `## Project`. (Runtime-file
     reverse-import via
@@ -139,10 +162,11 @@ def parse_context(path: Path) -> dict[str, str]:
     text = path.read_text(encoding="utf-8")
     sections: dict[str, str] = {}
     for name, body in iter_markdown_sections(text):
-        if name in sections:
-            sections[name] = f"{sections[name]}\n\n{body}".strip()
+        key = AGENT_SPECIFIC_ALIASES.get(name.lower(), name)
+        if key in sections:
+            sections[key] = f"{sections[key]}\n\n{body}".strip()
         else:
-            sections[name] = body
+            sections[key] = body
 
     return sections
 

--- a/packages/memtomem/tests/test_context.py
+++ b/packages/memtomem/tests/test_context.py
@@ -163,6 +163,20 @@ class TestGenerator:
         for name, content in result.items():
             assert len(content) > 0
 
+    @pytest.mark.parametrize("agent", sorted(GENERATORS))
+    def test_every_generator_emits_all_canonical_section_bodies(self, agent):
+        """No generator may silently drop a canonical section (#1247 id 39).
+
+        Canonical section names are in _RESERVED_SECTION_KEYS, so the
+        unknown-section passthrough skips them — a generator missing a branch
+        for one (copilot had no Architecture branch) makes that content vanish
+        from its output with no warning.
+        """
+        sections = self._sections()
+        content = generate_for_agent(agent, sections)
+        for body in sections.values():
+            assert body in content
+
     @pytest.mark.parametrize("agent", ["claude", "cursor", "gemini", "codex", "copilot"])
     def test_generate_preserves_unknown_sections(self, agent):
         sections = {
@@ -299,6 +313,73 @@ class TestSpecificSectionRoundTrip:
         regenerated = generate_for_agent(agent, sections)
         assert heading in regenerated
         assert marker in regenerated
+
+
+class TestCanonicalAgentSpecificAlias:
+    """Canonical `## <Agent>-Specific` headings must reach the right generator.
+
+    Sibling of TestSpecificSectionRoundTrip, which covers the reverse-import
+    leg (extract_sections_from_agent_file). This is the canonical-parse leg
+    (#1247 id 38): parse_context kept the verbatim `Claude-Specific` key, the
+    generators look up the short key (`Claude`), and _append_unknown_sections
+    suppresses `<agent>-specific` headings — so the section was silently
+    dropped from every generated file, including that agent's own. Generated
+    files *display* `## Claude-Specific`, so canonical authors copy it.
+    """
+
+    @pytest.mark.parametrize(
+        "heading,canonical",
+        [
+            ("Claude-Specific", "Claude"),
+            ("Cursor-Specific", "Cursor"),
+            ("Gemini-Specific", "Gemini"),
+            ("Codex-Specific", "Codex"),
+            ("Copilot-Specific", "Copilot"),
+        ],
+    )
+    def test_parse_context_folds_agent_specific_heading(self, tmp_path, heading, canonical):
+        ctx = tmp_path / "context.md"
+        ctx.write_text(f"# Project Context\n\n## {heading}\n\noverride body\n", encoding="utf-8")
+        sections = parse_context(ctx)
+        assert canonical in sections
+        assert heading not in sections
+        assert sections[canonical] == "override body"
+
+    def test_parse_context_folds_case_variants(self, tmp_path):
+        ctx = tmp_path / "context.md"
+        ctx.write_text("## CLAUDE-SPECIFIC\n\nshout body\n", encoding="utf-8")
+        assert parse_context(ctx)["Claude"] == "shout body"
+
+    def test_parse_context_merges_short_key_and_specific_heading(self, tmp_path):
+        ctx = tmp_path / "context.md"
+        ctx.write_text(
+            "## Claude\n\nfirst body\n\n## Claude-Specific\n\nsecond body\n",
+            encoding="utf-8",
+        )
+        sections = parse_context(ctx)
+        assert sections["Claude"] == "first body\n\nsecond body"
+        assert "Claude-Specific" not in sections
+
+    def test_parse_context_leaves_non_agent_specific_headings_unknown(self, tmp_path):
+        # The alias map must not over-match lookalike headings.
+        ctx = tmp_path / "context.md"
+        ctx.write_text("## Claudette-Specific\n\nnot an agent\n", encoding="utf-8")
+        sections = parse_context(ctx)
+        assert sections == {"Claudette-Specific": "not an agent"}
+
+    def test_canonical_specific_section_reaches_own_agent_only(self, tmp_path):
+        ctx = tmp_path / "context.md"
+        ctx.write_text(
+            "# Project Context\n\n## Project\n\nIntro.\n\n"
+            "## Claude-Specific\n\nclaude override body\n",
+            encoding="utf-8",
+        )
+        sections = parse_context(ctx)
+        claude_out = generate_for_agent("claude", sections)
+        gemini_out = generate_for_agent("gemini", sections)
+        assert "## Claude-Specific" in claude_out
+        assert "claude override body" in claude_out
+        assert "claude override body" not in gemini_out
 
 
 class TestParserHardening:

--- a/packages/memtomem/tests/test_context_install_all.py
+++ b/packages/memtomem/tests/test_context_install_all.py
@@ -943,3 +943,82 @@ def test_install_all_unusable_record_refuses_then_force_baks_all(
     assert result.files_written >= 1
     assert edited.read_bytes() == b"wiki\n"  # pin bytes restored
     assert edited.with_suffix(".md.bak").read_bytes() == b"local edit\n"
+
+
+# ── #1247 id 13: edits during the --all confirm prompt ───────────────────
+
+
+def test_cli_install_all_force_baks_file_edited_during_confirm_prompt(
+    wiki_root: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A skip(clean) row edited DURING the confirm prompt must get a .bak
+    under ``--force`` (#1247 id 13).
+
+    Pre-fix ``_apply_pinned_install`` trusted the classify-phase report:
+    skip rows carried a clean report, so ``--force`` re-extracted the pin
+    over the mid-prompt edit with no ``.bak`` at all.
+    """
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"v1\n"})
+    install_skill(tmp_path, "foo")
+
+    edited = tmp_path / ".memtomem" / "skills" / "foo" / "SKILL.md"
+
+    def _edit_then_confirm(*args: object, **kwargs: object) -> bool:
+        edited.write_bytes(b"edited during prompt\n")
+        _bump_mtime(edited)
+        return True
+
+    monkeypatch.setattr("memtomem.cli.context_cmd.click.confirm", _edit_then_confirm)
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["install", "--all", "--force"])
+
+    assert result.exit_code == 0, result.output
+    assert edited.read_bytes() == b"v1\n"  # pin bytes restored
+    bak = edited.with_suffix(".md.bak")
+    assert bak.exists(), result.output
+    assert bak.read_bytes() == b"edited during prompt\n"
+
+
+def test_cli_install_all_refuses_flat_sibling_appearing_during_confirm_prompt(
+    wiki_root: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dirty flat-layout sibling that APPEARS during the confirm prompt
+    must refuse at apply time, not be silently shadowed (#1247 id 13
+    design gate).
+
+    The row classifies ``install`` (dest absent, no flat yet), so the
+    classify-time flat probe sees nothing. Pre-fix the execute phase went
+    straight to extraction: ``.memtomem/agents/foo/`` was created next to
+    the live flat file, flipping fan-out serving away from the user's
+    bytes with exit 0.
+    """
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "agents", "foo", {"agent.md": b"wiki\n"})
+    install_agent(tmp_path, "foo")
+    shutil.rmtree(tmp_path / ".memtomem" / "agents" / "foo")
+
+    flat = tmp_path / ".memtomem" / "agents" / "foo.md"
+
+    def _plant_flat_then_confirm(*args: object, **kwargs: object) -> bool:
+        flat.write_bytes(b"# local flat\n")
+        _bump_mtime(flat)
+        return True
+
+    monkeypatch.setattr("memtomem.cli.context_cmd.click.confirm", _plant_flat_then_confirm)
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["install", "--all"])
+
+    assert result.exit_code == 1, result.output
+    assert "flat-layout" in result.output
+    assert "migrate" in result.output
+    assert flat.read_bytes() == b"# local flat\n"
+    assert not (tmp_path / ".memtomem" / "agents" / "foo").exists()

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -934,20 +934,24 @@ def test_cli_update_all_mid_loop_fs_error_continues(
     assert "1 failed" in result.output
 
 
-def test_cli_update_all_does_not_re_walk_for_dirty(
+def test_cli_update_all_re_walks_dirty_at_apply_time(
     wiki_root: Path,
     project_cwd: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Execute phase MUST consume the cached ``dirty_report`` from
-    classification — no second ``is_asset_dirty`` call per project.
+    """Execute phase MUST re-classify the dest tree at apply time — exactly
+    one extra ``is_asset_dirty`` call per actionable project (#1247 id 13).
 
-    Spy counts ``is_asset_dirty`` invocations during the whole flow:
-    classify calls it once for the dirty project (state=refuse with
-    --force allowed), and execute reuses the cached report. Total = 1
-    per project that needed classification. Without the cache, total
-    would be 2 per project.
+    Inverted pin: this test previously asserted ``call_count == 1`` ("the
+    execute phase consumes the cached dirty_report, no re-walk") — which
+    pinned the bug. The confirm prompt between classify and execute is
+    unbounded, so gating writes on the classify-time report silently
+    clobbered edits made during the prompt (and ``--force`` baked too few
+    files). Now: classify walks once for the preview table, and
+    ``_apply_update`` walks once for the gate. Total = 2 per actionable
+    project; a count of 1 means apply-time gating regressed to the stale
+    snapshot, 3+ means an accidental extra walk crept in.
     """
     _initialized_wiki(wiki_root)
     _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
@@ -977,9 +981,137 @@ def test_cli_update_all_does_not_re_walk_for_dirty(
     result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--yes", "--force"])
 
     assert result.exit_code == 0, result.output
-    # 1 = classification's call only. Execute used the cached DirtyReport
-    # from ProjectClassification — no second walk.
+    # 2 = classification's preview walk + _apply_update's gate walk.
+    assert call_count["n"] == 2
+
+
+def test_single_asset_update_walks_dirty_exactly_once(
+    wiki_root: Path,
+    project_cwd: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The non-batch path has no confirm prompt between classify and apply,
+    so moving the walk into ``_apply_update`` (#1247 id 13) must not add a
+    second walk there: ``_update_asset`` no longer pre-computes.
+    """
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project_cwd, "foo")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    real_is_asset_dirty = install_module.is_asset_dirty
+    call_count = {"n": 0}
+
+    def _spy(*args: object, **kwargs: object):
+        call_count["n"] += 1
+        return real_is_asset_dirty(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(install_module, "is_asset_dirty", _spy)
+
+    result = update_skill(project_cwd, "foo")
+
+    assert result.was_no_op is False
     assert call_count["n"] == 1
+
+
+# ── #1247 id 13: edits during the --all confirm prompt ──────────────────
+
+
+def test_cli_update_all_refuses_edit_made_during_confirm_prompt(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A project clean at classify whose dest is edited DURING the confirm
+    prompt must be refused at apply time, not silently overwritten (#1247
+    id 13).
+
+    The confirm window is unbounded — a human sits on the multi-project
+    preview table while other sessions write. Pre-fix the execute phase
+    consumed the stale clean ``dirty_report`` from classification, so
+    ``copy_tree_atomic`` replaced the mid-prompt edit with wiki bytes:
+    exit 0, no refusal, no .bak.
+    """
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+
+    proj = tmp_path / "race_proj"
+    proj.mkdir()
+    install_skill(proj, "foo")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj])
+    _patch_known_projects_path(monkeypatch, known)
+
+    target = proj / ".memtomem" / "skills" / "foo" / "SKILL.md"
+
+    def _edit_then_confirm(*args: object, **kwargs: object) -> bool:
+        target.write_bytes(b"edited during prompt\n")
+        _bump_mtime(target)
+        return True
+
+    monkeypatch.setattr("memtomem.cli.context_cmd.click.confirm", _edit_then_confirm)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all"])
+
+    assert result.exit_code == 1, result.output
+    assert target.read_bytes() == b"edited during prompt\n"
+    assert not target.with_suffix(".md.bak").exists()
+
+
+def test_cli_update_all_force_baks_file_dirtied_during_confirm_prompt(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--force`` must .bak files that became dirty DURING the confirm
+    prompt, not just the classify-time dirty set (#1247 id 13).
+
+    Pre-fix the .bak loop iterated the stale ``dirty_files`` — a file edited
+    mid-prompt was clobbered bak-less even though --force promises "each
+    modified file gets a .bak sibling".
+    """
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n", "EXTRA.md": b"e1\n"})
+
+    proj = tmp_path / "race_proj"
+    proj.mkdir()
+    install_skill(proj, "foo")
+
+    dest = proj / ".memtomem" / "skills" / "foo"
+    first = dest / "SKILL.md"
+    second = dest / "EXTRA.md"
+    first.write_bytes(b"edited before classify\n")
+    _bump_mtime(first)
+
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n", "EXTRA.md": b"e2\n"})
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj])
+    _patch_known_projects_path(monkeypatch, known)
+
+    def _edit_then_confirm(*args: object, **kwargs: object) -> bool:
+        second.write_bytes(b"edited during prompt\n")
+        _bump_mtime(second)
+        return True
+
+    monkeypatch.setattr("memtomem.cli.context_cmd.click.confirm", _edit_then_confirm)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--force"])
+
+    assert result.exit_code == 0, result.output
+    first_bak = first.with_suffix(".md.bak")
+    second_bak = second.with_suffix(".md.bak")
+    assert first_bak.exists()
+    assert first_bak.read_bytes() == b"edited before classify\n"
+    assert second_bak.exists(), result.output
+    assert second_bak.read_bytes() == b"edited during prompt\n"
+    assert second.read_bytes() == b"e2\n"
 
 
 # ── CLI: wiki dirty warn timing (single-asset & --all) ──────────────────


### PR DESCRIPTION
## Summary

Closes out the three remaining unverified-backlog code items from the #1247 campaign (B13 — ids 13, 38, 39 in the triage verdict table).

### id 13 (major) — `--all` gated writes on a dirty report computed before the confirm prompt

`mm context update --all` classifies every project, prints the preview table, waits on an **unbounded** interactive confirm, then executed against the classification-time `DirtyReport`:

- A project clean at classify whose dest was edited during the prompt was silently overwritten — the stale-clean report sailed past the dirty gate. No refusal, no `.bak`, exit 0.
- Under `--force`, the `.bak` loop iterated the stale `dirty_files`, so a file that became dirty mid-prompt was clobbered bak-less — violating the "each modified file gets a .bak sibling" contract the refusal message promises.
- `install --all` had the same shape via `_apply_pinned_install`: a skip(clean) row + `--force` re-extracted the pin with **no `.bak` at all**, and the flat-layout probe only ran at classify time, so a dirty flat `agents/<name>.md` appearing during the prompt was silently shadowed by the dir extraction (design-gate blocker, folded in).

Fix — the apply gate owns its evidence:

- `_apply_update` drops its `dirty_report` parameter and re-runs `is_asset_dirty` internally, immediately before the refuse/unprovable/flat gates and the `.bak` set. Classification reports are now **preview-only** (docstrings updated across the chain).
- `_apply_pinned_install` re-classifies the same way and re-probes the flat sibling; fresh-dirty rows without `--force` raise `StaleInstallError`, which the CLI loop already degrades to a red row + exit 1.
- The single-asset path no longer pre-computes, so it still walks exactly once (new pin).
- The no-re-walk perf pin (`test_cli_update_all_does_not_re_walk_for_dirty`, asserted 1 walk) is **inverted** to `test_cli_update_all_re_walks_dirty_at_apply_time` (2 walks: preview + gate).

Same plan-time-trust class as the settings-migrate fix (#1135 B4-3: "re-read and re-classify the target at apply time").

### id 38 (major) — canonical `## <Agent>-Specific` sections dropped from every output

`parse_context` kept verbatim heading keys; generators look up short keys (`Claude`), and the unknown-section passthrough suppresses casefolded `<agent>-specific` headings — so a canonical-authored `## Claude-Specific` section vanished from every generated file, **including claude's own**. Generated files *display* `## Claude-Specific`, so canonical authors naturally copy that heading back. The reverse-import leg was already aliased (`TestSpecificSectionRoundTrip`); this was the canonical-parse leg.

`parse_context` now folds `<agent>-specific` headings (any case) into the short key via a new shared `AGENT_SPECIFIC_ALIASES` map in `parser.py`; `extract_sections_from_agent_file`'s aliases and the generator suppression set both derive from it, so the three surfaces can't drift. Folding scope is deliberately the `-specific` aliases only — generated-file headings like `Coding Rules` still parse verbatim in canonical files.

### id 39 (minor) — CopilotGenerator silently dropped Architecture

No `Architecture` branch + reserved-key passthrough skip = the section vanished from `copilot-instructions.md` only. Added the branch (after Commands, mirroring cursor's tail order) and a parametrized parity test pinning that every generator emits every canonical section body.

## Review

- Codex design gate: 1 round — NEEDS-FIX (blocker: `_apply_pinned_install` missed the flat-layout re-probe for install/skip rows; folded into the implementation).
- Codex implementation gate: SHIP, 1 round (0 blocker / 0 major; 2 minor stale-docstring findings, folded in before push).

## Tests

- 11 new test functions; pre-fix-fail verified against main (id 13's five CLI confirm-race tests re-verified with a src-only revert: 5 fail on main source, all green post-fix).
- Negative pins: lookalike `## Claudette-Specific` stays an unknown section; single-asset update walks exactly once (no double-walk regression on the non-batch path).
- Full suite: 6415 passed, 11 skipped; 4 failed = the resident #1249 `test_session_tracing` failures (same baseline as B1–B12).

## Known adjacent gaps (not fixed here, by design)

- A `state="install"` row whose dest *appeared* during the prompt is gated by the fresh walk (refuse/.bak), but is not leftover-reconciled (additive residue only; the reconcile pass keeps its skip/refuse scope).
- The cached `lock_entry` itself is not re-read at apply time — a concurrent update that bumps `installed_at` makes the cached epoch older, which classifies *dirty* and refuses loud (safe direction). Entry-level freshness is id 15 (per-file digest design), deferred since B1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
