### PR TITLE
feat(context): install-provenance carry-over on shared-to-shared transfer (#1275)

### DIFF
--- a/docs/adr/0023-cross-project-artifact-transfer.md
+++ b/docs/adr/0023-cross-project-artifact-transfer.md
@@ -221,21 +221,48 @@ a bookkeeping failure must never fail or roll back a committed move:
 - **move out of `project_shared`** → drop the entry from the
   **source** project's `lock.json` (best-effort, loud warning on
   failure) — the #1123 B4-1 dangling-entry rule, now root-qualified;
-- **copy** → no `lock.json` change anywhere (the source keeps its
-  provenance; the destination copy has none — yet, see §9).
+- **copy** → the source's `lock.json` is never touched; the
+  destination may gain an entry via the §9 carry-over.
 
-### 9. Provenance carry-over — deferred to A-4 (#1275)
+### 9. Provenance carry-over (A-4 #1275)
 
-A `project_shared → project_shared` transfer of a wiki-installed
-artifact could carry the source's `lock.json` entry (commit pin,
-manifest, digests) to the destination so `mm context status` /
-`update` keep working there. That is **deliberately not part of this
-engine**: the design-gate finding stands that carry-over is only
-sound when the source asset is clean per `is_asset_dirty` (carrying a
-pin over locally-edited bytes would bless the edits as installed
-state), which needs its own decision pass. Until #1275 lands, a
-transferred artifact at the destination is simply unmanaged-canonical
-(same as a hand-created one): fully functional, no update lineage.
+A `project_shared → project_shared` transfer (move AND copy) of a
+wiki-installed artifact carries the source's `lock.json` entry to the
+destination so `mm context status` / `update` keep working there.
+The design-gate finding from A-2 stands as the gating rule — carrying
+a pin over locally-edited bytes would bless the edits as installed
+state, letting a later `mm context update` clobber them without its
+`--force` gate — so the carry is double-gated:
+
+1. **Pre-stage (source still on disk):** the entry must have a full
+   40-char SHA `wiki_commit` (the ADR-0008 stored-pin contract), a
+   valid per-file digest map (`digests_from_entry`; pre-#1247 mtime
+   entries never carry — mtime cleanliness is not byte evidence), and
+   classify `clean` under `is_asset_dirty`.
+2. **Post-promote (after the pair lock releases):** the promoted
+   destination tree is rehashed and must equal the source entry's
+   digest map exactly. Sidecar locks don't bind external writers, so
+   this equality gate — not the pre-stage check — is what closes the
+   classify→stage TOCTOU: the only digests ever written at the
+   destination are byte-identical to what the wiki install recorded.
+
+A clean carry upserts the destination entry with the carried
+`wiki_commit`, `files` derived from the rehashed map, and a fresh
+`installed_at`/`digests_installed_at` pair captured from the promoted
+tree (the `lockfile.upsert_entry` paired-key contract requires
+recompute, not verbatim copy). A copy-rename (`--as`) never carries:
+entries are keyed by wiki asset name, so an entry under the new name
+would point `update` at a different wiki asset. Failed or declined
+carries land the artifact untracked, with a human reason plus a
+stable `_skip_reasons.ProvenanceSkipCode` on the result
+(`provenance` / `provenance_reason` / `provenance_reason_code`).
+
+Bookkeeping order on a move: destination upsert first, then the
+source entry drop of §8 (unconditional — even when the carry
+declined, the source canonical is gone and a dangling entry is status
+noise). All of it stays best-effort and outside the pair lock: a
+corrupt destination lockfile warns loudly but never un-commits the
+transfer.
 
 ## Backward compatibility
 
@@ -301,8 +328,13 @@ transferred artifact at the destination is simply unmanaged-canonical
 - **In-engine Gate B prompting.** Rejected: surfaces own confirmation
   UX (CLI flag, web disclose-then-confirm); the engine stays
   prompt-free and headless-safe, same as `migrate_scope`.
-- **Carrying `lock.json` provenance in this PR.** Deferred to A-4
-  #1275 with the dirty-source guard as the open design point (§9).
+- **Unconditional `lock.json` provenance carry.** Rejected when A-4
+  #1275 landed the carry-over (§9): copying the entry (or rehashing
+  whatever bytes arrived) without the dirty/digest gates would bless
+  locally-edited bytes as installed wiki state, letting a later
+  `mm context update` clobber them without its `--force` gate. Same
+  reasoning rejected carrying mtime-only (pre-#1247) entries and
+  copy-renames.
 
 ## References
 

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -2936,10 +2936,13 @@ def _print_transfer_result(result: TransferResult, *, apply_: bool) -> None:
     """User-facing summary for one copy/move transfer (#1274).
 
     Sibling of :func:`_print_migrate_scope_result` with the transfer
-    extras: mode verb, copy-rename name, engine ``notes``, and the
+    extras: mode verb, copy-rename name, engine ``notes``, the
     engine's exact follow-up sync command (``TransferResult.sync_command``
     — cd-prefixed for cross-project tiers until A-9 lands a ``--project``
-    selector on sync) instead of a hand-built one.
+    selector on sync) instead of a hand-built one, and the shared→shared
+    provenance carry-over outcome (A-4 #1275; quiet when
+    ``not_applicable``, yellow with the engine's human reason when the
+    artifact lands untracked).
     """
     layout_note = " (flat layout)" if result.layout == "flat" else ""
     rename_note = f" as {result.dst_name}" if result.dst_name != result.name else ""
@@ -2957,6 +2960,16 @@ def _print_transfer_result(result: TransferResult, *, apply_: bool) -> None:
             )
             for path in result.fanout_planned:
                 click.echo(f"    - {path}")
+        if result.provenance == "carried":
+            click.echo(
+                "  will carry the wiki install provenance (lock.json entry) to the destination"
+            )
+        elif result.provenance == "not_carried":
+            click.secho(
+                f"  install provenance will not be carried — the artifact "
+                f"lands untracked: {result.provenance_reason}",
+                fg="yellow",
+            )
         confirm_note = " --confirm-project-shared" if result.to_scope == "project_shared" else ""
         click.echo(f"\nRun with --apply{confirm_note} to execute.")
         if result.needs_sync and result.sync_command:
@@ -2985,6 +2998,14 @@ def _print_transfer_result(result: TransferResult, *, apply_: bool) -> None:
         )
         for path in result.fanout_backed_up:
             click.echo(f"    - {path}")
+    if result.provenance == "carried":
+        click.echo("  carried the wiki install provenance (lock.json entry) to the destination")
+    elif result.provenance == "not_carried":
+        click.secho(
+            f"  install provenance not carried — the artifact lands "
+            f"untracked at the destination: {result.provenance_reason}",
+            fg="yellow",
+        )
     for note in result.notes:
         click.secho(f"  note: {note}", fg="yellow")
     if result.needs_sync and result.sync_command:

--- a/packages/memtomem/src/memtomem/context/_skip_reasons.py
+++ b/packages/memtomem/src/memtomem/context/_skip_reasons.py
@@ -81,6 +81,40 @@ VERSION_NOT_FOUND: Final = "version_not_found"
 # ``latest`` / no-label sync on a flat artifact is unaffected.
 VERSIONING_REQUIRES_DIR_LAYOUT: Final = "versioning_requires_dir_layout"
 
+# Transfer install-provenance skip codes (A-4 #1275) — emitted in
+# ``TransferResult.provenance_reason_code`` when a project_shared →
+# project_shared transfer does NOT carry the source's ``lock.json`` entry
+# to the destination. Same (human reason, stable code) pairing contract as
+# the sync/import codes above: CLI prints ``provenance_reason``, the web
+# route (A-5) / MCP action (A-13) match on the code.
+#
+# Source-side classification (pre-stage, while the source tree still
+# exists):
+PROVENANCE_SOURCE_LOCKFILE_UNREADABLE: Final = "source_lockfile_unreadable"
+PROVENANCE_RENAMED_COPY: Final = "renamed_copy"
+PROVENANCE_SOURCE_INVALID_PIN: Final = "source_invalid_pin"
+PROVENANCE_SOURCE_NO_DIGESTS: Final = "source_no_digests"
+PROVENANCE_SOURCE_DIRTY: Final = "source_dirty"
+PROVENANCE_SOURCE_UNPROVABLE: Final = "source_unprovable"
+# Destination-side verification (post-promote, best-effort):
+PROVENANCE_DEST_BYTES_UNVERIFIED: Final = "dest_bytes_unverified"
+PROVENANCE_DEST_LOCKFILE_ERROR: Final = "dest_lockfile_error"
+
+# Closed set for the provenance codes — separate from `SkipCode` because the
+# consumer surface differs (transfer result field, not per-item `skipped`
+# triples), and mixing the sets would let a fan-out code typo masquerade as
+# a provenance outcome (and vice versa) at construction sites.
+ProvenanceSkipCode = Literal[
+    "source_lockfile_unreadable",
+    "renamed_copy",
+    "source_invalid_pin",
+    "source_no_digests",
+    "source_dirty",
+    "source_unprovable",
+    "dest_bytes_unverified",
+    "dest_lockfile_error",
+]
+
 # Closed set of skip codes — typing dataclass `skipped` triples and route
 # response builders against `SkipCode` catches typos at the construction site
 # instead of letting an arbitrary string slip through to the wire.

--- a/packages/memtomem/src/memtomem/context/transfer.py
+++ b/packages/memtomem/src/memtomem/context/transfer.py
@@ -31,11 +31,26 @@ bytes against the **destination** root — per-vendor overrides live
 inside the artifact dir (``<name>/overrides/<vendor>.<ext>``) and
 travel with it. ``_remove_runtime_fanout_for`` takes the two roots
 separately for exactly this reason.
+
+Install-provenance carry-over (ADR-0023 §9, A-4 #1275): a
+``project_shared → project_shared`` transfer of a clean wiki install
+carries the source's ``lock.json`` entry to the destination so ``mm
+context status`` / ``update`` keep working there. The carry is gated
+twice — source classified clean under
+:func:`memtomem.context.dirty.is_asset_dirty` pre-stage, AND the
+promoted bytes rehashing to the source entry's exact digest map
+post-promote — because blessing locally-edited bytes as pristine wiki
+state would let a later ``mm context update`` clobber them without its
+``--force`` gate (the A-2 design-gate finding that deferred this
+feature). Dirty or unprovable sources still transfer; they just land
+untracked, with the reason on the result
+(``provenance_reason`` / ``provenance_reason_code``).
 """
 
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import logging
 import os
 import secrets
@@ -49,10 +64,31 @@ from typing import Literal
 import click
 
 from memtomem.config import TargetScope
-from memtomem.context._atomic import atomic_write_bytes
+from memtomem.context._atomic import (
+    atomic_write_bytes,
+    installed_at_from_dest,
+    iter_installed_files,
+)
 from memtomem.context._names import validate_name
+from memtomem.context._skip_reasons import (
+    PROVENANCE_DEST_BYTES_UNVERIFIED,
+    PROVENANCE_DEST_LOCKFILE_ERROR,
+    PROVENANCE_RENAMED_COPY,
+    PROVENANCE_SOURCE_DIRTY,
+    PROVENANCE_SOURCE_INVALID_PIN,
+    PROVENANCE_SOURCE_LOCKFILE_UNREADABLE,
+    PROVENANCE_SOURCE_NO_DIGESTS,
+    PROVENANCE_SOURCE_UNPROVABLE,
+    ProvenanceSkipCode,
+)
 from memtomem.context.agents import _KEY_VALUE_RE
-from memtomem.context.lockfile import Lockfile
+from memtomem.context.dirty import is_asset_dirty
+from memtomem.context.lockfile import (
+    _HEX_DIGITS,
+    Lockfile,
+    LockfileError,
+    digests_from_entry,
+)
 from memtomem.context.migrate import (
     _DIR_MANIFEST,
     SCOPE_MIGRATABLE_KINDS,
@@ -69,12 +105,21 @@ from memtomem.context.scope_resolver import ArtifactKind, canonical_artifact_dir
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["TransferMode", "TransferResult", "transfer_artifact"]
+__all__ = ["ProvenanceCarry", "TransferMode", "TransferResult", "transfer_artifact"]
 
 
 TransferMode = Literal["move", "copy"]
 
+#: Outcome of the shared→shared install-provenance carry-over (A-4 #1275).
+#: ``not_applicable`` covers every transfer the carry-over does not target:
+#: non-(shared→shared) tier pairs, and shared→shared sources with no
+#: ``lock.json`` entry at all (not wiki-tracked — nothing to carry, quiet).
+ProvenanceCarry = Literal["carried", "not_carried", "not_applicable"]
+
 _VALID_SCOPES: tuple[TargetScope, ...] = ("user", "project_shared", "project_local")
+
+#: ADR-0008 lockfile contract: ``wiki_commit`` is the FULL 40-char SHA.
+_FULL_SHA_LEN = 40
 
 
 @dataclass(frozen=True)
@@ -94,6 +139,16 @@ class TransferResult:
     (``needs_sync`` + ``sync_command`` carry the follow-up instead).
     ``notes`` carries non-fatal caveats the surface should show (today:
     the overrides-travel-verbatim caveat on a copy-rename).
+
+    ``provenance`` / ``provenance_reason`` / ``provenance_reason_code``
+    (A-4 #1275) report the shared→shared ``lock.json`` carry-over:
+    ``carried`` means the destination entry was written (on a dry-run:
+    will be, subject to apply-time re-verification); ``not_carried``
+    pairs a human ``provenance_reason`` with a stable
+    ``provenance_reason_code`` (the ``_skip_reasons`` contract — CLI
+    prints the reason, web/MCP surfaces match on the code);
+    ``not_applicable`` is every transfer the carry-over does not target
+    and stays quiet (both companion fields ``None``).
     """
 
     kind: ArtifactKind
@@ -114,6 +169,9 @@ class TransferResult:
     needs_sync: bool = False
     sync_command: str | None = None
     notes: tuple[str, ...] = ()
+    provenance: ProvenanceCarry = "not_applicable"
+    provenance_reason: str | None = None
+    provenance_reason_code: ProvenanceSkipCode | None = None
 
 
 def _resolve_root(root: Path | str | None) -> Path | None:
@@ -137,6 +195,247 @@ def _sync_followup(to_scope: TargetScope, dst_project_root: Path | None) -> tupl
     if to_scope != "user" and dst_project_root is not None:
         cmd = f"cd {shlex.quote(str(dst_project_root))} && {cmd}"
     return True, cmd
+
+
+@dataclass(frozen=True)
+class _ProvenancePlan:
+    """Pre-stage outcome of the shared→shared provenance classification.
+
+    ``carry=True`` captures the source entry's pin and digest map for the
+    post-promote verification (:func:`_carry_provenance`); ``carry=False``
+    pairs the human reason with its stable code. The "no ``lock.json``
+    entry at all" case returns ``None`` from the classifier instead of a
+    plan — not wiki-tracked is ``not_applicable``, not a skip.
+    """
+
+    carry: bool
+    wiki_commit: str | None = None
+    digests: dict[str, str] | None = None
+    reason: str | None = None
+    reason_code: ProvenanceSkipCode | None = None
+
+
+def _provenance_skip(reason: str, code: ProvenanceSkipCode) -> _ProvenancePlan:
+    return _ProvenancePlan(carry=False, reason=reason, reason_code=code)
+
+
+def _classify_provenance_carry(
+    kind: ArtifactKind,
+    name: str,
+    src_root: Path,
+    *,
+    renamed: bool,
+) -> _ProvenancePlan | None:
+    """Classify whether a shared→shared transfer may carry install provenance.
+
+    Runs while the source tree is still on disk (pre-stage in apply mode,
+    lock-free in dry-run). Returns ``None`` when the source has no
+    ``lock.json`` entry — a non-wiki artifact has nothing to carry and the
+    result stays ``not_applicable`` / quiet.
+
+    Carry requires, in order (each failure is a typed skip):
+
+    - a readable source lockfile (corrupt → the transfer itself must not
+      fail over bookkeeping; classify and move on);
+    - no copy-rename: entries are keyed by artifact name == wiki asset
+      name, so an entry under the new name would point ``mm context
+      update`` at a DIFFERENT wiki asset — if that asset exists, the
+      carried digests would classify the renamed copy clean and let
+      update silently clobber it with foreign bytes. The digest gate
+      alone does not close this: a manifest with no ``name:`` key makes
+      the rename rewrite a no-op, leaving the staged bytes identical.
+    - a full 40-char SHA ``wiki_commit`` (the ADR-0008 stored-pin
+      contract; carrying an abbreviated or malformed pin would mint
+      destination provenance that ``git checkout <pin>`` forensics and
+      reachability checks cannot reliably use);
+    - a valid per-file digest map (:func:`digests_from_entry`) — the
+      design-gate finding behind this whole feature: without byte
+      evidence, "clean" can only be claimed from mtimes, and rehashing
+      mtime-clean bytes would MANUFACTURE digest evidence over possibly
+      backdated local edits, blessing them as wiki bytes for a later
+      ``mm context update`` to clobber without the ``--force`` gate.
+      Pre-digest (#1247) installs therefore don't carry until updated or
+      reinstalled at the source;
+    - ``is_asset_dirty`` == ``clean`` over that digest map (modified,
+      added, deleted, or unreadable files all refuse — "cannot prove
+      clean" protects).
+    """
+    try:
+        entry = Lockfile.at(src_root).read_entry(kind, name)
+    except LockfileError as exc:
+        logger.warning(
+            "transfer: source lockfile at %s unreadable while classifying "
+            "provenance carry for %s/%s: %s",
+            src_root,
+            kind,
+            name,
+            exc,
+        )
+        return _provenance_skip(
+            "source project's lock.json is unreadable; fix or remove it, then "
+            "re-install at the destination to restore update lineage",
+            PROVENANCE_SOURCE_LOCKFILE_UNREADABLE,
+        )
+    if entry is None:
+        return None
+
+    if renamed:
+        return _provenance_skip(
+            "renamed copy: lock.json entries are keyed by wiki asset name, so "
+            "provenance under the new name would target a different wiki asset",
+            PROVENANCE_RENAMED_COPY,
+        )
+
+    wiki_commit = entry.get("wiki_commit")
+    if (
+        not isinstance(wiki_commit, str)
+        or len(wiki_commit) != _FULL_SHA_LEN
+        or not set(wiki_commit) <= _HEX_DIGITS
+    ):
+        return _provenance_skip(
+            "source entry's wiki_commit is not a full 40-char SHA (ADR-0008 pin contract)",
+            PROVENANCE_SOURCE_INVALID_PIN,
+        )
+
+    digests = digests_from_entry(entry)
+    if digests is None:
+        return _provenance_skip(
+            "source entry has no valid per-file digests (pre-digest install); "
+            "run `mm context update` at the source first, then retry",
+            PROVENANCE_SOURCE_NO_DIGESTS,
+        )
+
+    try:
+        report = is_asset_dirty(src_root, kind, name, lock_entry=entry)
+    except OSError as exc:
+        logger.warning(
+            "transfer: dirty classification failed for %s/%s at %s: %s",
+            kind,
+            name,
+            src_root,
+            exc,
+        )
+        return _provenance_skip(
+            f"source tree could not be classified ({exc}); cannot prove clean",
+            PROVENANCE_SOURCE_UNPROVABLE,
+        )
+    if report.reason == "clean":
+        return _ProvenancePlan(carry=True, wiki_commit=wiki_commit, digests=digests)
+    if report.reason == "dirty":
+        return _provenance_skip(
+            f"source has local edits ({report.summary()}); update or revert "
+            f"them at the source first, or re-install at the destination",
+            PROVENANCE_SOURCE_DIRTY,
+        )
+    # missing_dest (e.g. a flat-layout source shadowing a stale dir entry)
+    # or never_installed (malformed installed_at over an existing dest):
+    # the install record cannot vouch for the bytes being transferred.
+    return _provenance_skip(
+        f"source install record cannot vouch for the transferred bytes ({report.reason})",
+        PROVENANCE_SOURCE_UNPROVABLE,
+    )
+
+
+def _carry_provenance(
+    kind: ArtifactKind,
+    dst_name: str,
+    dst_path: Path,
+    dst_root: Path,
+    plan: _ProvenancePlan,
+) -> tuple[ProvenanceCarry, str | None, ProvenanceSkipCode | None]:
+    """Verify the promoted bytes and upsert the destination ``lock.json`` entry.
+
+    Best-effort by contract (issue #1275): runs AFTER the artifact pair
+    lock releases, and no failure here may fail or un-commit the
+    transfer — every refusal degrades to ``not_carried`` with a loud log.
+
+    The promoted tree is REHASHED and required to equal the source
+    entry's digest map exactly (keys and values). This closes the
+    classify→stage TOCTOU: sidecar locks don't bind external writers, so
+    an edit landing between the clean check and the staging rename would
+    otherwise be blessed as pristine wiki bytes. With the equality gate,
+    the only digests we ever record are byte-identical to what the wiki
+    install recorded — an edit landing after the rehash leaves entry ≠
+    disk, which classifies *dirty* later and makes ``mm context update``
+    refuse without ``--force`` (the protective direction).
+
+    The paired keys are recomputed per the ``lockfile.upsert_entry``
+    contract, not copied verbatim: ``installed_at`` is captured from the
+    promoted tree (:func:`installed_at_from_dest`) and
+    ``digests_installed_at`` is stamped from it inside ``upsert_entry``;
+    ``files`` derives from the rehashed map so the new entry is
+    internally consistent by construction (exactly how install writes
+    fresh entries).
+    """
+    rehashed: dict[str, str] = {}
+    try:
+        for file_path in iter_installed_files(dst_path):
+            rel = file_path.relative_to(dst_path).as_posix()
+            rehashed[rel] = hashlib.sha256(file_path.read_bytes()).hexdigest()
+    except OSError as exc:
+        logger.warning(
+            "transfer: cannot rehash promoted tree at %s for provenance "
+            "carry-over (%s); destination entry not written.",
+            dst_path,
+            exc,
+        )
+        return (
+            "not_carried",
+            f"promoted bytes could not be verified ({exc})",
+            PROVENANCE_DEST_BYTES_UNVERIFIED,
+        )
+    if rehashed != plan.digests:
+        logger.warning(
+            "transfer: promoted bytes at %s do not match the source install "
+            "digests (concurrent edit during transfer?); destination entry "
+            "not written.",
+            dst_path,
+        )
+        return (
+            "not_carried",
+            "promoted bytes do not match the source install digests (changed during transfer)",
+            PROVENANCE_DEST_BYTES_UNVERIFIED,
+        )
+
+    assert plan.wiki_commit is not None  # carry plans always capture the pin
+    try:
+        Lockfile.at(dst_root).upsert_entry(
+            kind,
+            dst_name,
+            wiki_commit=plan.wiki_commit,
+            installed_at=installed_at_from_dest(dst_path),
+            files=sorted(rehashed),
+            files_commit=plan.wiki_commit,
+            digests=rehashed,
+        )
+    except (LockfileError, OSError) as exc:
+        logger.warning(
+            "transfer: failed to write the destination lock.json entry for "
+            "%s/%s at %s (%s); the transfer itself is committed — the "
+            "artifact lands untracked (re-install there to restore update "
+            "lineage).",
+            kind,
+            dst_name,
+            dst_root,
+            exc,
+        )
+        return (
+            "not_carried",
+            f"destination lock.json could not be written ({exc})",
+            PROVENANCE_DEST_LOCKFILE_ERROR,
+        )
+    return "carried", None, None
+
+
+def _provenance_fields(
+    plan: _ProvenancePlan | None,
+) -> tuple[ProvenanceCarry, str | None, ProvenanceSkipCode | None]:
+    """Result-field triple for a classification outcome (dry-run / skip path)."""
+    if plan is None:
+        return "not_applicable", None, None
+    if plan.carry:
+        return "carried", None, None
+    return "not_carried", plan.reason, plan.reason_code
 
 
 def _remove_staging(staging: Path) -> None:
@@ -387,19 +686,25 @@ def transfer_artifact(
        iff ``to_scope == "project_shared"``, promote via ``os.replace``.
        Rollback preserves "staging deleted only when the bytes are
        verified safe elsewhere".
-    6. Outside the pair lock: drop the source project's ``lock.json``
-       entry when moving out of ``project_shared`` (bookkeeping must
-       never fail a committed move), then clean stale SOURCE runtime
-       fan-out under the two-root contract (discovery at the source
-       root, override/render verification against the destination
-       root). Destination fan-out is NOT generated — the result carries
+    6. Outside the pair lock (bookkeeping must never fail a committed
+       move): for a shared→shared transfer, carry the install
+       provenance to the destination ``lock.json`` when the source was
+       classified clean pre-stage AND the promoted bytes rehash to the
+       source entry's exact digest map (A-4 #1275; see
+       :func:`_classify_provenance_carry` / :func:`_carry_provenance`);
+       then drop the source project's entry when moving out of
+       ``project_shared``; then clean stale SOURCE runtime fan-out
+       under the two-root contract (discovery at the source root,
+       override/render verification against the destination root).
+       Destination fan-out is NOT generated — the result carries
        ``needs_sync`` + the exact follow-up sync command.
 
     Copy mode replaces step 5's staging with a byte copy
     (:func:`_stage_copy`, source never consumed), applies the optional
-    rename rewrite before the Gate A scan, and skips step 6 entirely
-    (no source fan-out cleanup, no lock.json change; destination
-    ``lock.json`` provenance carry-over is A-4 #1275). ``versions/`` +
+    rename rewrite before the Gate A scan, and runs only the carry-over
+    half of step 6 (no source fan-out cleanup, no source ``lock.json``
+    change — a shared→shared copy of a clean wiki install ends with the
+    entry at BOTH ends; a copy-rename never carries). ``versions/`` +
     ``versions.json`` live inside the artifact dir and travel
     implicitly in both modes.
     """
@@ -474,11 +779,25 @@ def transfer_artifact(
     # get the source-anchored offending-file hint instead.
     transfer_hint = mode == "copy" or cross_root
 
+    def _plan_provenance() -> _ProvenancePlan | None:
+        # shared→shared (A-4 #1275) — necessarily cross-project here: the
+        # same-store pairs were rejected above. Only this tier pair carries
+        # install provenance; the lockfile tracks project_shared installs
+        # only. ``None`` for every other pair == ``not_applicable``.
+        if src_scope != "project_shared" or to_scope != "project_shared" or src_root is None:
+            return None
+        return _classify_provenance_carry(kind, name, src_root, renamed=new_name is not None)
+
     if not apply_:
         # Dry-run: compute plan, no mutation. ``fanout_planned`` previews
         # the deletion half of a move — the same selection the apply-side
         # cleanup uses, so preview and apply cannot disagree about what
-        # gets removed. Copy has no deletion half by definition.
+        # gets removed. Copy has no deletion half by definition. The
+        # provenance triple previews the same classification apply runs
+        # pre-stage (apply additionally re-verifies the promoted bytes).
+        provenance, provenance_reason, provenance_reason_code = _provenance_fields(
+            _plan_provenance()
+        )
         return TransferResult(
             kind=kind,
             name=name,
@@ -504,6 +823,9 @@ def transfer_artifact(
             ),
             needs_sync=needs_sync,
             sync_command=sync_command,
+            provenance=provenance,
+            provenance_reason=provenance_reason,
+            provenance_reason_code=provenance_reason_code,
         )
 
     # ── apply path ───────────────────────────────────────────────────
@@ -515,6 +837,13 @@ def transfer_artifact(
         # had to take the same lock, but check defensively).
         if dst_path.exists():
             raise click.ClickException(f"destination appeared during lock acquire: {dst_path}.")
+
+        # Provenance classification must run while the SOURCE tree still
+        # exists (move staging consumes it). Read-only; the write half
+        # (`_carry_provenance`) runs after the lock releases and re-verifies
+        # the promoted bytes, so an edit slipping in between cannot be
+        # blessed (the equality gate there is the actual TOCTOU close).
+        provenance_plan = _plan_provenance()
 
         if mode == "copy":
             staging = _stage_copy(src_path, dst_path.parent, name_hint=dst_name)
@@ -682,10 +1011,22 @@ def transfer_artifact(
                         dst_path=dst_path,
                     ) from exc
 
-    # Lock released. Move-mode bookkeeping + source fan-out cleanup —
-    # both deliberately OUTSIDE the artifact pair lock: ``Lockfile``
-    # serializes on its own sidecar lock, and a partial fan-out cleanup
-    # failure must not roll back the committed canonical move.
+    # Lock released. Bookkeeping + source fan-out cleanup — all
+    # deliberately OUTSIDE the artifact pair lock: ``Lockfile``
+    # serializes on its own sidecar lock, and a bookkeeping or partial
+    # fan-out cleanup failure must not roll back the committed transfer.
+    #
+    # Provenance carry-over (A-4 #1275) runs FIRST, in both modes, so a
+    # shared→shared move upserts the destination entry before dropping
+    # the source one — the carried record never has a gap where neither
+    # project tracks the artifact.
+    provenance, provenance_reason, provenance_reason_code = _provenance_fields(provenance_plan)
+    if provenance_plan is not None and provenance_plan.carry:
+        assert dst_root is not None  # shared→shared implies a project root
+        provenance, provenance_reason, provenance_reason_code = _carry_provenance(
+            kind, dst_name, dst_path, dst_root, provenance_plan
+        )
+
     fanout_cleaned: list[Path] = []
     fanout_backed_up: list[Path] = []
     if mode == "move":
@@ -694,11 +1035,12 @@ def transfer_artifact(
         # leaves its entry dangling, and `mm context status` would then
         # iterate that entry, find the canonical gone, and report the
         # (now-moved) artifact as "missing" (#1123 B4-1). Drop the stale
-        # entry — at the SOURCE project's lockfile. Best-effort: the
-        # canonical move already committed inside the lock above, so a
-        # lock.json bookkeeping failure must NOT undo or fail the move —
-        # log loudly and continue. (Destination-side provenance carry-over
-        # for shared→shared transfers is A-4 #1275.)
+        # entry — at the SOURCE project's lockfile, unconditionally: even
+        # when the carry-over above declined or failed, the source
+        # canonical is gone and a dangling entry is pure status noise.
+        # Best-effort: the canonical move already committed inside the
+        # lock above, so a lock.json bookkeeping failure must NOT undo or
+        # fail the move — log loudly and continue.
         if src_scope == "project_shared" and src_root is not None:
             try:
                 Lockfile.at(src_root).remove_entry(kind, name)
@@ -745,4 +1087,7 @@ def transfer_artifact(
         needs_sync=needs_sync,
         sync_command=sync_command,
         notes=notes,
+        provenance=provenance,
+        provenance_reason=provenance_reason,
+        provenance_reason_code=provenance_reason_code,
     )

--- a/packages/memtomem/tests/test_cli_context_transfer.py
+++ b/packages/memtomem/tests/test_cli_context_transfer.py
@@ -438,3 +438,85 @@ def test_move_help_is_the_three_verb_comparison(cli_projects) -> None:
     assert result.exit_code == 0
     for needle in ("move ", "copy ", "migrate", "flat→dir layout adoption"):
         assert needle in result.output
+
+
+# ── install-provenance carry-over lines (A-4 #1275) ──────────────────
+
+
+def _wiki_install_entry_cli(root: Path, name: str = "foo") -> None:
+    """Wiki-install-shaped lock.json entry over the seeded agent dir."""
+    import hashlib
+
+    from memtomem.context._atomic import installed_at_from_dest, iter_installed_files
+    from memtomem.context.lockfile import Lockfile
+
+    dest = root / ".memtomem" / "agents" / name
+    digests = {
+        f.relative_to(dest).as_posix(): hashlib.sha256(f.read_bytes()).hexdigest()
+        for f in iter_installed_files(dest)
+    }
+    pin = "deadbeef" * 5
+    Lockfile.at(root).upsert_entry(
+        "agents",
+        name,
+        wiki_commit=pin,
+        installed_at=installed_at_from_dest(dest),
+        files=sorted(digests),
+        files_commit=pin,
+        digests=digests,
+    )
+
+
+def test_provenance_carried_line_on_clean_move(cli_projects) -> None:
+    _seed_agent(cli_projects, "project_shared", root_key="a")
+    _wiki_install_entry_cli(cli_projects["a"])
+    result = _invoke(
+        [
+            "move",
+            "agents",
+            "foo",
+            "--to-project",
+            str(cli_projects["b"]),
+            "--to",
+            "project_shared",
+            "--apply",
+            "--confirm-project-shared",
+            "-y",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    assert "carried the wiki install provenance" in result.output
+
+
+def test_provenance_not_carried_line_names_the_reason(cli_projects) -> None:
+    src = _seed_agent(cli_projects, "project_shared", root_key="a")
+    _wiki_install_entry_cli(cli_projects["a"])
+    (src / "agent.md").write_text("---\nname: foo\n---\n\nedited\n", encoding="utf-8")
+    result = _invoke(
+        [
+            "move",
+            "agents",
+            "foo",
+            "--to-project",
+            str(cli_projects["b"]),
+            "--to",
+            "project_shared",
+            "--apply",
+            "--confirm-project-shared",
+            "-y",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    assert "install provenance not carried" in result.output
+    assert "local edits" in result.output
+    # Dry-run previews the same refusal.
+    _seed_agent(cli_projects, "project_shared", name="bar", root_key="a")
+    _wiki_install_entry_cli(cli_projects["a"], name="bar")
+    (cli_projects["a"] / ".memtomem" / "agents" / "bar" / "agent.md").write_text(
+        "---\nname: bar\n---\n\nedited\n", encoding="utf-8"
+    )
+    preview = _invoke(
+        ["move", "agents", "bar", "--to-project", str(cli_projects["b"]), "--to", "project_shared"]
+    )
+    assert preview.exit_code == 0, preview.output
+    assert "install provenance will not be carried" in preview.output

--- a/packages/memtomem/tests/test_context_transfer.py
+++ b/packages/memtomem/tests/test_context_transfer.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import contextlib
 import errno
+import hashlib
 import shlex
 import shutil
 from pathlib import Path
@@ -30,11 +31,17 @@ from pathlib import Path
 import click
 import pytest
 
-from memtomem.context._atomic import _file_lock, _lock_path_for
-from memtomem.context.lockfile import Lockfile, utcnow_iso8601_z
+from memtomem.context._atomic import (
+    _file_lock,
+    _lock_path_for,
+    installed_at_from_dest,
+    iter_installed_files,
+)
+from memtomem.context.dirty import is_asset_dirty
+from memtomem.context.lockfile import Lockfile, digests_from_entry, utcnow_iso8601_z
 from memtomem.context.migrate import MigratePartialError
 from memtomem.context.privacy_scan import PrivacyBlockedError
-from memtomem.context.transfer import transfer_artifact
+from memtomem.context.transfer import _carry_provenance, _ProvenancePlan, transfer_artifact
 
 _MANIFEST_NAME = {"agents": "agent.md", "commands": "command.md", "skills": "SKILL.md"}
 _AGENT_BODY_CLEAN = "---\nname: foo\ndescription: a clean test agent\n---\n\nhello world\n"
@@ -266,8 +273,12 @@ def test_copy_keeps_source_lock_entry_and_fanout(two_projects):
     assert src_manifest.read_text(encoding="utf-8") == _AGENT_BODY_CLEAN
     assert Lockfile.at(two_projects["a"]).read_entry("agents", "foo") is not None
     assert fanout.is_file()
-    # Copy never plans/cleans fan-out; destination lock.json untouched (A-4).
+    # Copy never plans/cleans fan-out. The destination gains no lock.json
+    # entry here either: this legacy-shaped entry (abbreviated pin, no
+    # digests) fails the A-4 carry gates — see the provenance section below
+    # for the carried cases.
     assert result.fanout_cleaned == [] and result.fanout_backed_up == []
+    assert result.provenance == "not_carried"
     assert Lockfile.at(two_projects["b"]).read_entry("agents", "foo") is None
 
 
@@ -902,3 +913,281 @@ def test_copy_into_user_tier_sync_command(two_projects):
     assert result.sync_command == "mm context sync --scope user"
     dst_manifest = _canonical_root(two_projects, "agents", "user", "a") / "foo" / "agent.md"
     assert dst_manifest.read_text(encoding="utf-8") == _AGENT_BODY_CLEAN
+
+
+# ── install-provenance carry-over (A-4 #1275) ────────────────────────
+
+_FULL_PIN = "deadbeef" * 5  # 40-char lowercase hex — the ADR-0008 stored-pin shape
+_OTHER_PIN = "cafebabe" * 5
+
+
+def _wiki_install_entry(root: Path, kind: str, name: str, *, pin: str = _FULL_PIN) -> None:
+    """Write a wiki-install-shaped lock.json entry over the on-disk tree.
+
+    Mirrors what install/update write (#1247 id 15): per-file SHA-256
+    digests hashed from the canonical bytes, ``files`` == digest keys,
+    ``installed_at`` captured from the dest tree so the
+    ``digests_installed_at`` pairing validates and ``is_asset_dirty``
+    takes the digest branch.
+    """
+    dest = root / ".memtomem" / kind / name
+    digests = {
+        f.relative_to(dest).as_posix(): hashlib.sha256(f.read_bytes()).hexdigest()
+        for f in iter_installed_files(dest)
+    }
+    Lockfile.at(root).upsert_entry(
+        kind,
+        name,
+        wiki_commit=pin,
+        installed_at=installed_at_from_dest(dest),
+        files=sorted(digests),
+        files_commit=pin,
+        digests=digests,
+    )
+
+
+def _shared_to_shared(mode: str, two_projects, *, apply_: bool = True, new_name: str | None = None):
+    return transfer_artifact(
+        "agents",
+        "foo",
+        src_project_root=two_projects["a"],
+        from_scope="project_shared",
+        dst_project_root=two_projects["b"],
+        to_scope="project_shared",
+        mode=mode,
+        apply_=apply_,
+        new_name=new_name,
+    )
+
+
+def test_provenance_carried_on_clean_move(two_projects):
+    """Clean wiki install, shared→shared move: entry lands at B, leaves A.
+
+    The destination entry must be status-serviceable: carried pin, valid
+    digest pairing (``digests_from_entry`` non-None), and a clean
+    ``is_asset_dirty`` classification — the inputs that make ``mm context
+    status`` render ok/behind instead of untracked. ``versions/`` travels
+    inside the artifact dir and is part of the digest surface.
+    """
+    src_manifest = _write_canonical(
+        two_projects, "agents", "project_shared", "a", "foo", _AGENT_BODY_CLEAN
+    )
+    _write_versions(src_manifest.parent, _AGENT_BODY_CLEAN)
+    _wiki_install_entry(two_projects["a"], "agents", "foo")
+    src_entry = Lockfile.at(two_projects["a"]).read_entry("agents", "foo")
+    assert src_entry is not None
+
+    result = _shared_to_shared("move", two_projects)
+
+    assert result.transferred is True
+    assert result.provenance == "carried"
+    assert result.provenance_reason is None and result.provenance_reason_code is None
+    dst_entry = Lockfile.at(two_projects["b"]).read_entry("agents", "foo")
+    assert dst_entry is not None
+    assert dst_entry["wiki_commit"] == _FULL_PIN
+    assert dst_entry["files"] == src_entry["files"]
+    assert dst_entry["digests"] == src_entry["digests"]
+    # Paired keys recomputed from the promoted tree, and the pairing
+    # validates there (digest branch active at the destination).
+    assert digests_from_entry(dst_entry) is not None
+    assert is_asset_dirty(two_projects["b"], "agents", "foo").reason == "clean"
+    # Source entry removed AFTER the destination carry (move semantics).
+    assert Lockfile.at(two_projects["a"]).read_entry("agents", "foo") is None
+
+
+def test_provenance_carried_on_clean_copy_keeps_source_entry(two_projects):
+    """Clean wiki install, shared→shared copy: entries at BOTH ends, source verbatim."""
+    _write_canonical(two_projects, "agents", "project_shared", "a", "foo", _AGENT_BODY_CLEAN)
+    _wiki_install_entry(two_projects["a"], "agents", "foo")
+    src_entry_before = Lockfile.at(two_projects["a"]).read_entry("agents", "foo")
+
+    result = _shared_to_shared("copy", two_projects)
+
+    assert result.provenance == "carried"
+    assert Lockfile.at(two_projects["a"]).read_entry("agents", "foo") == src_entry_before
+    dst_entry = Lockfile.at(two_projects["b"]).read_entry("agents", "foo")
+    assert dst_entry is not None and dst_entry["wiki_commit"] == _FULL_PIN
+    assert is_asset_dirty(two_projects["b"], "agents", "foo").reason == "clean"
+
+
+def test_provenance_dirty_source_move_lands_untracked(two_projects):
+    """Dirty source: bytes still move, no destination entry, source entry dropped."""
+    src_manifest = _write_canonical(
+        two_projects, "agents", "project_shared", "a", "foo", _AGENT_BODY_CLEAN
+    )
+    _wiki_install_entry(two_projects["a"], "agents", "foo")
+    src_manifest.write_text(_AGENT_BODY_CLEAN + "\nlocal edit\n", encoding="utf-8")
+
+    result = _shared_to_shared("move", two_projects)
+
+    assert result.transferred is True  # dirty blocks the carry, not the move
+    assert result.provenance == "not_carried"
+    assert result.provenance_reason_code == "source_dirty"
+    assert "local edits" in result.provenance_reason
+    dst_dir = _canonical_root(two_projects, "agents", "project_shared", "b") / "foo"
+    assert (dst_dir / "agent.md").read_text(encoding="utf-8").endswith("local edit\n")
+    assert Lockfile.at(two_projects["b"]).read_entry("agents", "foo") is None
+    # Move still drops the (now-dangling) source entry — #1123 B4-1.
+    assert Lockfile.at(two_projects["a"]).read_entry("agents", "foo") is None
+
+
+def test_provenance_dirty_source_copy_keeps_source_entry(two_projects):
+    """Dirty source on copy: no destination entry, source entry untouched."""
+    src_manifest = _write_canonical(
+        two_projects, "agents", "project_shared", "a", "foo", _AGENT_BODY_CLEAN
+    )
+    _wiki_install_entry(two_projects["a"], "agents", "foo")
+    (src_manifest.parent / "extra.md").write_text("unrecorded addition\n", encoding="utf-8")
+
+    result = _shared_to_shared("copy", two_projects)
+
+    assert result.provenance == "not_carried"
+    assert result.provenance_reason_code == "source_dirty"
+    assert Lockfile.at(two_projects["b"]).read_entry("agents", "foo") is None
+    assert Lockfile.at(two_projects["a"]).read_entry("agents", "foo") is not None
+
+
+def test_provenance_not_applicable_without_entry_and_other_tier_pairs(two_projects):
+    """No lock.json entry → quiet not_applicable; non-shared→shared pairs likewise."""
+    _write_canonical(two_projects, "agents", "project_shared", "a", "foo", _AGENT_BODY_CLEAN)
+
+    result = _shared_to_shared("copy", two_projects)
+    assert result.provenance == "not_applicable"
+    assert result.provenance_reason is None and result.provenance_reason_code is None
+
+    # shared→project_local with a CLEAN wiki entry: the lockfile only
+    # tracks project_shared installs, so the pair stays not_applicable
+    # (and the move-out entry drop keeps today's behavior).
+    _write_canonical(two_projects, "commands", "project_shared", "a", "bar", _AGENT_BODY_CLEAN)
+    _wiki_install_entry(two_projects["a"], "commands", "bar")
+    result = transfer_artifact(
+        "commands",
+        "bar",
+        src_project_root=two_projects["a"],
+        from_scope="project_shared",
+        dst_project_root=two_projects["b"],
+        to_scope="project_local",
+        mode="move",
+        apply_=True,
+    )
+    assert result.provenance == "not_applicable"
+    assert Lockfile.at(two_projects["a"]).read_entry("commands", "bar") is None
+
+
+def test_provenance_legacy_entry_without_digests_not_carried(two_projects):
+    """Pre-digest entry (mtime evidence only) must not carry — no minting digests."""
+    src_manifest = _write_canonical(
+        two_projects, "agents", "project_shared", "a", "foo", _AGENT_BODY_CLEAN
+    )
+    Lockfile.at(two_projects["a"]).upsert_entry(
+        "agents",
+        "foo",
+        wiki_commit=_FULL_PIN,
+        installed_at=installed_at_from_dest(src_manifest.parent),
+    )
+
+    result = _shared_to_shared("copy", two_projects)
+
+    assert result.provenance == "not_carried"
+    assert result.provenance_reason_code == "source_no_digests"
+    assert Lockfile.at(two_projects["b"]).read_entry("agents", "foo") is None
+
+
+def test_provenance_abbreviated_pin_not_carried(two_projects):
+    """A non-40-hex wiki_commit violates the ADR-0008 stored-pin contract."""
+    _write_canonical(two_projects, "agents", "project_shared", "a", "foo", _AGENT_BODY_CLEAN)
+    _wiki_install_entry(two_projects["a"], "agents", "foo", pin="abc123")
+
+    result = _shared_to_shared("copy", two_projects)
+
+    assert result.provenance == "not_carried"
+    assert result.provenance_reason_code == "source_invalid_pin"
+    assert Lockfile.at(two_projects["b"]).read_entry("agents", "foo") is None
+
+
+def test_provenance_renamed_copy_not_carried(two_projects):
+    """--as rename: entries are keyed by wiki asset name; carrying would mistarget update."""
+    _write_canonical(two_projects, "agents", "project_shared", "a", "foo", _AGENT_BODY_CLEAN)
+    _wiki_install_entry(two_projects["a"], "agents", "foo")
+
+    result = _shared_to_shared("copy", two_projects, new_name="bar")
+
+    assert result.provenance == "not_carried"
+    assert result.provenance_reason_code == "renamed_copy"
+    dst_lock = Lockfile.at(two_projects["b"])
+    assert dst_lock.read_entry("agents", "bar") is None
+    assert dst_lock.read_entry("agents", "foo") is None
+
+
+def test_provenance_corrupt_dest_lockfile_warns_but_move_commits(two_projects, caplog):
+    """Corrupt destination lock.json: loud warning, no un-commit, garbage preserved."""
+    _write_canonical(two_projects, "agents", "project_shared", "a", "foo", _AGENT_BODY_CLEAN)
+    _wiki_install_entry(two_projects["a"], "agents", "foo")
+    dst_lock_path = two_projects["b"] / ".memtomem" / "lock.json"
+    dst_lock_path.parent.mkdir(parents=True, exist_ok=True)
+    dst_lock_path.write_bytes(b"{not json")
+
+    with caplog.at_level("WARNING", logger="memtomem.context.transfer"):
+        result = _shared_to_shared("move", two_projects)
+
+    assert result.transferred is True
+    dst_manifest = (
+        _canonical_root(two_projects, "agents", "project_shared", "b") / "foo" / "agent.md"
+    )
+    assert dst_manifest.read_text(encoding="utf-8") == _AGENT_BODY_CLEAN
+    assert result.provenance == "not_carried"
+    assert result.provenance_reason_code == "dest_lockfile_error"
+    assert any("destination lock.json" in r.message for r in caplog.records)
+    # The corrupt file is preserved for the user to fix — never reset
+    # (#1247 id 16: a tolerant reset would be persisted).
+    assert dst_lock_path.read_bytes() == b"{not json"
+
+
+def test_provenance_corrupt_source_lockfile_not_carried(two_projects, caplog):
+    """Corrupt SOURCE lock.json: transfer proceeds, provenance skip says why."""
+    _write_canonical(two_projects, "agents", "project_shared", "a", "foo", _AGENT_BODY_CLEAN)
+    src_lock_path = two_projects["a"] / ".memtomem" / "lock.json"
+    src_lock_path.parent.mkdir(parents=True, exist_ok=True)
+    src_lock_path.write_bytes(b"\x00garbage")
+
+    with caplog.at_level("WARNING", logger="memtomem.context.transfer"):
+        result = _shared_to_shared("move", two_projects)
+
+    assert result.transferred is True
+    assert result.provenance == "not_carried"
+    assert result.provenance_reason_code == "source_lockfile_unreadable"
+    assert Lockfile.at(two_projects["b"]).read_entry("agents", "foo") is None
+
+
+def test_provenance_dry_run_previews_without_writing(two_projects):
+    """Dry-run reports the carry plan and mutates neither lockfile."""
+    _write_canonical(two_projects, "agents", "project_shared", "a", "foo", _AGENT_BODY_CLEAN)
+    _wiki_install_entry(two_projects["a"], "agents", "foo")
+
+    preview = _shared_to_shared("move", two_projects, apply_=False)
+
+    assert preview.transferred is False
+    assert preview.provenance == "carried"  # planned; apply re-verifies
+    assert Lockfile.at(two_projects["b"]).read_entry("agents", "foo") is None
+    assert Lockfile.at(two_projects["a"]).read_entry("agents", "foo") is not None
+
+    applied = _shared_to_shared("move", two_projects)
+    assert applied.provenance == "carried"  # dry-run/apply parity on the clean path
+
+
+def test_carry_provenance_digest_mismatch_refuses(two_projects):
+    """The post-promote equality gate: foreign bytes at dst → no entry written.
+
+    Unit-level pin of the TOCTOU close — a plan whose digest map does not
+    match the on-disk destination tree (as if the bytes changed between
+    classification and promote) must refuse rather than bless.
+    """
+    _write_canonical(two_projects, "agents", "project_shared", "b", "foo", _AGENT_BODY_CLEAN)
+    dst_path = _canonical_root(two_projects, "agents", "project_shared", "b") / "foo"
+    plan = _ProvenancePlan(carry=True, wiki_commit=_FULL_PIN, digests={"agent.md": "0" * 64})
+
+    outcome = _carry_provenance("agents", "foo", dst_path, two_projects["b"], plan)
+
+    assert outcome[0] == "not_carried"
+    assert outcome[2] == "dest_bytes_unverified"
+    assert Lockfile.at(two_projects["b"]).read_entry("agents", "foo") is None


### PR DESCRIPTION
Closes #1275. Part of #1270 (campaign item A-4). Depends on the A-2 engine (#1298) and surfaces through the A-3 CLI verbs (#1299).

## What

A `project_shared → project_shared` transfer (move AND copy) of a wiki-installed artifact now carries the source's `lock.json` entry to the destination, so `mm context status` / `mm context update` keep working there instead of silently downgrading the artifact to `untracked` — preserving the update lineage the per-file digest work (#1247 id 15, #1268) invested in.

## How — double-gated against the A-2 design-gate finding

Carrying a pin over locally-edited bytes would bless the edits as installed wiki state, letting a later `mm context update` clobber them without its `--force` gate. The carry is therefore gated twice:

1. **Pre-stage** (source still on disk, inside the pair lock): the entry must have a full 40-char SHA `wiki_commit` (ADR-0008 stored-pin contract), a valid per-file digest map (`digests_from_entry` — pre-digest mtime entries never carry; mtime cleanliness is not byte evidence), and classify `clean` under `is_asset_dirty`.
2. **Post-promote** (after the pair lock releases): the promoted destination tree is rehashed and must equal the source entry's digest map exactly. Sidecar locks don't bind external writers, so this equality gate — not the pre-stage check — closes the classify→stage TOCTOU: the only digests ever written at the destination are byte-identical to what the wiki install recorded.

A clean carry upserts the destination entry with recomputed paired keys (`installed_at` captured from the promoted tree; `upsert_entry` stamps `digests_installed_at`), and a move then drops the source entry — ordered so the carried record never has an untracked gap. Copy keeps the source entry (entries at both ends). A copy-rename (`--as`) never carries: entries are keyed by wiki asset name, so an entry under the new name would point `update` at a different wiki asset.

All bookkeeping stays best-effort outside the artifact pair lock: a corrupt destination lockfile warns loudly but never un-commits the transfer; a corrupt source lockfile skips the carry with the reason and the transfer proceeds.

## Result / surface plumbing

`TransferResult` gains `provenance: Literal["carried","not_carried","not_applicable"]` plus a `(provenance_reason, provenance_reason_code)` pair following the `_skip_reasons` house contract (human prose for the CLI, stable code for the upcoming A-5 web route / A-13 MCP action). Non-wiki sources stay quiet (`not_applicable`); every decline names its reason. Dry-run previews the same classification apply runs pre-stage.

## Acceptance criteria → tests (`test_context_transfer.py`, `test_cli_context_transfer.py`)

- Clean shared→shared move: entry lands at B (pin carried, digest pairing validates, `is_asset_dirty` clean — the status ok/behind inputs), source entry removed → `test_provenance_carried_on_clean_move`
- Clean copy: entries at both ends, source verbatim → `test_provenance_carried_on_clean_copy_keeps_source_entry`
- Dirty source: transfer still happens, lands untracked with reason; source entry removed on move / kept on copy → `test_provenance_dirty_source_{move_lands_untracked,copy_keeps_source_entry}`
- Non-wiki artifacts stay untracked, quiet; other tier pairs `not_applicable` → `test_provenance_not_applicable_without_entry_and_other_tier_pairs`
- Corrupt destination lockfile: loud warning, move committed, garbage preserved (#1247 id 16 no-reset rule) → `test_provenance_corrupt_dest_lockfile_warns_but_move_commits`
- Gate hardening: legacy no-digest entry, abbreviated pin, renamed copy, corrupt source lockfile, post-promote digest mismatch (TOCTOU unit pin), dry-run no-mutation parity → 6 further tests; CLI line rendering ×2.

ADR-0023 §8/§9 updated to the landed semantics (§9 documents the double gate; the Considered & rejected bullet now records the rejected *unconditional* carry).

## Review trail

Codex design gate (pre-implementation): NEEDS-FIX → folded the full-40-hex `wiki_commit` gate (ADR-0008) and the stable reason-code pairing. Codex diff review: NEEDS-FIX → folded the stale ADR deferral bullet rewrite. Both re-verified.

Note: full-suite runs show pre-existing ordering-dependent flakes in `test_session_tracing.py` (config-validation classes; reproducible on origin/main, pass in isolation) — unrelated to this change, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
