### PR TITLE
fix(web): warn once when conflict-draft stash fails (#1291)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -3396,8 +3396,21 @@ function _ctxStashKey(type, name) {
 // mid-conflict — and recomputing at clear time would target a different
 // namespace than stash time, orphaning the draft (and resurrecting it later
 // after the user already discarded/saved). One key per editor session.
+// Once-per-page-session latch for stash-failure feedback (#1291). The stash
+// exists to survive navigation, so a silent drop means the user's conflict
+// buffer can vanish with no warning; but a busted sessionStorage (quota,
+// private mode) fails on EVERY stash, so repeat failures stay quiet after
+// the first warning.
+let _ctxStashWarnedOnce = false;
 function _ctxStashDraft(key, content) {
-  try { sessionStorage.setItem(key, content); } catch (_e) { /* quota / private mode */ }
+  try {
+    sessionStorage.setItem(key, content);
+  } catch (_e) { // quota / private mode
+    if (!_ctxStashWarnedOnce) {
+      _ctxStashWarnedOnce = true;
+      showToast(t('settings.ctx.draft_stash_failed'), 'warning');
+    }
+  }
 }
 function _ctxRestoreDraft(key, type, name) {
   try {

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1488,7 +1488,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=18"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=72"></script>
+  <script src="/context-gateway.js?v=73"></script>
   <script src="/context-portal.js?v=2"></script>
   <script src="/path-picker.js?v=4"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -478,6 +478,7 @@
   "settings.ctx.diff_tab_hint": "Click the Diff tab to load...",
   "settings.ctx.diff_failed": "Diff failed",
   "settings.ctx.diff_failed_detail": "Diff failed: {error}",
+  "settings.ctx.draft_stash_failed": "Draft could not be saved locally — keep this tab open until you save.",
   "settings.ctx.no_runtime_targets": "No runtime targets found.",
   "settings.ctx.tier_option_user": "User",
   "settings.ctx.tier_option_project_shared": "Project (shared)",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -478,6 +478,7 @@
   "settings.ctx.diff_tab_hint": "Diff 탭을 클릭하면 불러옵니다...",
   "settings.ctx.diff_failed": "Diff에 실패했습니다",
   "settings.ctx.diff_failed_detail": "Diff 실패: {error}",
+  "settings.ctx.draft_stash_failed": "초안을 로컬에 저장하지 못했습니다 — 저장할 때까지 이 탭을 닫지 마세요.",
   "settings.ctx.no_runtime_targets": "런타임 대상이 없습니다.",
   "settings.ctx.tier_option_user": "사용자",
   "settings.ctx.tier_option_project_shared": "프로젝트(공유)",

--- a/packages/memtomem/tests-js/ctx-draft-stash-warning.test.mjs
+++ b/packages/memtomem/tests-js/ctx-draft-stash-warning.test.mjs
@@ -1,0 +1,61 @@
+/* Regression guard for #1291 — ``_ctxStashDraft`` swallowed sessionStorage
+ * failures (quota exceeded, private browsing) silently. The stash exists to
+ * survive navigation, so a silent drop means a user's conflict-edit buffer
+ * can vanish with no warning.
+ *
+ * The fix warns ONCE per page session ('warning' toast,
+ * ``settings.ctx.draft_stash_failed``) on the first failure; later failures
+ * stay quiet — a busted sessionStorage fails on every stash and a toast per
+ * keystroke would be worse than the silence it replaces.
+ *
+ * Mutation that bites: reverting the catch to the bare comment removes the
+ * toast (first assertion); dropping the ``_ctxStashWarnedOnce`` latch makes
+ * the second stash add a second toast (exactly-once assertion).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+describe('draft stash failure warning', () => {
+  it('toasts once on the first failure, stays quiet after', async () => {
+    const dom = await bootApp({
+      scripts: ['i18n.js', 'app.js', 'context-gateway.js'],
+    });
+    const { window } = dom;
+    await window.I18N.init();
+
+    const proto = Object.getPrototypeOf(window.sessionStorage);
+    const original = proto.setItem;
+    proto.setItem = () => {
+      throw new window.DOMException('quota exceeded', 'QuotaExceededError');
+    };
+    try {
+      window._ctxStashDraft('m2m-ctx-conflict-buffer:test', 'draft body');
+      let toasts = window.document.querySelectorAll('#toast-container .toast-warning');
+      expect(toasts.length).toBe(1);
+      const text = toasts[0].textContent || '';
+      // Localized copy, not the raw key (cold-boot fallback echoes EN literal).
+      expect(text).toContain('keep this tab open');
+      expect(text).not.toContain('settings.ctx.draft_stash_failed');
+
+      // Second failure in the same page session: no second toast.
+      window._ctxStashDraft('m2m-ctx-conflict-buffer:test', 'draft body 2');
+      toasts = window.document.querySelectorAll('#toast-container .toast-warning');
+      expect(toasts.length).toBe(1);
+    } finally {
+      proto.setItem = original;
+    }
+  });
+
+  it('stays silent when sessionStorage works', async () => {
+    const dom = await bootApp({
+      scripts: ['i18n.js', 'app.js', 'context-gateway.js'],
+    });
+    const { window } = dom;
+    await window.I18N.init();
+
+    window._ctxStashDraft('m2m-ctx-conflict-buffer:test', 'draft body');
+    expect(window.sessionStorage.getItem('m2m-ctx-conflict-buffer:test')).toBe('draft body');
+    expect(window.document.querySelectorAll('#toast-container .toast').length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

`_ctxStashDraft` swallowed sessionStorage failures (quota exceeded, private browsing) silently. The draft stash exists so a conflict-edit buffer survives navigation — a silent drop means exactly that buffer can vanish with no warning at the moment the user relies on it.

## Fix

- First stash failure in a page session emits a `'warning'` toast: "Draft could not be saved locally — keep this tab open until you save." (`settings.ctx.draft_stash_failed`, en+ko in the same PR).
- A module-scoped latch keeps later failures quiet — a busted sessionStorage fails on every stash, and a toast per keystroke would be worse than the silence it replaces.
- `context-gateway.js` cache-bust bumped `?v=71 → ?v=72`.

## Tests

- New vitest spec `ctx-draft-stash-warning.test.mjs`: exactly-once toast with localized copy (not the raw key), second failure silent, success path stores with zero toasts.
- Mutation-validated: reverting to the silent catch fails the first assertion; dropping the latch would fail the exactly-once assertion.
- Full vitest suite green; `test_i18n.py` parity gate green (66 passed).

Fixes #1291. Part of the UX-track campaign #1271.

Note: bumps the same `?v` line as #1293 — whichever lands second resolves the one-line conflict by bumping one step further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
