### PR TITLE
feat(context): mm context projects group — CLI face of the multi-project registry (#1272)

### DIFF
--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -1220,6 +1220,14 @@ mm context version create agents my-agent --note "stable"          # snapshot th
 mm context version promote agents my-agent --to production --version v1 # move a label pointer (e.g. production) to a specific version (e.g. v1)
 mm context version list agents my-agent                            # list all versions and label pointers for an artifact
 
+# Multi-project registry (same registry the web portal manages)
+mm context projects list               # discovered scopes: scope_id, health, enrollment
+mm context projects list --json        # same fields as GET /api/context/projects
+mm context projects add ~/work/proj --label "My Project"  # register (idempotent)
+mm context projects pause <scope_id|path>   # exclude from --all batches / web Sync
+mm context projects resume <scope_id|path>  # re-include
+mm context projects remove <scope_id|path>  # unregister (project files untouched)
+
 # Note: cursor / codex / copilot fold ## Rules + ## Style into a single block;
 # `generate` warns on stderr when both sections are populated. context.md is
 # the source of truth — edit there, not in generated files.

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -61,7 +61,15 @@ from memtomem.context.migrate import (
     migrate_one,
     migrate_scope,
 )
-from memtomem.context.projects import KnownProjectsStore
+from memtomem.context.projects import (
+    KnownProjectsCorruptError,
+    KnownProjectsStore,
+    ProjectScope,
+    UnknownProjectSelectorError,
+    annotate_project_health,
+    discover_project_scopes,
+    resolve_project_selector,
+)
 from memtomem.context.lockfile import LockfileError
 from memtomem.context.status import classify_status, load_with_recovery, scan_user_artifacts
 from memtomem.context.generator import (

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -67,6 +67,7 @@ from memtomem.context.projects import (
     ProjectScope,
     UnknownProjectSelectorError,
     annotate_project_health,
+    compute_scope_id,
     discover_project_scopes,
     resolve_project_selector,
 )
@@ -3724,3 +3725,176 @@ def rescan_cmd(
 
     if violations:
         raise SystemExit(1)
+
+
+# ── mm context projects ──────────────────────────────────────────────────
+#
+# CLI face of the multi-project registry (#1272, mechanism-track campaign
+# #1270). Web has had discovery + enrollment since ADR-0021; these commands
+# expose the same KnownProjectsStore / discover_project_scopes surface so
+# cross-project flags (--to-project, --all-projects) have a CLI-native way
+# to enumerate scope_ids and manage enrollment.
+
+
+def _projects_gateway_cfg() -> ContextGatewayConfig:
+    """One construction point so every subcommand reads the same env/config."""
+    return ContextGatewayConfig()
+
+
+def _projects_store(cfg: ContextGatewayConfig) -> KnownProjectsStore:
+    return KnownProjectsStore(Path(cfg.known_projects_path).expanduser())
+
+
+def _projects_discover(cfg: ContextGatewayConfig) -> list[ProjectScope]:
+    """Discover with the exact flags the web GET /api/context/projects uses."""
+    return discover_project_scopes(
+        Path.cwd(),
+        Path(cfg.known_projects_path).expanduser(),
+        experimental_claude_projects_scan=cfg.experimental_claude_projects_scan,
+        auto_display_configured_projects=cfg.auto_display_configured_projects,
+    )
+
+
+def _projects_resolve_or_die(selector: str, scopes: list[ProjectScope]) -> tuple[Path, str]:
+    """Resolve a ``scope_id | path`` selector → ``(root, scope_id)`` or exit."""
+    try:
+        root, scope = resolve_project_selector(selector, scopes)
+    except UnknownProjectSelectorError as exc:
+        raise click.ClickException(str(exc)) from exc
+    return root, scope.scope_id if scope is not None else compute_scope_id(root)
+
+
+@context.group("projects")
+def projects_group() -> None:
+    """Inspect and manage the multi-project registry (known_projects.json).
+
+    Subcommands accept a project as either its ``p-<sha12>`` scope_id (from
+    ``list``) or a filesystem path. ``pause`` / ``resume`` flip the per-project
+    sync-enrollment flag that ``--all`` batch commands and the web Sync gate
+    honor.
+    """
+
+
+@projects_group.command("list")
+@click.option(
+    "--json",
+    "json_out",
+    is_flag=True,
+    help="Emit the discovery payload as JSON (same fields as GET /api/context/projects).",
+)
+def projects_list_cmd(json_out: bool) -> None:
+    """List every discovered project scope with health and enrollment."""
+    cfg = _projects_gateway_cfg()
+    scopes = _projects_discover(cfg)
+    if json_out:
+        rows = []
+        for s in scopes:
+            health = annotate_project_health(s)
+            rows.append(
+                {
+                    "scope_id": s.scope_id,
+                    "label": s.label,
+                    "root": str(s.root) if s.root is not None else None,
+                    "tier": s.tier,
+                    "sources": list(s.sources),
+                    "missing": health.missing,
+                    "stale": health.stale,
+                    "experimental": s.experimental,
+                    "enabled": s.enabled,
+                    "sync_eligible": s.sync_eligible,
+                }
+            )
+        click.echo(json.dumps({"scopes": rows}, indent=2))
+        return
+
+    click.echo(f"{len(scopes)} project scope(s):")
+    for s in scopes:
+        health = annotate_project_health(s)
+        # Pad BEFORE styling — ANSI escapes are invisible but count toward
+        # f-string width, so styling first skews the columns.
+        if health.missing:
+            health_txt = click.style(f"{'missing':<8}", fg="red")
+        elif health.stale:
+            health_txt = click.style(f"{'stale':<8}", fg="yellow")
+        else:
+            health_txt = click.style(f"{'ok':<8}", fg="green")
+        if s.enabled:
+            enrollment = f"{'enabled':<8}"
+        else:
+            enrollment = click.style(f"{'paused':<8}", fg="yellow")
+        eligible = "sync" if s.sync_eligible else "-"
+        sources = ",".join(s.sources)
+        click.echo(
+            f"  {s.scope_id}  {health_txt}  {enrollment}  {eligible:<4}  "
+            f"{s.label}  ({s.root})  [{sources}]"
+        )
+
+
+@projects_group.command("add")
+@click.argument("path", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.option("--label", default=None, help="Display label for the project.")
+def projects_add_cmd(path: Path, label: str | None) -> None:
+    """Register PATH in known_projects.json (idempotent)."""
+    cfg = _projects_gateway_cfg()
+    store = _projects_store(cfg)
+    try:
+        already = any(
+            compute_scope_id(e.root) == compute_scope_id(path) for e in store.load(strict=True)
+        )
+        entry = store.add(path, label=label)
+    except KnownProjectsCorruptError as exc:
+        raise click.ClickException(str(exc)) from exc
+    scope_id = compute_scope_id(entry.root)
+    if already:
+        click.echo(f"Already registered: {scope_id} ({entry.root})")
+    else:
+        click.secho(f"Registered: {scope_id} ({entry.root})", fg="green")
+
+
+@projects_group.command("remove")
+@click.argument("selector")
+def projects_remove_cmd(selector: str) -> None:
+    """Unregister a project (scope_id or path). Does not touch the project's files."""
+    cfg = _projects_gateway_cfg()
+    scopes = _projects_discover(cfg)
+    _root, scope_id = _projects_resolve_or_die(selector, scopes)
+    try:
+        removed = _projects_store(cfg).remove_by_scope_id(scope_id)
+    except KnownProjectsCorruptError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if not removed:
+        raise click.ClickException(
+            f"{selector!r} resolved to {scope_id} but it has no known_projects entry "
+            f"(server-cwd and scan-discovered scopes are not registered; nothing to remove)"
+        )
+    click.secho(f"Removed: {scope_id}", fg="green")
+
+
+def _projects_set_enabled(selector: str, *, enabled: bool, verb: str) -> None:
+    cfg = _projects_gateway_cfg()
+    scopes = _projects_discover(cfg)
+    _root, scope_id = _projects_resolve_or_die(selector, scopes)
+    try:
+        entry = _projects_store(cfg).set_enabled_by_scope_id(scope_id, enabled)
+    except KnownProjectsCorruptError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if entry is None:
+        raise click.ClickException(
+            f"{selector!r} resolved to {scope_id} but it has no known_projects entry — "
+            f"only registered projects can be {verb}d; run `mm context projects add <path>` first"
+        )
+    click.secho(f"{verb.capitalize()}d: {scope_id} ({entry.root})", fg="green")
+
+
+@projects_group.command("pause")
+@click.argument("selector")
+def projects_pause_cmd(selector: str) -> None:
+    """Pause sync enrollment for a registered project (skipped by --all batches)."""
+    _projects_set_enabled(selector, enabled=False, verb="pause")
+
+
+@projects_group.command("resume")
+@click.argument("selector")
+def projects_resume_cmd(selector: str) -> None:
+    """Resume sync enrollment for a paused project."""
+    _projects_set_enabled(selector, enabled=True, verb="resume")

--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -21,6 +21,7 @@ import logging
 import os
 import re
 import sys
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path, PurePath
@@ -53,6 +54,14 @@ class KnownProjectsCorruptError(RuntimeError):
     default. Version mismatch is folded in (no separate version error like the
     lockfile's): ``_write`` re-renders at the current version, so mutating a
     future-version file is the same clobber hazard as mutating a corrupt one.
+    """
+
+
+class UnknownProjectSelectorError(ValueError):
+    """A project selector matched neither a discovered scope_id nor an existing path.
+
+    Raised by :func:`resolve_project_selector`. CLI surfaces translate this
+    into a usage error; the message already names both interpretations tried.
     """
 
 
@@ -872,3 +881,68 @@ def has_runtime_marker(root: Path) -> bool:
     checkout.
     """
     return any((root / m).is_dir() for m in _MARKER_DIRS)
+
+
+# ── CLI / web project selector ───────────────────────────────────────────
+
+
+_SCOPE_ID_SHAPE = re.compile(r"^p-[0-9a-f]{12}$")
+
+
+def resolve_project_selector(
+    selector: str,
+    scopes: Sequence[ProjectScope],
+) -> tuple[Path, ProjectScope | None]:
+    """Resolve a user-supplied ``scope_id | path`` selector to a project root.
+
+    Shared by the ``mm context projects`` subcommands and the cross-project
+    flags that take a destination project (``--to-project``, ``--project``,
+    ``--all-projects`` siblings) so every surface accepts the same two forms.
+
+    Resolution is deterministic, not heuristic:
+
+    1. A selector matching the ``p-<sha12>`` shape is ONLY treated as a
+       scope_id. Match against *scopes* (case-sensitive, exact) → that
+       scope's root. No match → :class:`UnknownProjectSelectorError` — it
+       does NOT fall through to the path interpretation, so a directory that
+       happens to be named like a scope_id cannot be selected ambiguously
+       (spell it ``./p-...`` to force the path reading).
+    2. Anything else is a filesystem path: ``expanduser`` + resolved, and it
+       must be an existing directory. Returns the matching discovered scope
+       when one shares the same ``compute_scope_id`` (so callers see
+       enrollment state), else ``None`` — explicitly typing a path is consent
+       to operate on an unregistered root; callers gate further (e.g. a
+       paused *registered* destination still refuses).
+
+    A scope_id match whose scope has no root (defensive — discovery always
+    sets one today) raises :class:`UnknownProjectSelectorError` rather than
+    returning a rootless scope.
+    """
+    if _SCOPE_ID_SHAPE.match(selector):
+        for scope in scopes:
+            if scope.scope_id == selector:
+                if scope.root is None:
+                    raise UnknownProjectSelectorError(
+                        f"scope {selector} has no resolvable root; re-register it by path"
+                    )
+                return scope.root, scope
+        raise UnknownProjectSelectorError(
+            f"no discovered project has scope_id {selector!r} (run `mm context projects "
+            f"list`); to select a directory literally named like a scope_id, "
+            f"prefix it with ./"
+        )
+
+    candidate = Path(selector).expanduser()
+    try:
+        resolved = candidate.resolve(strict=False)
+    except OSError:
+        resolved = candidate
+    if not resolved.is_dir():
+        raise UnknownProjectSelectorError(
+            f"{selector!r} is neither a discovered scope_id nor an existing directory"
+        )
+    wanted = compute_scope_id(resolved)
+    for scope in scopes:
+        if scope.scope_id == wanted:
+            return resolved, scope
+    return resolved, None

--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -36,9 +36,11 @@ __all__ = [
     "ProjectHealth",
     "KnownProjectsCorruptError",
     "KnownProjectsStore",
+    "UnknownProjectSelectorError",
     "compute_scope_id",
     "discover_project_scopes",
     "annotate_project_health",
+    "resolve_project_selector",
 ]
 
 

--- a/packages/memtomem/tests/test_cli_context_projects.py
+++ b/packages/memtomem/tests/test_cli_context_projects.py
@@ -1,0 +1,158 @@
+"""CLI tests for ``mm context projects`` (#1272, campaign #1270).
+
+The group is the CLI face of the same ``KnownProjectsStore`` /
+``discover_project_scopes`` surface the web portal uses; these tests pin:
+
+- ``list`` shows the server-cwd scope plus registered entries, with the
+  ``--json`` payload carrying the web-parity field names;
+- ``add`` is idempotent and distinguishes "Registered" from "Already
+  registered";
+- ``pause`` / ``resume`` flip the enrollment flag the ``--all`` batches and
+  the web Sync gate honor, and refuse unregistered scopes with a hint;
+- ``remove`` refuses scopes that have no registry entry;
+- a corrupt ``known_projects.json`` surfaces the named strict-load error and
+  is NOT re-baselined by a mutation (#1247 id 16 parity).
+
+Isolation: ``ContextGatewayConfig`` is monkeypatched (the established
+``_patch_known_projects_path`` pattern from ``test_context_update.py``)
+and HOME/USERPROFILE point into ``tmp_path`` so the optional
+``~/.claude/projects`` scan can never read the host (Windows resolves
+``Path.home()`` via USERPROFILE first — patch both).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli.context_cmd import context
+from memtomem.context.projects import KnownProjectsStore, compute_scope_id
+
+
+@pytest.fixture()
+def cli_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    kp = tmp_path / "known_projects.json"
+
+    class _FakeCfg:
+        known_projects_path = kp
+        # Production defaults — the HOME patch above keeps the scan hermetic.
+        experimental_claude_projects_scan = False
+        auto_display_configured_projects = True
+
+    monkeypatch.setattr("memtomem.cli.context_cmd.ContextGatewayConfig", lambda: _FakeCfg())
+
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    other = tmp_path / "other"
+    other.mkdir()
+    return {"kp": kp, "cwd": cwd, "other": other}
+
+
+def test_list_shows_cwd_and_registered(cli_env: dict[str, Path]) -> None:
+    KnownProjectsStore(cli_env["kp"]).add(cli_env["other"], label="Other")
+    result = CliRunner().invoke(context, ["projects", "list"])
+    assert result.exit_code == 0, result.output
+    assert "2 project scope(s):" in result.output
+    assert "Server CWD" in result.output
+    assert "Other" in result.output
+
+
+def test_list_json_carries_web_parity_fields(cli_env: dict[str, Path]) -> None:
+    KnownProjectsStore(cli_env["kp"]).add(cli_env["other"])
+    result = CliRunner().invoke(context, ["projects", "list", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert {s["scope_id"] for s in payload["scopes"]} == {
+        compute_scope_id(cli_env["cwd"]),
+        compute_scope_id(cli_env["other"]),
+    }
+    row = payload["scopes"][0]
+    for field in (
+        "scope_id",
+        "label",
+        "root",
+        "tier",
+        "sources",
+        "missing",
+        "stale",
+        "experimental",
+        "enabled",
+        "sync_eligible",
+    ):
+        assert field in row, f"missing web-parity field {field!r}"
+
+
+def test_add_is_idempotent_with_distinct_copy(cli_env: dict[str, Path]) -> None:
+    runner = CliRunner()
+    first = runner.invoke(context, ["projects", "add", str(cli_env["other"])])
+    assert first.exit_code == 0, first.output
+    assert "Registered:" in first.output
+    second = runner.invoke(context, ["projects", "add", str(cli_env["other"])])
+    assert second.exit_code == 0, second.output
+    assert "Already registered:" in second.output
+    assert len(KnownProjectsStore(cli_env["kp"]).load()) == 1
+
+
+def test_pause_resume_round_trip(cli_env: dict[str, Path]) -> None:
+    KnownProjectsStore(cli_env["kp"]).add(cli_env["other"])
+    scope_id = compute_scope_id(cli_env["other"])
+    runner = CliRunner()
+
+    paused = runner.invoke(context, ["projects", "pause", scope_id])
+    assert paused.exit_code == 0, paused.output
+    listing = runner.invoke(context, ["projects", "list", "--json"])
+    rows = {s["scope_id"]: s for s in json.loads(listing.output)["scopes"]}
+    assert rows[scope_id]["enabled"] is False
+    assert rows[scope_id]["sync_eligible"] is False
+
+    resumed = runner.invoke(context, ["projects", "resume", str(cli_env["other"])])
+    assert resumed.exit_code == 0, resumed.output
+    listing = runner.invoke(context, ["projects", "list", "--json"])
+    rows = {s["scope_id"]: s for s in json.loads(listing.output)["scopes"]}
+    assert rows[scope_id]["enabled"] is True
+    assert rows[scope_id]["sync_eligible"] is True
+
+
+def test_pause_unregistered_scope_hints_add(cli_env: dict[str, Path]) -> None:
+    # Server cwd is discovered but has no registry entry.
+    result = CliRunner().invoke(context, ["projects", "pause", str(cli_env["cwd"])])
+    assert result.exit_code != 0
+    assert "mm context projects add" in result.output
+
+
+def test_remove_registered_and_unregistered(cli_env: dict[str, Path]) -> None:
+    KnownProjectsStore(cli_env["kp"]).add(cli_env["other"])
+    runner = CliRunner()
+    removed = runner.invoke(context, ["projects", "remove", str(cli_env["other"])])
+    assert removed.exit_code == 0, removed.output
+    assert KnownProjectsStore(cli_env["kp"]).load() == []
+
+    again = runner.invoke(context, ["projects", "remove", str(cli_env["other"])])
+    assert again.exit_code != 0
+    assert "no known_projects entry" in again.output
+
+
+def test_unknown_selector_is_a_usage_error(cli_env: dict[str, Path]) -> None:
+    result = CliRunner().invoke(context, ["projects", "pause", "p-000000000000"])
+    assert result.exit_code != 0
+    assert "no discovered project has scope_id" in result.output
+
+
+def test_corrupt_registry_named_error_and_no_rebaseline(cli_env: dict[str, Path]) -> None:
+    corrupt = b"{not json"
+    cli_env["kp"].write_bytes(corrupt)
+    result = CliRunner().invoke(context, ["projects", "add", str(cli_env["other"])])
+    assert result.exit_code != 0
+    assert "not valid JSON" in result.output
+    # Strict-load refusal must leave the corrupt bytes untouched (#1247 id 16):
+    # a tolerant fallback would have re-baselined the file to one entry.
+    assert cli_env["kp"].read_bytes() == corrupt

--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -1288,3 +1288,76 @@ def test_decode_stale_colliding_anchor_does_not_drop_live_match(
     claude = [s for s in scopes if "claude-projects" in s.sources]
     assert len(claude) == 1
     assert claude[0].root == live.resolve()
+
+
+# ── resolve_project_selector (#1272) ─────────────────────────────────────
+
+
+def _discover(tmp_path: Path, cwd: Path) -> list[ProjectScope]:
+    kp = tmp_path / "kp.json"
+    return discover_project_scopes(cwd, kp, experimental_claude_projects_scan=False)
+
+
+def test_selector_scope_id_resolves_to_root(tmp_path: Path) -> None:
+    from memtomem.context.projects import resolve_project_selector
+
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    scopes = _discover(tmp_path, cwd)
+    root, scope = resolve_project_selector(scopes[0].scope_id, scopes)
+    assert root == cwd.resolve()
+    assert scope is scopes[0]
+
+
+def test_selector_scope_id_shape_never_falls_through_to_path(tmp_path: Path) -> None:
+    """A directory literally named like a scope_id must not be selected by the
+    bare token — the scope_id interpretation is exclusive; ``./`` forces the
+    path reading."""
+    from memtomem.context.projects import (
+        UnknownProjectSelectorError,
+        resolve_project_selector,
+    )
+
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    trap = cwd / "p-aaaaaaaaaaaa"
+    trap.mkdir()
+    scopes = _discover(tmp_path, cwd)
+
+    with pytest.raises(UnknownProjectSelectorError, match="no discovered project"):
+        resolve_project_selector("p-aaaaaaaaaaaa", scopes)
+
+    # Forced path reading selects the trap dir and reports it unregistered.
+    root, scope = resolve_project_selector(str(trap), scopes)
+    assert root == trap.resolve()
+    assert scope is None
+
+
+def test_selector_path_matches_registered_scope(tmp_path: Path) -> None:
+    from memtomem.context.projects import resolve_project_selector
+
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+    kp = tmp_path / "kp.json"
+    KnownProjectsStore(kp).add(other)
+    scopes = discover_project_scopes(cwd, kp, experimental_claude_projects_scan=False)
+
+    root, scope = resolve_project_selector(str(other), scopes)
+    assert root == other.resolve()
+    assert scope is not None
+    assert scope.scope_id == compute_scope_id(other)
+
+
+def test_selector_nonexistent_path_raises(tmp_path: Path) -> None:
+    from memtomem.context.projects import (
+        UnknownProjectSelectorError,
+        resolve_project_selector,
+    )
+
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    scopes = _discover(tmp_path, cwd)
+    with pytest.raises(UnknownProjectSelectorError, match="existing directory"):
+        resolve_project_selector(str(tmp_path / "nope"), scopes)


### PR DESCRIPTION
## Problem

Multi-project discovery and enrollment have been web-only since ADR-0021 (`context/projects.py` + the portal). The CLI had no way to enumerate scope_ids or pause/resume a project's sync enrollment, and the campaign's upcoming cross-project flags (`--to-project`, `--all-projects`) need one selector that works the same on every surface.

## What ships

- **`mm context projects list [--json]`** — same scope set as `GET /api/context/projects` (same `discover_project_scopes` flags; `--json` carries the web-parity field names), health via `annotate_project_health`.
- **`add <path> [--label]`** — idempotent; output distinguishes "Registered" from "Already registered".
- **`pause` / `resume <scope_id|path>`** — flip the enrollment flag that `--all` batches and the web Sync gate honor; unregistered scopes refuse with an `add` hint.
- **`remove <scope_id|path>`** — unregisters without touching the project's files.
- **Shared selector**: new `resolve_project_selector` in `context/projects.py` (exported) — deterministic two-form resolution: `p-<sha12>`-shaped input is only ever a scope_id (a directory named like one needs `./` to force the path reading); any other input is a path that must exist. Later campaign flags reuse it.
- All mutations ride the store's strict-load path: a corrupt `known_projects.json` surfaces the named error and is never re-baselined (#1247 id 16 parity, pinned).
- `docs/guides/reference.md` gains the command block.

## Verification

- 8 new CLI tests (HOME **and** USERPROFILE isolated — Windows resolves `Path.home()` via USERPROFILE first — so the optional `~/.claude/projects` scan can never read the host) + 4 resolver unit tests; full `test_context_projects.py` suite green (87 passed).
- `ruff check` + `format --check` clean; `mypy` clean on both touched modules (advisory gate).
- Doc rehearsal: every documented invocation executed end-to-end against an isolated HOME (`add --label` → `list` → `list --json` → `pause <scope_id>` → `resume <path>` → `remove`).

Fixes #1272. Part of the mechanism-track campaign #1270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
