### PR TITLE
fix(context): per-file content digests close the install-race dirty hole (#1247 id 15)

### DIFF
--- a/docs/adr/0008-wiki-layer.md
+++ b/docs/adr/0008-wiki-layer.md
@@ -53,6 +53,17 @@ unchanged.
 `mm context update <type> <name>` MUST detect when project canonical was
 modified after install (mtime > `lockfile.installed_at`).
 
+> **2026-06 (#1247):** the parenthetical mtime rule is superseded when
+> the entry records per-file content digests (see "Lockfile schema"):
+> detection upgrades to byte equality against `digests` — closing the
+> during-install absorption window where an edit racing the post-copy
+> `installed_at` capture classified clean forever (id 15), reclassifying
+> touch-only edits (mtime bumped, bytes identical) as clean, and
+> reclassifying unreadable files as dirty-with-warning (cannot prove
+> clean; the read error surfaces loudly pre-mutation on the `--force`
+> path). The strict-mtime rule remains the binding contract for
+> pre-digest entries, bit-for-bit.
+
 Default behavior: refuse with a clear error. `--force` overwrites and
 leaves a `.bak` copy of each clobbered file. This mirrors ADR-0001's
 on_drop policy of never silently dropping data. The `.bak` write is
@@ -98,7 +109,7 @@ be reconsidered in v2 if a real workflow demands it.
          │  mm context install <type> <name>   (copytree + lockfile pin)
          ▼
 <project>/.memtomem/                 ← project canonical (Invariant 1)
-├── lock.json                        ← { skills: { foo: { wiki_commit, installed_at, files, files_commit } } }
+├── lock.json                        ← { skills: { foo: { wiki_commit, installed_at, files, files_commit, digests, digests_installed_at } } }
 ├── skills/<name>/SKILL.md + overrides/...
 ├── agents/<name>/...
 └── commands/<name>/...
@@ -163,13 +174,18 @@ are out of scope for the install/upgrade lifecycle.
   "skills": {
     "foo": {
       "wiki_commit": "abc123def4567890abc123def4567890abc12345",
-      "installed_at": "2026-04-30T12:34:56Z",
+      "installed_at": "2026-04-30T12:34:56.123456Z",
       "files": ["SKILL.md", "scripts/run.py"],
-      "files_commit": "abc123def4567890abc123def4567890abc12345"
+      "files_commit": "abc123def4567890abc123def4567890abc12345",
+      "digests": {
+        "SKILL.md": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+        "scripts/run.py": "…64 lowercase hex…"
+      },
+      "digests_installed_at": "2026-04-30T12:34:56.123456Z"
     }
   },
-  "agents":   { "bar": { "wiki_commit": "…", "installed_at": "…", "files": ["…"], "files_commit": "…" } },
-  "commands": { "baz": { "wiki_commit": "…", "installed_at": "…", "files": ["…"], "files_commit": "…" } }
+  "agents":   { "bar": { "wiki_commit": "…", "installed_at": "…", "files": ["…"], "files_commit": "…", "digests": {}, "digests_installed_at": "…" } },
+  "commands": { "baz": { "wiki_commit": "…", "installed_at": "…", "files": ["…"], "files_commit": "…", "digests": {}, "digests_installed_at": "…" } }
 }
 ```
 
@@ -192,6 +208,45 @@ the pin moves — the commit pairing detects exactly that. Entries
 without a valid manifest degrade to the pre-manifest behavior
 (deletions invisible to the dirty walk; reconcile falls back to the
 `mtime <= installed_at` guard).
+
+`digests` / `digests_installed_at` (added with the #1247 id 15
+content-digest work) record the SHA-256 of **the bytes the writing
+operation put into dest** — content identity of the install, not commit
+provenance (install/update copy from the wiki *working tree*; the digest
+map inherits exactly the pre-existing `wiki_commit` provenance
+imprecision and adds none). The algorithm is fixed at SHA-256; an
+algorithm change is a NEW key name, not a value prefix. Hashes are
+computed from the in-memory bytes the copier wrote, never from a re-read
+of dest (a re-read would bless a concurrent edit — the TOCTOU this map
+exists to close). They power byte-exact dirty detection (Invariant 2
+rider) and digest-provenance reconcile: when the old entry carries valid
+digests, they are the single provenance set for both reconcile decisions
+and the `files` manifest is not consulted.
+
+The two pairings deliberately use different tokens: the manifest is
+commit-scoped *membership* (`files_commit == wiki_commit`), digests are
+write-scoped *content* (`digests_installed_at == installed_at`, string
+equality, no ISO parsing). `installed_at` is refreshed by every
+entry-writing operation, so any rewrite by a non-digest-aware tool
+self-invalidates the pair — including a pin moved A→B→A, which the
+commit pairing cannot catch. Consumers MUST honor `digests` only when
+the pairing holds and the shape validates (`digests_from_entry`: dict of
+manifest-shaped relpaths → 64-char lowercase hex); anything else
+degrades to the pre-digest (mtime) behavior, never crashes.
+
+**Key ownership (clear-on-omit):** a digest-aware `upsert_entry` call
+that omits `digests` MUST delete both keys rather than preserve them —
+`installed_at` is mtime-derived, not a nonce, so a preserved stale pair
+could later re-match by collision. The unknown-field round-trip rule
+below binds only tools the keys are *unknown to* (pre-digest clients
+preserve them verbatim, which is exactly what the pairing degrade
+catches); for the tool that defines the keys they are schema fields, not
+unknowns. Residual limitation (documented, fail-safe): a pre-digest
+client rewrite that lands on the byte-identical microsecond ISO string
+falsely re-validates the stale map — the consequence direction is safe
+by construction: stale digests vs newer bytes → mismatch → **dirty**
+(refuse / `--force`+`.bak`); a silent **clean** additionally requires
+the current bytes to equal what was once installed.
 
 Reads MUST preserve unknown top-level and per-entry fields (round-trip
 through plain `dict` is sufficient). The `version` field is reserved for

--- a/packages/memtomem/src/memtomem/context/_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_atomic.py
@@ -20,6 +20,7 @@ module and covers ``~/.memtomem/config.json`` specifically.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import tempfile
@@ -196,14 +197,20 @@ def copy_tree_atomic(
     mode: int = 0o644,
     skip_top_level: frozenset[str] | None = None,
     skip_suffixes: frozenset[str] = frozenset(),
-) -> int:
+) -> dict[str, str]:
     """Recursively mirror *src* → *dst*, each file via :func:`atomic_write_bytes`.
 
-    Returns the number of files written. ``mode`` (default ``0o644``) is the
-    permission bits applied to copied files — ``0o644`` matches the
-    convention for content meant to be read by other tools (e.g. fan-out
-    target runtimes), unlike the ``0o600`` default of ``atomic_write_bytes``
-    which is tuned for state files.
+    Returns ``{posix_relpath: sha256_hex}`` over the files written, relpaths
+    relative to this call's *dst*. The digest is computed from the same
+    in-memory ``bytes`` object handed to ``atomic_write_bytes`` — never from
+    a re-read of *dst*, which would bless a concurrent edit landing between
+    write and hash (the #1247 id 15 TOCTOU this map exists to close). The
+    map IS the written set: ``len(map)`` == files written, skipped entries
+    never appear. ``mode`` (default ``0o644``) is the permission bits
+    applied to copied files — ``0o644`` matches the convention for content
+    meant to be read by other tools (e.g. fan-out target runtimes), unlike
+    the ``0o600`` default of ``atomic_write_bytes`` which is tuned for
+    state files.
 
     Entries named in :data:`COPY_SKIP_NAMES` are skipped silently at every
     depth. ``skip_top_level`` names additional entries skipped ONLY at the
@@ -223,9 +230,38 @@ def copy_tree_atomic(
     ``/etc/passwd`` (or any out-of-tree target) would violate that contract.
     Callers who want to mirror symlinks must do so explicitly.
     """
-    extra_skip = skip_top_level or frozenset()
+    digests: dict[str, str] = {}
+    _copy_tree_collect(
+        src,
+        dst,
+        "",
+        digests,
+        mode=mode,
+        extra_skip=skip_top_level or frozenset(),
+        skip_suffixes=skip_suffixes,
+    )
+    return digests
+
+
+def _copy_tree_collect(
+    src: Path,
+    dst: Path,
+    rel_prefix: str,
+    digests: dict[str, str],
+    *,
+    mode: int,
+    extra_skip: frozenset[str],
+    skip_suffixes: frozenset[str],
+) -> None:
+    """Recursive body of :func:`copy_tree_atomic`.
+
+    Threads the accumulating rel→digest map and the rel prefix (the old
+    self-recursion restarted relpaths at each level, which was fine for a
+    count but not for a map keyed by root-relative paths). ``extra_skip``
+    is passed empty on recursion — ``skip_top_level`` is root-only by
+    contract.
+    """
     dst.mkdir(parents=True, exist_ok=True)
-    written = 0
     for entry in src.iterdir():
         if entry.name in COPY_SKIP_NAMES or entry.name in extra_skip:
             continue
@@ -235,13 +271,21 @@ def copy_tree_atomic(
             logger.warning("copy_tree_atomic: skipping symlink %s", entry)
             continue
         target = dst / entry.name
+        rel = f"{rel_prefix}{entry.name}"
         if entry.is_file():
-            atomic_write_bytes(target, entry.read_bytes(), mode=mode)
-            written += 1
+            data = entry.read_bytes()
+            atomic_write_bytes(target, data, mode=mode)
+            digests[rel] = hashlib.sha256(data).hexdigest()
         elif entry.is_dir():
-            # skip_top_level intentionally not threaded into the recursion.
-            written += copy_tree_atomic(entry, target, mode=mode, skip_suffixes=skip_suffixes)
-    return written
+            _copy_tree_collect(
+                entry,
+                target,
+                f"{rel}/",
+                digests,
+                mode=mode,
+                extra_skip=frozenset(),
+                skip_suffixes=skip_suffixes,
+            )
 
 
 def is_copy_skipped_rel(rel: str | PurePosixPath) -> bool:

--- a/packages/memtomem/src/memtomem/context/dirty.py
+++ b/packages/memtomem/src/memtomem/context/dirty.py
@@ -4,10 +4,27 @@ Pure classifier used by ``mm context update`` to decide whether the
 on-disk tree at ``<project>/.memtomem/<type>/<name>/`` still matches the
 wiki state recorded in :class:`memtomem.context.lockfile.Lockfile`.
 
-The compare rule is **strict** ``mtime > installed_at_epoch`` — only files
-whose modification time is *strictly* later than the lockfile's
-``installed_at`` are flagged dirty. Equality is clean. ``installed_at``
-is captured from the filesystem itself by
+When the entry carries a valid per-file digest map
+(:func:`memtomem.context.lockfile.digests_from_entry`, #1247 id 15), the
+compare rule is **byte equality**: a file is dirty iff its current
+SHA-256 differs from the digest recorded for the bytes the installing
+operation wrote — mtime is not consulted at all on this branch (mixing
+it in would re-import its false positives for zero detection gain). This
+closes the during-install absorption window: a concurrent edit landing
+at any point after a file's write leaves current bytes ≠ recorded digest
+→ dirty, where the scalar ``installed_at`` capture absorbed it →
+permanently clean → silent clobber on the next update. A file that
+cannot be **read** on this branch classifies dirty with a warning —
+"cannot prove clean" must protect, never crash the whole status walk and
+never silently pass; the underlying OSError then surfaces loudly at
+mutation time, before the first dest write (Gate A scans ``--force``'s
+``.bak`` set and ``privacy_scan`` raises on unreadable files).
+
+For **legacy entries** (no/invalid/stale digests) the rule remains
+strict ``mtime > installed_at_epoch`` — only files whose modification
+time is *strictly* later than the lockfile's ``installed_at`` are
+flagged dirty. Equality is clean. ``installed_at`` is captured from the
+filesystem itself by
 :func:`memtomem.context._atomic.installed_at_from_dest` (``max
 st_mtime_ns`` ceiled to microsecond), so on every platform the install's
 own writes round-trip to a value ``<= installed_at_epoch`` and the
@@ -28,6 +45,7 @@ the dest tree separately.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from dataclasses import dataclass
 from datetime import datetime
@@ -35,7 +53,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from memtomem.context._atomic import iter_installed_files
-from memtomem.context.lockfile import Lockfile, manifest_from_entry
+from memtomem.context.lockfile import Lockfile, digests_from_entry, manifest_from_entry
 
 logger = logging.getLogger(__name__)
 
@@ -53,27 +71,35 @@ DirtyReason = Literal["clean", "dirty", "never_installed", "missing_dest"]
 class DirtyReport:
     """Outcome of a dirty check on a single installed asset.
 
-    - ``reason="clean"`` — dest exists, every checked file's mtime is
-      ``<= installed_at_epoch``, and no manifest entry is missing.
-    - ``reason="dirty"`` — at least one checked file has
-      ``mtime > installed_at_epoch`` (paths in ``dirty_files``) and/or at
-      least one manifest-recorded file is gone from disk (paths in
-      ``missing_files``) — a user deletion is a local edit too (#1247).
+    - ``reason="clean"`` — dest exists and no checked file diverged:
+      on digest entries every file's current SHA-256 equals its recorded
+      digest, on legacy entries every file's mtime is
+      ``<= installed_at_epoch``; and no recorded file is missing.
+    - ``reason="dirty"`` — at least one checked file diverged (digest
+      mismatch / unreadable / unrecorded addition on digest entries,
+      ``mtime > installed_at_epoch`` on legacy entries; paths in
+      ``dirty_files``) and/or at least one recorded file is gone from
+      disk (paths in ``missing_files``) — a user deletion is a local
+      edit too (#1247).
     - ``reason="never_installed"`` — no usable lockfile entry;
       ``installed_at`` is ``None`` and ``dirty_files`` / ``checked_files``
       are empty. Returned for "no entry at all" and "entry exists but
       missing / non-string / unparseable ``installed_at``" — all are
-      unrecoverable states for a strict mtime compare (#1247: an
-      unparseable ISO string previously crashed with ``ValueError``
-      instead of degrading like its non-string siblings).
+      unrecoverable states (#1247: an unparseable ISO string previously
+      crashed with ``ValueError`` instead of degrading like its
+      non-string siblings). Deliberately NOT widened to "digests valid
+      but installed_at malformed" — unprovable-record semantics stay
+      uniform, and the ``digests_installed_at == installed_at`` pairing
+      makes such an entry degrade anyway.
     - ``reason="missing_dest"`` — lockfile entry exists but
       ``<project>/.memtomem/<type>/<name>/`` was deleted; ``installed_at``
       is the lockfile value, ``dirty_files`` empty.
 
-    ``missing_files`` is populated only when the entry carries a valid
-    file manifest (see
-    :func:`memtomem.context.lockfile.manifest_from_entry`); legacy entries
-    keep the pre-manifest behavior (deletions invisible).
+    ``missing_files`` derives from the digest map's keys on digest
+    entries, and from the file manifest (see
+    :func:`memtomem.context.lockfile.manifest_from_entry`) on legacy
+    entries that carry one; pre-manifest entries keep deletions
+    invisible.
     """
 
     reason: DirtyReason
@@ -162,19 +188,58 @@ def is_asset_dirty(
     dirty: list[Path] = []
     checked = 0
     present_rels: set[str] = set()
-    for file_path in iter_installed_files(dest):
-        checked += 1
-        present_rels.add(file_path.relative_to(dest).as_posix())
-        if file_path.stat().st_mtime > installed_at_epoch:
-            dirty.append(file_path)
-
-    # Deletion detection (#1247): a manifest-recorded file gone from disk
-    # is a local edit. Valid-manifest entries only — legacy/stale/malformed
-    # manifests degrade to the pre-manifest behavior (deletions invisible).
     missing: list[Path] = []
-    manifest = manifest_from_entry(lock_entry)
-    if manifest is not None:
-        missing = [dest / rel for rel in sorted(manifest - present_rels)]
+    digests = digests_from_entry(lock_entry)
+    if digests is not None:
+        # Digest branch (#1247 id 15): byte equality against the SHA-256
+        # recorded for the bytes the install wrote. mtime is deliberately
+        # not consulted — it would re-import touch-only false positives
+        # for zero detection gain. Deltas vs legacy: touch-only edit →
+        # clean, backdated edit/addition → dirty, unreadable → dirty+warn.
+        for file_path in iter_installed_files(dest):
+            checked += 1
+            rel = file_path.relative_to(dest).as_posix()
+            present_rels.add(rel)
+            recorded = digests.get(rel)
+            if recorded is None:
+                dirty.append(file_path)  # local addition — never recorded
+                continue
+            try:
+                blob = file_path.read_bytes()
+            except OSError as exc:
+                # Fail-safe: cannot prove clean. The read error itself
+                # surfaces loudly pre-mutation (Gate A / copy2), not here —
+                # `mm context status` over N projects must stay usable.
+                logger.warning(
+                    "%s/%s: cannot read %s for digest check (%s); classifying dirty",
+                    asset_type,
+                    name,
+                    file_path,
+                    exc,
+                )
+                dirty.append(file_path)
+                continue
+            if hashlib.sha256(blob).hexdigest() != recorded:
+                dirty.append(file_path)
+        # Deletion detection from the digest map's own keys — when digests
+        # validate, `files` was written by the same upsert from the same
+        # set; if a hand-edit makes them diverge, the digest map is the
+        # single record we trust (mirrored on the reconcile side).
+        missing = [dest / rel for rel in sorted(digests.keys() - present_rels)]
+    else:
+        # Legacy branch — pre-digest behavior verbatim.
+        for file_path in iter_installed_files(dest):
+            checked += 1
+            present_rels.add(file_path.relative_to(dest).as_posix())
+            if file_path.stat().st_mtime > installed_at_epoch:
+                dirty.append(file_path)
+
+        # Deletion detection (#1247): a manifest-recorded file gone from disk
+        # is a local edit. Valid-manifest entries only — legacy/stale/malformed
+        # manifests degrade to the pre-manifest behavior (deletions invisible).
+        manifest = manifest_from_entry(lock_entry)
+        if manifest is not None:
+            missing = [dest / rel for rel in sorted(manifest - present_rels)]
 
     return DirtyReport(
         reason="dirty" if (dirty or missing) else "clean",

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -863,18 +863,23 @@ def _apply_update(
     digest_map = copy_tree_atomic(src, dest, skip_suffixes=DIRTY_SKIP_SUFFIXES)
 
     # Mirror semantics (#1247): drop dest files the wiki no longer ships.
-    # Membership uses the COPIER's effective file set (iter_installed_files
-    # shares copy_tree_atomic's skip rules) — a bare (src / rel).is_file()
-    # would count a symlink the copier skips as present, stranding the old
-    # regular file in dest (Codex implementation-gate M1). The guard epoch
-    # is the PRE-update install timestamp (the same basis ``dirty_report``
-    # classified against) — the freshly captured value below is >= every
-    # current mtime and would approve deleting anything. ``old_digests``
-    # likewise comes from the OLD entry (#1247 id 15).
-    src_files = {p.relative_to(src).as_posix() for p in iter_installed_files(src)}
+    # Membership is the copier's RETURNED written set, not a re-walk of
+    # ``src`` (#1247 id 15 impl gate): the wiki working tree is mutable,
+    # so a post-copy walk reads a DIFFERENT snapshot than the one copied —
+    # a file dropped from the worktree in that window would erase a file
+    # this update just wrote (when its bytes are unchanged between
+    # versions they still match the OLD digests → "provably untouched")
+    # while ``files=``/``digests=`` below record it — a phantom entry.
+    # The map shares the copier's skip rules by construction, covering
+    # B5's symlink concern (a wiki file replaced by a symlink is absent
+    # from the map, so the old regular file in dest reconciles away). The
+    # guard epoch is the PRE-update install timestamp (the same basis
+    # ``dirty_report`` classified against) — the freshly captured value
+    # below is >= every current mtime and would approve deleting
+    # anything. ``old_digests`` likewise comes from the OLD entry.
     files_removed = _reconcile_removed_files(
         dest,
-        src_has=lambda rel: rel in src_files,
+        src_has=lambda rel: rel in digest_map,
         old_installed_at_epoch=_installed_at_epoch(lock_entry),
         baked=frozenset(files_to_bak),
         manifest=manifest_from_entry(lock_entry),

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -23,6 +23,7 @@ clobbered") without depending on PR-D's mtime/dirty detection. PR-D's
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import shutil
 from collections.abc import Callable
@@ -40,7 +41,12 @@ from memtomem.context._atomic import (
 )
 from memtomem.context._names import validate_name
 from memtomem.context.dirty import DirtyReport, is_asset_dirty
-from memtomem.context.lockfile import Lockfile, LockfileError, manifest_from_entry
+from memtomem.context.lockfile import (
+    Lockfile,
+    LockfileError,
+    digests_from_entry,
+    manifest_from_entry,
+)
 from memtomem.context.privacy_scan import (
     raise_or_collect,
     scan_artifact_tree,
@@ -268,16 +274,6 @@ def _flat_layout_probe(
     return flat, flat.stat().st_mtime > epoch
 
 
-def _manifest_relpaths(dest: Path) -> list[str]:
-    """The asset's installed file set as sorted POSIX relpaths.
-
-    Walks via :func:`iter_installed_files` — the exact set the dirty
-    checker and ``installed_at`` capture observe, so the recorded manifest
-    can never disagree with the walker about membership.
-    """
-    return sorted(p.relative_to(dest).as_posix() for p in iter_installed_files(dest))
-
-
 def _reconcile_removed_files(
     dest: Path,
     *,
@@ -285,6 +281,7 @@ def _reconcile_removed_files(
     old_installed_at_epoch: float | None,
     baked: frozenset[Path],
     manifest: frozenset[str] | None,
+    old_digests: dict[str, str] | None = None,
 ) -> tuple[Path, ...]:
     """Delete dest files absent from the copy source (#1247).
 
@@ -293,6 +290,22 @@ def _reconcile_removed_files(
     the new commit and status reports ``ok``. Decision rule per dest-only
     file (walked via :func:`iter_installed_files`, so ``.bak`` siblings
     and skip-listed names are never candidates):
+
+    When ``old_digests`` is valid (the OLD entry recorded digests, #1247
+    id 15), it is the **single provenance set for both decisions** — the
+    ``files`` manifest is not consulted at all on this branch (a
+    hand-merged divergent manifest must not indefinitely protect a
+    digest-tracked, wiki-dropped file):
+
+    1. relpath **not** in ``old_digests`` → user-added file: keep.
+    2. relpath recorded → delete when the current bytes hash to the
+       recorded digest (provably untouched — this also retires the
+       legacy false-KEEP of an untouched file with fresh mtime, e.g. a
+       cross-machine checkout) **or** when it is in ``baked``. An
+       unreadable file is neither provable nor baked → rule 3.
+    3. Anything else → keep with a warning (when in doubt, never delete).
+
+    Legacy fallback (no valid old digests):
 
     1. ``manifest`` valid and relpath **not** recorded → user-added file:
        keep (never silently delete user-authored content).
@@ -313,15 +326,35 @@ def _reconcile_removed_files(
         rel = f.relative_to(dest).as_posix()
         if src_has(rel):
             continue
-        if manifest is not None and rel not in manifest:
-            logger.debug("reconcile: keeping user-added file %s", f)
-            continue
-        provably_old = (
-            old_installed_at_epoch is not None and f.stat().st_mtime <= old_installed_at_epoch
-        )
-        if not (provably_old or f in baked):
-            logger.warning("reconcile: keeping dest-only file with fresh mtime and no .bak: %s", f)
-            continue
+        if old_digests is not None:
+            if rel not in old_digests:
+                logger.debug("reconcile: keeping user-added file %s", f)
+                continue
+            provably_untouched = f in baked
+            if not provably_untouched:
+                try:
+                    provably_untouched = (
+                        hashlib.sha256(f.read_bytes()).hexdigest() == old_digests[rel]
+                    )
+                except OSError:
+                    provably_untouched = False  # unreadable: can't prove — rule 3
+            if not provably_untouched:
+                logger.warning(
+                    "reconcile: keeping dest-only file with unproven bytes and no .bak: %s", f
+                )
+                continue
+        else:
+            if manifest is not None and rel not in manifest:
+                logger.debug("reconcile: keeping user-added file %s", f)
+                continue
+            provably_old = (
+                old_installed_at_epoch is not None and f.stat().st_mtime <= old_installed_at_epoch
+            )
+            if not (provably_old or f in baked):
+                logger.warning(
+                    "reconcile: keeping dest-only file with fresh mtime and no .bak: %s", f
+                )
+                continue
         f.unlink(missing_ok=True)
         removed.append(f)
 
@@ -476,8 +509,12 @@ def _install_asset(
 
     ``installed_at`` is captured at the lockfile-upsert boundary (after the
     copytree completes) so that a subsequent ``mm context update``'s
-    ``mtime > installed_at`` dirty check cannot false-positive on the
-    install's own writes.
+    legacy ``mtime > installed_at`` dirty check cannot false-positive on
+    the install's own writes. An editor racing the install used to be
+    absorbed by that scalar capture (edit mtime folded under the post-copy
+    max → permanently clean → silent clobber, #1247 id 15); the per-file
+    ``digests`` recorded from the copier's written bytes close that
+    window — a concurrent edit at ANY point leaves bytes ≠ digest → dirty.
     """
     validated = validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
     project_root = Path(project_root).expanduser()
@@ -539,16 +576,20 @@ def _install_asset(
     )
 
     dest.parent.mkdir(parents=True, exist_ok=True)
-    files_written = copy_tree_atomic(src, dest, skip_suffixes=DIRTY_SKIP_SUFFIXES)
+    digest_map = copy_tree_atomic(src, dest, skip_suffixes=DIRTY_SKIP_SUFFIXES)
 
+    # files= derives from the copier's WRITTEN set, not a post-copy re-walk
+    # (#1247 id 15) — a concurrent addition landing during the copy can no
+    # longer be absorbed into the manifest as if wiki-shipped.
     installed_at = installed_at_from_dest(dest)
     lock.upsert_entry(
         asset_type,
         validated,
         wiki_commit=wiki_commit,
         installed_at=installed_at,
-        files=_manifest_relpaths(dest),
+        files=sorted(digest_map),
         files_commit=wiki_commit,
+        digests=digest_map,
     )
 
     return InstallResult(
@@ -557,7 +598,7 @@ def _install_asset(
         wiki_commit=wiki_commit,
         installed_at=installed_at,
         dest=dest,
-        files_written=files_written,
+        files_written=len(digest_map),
     )
 
 
@@ -819,7 +860,7 @@ def _apply_update(
         bak_paths.append(bak)
 
     dest.parent.mkdir(parents=True, exist_ok=True)
-    files_written = copy_tree_atomic(src, dest, skip_suffixes=DIRTY_SKIP_SUFFIXES)
+    digest_map = copy_tree_atomic(src, dest, skip_suffixes=DIRTY_SKIP_SUFFIXES)
 
     # Mirror semantics (#1247): drop dest files the wiki no longer ships.
     # Membership uses the COPIER's effective file set (iter_installed_files
@@ -828,7 +869,8 @@ def _apply_update(
     # regular file in dest (Codex implementation-gate M1). The guard epoch
     # is the PRE-update install timestamp (the same basis ``dirty_report``
     # classified against) — the freshly captured value below is >= every
-    # current mtime and would approve deleting anything.
+    # current mtime and would approve deleting anything. ``old_digests``
+    # likewise comes from the OLD entry (#1247 id 15).
     src_files = {p.relative_to(src).as_posix() for p in iter_installed_files(src)}
     files_removed = _reconcile_removed_files(
         dest,
@@ -836,6 +878,7 @@ def _apply_update(
         old_installed_at_epoch=_installed_at_epoch(lock_entry),
         baked=frozenset(files_to_bak),
         manifest=manifest_from_entry(lock_entry),
+        old_digests=digests_from_entry(lock_entry),
     )
 
     installed_at = installed_at_from_dest(dest)
@@ -845,8 +888,9 @@ def _apply_update(
         name,
         wiki_commit=wiki_commit,
         installed_at=installed_at,
-        files=_manifest_relpaths(dest),
+        files=sorted(digest_map),
         files_commit=wiki_commit,
+        digests=digest_map,
     )
 
     old_wiki_commit = cast(str, lock_entry.get("wiki_commit", ""))
@@ -860,7 +904,7 @@ def _apply_update(
         was_no_op=False,
         bak_files_written=tuple(bak_paths),
         dest=dest,
-        files_written=files_written,
+        files_written=len(digest_map),
         files_removed=files_removed,
     )
 
@@ -1399,7 +1443,7 @@ def _apply_pinned_install(
         shutil.copy2(f, bak)
         bak_paths.append(bak)
 
-    files_written = wiki.copy_asset_at_commit(pin, asset_type, name, dest)
+    digest_map = wiki.copy_asset_at_commit(pin, asset_type, name, dest)
 
     # Mirror semantics (#1247): a re-extraction over an existing dest must
     # also retire dest-only leftovers (pre-B1 additive-update residue,
@@ -1416,6 +1460,7 @@ def _apply_pinned_install(
             old_installed_at_epoch=_installed_at_epoch(entry),
             baked=frozenset(files_to_bak),
             manifest=manifest_from_entry(entry),
+            old_digests=digests_from_entry(entry),
         )
 
     installed_at = installed_at_from_dest(dest)
@@ -1427,8 +1472,9 @@ def _apply_pinned_install(
         name,
         wiki_commit=pin,
         installed_at=installed_at,
-        files=_manifest_relpaths(dest),
+        files=sorted(digest_map),
         files_commit=pin,
+        digests=digest_map,
     )
 
     return InstallResult(
@@ -1437,6 +1483,6 @@ def _apply_pinned_install(
         wiki_commit=pin,
         installed_at=installed_at,
         dest=dest,
-        files_written=files_written,
+        files_written=len(digest_map),
         files_removed=files_removed,
     )

--- a/packages/memtomem/src/memtomem/context/lockfile.py
+++ b/packages/memtomem/src/memtomem/context/lockfile.py
@@ -39,6 +39,7 @@ __all__ = [
     "LockfileCorruptError",
     "LockfileError",
     "LockfileVersionError",
+    "digests_from_entry",
     "manifest_from_entry",
     "utcnow_iso8601_z",
 ]
@@ -117,14 +118,78 @@ def manifest_from_entry(entry: dict[str, Any]) -> frozenset[str] | None:
         return None
     out: set[str] = set()
     for item in files:
-        if not isinstance(item, str) or not item:
-            return None
-        if item.startswith("/") or "\\" in item:
-            return None
-        if ".." in item.split("/"):
+        if not _is_valid_relpath(item):
             return None
         out.add(item)
     return frozenset(out)
+
+
+def _is_valid_relpath(item: object) -> bool:
+    """Shared relpath shape rule for ``files`` members and ``digests`` keys.
+
+    Non-empty ``str`` POSIX relpath — no leading ``/``, no ``..`` segment,
+    no ``\\``. ``lock.json`` can be git-tracked and hand-merged, so callers
+    treat a violation as "degrade to no manifest/digests", never crash.
+    """
+    if not isinstance(item, str) or not item:
+        return False
+    if item.startswith("/") or "\\" in item:
+        return False
+    return ".." not in item.split("/")
+
+
+_HEX_DIGITS = frozenset("0123456789abcdef")
+
+
+def digests_from_entry(entry: dict[str, Any]) -> dict[str, str] | None:
+    """Return the entry's validated per-file digest map, or ``None``.
+
+    ``digests`` / ``digests_installed_at`` (#1247 id 15) record the SHA-256
+    of **the bytes the writing operation put into dest** — content identity
+    of the install, not commit provenance. The map is honored only when:
+
+    - ``digests_installed_at`` is a ``str`` equal to the entry's
+      ``installed_at``. Every entry-writing operation rewrites
+      ``installed_at`` and :meth:`Lockfile.upsert_entry` stamps
+      ``digests_installed_at`` from the same value, so the pairing proves
+      "these digests were written by the same upsert that last (re)wrote
+      this entry". A pre-digest tool preserves the unknown ``digests*``
+      keys verbatim while moving ``installed_at`` → mismatch → degrade.
+      Unlike the commit pairing of ``files_commit``, this also degrades an
+      old tool moving the pin A→B→A: each old-tool write refreshes
+      ``installed_at``. Residual limitation (documented, fail-safe): a
+      pre-digest rewrite landing on the byte-identical µs ISO string would
+      falsely re-validate the stale map — stale digests vs newer bytes
+      still classify **dirty**; a silent clean additionally requires the
+      current bytes to equal what was once installed. String equality only
+      — no ISO parsing; a malformed ``installed_at`` already degrades the
+      whole entry to ``never_installed`` before any digest consumer runs.
+    - ``digests`` is a dict of relpath → digest where every key passes the
+      manifest relpath shape rules (:func:`_is_valid_relpath`) and every
+      value is a 64-char lowercase-hex string (algorithm fixed: SHA-256;
+      an algorithm change is a new key name, not a value prefix).
+
+    Any violation → ``None`` (degrade to the legacy mtime behavior), never
+    crash or mis-answer — lock.json is git-tracked and hand-merged, so
+    malformed shapes are an ordinary event.
+    """
+    digests = entry.get("digests")
+    digests_installed_at = entry.get("digests_installed_at")
+    installed_at = entry.get("installed_at")
+    if not isinstance(digests_installed_at, str) or not isinstance(installed_at, str):
+        return None
+    if digests_installed_at != installed_at:
+        return None
+    if not isinstance(digests, dict):
+        return None
+    out: dict[str, str] = {}
+    for rel, digest in digests.items():
+        if not _is_valid_relpath(rel):
+            return None
+        if not isinstance(digest, str) or len(digest) != 64 or not set(digest) <= _HEX_DIGITS:
+            return None
+        out[rel] = digest
+    return out
 
 
 class Lockfile:
@@ -261,6 +326,7 @@ class Lockfile:
         installed_at: str,
         files: list[str] | None = None,
         files_commit: str | None = None,
+        digests: dict[str, str] | None = None,
     ) -> None:
         """Insert or replace the ``(asset_type, name)`` entry.
 
@@ -275,6 +341,20 @@ class Lockfile:
         preservation contract as the rest of the entry) — consumers detect
         the resulting staleness via the ``files_commit`` pairing, see
         :func:`manifest_from_entry`.
+
+        ``digests`` (#1247 id 15): per-file SHA-256 of the bytes the
+        operation wrote into dest, stored with sorted keys. When passed,
+        ``digests_installed_at`` is stamped from the same value written to
+        ``installed_at`` — there is no second kwarg, so the freshness
+        pairing cannot be mis-assembled by a caller. When **omitted**, any
+        existing ``digests`` / ``digests_installed_at`` keys are DELETED,
+        not preserved: this method owns those keys, and a digest-less write
+        that kept them would leave a stale-but-potentially-re-matching pair
+        behind (``installed_at`` is mtime-derived, not a nonce). The
+        unknown-field round-trip contract is untouched — it binds tools the
+        keys are *unknown to*; pre-digest clients preserve them verbatim,
+        which is exactly what the :func:`digests_from_entry` pairing
+        degrade catches.
         """
         if (files is None) != (files_commit is None):
             raise ValueError("files and files_commit must be passed together")
@@ -295,6 +375,12 @@ class Lockfile:
             if files is not None:
                 merged["files"] = sorted(files)
                 merged["files_commit"] = files_commit
+            if digests is not None:
+                merged["digests"] = {rel: digests[rel] for rel in sorted(digests)}
+                merged["digests_installed_at"] = installed_at
+            else:
+                merged.pop("digests", None)
+                merged.pop("digests_installed_at", None)
             section[name] = merged
 
             atomic_write_bytes(

--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -235,7 +235,7 @@ class WikiStore:
         asset_type: str,
         name: str,
         dest: Path,
-    ) -> int:
+    ) -> dict[str, str]:
         """Materialize ``<wiki>/<asset_type>/<name>/`` at *commit* into *dest*.
 
         Implementation flow:
@@ -258,7 +258,10 @@ class WikiStore:
         The wiki working tree is **never touched** — every read uses the
         commit's git objects directly, so a concurrent ``git checkout``
         / edit in ``~/.memtomem-wiki/`` cannot bleed through. Returns
-        the count of files written.
+        the rel→SHA-256 map of the files written (``copy_tree_atomic``'s
+        return, #1247 id 15): the tmpdir bytes it hashes are the
+        git-object bytes just materialized, so for dest purposes each
+        digest describes exactly what was written to *dest*.
         """
         # Deferred import: install.py imports wiki.store at module load;
         # the reverse import here would cycle. Local resolves at call time.

--- a/packages/memtomem/tests/test_context_install.py
+++ b/packages/memtomem/tests/test_context_install.py
@@ -7,6 +7,7 @@ Invariant 2 (refuse-on-conflict instead of silent clobber).
 
 from __future__ import annotations
 
+import hashlib
 import json
 import multiprocessing as mp
 import shutil
@@ -458,7 +459,11 @@ def test_lockfile_contains_only_mandated_keys_per_entry(wiki_root: Path, tmp_pat
 
     ``files`` + ``files_commit`` joined the schema with the #1247
     deletion-fidelity work (the installed file manifest enabling
-    deletion-dirty detection and update reconciliation).
+    deletion-dirty detection and update reconciliation); ``digests`` +
+    ``digests_installed_at`` with the #1247 id 15 content-digest work
+    (byte-exact dirty detection closing the during-install absorption
+    window). The digest is the SHA-256 of the bytes the copier wrote,
+    paired to the entry's own ``installed_at``.
     """
     _initialized_wiki(wiki_root)
     _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
@@ -468,9 +473,19 @@ def test_lockfile_contains_only_mandated_keys_per_entry(wiki_root: Path, tmp_pat
     lock = Lockfile.at(project)
     entry = lock.read_entry("skills", "foo")
     assert entry is not None
-    assert set(entry) == {"wiki_commit", "installed_at", "files", "files_commit"}
+    assert set(entry) == {
+        "wiki_commit",
+        "installed_at",
+        "files",
+        "files_commit",
+        "digests",
+        "digests_installed_at",
+    }
     assert entry["files"] == ["SKILL.md"]
     assert entry["files_commit"] == entry["wiki_commit"]
+    assert entry["digests"] == {"SKILL.md": hashlib.sha256(b"x").hexdigest()}
+    assert entry["digests_installed_at"] == entry["installed_at"]
+    assert entry["files"] == sorted(entry["digests"])  # same written set, one source
 
 
 # ── Gate A on wiki-install ingress (ADR-0011 §5, #1247 id 3) ─────────────

--- a/packages/memtomem/tests/test_context_install_all.py
+++ b/packages/memtomem/tests/test_context_install_all.py
@@ -513,11 +513,16 @@ def test_force_reextraction_removes_stale_dest_only_file(
     # the legacy-entry deletion rule, not the user-added keep rule.
     past = datetime.now(timezone.utc).timestamp() - 3600
     os.utime(stale, (past, past))
-    # Pre-B1 entries carry no manifest — simulate one by stripping the keys.
+    # Pre-B1 entries carry no manifest and no digests — simulate one by
+    # stripping all four keys (with a valid digest pairing left in place,
+    # the unrecorded leftover would correctly classify user-added → keep;
+    # that digest-branch behavior is pinned in test_dirty_digest.py).
     lock_path = tmp_path / ".memtomem" / "lock.json"
     doc = json.loads(lock_path.read_text(encoding="utf-8"))
     doc["skills"]["foo"].pop("files", None)
     doc["skills"]["foo"].pop("files_commit", None)
+    doc["skills"]["foo"].pop("digests", None)
+    doc["skills"]["foo"].pop("digests_installed_at", None)
     lock_path.write_text(json.dumps(doc), encoding="utf-8")
 
     monkeypatch.chdir(tmp_path)

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -1354,7 +1354,13 @@ def test_update_stale_manifest_guard_ignores_mismatched_files_commit(
 ) -> None:
     """An entry whose ``files_commit`` doesn't match ``wiki_commit`` (older
     tool rewrote the entry, or a hand-merged lock.json) must behave as if no
-    manifest exists: no missing-file dirty, legacy mtime rule applies."""
+    manifest exists: no missing-file dirty, legacy mtime rule applies.
+
+    The digest keys are stripped too — install records them since #1247
+    id 15, and a valid digest pairing would (correctly) catch the deletion
+    on the digest branch before the manifest guard is ever consulted; the
+    digest-branch deletion behavior is pinned in test_dirty_digest.py.
+    """
     from memtomem.context.dirty import is_asset_dirty
 
     _initialized_wiki(wiki_root)
@@ -1363,6 +1369,8 @@ def test_update_stale_manifest_guard_ignores_mismatched_files_commit(
 
     entry = _lock_entry(tmp_path, "skills", "web")
     entry["files_commit"] = "0" * 40
+    entry.pop("digests", None)
+    entry.pop("digests_installed_at", None)
     _rewrite_lock_entry(tmp_path, "skills", "web", entry)
 
     (tmp_path / ".memtomem" / "skills" / "web" / "a.md").unlink()

--- a/packages/memtomem/tests/test_dirty_digest.py
+++ b/packages/memtomem/tests/test_dirty_digest.py
@@ -1,0 +1,842 @@
+"""Per-file content-digest dirty detection (#1247 id 15).
+
+The defect: all three install sites captured ``installed_at`` from the
+dest tree AFTER the copy (``max st_mtime``), so a concurrent edit landing
+between a file's write and that capture sat at ``mtime <= installed_at``
+— classified clean **permanently**, and the next update silently
+overwrote the user's bytes. The fix records a SHA-256 per installed file,
+computed from the in-memory bytes the copier wrote, and the dirty check
+compares bytes instead of mtimes whenever the entry carries a valid map
+(``digests`` paired to the entry's own ``installed_at`` via
+``digests_installed_at``).
+
+Test discipline (campaign convention):
+
+- The bug-class and semantic-delta tests fail against main's src tree
+  (validated via ``git restore --source origin/main --worktree -- <src>``
+  before the fix commit is finalized).
+- Negative pins documenting degrade paths pass on both trees where the
+  shapes allow it; the load-bearing guards (digest compare, pairing
+  equality, clear-on-omit) are additionally mutation-validated — see the
+  PR description for the exact mutations and which pins go red.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from memtomem.context import _atomic as atomic_module
+from memtomem.context._atomic import DIRTY_SKIP_SUFFIXES, copy_tree_atomic
+from memtomem.context.dirty import is_asset_dirty
+from memtomem.context.install import (
+    StaleInstallError,
+    _reconcile_removed_files,
+    install_skill,
+    update_skill,
+)
+from memtomem.context.lockfile import Lockfile, digests_from_entry, manifest_from_entry
+from memtomem.context.privacy_scan import PrivacyScanReadError
+from memtomem.wiki.store import WikiStore
+
+requires_posix_perms = pytest.mark.skipif(
+    os.name == "nt" or (hasattr(os, "geteuid") and os.geteuid() == 0),
+    reason="needs POSIX permissions and a non-root user",
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _initialized_wiki(wiki_root_path: Path) -> WikiStore:
+    store = WikiStore.at_default()
+    store.init()
+    return store
+
+
+def _commit_wiki(wiki_root_path: Path, message: str) -> str:
+    subprocess.run(["git", "-C", str(wiki_root_path), "add", "-A"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root_path), "commit", "-m", message],
+        check=True,
+        capture_output=True,
+    )
+    return WikiStore.at_default().current_commit()
+
+
+def _seed_wiki_skill(wiki_root_path: Path, name: str, files: dict[str, bytes]) -> str:
+    """Add ``skills/<name>/`` to wiki + git commit. Returns the commit SHA."""
+    skill_dir = wiki_root_path / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    for relpath, data in files.items():
+        target = skill_dir / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    return _commit_wiki(wiki_root_path, f"add {name}")
+
+
+def _modify_wiki_skill(wiki_root_path: Path, name: str, files: dict[str, bytes]) -> str:
+    """Modify wiki skill files + commit. Wiki HEAD advances. Returns new SHA."""
+    skill_dir = wiki_root_path / "skills" / name
+    for relpath, data in files.items():
+        target = skill_dir / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    return _commit_wiki(wiki_root_path, f"modify {name}")
+
+
+def _drop_wiki_file(wiki_root_path: Path, name: str, rel: str) -> str:
+    """Delete one file from the wiki skill + commit. Returns new SHA."""
+    (wiki_root_path / "skills" / name / rel).unlink()
+    return _commit_wiki(wiki_root_path, f"drop {rel} from {name}")
+
+
+def _lock_path(project: Path) -> Path:
+    return project / ".memtomem" / "lock.json"
+
+
+def _entry(project: Path, asset_type: str = "skills", name: str = "web") -> dict:
+    doc = json.loads(_lock_path(project).read_text(encoding="utf-8"))
+    return doc[asset_type][name]
+
+
+def _surgery(project: Path, mutate, asset_type: str = "skills", name: str = "web") -> None:
+    """Rewrite one lock entry via *mutate(entry_dict)* — direct dict surgery.
+
+    Deliberately NOT ``upsert_entry``: the §9.6 degrade fixtures simulate a
+    pre-digest tool that preserves the ``digests*`` keys verbatim while
+    moving ``installed_at``, which the digest-aware upsert can no longer
+    produce (it clears the keys when ``digests`` is omitted).
+    """
+    lock_path = _lock_path(project)
+    doc = json.loads(lock_path.read_text(encoding="utf-8"))
+    mutate(doc[asset_type][name])
+    lock_path.write_text(json.dumps(doc), encoding="utf-8")
+
+
+def _epoch(installed_at: str) -> float:
+    return datetime.fromisoformat(installed_at.replace("Z", "+00:00")).timestamp()
+
+
+def _backdate(path: Path, installed_at: str, *, margin: float = 0.001) -> None:
+    """Set *path*'s mtime strictly below the entry's installed_at epoch."""
+    target = _epoch(installed_at) - margin
+    os.utime(path, (target, target))
+
+
+def _iso_at(epoch: float) -> str:
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+# ── bug class: absorbed concurrent edits (pre-fix-fail vs main) ──────────
+
+
+def test_absorbed_backdated_edit_classifies_dirty_and_refuses(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """§9.1 — the id 15 repro. A user edit whose mtime sits at/below
+    ``installed_at`` (exactly what an edit racing the install's post-copy
+    capture looks like) was permanently clean on main; the next update
+    silently overwrote the user's bytes. Digests classify it dirty, the
+    no-force update refuses, and the bytes survive."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n", "scripts/a.md": b"original\n"})
+    install_skill(tmp_path, "web")
+
+    edited = tmp_path / ".memtomem" / "skills" / "web" / "scripts" / "a.md"
+    edited.write_bytes(b"user bytes the install raced past\n")
+    _backdate(edited, _entry(tmp_path)["installed_at"])
+
+    report = is_asset_dirty(tmp_path, "skills", "web")
+    assert report.reason == "dirty"
+    assert report.dirty_files == (edited,)
+
+    _modify_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web v2\n"})
+    with pytest.raises(StaleInstallError):
+        update_skill(tmp_path, "web")
+    assert edited.read_bytes() == b"user bytes the install raced past\n"
+
+
+def test_absorbed_backdated_edit_force_preserves_bak(wiki_root: Path, tmp_path: Path) -> None:
+    """§9.1 force half: ``--force`` lands the user bytes in a ``.bak``
+    sibling before the wiki bytes overwrite — on main no ``.bak`` was
+    written because the file classified clean."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n", "scripts/a.md": b"original\n"})
+    install_skill(tmp_path, "web")
+
+    edited = tmp_path / ".memtomem" / "skills" / "web" / "scripts" / "a.md"
+    edited.write_bytes(b"user bytes\n")
+    _backdate(edited, _entry(tmp_path)["installed_at"])
+    _modify_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web v2\n"})
+
+    result = update_skill(tmp_path, "web", force=True)
+
+    bak = edited.with_suffix(edited.suffix + ".bak")
+    assert [p.name for p in result.bak_files_written] == ["a.md.bak"]
+    assert bak.read_bytes() == b"user bytes\n"
+    assert edited.read_bytes() == b"original\n"  # wiki bytes restored
+
+
+def test_mid_copy_interleave_detected(
+    wiki_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """§9.2 — an edit landing DURING the copy pipeline (after the file's own
+    write, before the post-copy capture) leaves dest bytes ≠ the bytes the
+    copier wrote. The digest is computed from the in-memory data, so the
+    race is visible no matter when it lands; the scalar capture absorbed it."""
+    real_write = atomic_module.atomic_write_bytes
+    raced = {"done": False}
+
+    def racing_write(path: Path, data: bytes, mode: int = 0o600) -> None:
+        real_write(path, data, mode=mode)
+        if path.name == "a.md" and not raced["done"]:
+            raced["done"] = True
+            st = path.stat()
+            path.write_bytes(b"raced bytes\n")
+            os.utime(path, ns=(st.st_mtime_ns, st.st_mtime_ns))  # mtime as if untouched
+
+    monkeypatch.setattr(atomic_module, "atomic_write_bytes", racing_write)
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n", "a.md": b"original\n"})
+    install_skill(tmp_path, "web")
+
+    assert raced["done"], "fixture failed to interleave the racing write"
+    report = is_asset_dirty(tmp_path, "skills", "web")
+    assert report.reason == "dirty"
+    assert [p.name for p in report.dirty_files] == ["a.md"]
+
+
+def test_backdated_addition_detected(wiki_root: Path, tmp_path: Path) -> None:
+    """§9.3 — a file added to dest with an old mtime was invisible to the
+    mtime walk; on the digest branch any rel absent from the recorded map
+    is a local addition → dirty."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n"})
+    install_skill(tmp_path, "web")
+
+    added = tmp_path / ".memtomem" / "skills" / "web" / "added.md"
+    added.write_bytes(b"smuggled\n")
+    _backdate(added, _entry(tmp_path)["installed_at"])
+
+    report = is_asset_dirty(tmp_path, "skills", "web")
+    assert report.reason == "dirty"
+    assert report.dirty_files == (added,)
+
+
+def test_backdated_addition_invisible_on_legacy_entry(wiki_root: Path, tmp_path: Path) -> None:
+    """§9.3 paired negative — documents the legacy gap explicitly: the same
+    backdated addition on a digest-less entry stays clean (pre-digest
+    behavior, bit-for-bit)."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n"})
+    install_skill(tmp_path, "web")
+
+    def strip(entry: dict) -> None:
+        entry.pop("digests", None)
+        entry.pop("digests_installed_at", None)
+
+    _surgery(tmp_path, strip)
+    added = tmp_path / ".memtomem" / "skills" / "web" / "added.md"
+    added.write_bytes(b"smuggled\n")
+    _backdate(added, _entry(tmp_path)["installed_at"])
+
+    report = is_asset_dirty(tmp_path, "skills", "web")
+    assert report.reason == "clean"
+
+
+def test_deletion_detected_via_digest_keys_without_manifest(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """§9.13 — ``missing_files`` derives from the digest map's keys on the
+    digest branch, independent of the ``files`` manifest."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n", "scripts/a.md": b"a\n"})
+    install_skill(tmp_path, "web")
+
+    def drop_manifest(entry: dict) -> None:
+        entry.pop("files", None)
+        entry.pop("files_commit", None)
+
+    _surgery(tmp_path, drop_manifest)
+    gone = tmp_path / ".memtomem" / "skills" / "web" / "scripts" / "a.md"
+    gone.unlink()
+
+    report = is_asset_dirty(tmp_path, "skills", "web")
+    assert report.reason == "dirty"
+    assert report.dirty_files == ()
+    assert report.missing_files == (gone,)
+
+
+# ── semantic deltas (pre-fix-fail vs main) ───────────────────────────────
+
+
+def test_touch_only_edit_clean_on_digest_entry(wiki_root: Path, tmp_path: Path) -> None:
+    """Delta 1 (§9.5): mtime bumped, bytes identical → clean on digest
+    entries (was dirty — false refusals and manufactured ``.bak``\\ s for
+    unchanged bytes). The follow-up no-force update succeeds bak-less."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n"})
+    install_skill(tmp_path, "web")
+
+    touched = tmp_path / ".memtomem" / "skills" / "web" / "SKILL.md"
+    future = datetime.now(timezone.utc).timestamp() + 30
+    os.utime(touched, (future, future))
+
+    report = is_asset_dirty(tmp_path, "skills", "web")
+    assert report.reason == "clean"
+
+    _modify_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web v2\n"})
+    result = update_skill(tmp_path, "web")  # no force needed
+    assert result.bak_files_written == ()
+    assert touched.read_bytes() == b"# web v2\n"
+
+
+def test_reconcile_deletes_untouched_wiki_dropped_file_with_fresh_mtime(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """§9.4 — legacy false-KEEP closure. A wiki-dropped file whose bytes are
+    untouched but whose mtime is fresh (cross-machine checkout shape) was
+    kept forever with a repeating warning (and on main the fresh mtime
+    additionally classified the whole asset dirty → refuse). Digest equality
+    proves it untouched: the no-force update succeeds and reconciles it away."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n", "dropme.md": b"old\n"})
+    install_skill(tmp_path, "web")
+
+    _drop_wiki_file(wiki_root, "web", "dropme.md")
+    dropped = tmp_path / ".memtomem" / "skills" / "web" / "dropme.md"
+    future = datetime.now(timezone.utc).timestamp() + 30
+    os.utime(dropped, (future, future))  # fresh mtime, identical bytes
+
+    result = update_skill(tmp_path, "web")  # no force
+
+    assert not dropped.exists()
+    assert [p.name for p in result.files_removed] == ["dropme.md"]
+    assert _entry(tmp_path)["files"] == ["SKILL.md"]
+
+
+def test_reconcile_digest_provenance_beats_divergent_manifest(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """§9.15 — when the old entry carries valid digests, they are the single
+    provenance set for reconcile; a hand-edited ``files`` manifest missing
+    the rel must not protect a digest-tracked, wiki-dropped file."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n", "r.md": b"r\n"})
+    install_skill(tmp_path, "web")
+
+    _surgery(tmp_path, lambda entry: entry.update(files=["SKILL.md"]))  # hand-drop r.md
+    entry = _entry(tmp_path)
+    assert manifest_from_entry(entry) == frozenset({"SKILL.md"})  # divergent but valid
+    assert "r.md" in digests_from_entry(entry)  # digests still track it
+
+    _drop_wiki_file(wiki_root, "web", "r.md")
+    result = update_skill(tmp_path, "web")
+
+    assert not (tmp_path / ".memtomem" / "skills" / "web" / "r.md").exists()
+    assert [p.name for p in result.files_removed] == ["r.md"]
+
+
+@requires_posix_perms
+def test_unreadable_file_classifies_dirty_with_warning(
+    wiki_root: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """§9.16 status half — the digest branch must read bytes, so an
+    unreadable file is a new failure mode: classify dirty + warn (cannot
+    prove clean), never raise (one chmod'd file must not 500 a status walk
+    over N projects) and never silently pass (was: clean, stat needs no
+    read permission)."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n", "locked.md": b"x\n"})
+    install_skill(tmp_path, "web")
+
+    locked = tmp_path / ".memtomem" / "skills" / "web" / "locked.md"
+    locked.chmod(0o000)
+    try:
+        with caplog.at_level(logging.WARNING, logger="memtomem.context.dirty"):
+            report = is_asset_dirty(tmp_path, "skills", "web")
+    finally:
+        locked.chmod(0o644)
+
+    assert report.reason == "dirty"
+    assert report.dirty_files == (locked,)
+    assert any("cannot read" in r.message for r in caplog.records)
+
+
+@requires_posix_perms
+def test_unreadable_file_force_update_fails_loudly_before_any_mutation(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """§9.16 mutation half — under ``--force`` the unreadable dirty file is
+    in the ``.bak`` set, and the pipeline fails loudly BEFORE the first dest
+    mutation (Gate A's read error, or OSError from any path that reaches
+    ``copy2``): no ``.bak`` written, dest bytes untouched, no lockfile
+    drift. The invariant is pinned, not the call site."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n", "locked.md": b"x\n"})
+    install_skill(tmp_path, "web")
+    entry_before = _entry(tmp_path)
+
+    _modify_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web v2\n"})
+    dest = tmp_path / ".memtomem" / "skills" / "web"
+    locked = dest / "locked.md"
+    locked.chmod(0o000)
+    try:
+        with pytest.raises((PrivacyScanReadError, OSError)):
+            update_skill(tmp_path, "web", force=True)
+    finally:
+        locked.chmod(0o644)
+
+    assert not list(dest.rglob("*.bak"))
+    assert (dest / "SKILL.md").read_bytes() == b"# web\n"  # v2 never landed
+    assert _entry(tmp_path) == entry_before
+
+
+# ── pairing degrade negative pins (§9.6) ─────────────────────────────────
+
+
+def test_pairing_degrade_on_old_tool_rewrite(wiki_root: Path, tmp_path: Path) -> None:
+    """§9.6 — a pre-digest tool rewriting the entry preserves the unknown
+    ``digests*`` keys verbatim while refreshing ``installed_at``; the
+    pairing mismatch must degrade the entry to the legacy branch (where a
+    backdated edit is invisible again — honoring the stale map would
+    false-dirty every file the old tool's update rewrote)."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n", "a.md": b"original\n"})
+    install_skill(tmp_path, "web")
+
+    edited = tmp_path / ".memtomem" / "skills" / "web" / "a.md"
+    edited.write_bytes(b"changed bytes\n")
+    _backdate(edited, _entry(tmp_path)["installed_at"])
+    assert is_asset_dirty(tmp_path, "skills", "web").reason == "dirty"  # digest catches it
+
+    # Old-tool rewrite simulation: installed_at moves, digests* preserved.
+    new_installed_at = _iso_at(_epoch(_entry(tmp_path)["installed_at"]) + 10)
+    _surgery(tmp_path, lambda entry: entry.update(installed_at=new_installed_at))
+
+    assert digests_from_entry(_entry(tmp_path)) is None
+    report = is_asset_dirty(tmp_path, "skills", "web")
+    assert report.reason == "clean"  # legacy branch: backdated edit invisible
+
+
+def test_pairing_degrade_survives_a_b_a_pin_roundtrip(wiki_root: Path, tmp_path: Path) -> None:
+    """§9.6 A→B→A variant — the reason the pairing token is ``installed_at``
+    and not ``wiki_commit``: an old tool moving the pin away and back
+    re-validates the COMMIT pairing (``files_commit`` carries that
+    documented hole) but must not re-validate the digests, because every
+    old-tool write refreshed ``installed_at``."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n", "a.md": b"original\n"})
+    install_skill(tmp_path, "web")
+    entry0 = _entry(tmp_path)
+    pin_a = entry0["wiki_commit"]
+    t0 = _epoch(entry0["installed_at"])
+
+    def roundtrip(entry: dict) -> None:
+        # A→B (old tool update): pin + manifest move, installed_at refreshes.
+        # B→A (old tool restore): everything back at A, installed_at fresh again.
+        entry["wiki_commit"] = pin_a
+        entry["files_commit"] = pin_a
+        entry["installed_at"] = _iso_at(t0 + 20)
+
+    _surgery(tmp_path, roundtrip)
+
+    entry = _entry(tmp_path)
+    assert manifest_from_entry(entry) is not None  # commit pairing re-matched (known hole)
+    assert digests_from_entry(entry) is None  # installed_at pairing did not
+
+    edited = tmp_path / ".memtomem" / "skills" / "web" / "a.md"
+    edited.write_bytes(b"changed bytes\n")
+    _backdate(edited, entry["installed_at"])
+    assert is_asset_dirty(tmp_path, "skills", "web").reason == "clean"  # legacy, not stale map
+
+
+def test_pairing_collision_consequence_is_fail_safe(wiki_root: Path, tmp_path: Path) -> None:
+    """§9.6 collision variant — ``installed_at`` is mtime-derived, so a
+    pre-digest rewrite CAN land on the byte-identical ISO string (documented
+    residual). The guard then accepts the stale pair; the pinned consequence
+    direction: byte-mismatching files classify **dirty** (refuse/.bak), and
+    only byte-identical-to-stale-record files classify clean — never a
+    silent clean over diverged bytes."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n", "a.md": b"original\n"})
+    install_skill(tmp_path, "web")
+
+    edited = tmp_path / ".memtomem" / "skills" / "web" / "a.md"
+    edited.write_bytes(b"changed bytes\n")
+    _backdate(edited, _entry(tmp_path)["installed_at"])
+
+    # Old-tool rewrite whose fresh installed_at collides byte-for-byte with
+    # the stale digests_installed_at: move both to the same new value.
+    collided = _iso_at(_epoch(_entry(tmp_path)["installed_at"]) + 10)
+
+    def collide(entry: dict) -> None:
+        entry["installed_at"] = collided
+        entry["digests_installed_at"] = collided
+
+    _surgery(tmp_path, collide)
+
+    assert digests_from_entry(_entry(tmp_path)) is not None  # guard accepts (residual)
+    report = is_asset_dirty(tmp_path, "skills", "web")
+    assert report.reason == "dirty"  # fail-safe: mismatching bytes refuse
+    assert [p.name for p in report.dirty_files] == ["a.md"]  # untouched SKILL.md stays clean
+
+
+# ── malformed digests degrade (§9.7) ─────────────────────────────────────
+
+_VALID_HEX = "0" * 64
+
+
+@pytest.mark.parametrize(
+    "digests_value, pairing_value",
+    [
+        ("not-a-dict", "PAIR"),  # digests not a dict
+        ({"": _VALID_HEX}, "PAIR"),  # empty rel
+        ({"../escape.md": _VALID_HEX}, "PAIR"),  # traversal rel
+        ({"/abs.md": _VALID_HEX}, "PAIR"),  # absolute rel
+        ({"a\\b.md": _VALID_HEX}, "PAIR"),  # backslash rel
+        ({"a.md": "zz" * 32}, "PAIR"),  # non-hex value
+        ({"a.md": "0" * 63}, "PAIR"),  # wrong length
+        ({"a.md": "A" * 64}, "PAIR"),  # uppercase hex — not lowercase
+        ({"a.md": 42}, "PAIR"),  # non-string value
+        ({"a.md": _VALID_HEX}, None),  # digests_installed_at missing
+        ({"a.md": _VALID_HEX}, 123),  # digests_installed_at non-string
+    ],
+)
+def test_malformed_digests_degrade_to_legacy(
+    wiki_root: Path, tmp_path: Path, digests_value: object, pairing_value: object
+) -> None:
+    """§9.7 — lock.json is git-tracked and hand-merged: every malformed
+    shape degrades to the legacy classification (backdated edit invisible),
+    never crashes, never half-applies. ``"PAIR"`` means "keep the valid
+    pairing value" so the shape under test is the only defect."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n", "a.md": b"original\n"})
+    install_skill(tmp_path, "web")
+
+    def corrupt(entry: dict) -> None:
+        entry["digests"] = digests_value
+        if pairing_value is None:
+            entry.pop("digests_installed_at", None)
+        elif pairing_value != "PAIR":
+            entry["digests_installed_at"] = pairing_value
+
+    _surgery(tmp_path, corrupt)
+    assert digests_from_entry(_entry(tmp_path)) is None
+
+    edited = tmp_path / ".memtomem" / "skills" / "web" / "a.md"
+    edited.write_bytes(b"changed bytes\n")
+    _backdate(edited, _entry(tmp_path)["installed_at"])
+
+    report = is_asset_dirty(tmp_path, "skills", "web")
+    assert report.reason == "clean"  # legacy branch took over, no crash
+
+
+# ── reconcile decision rules, unit level (§9.4/9.15 shapes) ──────────────
+
+
+class TestReconcileDigestRules:
+    """Exercise ``_reconcile_removed_files`` rules directly — the integration
+    paths above can't reach every keep/delete arm deterministically (rule 3
+    needs a fresh-mtime non-baked file, which the normal classify→gate flow
+    refuses before reconcile; only the ``--all`` confirm race reaches it)."""
+
+    def _tree(self, tmp_path: Path, files: dict[str, bytes]) -> Path:
+        dest = tmp_path / "dest"
+        for rel, data in files.items():
+            target = dest / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(data)
+        return dest
+
+    def test_unrecorded_rel_kept_as_user_added(self, tmp_path: Path) -> None:
+        dest = self._tree(tmp_path, {"keep.md": b"user\n"})
+        removed = _reconcile_removed_files(
+            dest,
+            src_has=lambda rel: False,
+            old_installed_at_epoch=None,
+            baked=frozenset(),
+            manifest=None,
+            old_digests={"other.md": _sha(b"x")},
+        )
+        assert removed == ()
+        assert (dest / "keep.md").exists()
+
+    def test_recorded_untouched_bytes_deleted_despite_fresh_mtime(self, tmp_path: Path) -> None:
+        dest = self._tree(tmp_path, {"gone.md": b"wiki\n"})
+        future = datetime.now(timezone.utc).timestamp() + 30
+        os.utime(dest / "gone.md", (future, future))
+        removed = _reconcile_removed_files(
+            dest,
+            src_has=lambda rel: False,
+            old_installed_at_epoch=None,
+            baked=frozenset(),
+            manifest=None,
+            old_digests={"gone.md": _sha(b"wiki\n")},
+        )
+        assert [p.name for p in removed] == ["gone.md"]
+        assert not (dest / "gone.md").exists()
+
+    def test_recorded_diverged_bytes_kept_with_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        dest = self._tree(tmp_path, {"edited.md": b"user edit\n"})
+        with caplog.at_level(logging.WARNING, logger="memtomem.context.install"):
+            removed = _reconcile_removed_files(
+                dest,
+                src_has=lambda rel: False,
+                old_installed_at_epoch=None,
+                baked=frozenset(),
+                manifest=None,
+                old_digests={"edited.md": _sha(b"wiki\n")},
+            )
+        assert removed == ()
+        assert (dest / "edited.md").exists()
+        assert any("unproven bytes" in r.message for r in caplog.records)
+
+    def test_recorded_diverged_but_baked_deleted(self, tmp_path: Path) -> None:
+        dest = self._tree(tmp_path, {"edited.md": b"user edit\n"})
+        removed = _reconcile_removed_files(
+            dest,
+            src_has=lambda rel: False,
+            old_installed_at_epoch=None,
+            baked=frozenset({dest / "edited.md"}),
+            manifest=None,
+            old_digests={"edited.md": _sha(b"wiki\n")},
+        )
+        assert [p.name for p in removed] == ["edited.md"]
+
+    @requires_posix_perms
+    def test_recorded_unreadable_kept_with_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Unreadable is neither provable nor baked → rule 3 keep —
+        consistent with the dirty check's fail-safe direction."""
+        dest = self._tree(tmp_path, {"locked.md": b"wiki\n"})
+        (dest / "locked.md").chmod(0o000)
+        try:
+            with caplog.at_level(logging.WARNING, logger="memtomem.context.install"):
+                removed = _reconcile_removed_files(
+                    dest,
+                    src_has=lambda rel: False,
+                    old_installed_at_epoch=None,
+                    baked=frozenset(),
+                    manifest=None,
+                    old_digests={"locked.md": _sha(b"wiki\n")},
+                )
+        finally:
+            (dest / "locked.md").chmod(0o644)
+        assert removed == ()
+        assert (dest / "locked.md").exists()
+
+    def test_digest_branch_ignores_manifest(self, tmp_path: Path) -> None:
+        """§9.15 unit shape: rel recorded in digests but hand-dropped from
+        the manifest — digest provenance wins, the file is deleted."""
+        dest = self._tree(tmp_path, {"r.md": b"wiki\n"})
+        removed = _reconcile_removed_files(
+            dest,
+            src_has=lambda rel: False,
+            old_installed_at_epoch=None,
+            baked=frozenset(),
+            manifest=frozenset({"SKILL.md"}),  # r.md absent — would keep as user-added
+            old_digests={"r.md": _sha(b"wiki\n")},
+        )
+        assert [p.name for p in removed] == ["r.md"]
+
+    def test_legacy_fresh_mtime_kept_with_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """§9.4 paired negative — today's legacy behavior, unchanged: no
+        digests, manifest-recorded, fresh mtime, not baked → keep + warn
+        (the false-KEEP the digest branch retires)."""
+        dest = self._tree(tmp_path, {"dropme.md": b"wiki\n"})
+        past_epoch = datetime.now(timezone.utc).timestamp() - 3600
+        with caplog.at_level(logging.WARNING, logger="memtomem.context.install"):
+            removed = _reconcile_removed_files(
+                dest,
+                src_has=lambda rel: False,
+                old_installed_at_epoch=past_epoch,  # file mtime is now → fresh
+                baked=frozenset(),
+                manifest=frozenset({"dropme.md"}),
+                old_digests=None,
+            )
+        assert removed == ()
+        assert (dest / "dropme.md").exists()
+        assert any("fresh mtime" in r.message for r in caplog.records)
+
+
+# ── capture: copy_tree_atomic digest map (§9.9) ──────────────────────────
+
+
+class TestCopyTreeAtomicDigestMap:
+    def test_map_covers_written_set_with_posix_rels_and_source_hashes(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        (src / "scripts").mkdir(parents=True)
+        (src / "SKILL.md").write_bytes(b"# top\n")
+        (src / "scripts" / "run.py").write_bytes(b"print()\n")
+        dst = tmp_path / "dst"
+
+        digest_map = copy_tree_atomic(src, dst)
+
+        assert digest_map == {
+            "SKILL.md": _sha(b"# top\n"),
+            "scripts/run.py": _sha(b"print()\n"),
+        }
+        written = [p for p in dst.rglob("*") if p.is_file()]
+        assert len(digest_map) == len(written)
+
+    def test_skip_rules_keep_entries_out_of_map(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        (src / "__pycache__").mkdir(parents=True)
+        (src / ".git").mkdir()
+        (src / "SKILL.md").write_bytes(b"x\n")
+        (src / "old.md.bak").write_bytes(b"bak\n")
+        (src / ".DS_Store").write_bytes(b"\x00")
+        (src / "__pycache__" / "a.pyc").write_bytes(b"\x00")
+        (src / ".git" / "HEAD").write_bytes(b"ref\n")
+        dst = tmp_path / "dst"
+
+        digest_map = copy_tree_atomic(src, dst, skip_suffixes=DIRTY_SKIP_SUFFIXES)
+
+        assert sorted(digest_map) == ["SKILL.md"]
+        assert [p.name for p in dst.rglob("*")] == ["SKILL.md"]
+
+    @pytest.mark.requires_symlinks
+    def test_symlinks_skipped_and_absent_from_map(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "SKILL.md").write_bytes(b"x\n")
+        (src / "link.md").symlink_to("SKILL.md")
+        dst = tmp_path / "dst"
+
+        digest_map = copy_tree_atomic(src, dst)
+
+        assert sorted(digest_map) == ["SKILL.md"]
+        assert not (dst / "link.md").exists()
+
+    def test_skip_top_level_is_root_only(self, tmp_path: Path) -> None:
+        """Root ``overrides/`` excluded, nested ``scripts/overrides/`` kept —
+        the rel-prefix recursion must not widen the root-only contract."""
+        src = tmp_path / "src"
+        (src / "overrides").mkdir(parents=True)
+        (src / "scripts" / "overrides").mkdir(parents=True)
+        (src / "overrides" / "claude.md").write_bytes(b"vendor\n")
+        (src / "scripts" / "overrides" / "nested.md").write_bytes(b"nested\n")
+        dst = tmp_path / "dst"
+
+        digest_map = copy_tree_atomic(src, dst, skip_top_level=frozenset({"overrides"}))
+
+        assert sorted(digest_map) == ["scripts/overrides/nested.md"]
+        assert not (dst / "overrides").exists()
+        assert (dst / "scripts" / "overrides" / "nested.md").read_bytes() == b"nested\n"
+
+
+# ── schema: upsert_entry digests contract (§9.12) ────────────────────────
+
+
+class TestUpsertEntryDigests:
+    def test_digests_stamp_pairing_from_written_installed_at(self, tmp_path: Path) -> None:
+        lock = Lockfile.at(tmp_path)
+        lock.upsert_entry(
+            "skills",
+            "web",
+            wiki_commit="a" * 40,
+            installed_at="2026-06-12T00:00:00.000000Z",
+            files=["b.md", "a.md"],
+            files_commit="a" * 40,
+            digests={"b.md": _sha(b"b"), "a.md": _sha(b"a")},
+        )
+
+        entry = lock.read_entry("skills", "web")
+        assert entry is not None
+        assert entry["digests_installed_at"] == "2026-06-12T00:00:00.000000Z"
+        assert list(entry["digests"]) == ["a.md", "b.md"]  # stored sorted
+        assert digests_from_entry(entry) == {"a.md": _sha(b"a"), "b.md": _sha(b"b")}
+
+    def test_omitting_digests_clears_prior_pair_but_keeps_unknown_keys(
+        self, tmp_path: Path
+    ) -> None:
+        """Clear-on-omit (R2 Major 1 fold): the digest-aware writer owns the
+        keys — a digest-less rewrite must not leave a stale pair that a
+        later mtime collision could re-validate. Truly-unknown sibling keys
+        keep round-tripping verbatim."""
+        lock = Lockfile.at(tmp_path)
+        lock.upsert_entry(
+            "skills",
+            "web",
+            wiki_commit="a" * 40,
+            installed_at="2026-06-12T00:00:00.000000Z",
+            digests={"a.md": _sha(b"a")},
+        )
+        # Plant an unknown sibling key the way a future tool would.
+        lock_path = tmp_path / ".memtomem" / "lock.json"
+        doc = json.loads(lock_path.read_text(encoding="utf-8"))
+        doc["skills"]["web"]["compat"] = "v2"
+        lock_path.write_text(json.dumps(doc), encoding="utf-8")
+
+        lock.upsert_entry(
+            "skills",
+            "web",
+            wiki_commit="b" * 40,
+            installed_at="2026-06-12T01:00:00.000000Z",
+        )
+
+        entry = lock.read_entry("skills", "web")
+        assert entry is not None
+        assert "digests" not in entry
+        assert "digests_installed_at" not in entry
+        assert entry["compat"] == "v2"  # unknown key still round-trips
+
+
+# ── all three install sites record paired digests (§9.11) ────────────────
+
+
+def test_install_update_and_pinned_reinstall_record_paired_digests(
+    wiki_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Site sweep: fresh install, update-with-reconcile, and the pinned
+    ``install --all`` re-extraction all write ``digests`` whose pairing
+    token equals the entry's ``installed_at`` and whose key set IS the
+    ``files`` manifest."""
+    from click.testing import CliRunner
+
+    from memtomem.cli.context_cmd import context as context_group
+
+    def assert_paired(entry: dict, expected: dict[str, bytes]) -> None:
+        assert entry["digests"] == {rel: _sha(data) for rel, data in expected.items()}
+        assert entry["digests_installed_at"] == entry["installed_at"]
+        assert entry["files"] == sorted(entry["digests"])
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"v1\n", "dropme.md": b"d\n"})
+
+    # Site 1: install.
+    install_skill(tmp_path, "web")
+    assert_paired(_entry(tmp_path), {"SKILL.md": b"v1\n", "dropme.md": b"d\n"})
+
+    # Site 2: update — wiki advances AND drops a file, so reconcile runs.
+    _modify_wiki_skill(wiki_root, "web", {"SKILL.md": b"v2\n"})
+    _drop_wiki_file(wiki_root, "web", "dropme.md")
+    update_skill(tmp_path, "web")
+    assert_paired(_entry(tmp_path), {"SKILL.md": b"v2\n"})
+
+    # Site 3: pinned re-extraction (dest deleted → state="install" at pin).
+    import shutil
+
+    shutil.rmtree(tmp_path / ".memtomem" / "skills" / "web")
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(context_group, ["install", "--all", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert_paired(_entry(tmp_path), {"SKILL.md": b"v2\n"})

--- a/packages/memtomem/tests/test_dirty_digest.py
+++ b/packages/memtomem/tests/test_dirty_digest.py
@@ -349,6 +349,43 @@ def test_reconcile_digest_provenance_beats_divergent_manifest(
     assert [p.name for p in result.files_removed] == ["r.md"]
 
 
+def test_reconcile_membership_is_written_set_not_post_copy_src_walk(
+    wiki_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex impl-gate Major: ``_apply_update`` derived reconcile membership
+    by re-walking the wiki working tree AFTER the copy returned. A src
+    mutation landing in that window (file dropped from the worktree) made
+    reconcile erase a file this very update just wrote — its unchanged
+    bytes still matched the OLD digests ("provably untouched") — while
+    ``files``/``digests`` recorded it: a phantom lock entry that the next
+    dirty check reports as a local deletion. Membership must come from the
+    copier's returned written set."""
+    import memtomem.context.install as install_module
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"v1\n", "keep.md": b"same\n"})
+    install_skill(tmp_path, "web")
+    _modify_wiki_skill(wiki_root, "web", {"SKILL.md": b"v2\n"})  # keep.md unchanged
+
+    real_copy = install_module.copy_tree_atomic
+
+    def copy_then_mutate_src(src: Path, dst: Path, **kwargs: object) -> dict[str, str]:
+        result = real_copy(src, dst, **kwargs)  # type: ignore[arg-type]
+        (src / "keep.md").unlink()  # worktree mutation in the copy→reconcile window
+        return result
+
+    monkeypatch.setattr(install_module, "copy_tree_atomic", copy_then_mutate_src)
+    result = update_skill(tmp_path, "web")
+
+    kept = tmp_path / ".memtomem" / "skills" / "web" / "keep.md"
+    assert kept.read_bytes() == b"same\n"  # the file this update wrote survives
+    assert result.files_removed == ()
+    entry = _entry(tmp_path)
+    assert entry["files"] == ["SKILL.md", "keep.md"]
+    assert "keep.md" in entry["digests"]  # record and dest agree — no phantom
+    assert is_asset_dirty(tmp_path, "skills", "web").reason == "clean"
+
+
 @requires_posix_perms
 def test_unreadable_file_classifies_dirty_with_warning(
     wiki_root: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture

--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import subprocess
 from pathlib import Path
 
@@ -327,9 +328,11 @@ class TestCopyAssetAtCommit:
         )
 
         dest = tmp_path / "out" / "foo"
-        files_written = store.copy_asset_at_commit(old_pin, "skills", "foo", dest)
+        digest_map = store.copy_asset_at_commit(old_pin, "skills", "foo", dest)
 
-        assert files_written == 1
+        # rel→digest map over the GIT-OBJECT bytes at the pin (#1247 id 15)
+        # — exactly the bytes written to dest, not the v2 working tree/HEAD.
+        assert digest_map == {"SKILL.md": hashlib.sha256(b"v1\n").hexdigest()}
         assert (dest / "SKILL.md").read_bytes() == b"v1\n"  # NOT the v2 HEAD
 
     def test_copies_nested_subdirs(self, wiki_root: Path, tmp_path: Path) -> None:
@@ -347,9 +350,11 @@ class TestCopyAssetAtCommit:
         )
 
         dest = tmp_path / "foo"
-        files_written = store.copy_asset_at_commit(pin, "skills", "foo", dest)
+        digest_map = store.copy_asset_at_commit(pin, "skills", "foo", dest)
 
-        assert files_written == 3
+        # Nested rels are POSIX, relative to dest (#1247 id 15).
+        assert sorted(digest_map) == ["SKILL.md", "references/a.md", "scripts/run.sh"]
+        assert digest_map["scripts/run.sh"] == hashlib.sha256(b"#!/bin/bash\necho hi\n").hexdigest()
         assert (dest / "SKILL.md").read_bytes() == b"# foo\n"
         assert (dest / "scripts" / "run.sh").read_bytes() == b"#!/bin/bash\necho hi\n"
         assert (dest / "references" / "a.md").read_bytes() == b"a\n"
@@ -413,12 +418,12 @@ class TestCopyAssetAtCommit:
 
         recorded = _record_store_git_argv(monkeypatch)
         dest = tmp_path / "out" / "foo"
-        files_written = store.copy_asset_at_commit(pin, "skills", "foo", dest)
+        digest_map = store.copy_asset_at_commit(pin, "skills", "foo", dest)
 
         show_args = [arg for argv in recorded if argv[:2] == ["git", "show"] for arg in argv]
         assert any(arg.endswith(":skills/foo/SKILL.md") for arg in show_args)  # spy is live
         assert not any("foo.md.bak" in arg for argv in recorded for arg in argv)
-        assert files_written == 1
+        assert sorted(digest_map) == ["SKILL.md"]  # skipped rel absent from the map too
         assert (dest / "SKILL.md").read_bytes() == b"# foo\n"
         assert not list(dest.rglob("*.bak"))
 
@@ -448,11 +453,11 @@ class TestCopyAssetAtCommit:
 
         recorded = _record_store_git_argv(monkeypatch)
         dest = tmp_path / "out" / "foo"
-        files_written = store.copy_asset_at_commit(pin, "skills", "foo", dest)
+        digest_map = store.copy_asset_at_commit(pin, "skills", "foo", dest)
 
         show_args = [arg for argv in recorded if argv[:2] == ["git", "show"] for arg in argv]
         assert any(arg.endswith(":skills/foo/SKILL.md") for arg in show_args)  # spy is live
         assert not any("__pycache__" in arg for argv in recorded for arg in argv)
-        assert files_written == 1
+        assert sorted(digest_map) == ["SKILL.md"]  # skipped rel absent from the map too
         assert (dest / "SKILL.md").read_bytes() == b"# foo\n"
         assert not (dest / "__pycache__").exists()


### PR DESCRIPTION
## Summary

Closes the final unchecked row of #1247 (id 15): **`installed_at` captured from post-copy max mtime absorbs concurrent edits → permanent clean misclassification → next update silently overwrites user bytes.**

All three install sites (`_install_asset`, `_apply_update`, `_apply_pinned_install`) derived `installed_at` from the dest tree *after* the copy. An edit landing between a file's write and that capture sits at `mtime <= installed_at`, so dirty.py's strict `mtime > installed_at_epoch` classifies it clean — forever (the mtime never changes again absent a second edit). The next `mm context update` takes no `.bak` and overwrites the user's bytes: silent data loss against ADR-0008 Invariant 2. A scalar timestamp cannot close this window even if captured per-write; only per-file evidence can.

Design: `.agents-dev/log/ctx-1247-id15-digest-design.md` v3 — converged through two Codex design-gate rounds (R1: commit pairing unsound for working-tree copies + reconcile provenance conflict; R2: mtime-derived pairing collision hole → clear-on-omit + documented fail-safe residual).

## Mechanism

- **Capture** — `copy_tree_atomic` returns `{posix_rel: sha256}` computed from the **in-memory bytes it wrote** (never a dest re-read, which would bless the very race being fixed). `copy_asset_at_commit` widens identically (its digests describe the git-object bytes materialized at the pin). All three install sites store the map as lock-entry `digests` + `digests_installed_at`; `files=` now derives from the copier's written set (a concurrent *addition* mid-copy can no longer be absorbed into the manifest), retiring `_manifest_relpaths`.
- **Schema** (ADR-0008 amended) — `digests` records *content identity of the install, not commit provenance*. Freshness pairing is `digests_installed_at == installed_at` (string equality): every entry-writing operation refreshes `installed_at`, so any pre-digest tool rewrite self-invalidates the pair — **including a pin moved A→B→A**, which `files_commit`-style commit pairing cannot catch. The digest-aware `upsert_entry` **owns** the keys: omitting `digests` clears both (`installed_at` is mtime-derived, not a nonce — a preserved stale pair could re-match by collision). The residual µs-collision is documented in the ADR with its fail-safe direction: stale digests vs newer bytes → dirty; silent clean requires bytes identical to what was once installed. Algorithm fixed SHA-256; algorithm change = new key name. No lockfile `version` bump (additive keys under the ADR-0008 round-trip contract).
- **Dirty check** — `is_asset_dirty` gains a digest branch: byte equality, no mtime consultation; `missing_files` derives from the digest map's keys. Legacy entries (no/invalid/stale digests) keep today's behavior **bit-for-bit**.
- **Reconcile** — when the old entry carries valid digests they are the single provenance set for both decisions (keep-user-added / delete-untouched); the `files` manifest is not consulted on that branch, so a hand-merged divergent manifest can no longer shield a digest-tracked, wiki-dropped file. Digest equality also retires the legacy false-KEEP of untouched wiki-dropped files with fresh mtimes (cross-machine checkouts).

## Semantic deltas (digest entries only; all pinned by tests)

1. Touch-only edit (mtime bumped, bytes identical) → **clean** (was dirty; no more manufactured `.bak`s).
2. Backdated edit (bytes changed, mtime ≤ installed_at) → **dirty** (was clean = the id 15 silent clobber).
3. Backdated addition → **dirty** (was invisible).
4. Cross-machine checkout (lock.json + dest via project git) → clean where bytes match (was all-dirty).
5. Unreadable file → **dirty + warning** (was clean — stat needs no read permission); the read error surfaces loudly pre-mutation: under `--force` the file is in the `.bak` set, which Gate A scans before the first dest write (`PrivacyScanReadError`), leaving no `.bak`, no dest write, no lockfile drift.

## Validation

- **Pre-fix-fail**: with the four behavior modules (`_atomic`/`dirty`/`install`/`wiki.store`) reverted to origin/main (new `lockfile.py` kept so imports resolve — its digest APIs are dead code without writers), **24/39** new tests fail, covering the absorbed-edit repro, mid-copy interleave (monkeypatched `atomic_write_bytes` racing writer), backdated addition, digest-keyed deletion, touch-only delta, reconcile false-KEEP closure, digest-vs-manifest divergence, both unreadable halves, and the capture/schema units. The 15 that pass on main are the intended both-pass degrade pins (pairing mismatch → legacy, malformed-shape parametrize, legacy-gap documentation).
- **Mutation validation** (per pin-test discipline), each followed by restore:
  - neutralize the digest byte compare (`if False and …`) → 5 pins red (absorbed-edit ×2, mid-copy, degrade sanity, collision fail-safe);
  - neutralize the pairing guard (accept any `digests_installed_at`) → 2 pins red (old-tool rewrite degrade, A→B→A roundtrip);
  - neutralize clear-on-omit (preserve instead of pop) → 1 pin red (upsert ownership contract).
- **Codex implementation gate**: one round — NEEDS-FIX (0 blockers, 1 Major: `_apply_update` derived reconcile membership by re-walking the mutable wiki working tree after the copy returned, so a worktree mutation in that window could erase a file the update had just written while `files`/`digests` recorded it). Folded verbatim in the second commit: membership = the copy's returned written set (`src_has=lambda rel: rel in digest_map`), plus the reviewer-requested regression test (src mutated immediately post-copy; pre-fold-fail verified — the pre-fold tree deletes the file and the assert fails with FileNotFoundError). The pinned-install path is untouched (its membership reads immutable git objects at the pin).
- Full suite: `uv run pytest -m "not ollama"` green (`test_session_tracing.py` excluded = pre-existing #1249 reds; `test_web_cli.py` excluded on this machine only — all 12 fail identically on clean main here, env-dependent startup class, green in CI); `ruff check` + `ruff format --check` clean; `mypy` on the five changed modules clean.

## Out of scope (per design §3a/§4c)

- Copying install/update bytes from git objects, or refusing dirty wiki worktrees (product-level behavior changes; the digest contract deliberately asserts no commit provenance).
- Dest-tree locking and post-copy verify passes (cannot exclude non-mm writers / reintroduces the TOCTOU).
- Digest-based recovery for malformed `installed_at` (B6-7 unprovable-record semantics stay uniform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
