### PR TITLE
fix(web): last-sync tooltip shows local time, not raw UTC ISO (#1290)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -1116,8 +1116,10 @@ function _renderCtxOverview(data) {
   // users diagnosing "did this actually reach Claude/Codex?" trusted it too
   // much. The label is now data-source-accurate and the explanation is
   // attached via ``title=`` on the label span (the row-level ``title=``
-  // still carries the raw ISO so the diagnose case keeps the absolute
-  // timestamp on hover). Suppress the line when the backend returns null
+  // still carries the absolute timestamp so the diagnose case keeps it on
+  // hover — rendered in the viewer's locale/TZ, not the raw UTC ISO, which
+  // read as a "wrong" date for non-UTC users; ``data-iso`` keeps the
+  // machine-readable form). Suppress the line when the backend returns null
   // (fresh / empty project — no canonical files yet); rendering a "never"
   // sentinel or epoch-zero relative would be more confusing than silent
   // absence.
@@ -1128,8 +1130,9 @@ function _renderCtxOverview(data) {
   if (lastSyncedAt) {
     const rel = escapeHtml(relativeTime(lastSyncedAt));
     const iso = escapeHtml(lastSyncedAt);
+    const localAbs = escapeHtml(new Date(lastSyncedAt).toLocaleString());
     const labelTip = escapeHtml(t('settings.ctx.last_synced_tooltip'));
-    lastSyncHtml = `<div class="ctx-overview-last-sync" title="${iso}">
+    lastSyncHtml = `<div class="ctx-overview-last-sync" title="${localAbs}">
         <span class="ctx-overview-last-sync-label" title="${labelTip}">${escapeHtml(t('settings.ctx.last_synced_label'))}</span>
         <span class="ctx-overview-last-sync-value" data-iso="${iso}">${rel}</span>
       </div>`;

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1488,7 +1488,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=18"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=71"></script>
+  <script src="/context-gateway.js?v=72"></script>
   <script src="/context-portal.js?v=2"></script>
   <script src="/path-picker.js?v=4"></script>
 </body>

--- a/packages/memtomem/tests-js/ctx-overview-last-sync-tooltip.test.mjs
+++ b/packages/memtomem/tests-js/ctx-overview-last-sync-tooltip.test.mjs
@@ -1,0 +1,68 @@
+/* Regression guard for #1290 — the overview "Canonical updated" row's hover
+ * ``title`` used to carry the raw UTC ISO string (``2026-06-12T03:00:00Z``).
+ * For non-UTC users the tooltip showed a different date/time than their wall
+ * clock (the #677 hazard class, this time via ``title=`` instead of a slice).
+ *
+ * The fix keeps the #1076 intent — absolute timestamp on hover for the
+ * "did this actually reach my runtimes?" diagnose case — but renders it via
+ * ``new Date(iso).toLocaleString()`` (the detail-pane "Modified" precedent),
+ * while ``data-iso`` keeps the machine-readable raw form.
+ *
+ * Mutation that bites: reverting ``title="${localAbs}"`` back to
+ * ``title="${iso}"`` flips the positive assertion (title === toLocaleString)
+ * AND the negative one (title !== raw ISO) — ``toLocaleString()`` never
+ * round-trips to the ISO shape in any locale/TZ, so both hold on UTC CI too.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+const RAW_ISO = '2026-06-12T03:00:00Z';
+
+function stubOverviewFetch(window) {
+  const upstream = window.fetch;
+  window.fetch = async (input) => {
+    const url = typeof input === 'string' ? input : input?.url || '';
+    if (url.endsWith('/api/context/overview')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          skills:   { total: 1, in_sync: 1 },
+          commands: { total: 0 },
+          agents:   { total: 0 },
+          last_synced_at: RAW_ISO,
+        }),
+      };
+    }
+    // Keep the projects fetch silent (valid empty payload) so no error toast
+    // races the overview render — same rationale as the sync-all tooltip suite.
+    if (url.includes('/api/context/projects')) {
+      return { ok: true, status: 200, json: async () => ({ scopes: [] }) };
+    }
+    return upstream(input);
+  };
+}
+
+describe('overview last-sync tooltip', () => {
+  it('renders the hover title in local time, keeps data-iso raw', async () => {
+    const dom = await bootApp({
+      scripts: ['i18n.js', 'app.js', 'context-gateway.js'],
+    });
+    const { window } = dom;
+    stubOverviewFetch(window);
+    await window.I18N.init();
+
+    await window.loadCtxOverview();
+
+    const row = window.document.querySelector('.ctx-overview-last-sync');
+    expect(row).toBeTruthy();
+    // Positive pin: the exact toLocaleString rendering for this environment.
+    expect(row.getAttribute('title')).toBe(new Date(RAW_ISO).toLocaleString());
+    // Negative pin: the raw UTC ISO no longer leaks into the tooltip.
+    expect(row.getAttribute('title')).not.toBe(RAW_ISO);
+    // Machine-readable form survives on the value span.
+    const value = row.querySelector('.ctx-overview-last-sync-value');
+    expect(value.getAttribute('data-iso')).toBe(RAW_ISO);
+  });
+});

--- a/packages/memtomem/tests/web/test_context_gateway_overview.py
+++ b/packages/memtomem/tests/web/test_context_gateway_overview.py
@@ -1135,10 +1135,11 @@ def _build_iso(seconds_ago: int) -> str:
 
 def test_overview_last_sync_renders_relative_text_and_iso_tooltip(page, mm_web_url: str) -> None:
     """ADR-0009 §1.c pin: header surfaces ``last_synced_at`` as a relative
-    string ("5m ago") with the full ISO timestamp exposed via ``title=`` on
-    the row container. The raw ISO is also reflected on the value span's
-    ``data-iso`` attribute so screen-reader / scraping consumers don't have
-    to parse the localized relative form.
+    string ("5m ago") with the absolute timestamp exposed via ``title=`` on
+    the row container — rendered in the viewer's locale/TZ (#1290), not the
+    raw UTC ISO, which read as a "wrong" date for non-UTC users. The raw ISO
+    is reflected on the value span's ``data-iso`` attribute so screen-reader
+    / scraping consumers don't have to parse either localized form.
     """
     install_default_stubs(page)
     iso = _build_iso(seconds_ago=300)  # ~5 minutes ago
@@ -1161,9 +1162,17 @@ def test_overview_last_sync_renders_relative_text_and_iso_tooltip(page, mm_web_u
     assert row.count() == 1, (
         f"freshness row must render when last_synced_at is set; got {row.count()}"
     )
-    # ``title`` carries the unredacted ISO for the diagnose case.
-    assert row.get_attribute("title") == iso, (
-        f"freshness row title= must carry the raw ISO; got {row.get_attribute('title')!r}"
+    # ``title`` keeps the absolute timestamp for the diagnose case, but in
+    # the browser's own locale/TZ (#1290). Compute the expectation inside the
+    # same page so the pin is exact yet locale/TZ-agnostic, and pair it with
+    # the negative pin that the raw UTC ISO no longer leaks.
+    expected_local = page.evaluate(f"new Date({iso!r}).toLocaleString()")
+    assert row.get_attribute("title") == expected_local, (
+        f"freshness row title= must carry the localized absolute timestamp; "
+        f"got {row.get_attribute('title')!r}, expected {expected_local!r}"
+    )
+    assert row.get_attribute("title") != iso, (
+        "freshness row title= must not expose the raw UTC ISO (#1290)"
     )
     value = row.locator(".ctx-overview-last-sync-value")
     assert value.get_attribute("data-iso") == iso, (


### PR DESCRIPTION
## Problem

The context dashboard's "Canonical updated" row keeps an absolute timestamp on hover for the diagnose case (#1076), but rendered it as the **raw UTC ISO string** (`title="2026-06-12T03:00:00Z"`). For non-UTC users the tooltip showed a different date/time than their wall clock — the #677 hazard class resurfacing via `title=` instead of a date slice.

## Fix

- `title` now renders via `new Date(iso).toLocaleString()` (same precedent as the detail-pane "Modified" value); `data-iso` keeps the machine-readable raw ISO for non-tooltip consumers.
- Swept `context-gateway.js` + `context-portal.js` for other interpolated `title=` attributes: every other one carries label text, not a timestamp — no further sites.
- `context-gateway.js` cache-bust bumped `?v=71 → ?v=72`.

## Tests

- Updated the Playwright pin (`test_overview_last_sync_renders_relative_text_and_iso_tooltip`) — the expectation is computed inside the page (`page.evaluate("new Date(...).toLocaleString()")`) so it is exact yet locale/TZ-agnostic, paired with a negative pin that the raw ISO no longer leaks.
- New vitest spec `ctx-overview-last-sync-tooltip.test.mjs` mirrors both pins + `data-iso` preservation; mutation-validated (reverting the production line makes it fail).
- Full `tests-js` suite green (34 files / 178 tests); `ruff check` + `format --check` clean on the touched test.

Fixes #1290. Part of the UX-track campaign #1271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
