### PR TITLE
feat(context): web POST /api/context/{kind}/{name}/transfer — cross-project move/copy route (#1276)

### DIFF
--- a/docs/adr/0015-context-gateway-scope-vocabulary.md
+++ b/docs/adr/0015-context-gateway-scope-vocabulary.md
@@ -285,6 +285,17 @@ revisit the locked routes.
 
 Affects: routes listed in §2d.
 
+> **2026-06 rider (#1276):** ADR-0023 §10 carves the one non-sync
+> mutator exception: `POST /api/context/{kind}/{name}/transfer` accepts
+> a destination project selector in the request body
+> (`to_project_scope_id`). The exception is bounded — exactly one
+> artifact per invocation, destinations addressable only as discovered
+> `project_scope_id`s, destination sync-eligibility enforced with the
+> same 409 reason-code shape as the §2d sync routes, and the two risky
+> tiers (`project_shared`, `user`) gated behind a disclose-then-confirm
+> round-trip. Create / update / delete / import routes remain cwd-locked
+> as decided above.
+
 #### 4e. Settings per-request `target_scope` override — superseded by parity change
 
 Original decision: settings routes derived `target_scope` from

--- a/docs/adr/0023-cross-project-artifact-transfer.md
+++ b/docs/adr/0023-cross-project-artifact-transfer.md
@@ -264,6 +264,80 @@ noise). All of it stays best-effort and outside the pair lock: a
 corrupt destination lockfile warns loudly but never un-commits the
 transfer.
 
+### 10. Web route surface (A-5 #1276)
+
+`POST /api/context/{kind}/{name}/transfer`
+(`web/routes/context_transfer.py`) is the web face of the engine, and
+the **narrow exception to ADR-0015 §4d** (mutators stay cwd-locked):
+it accepts a destination project selector in the request body. The
+exception is bounded the same way §3 bounds the engine — exactly one
+artifact per invocation, exactly two roots — plus web-specific rails:
+destinations are addressable **only** as discovered `project_scope_id`s
+(no typed-path consent valve; that stays CLI-only), and the two risky
+tiers require an explicit per-request opt-in flag. ADR-0015 §4d carries
+a dated rider pointing here.
+
+Request: source = path `{kind}/{name}` + the standard
+`?project_scope_id=`/`?scope_id=` query selector (server cwd default) +
+optional body `from_scope`; destination = body `to_target_scope` +
+optional body `to_project_scope_id` (source project when omitted); body
+`mode` (`move`|`copy`), `as_name` (copy-rename), and the two confirm
+flags below. `?dry_run=true` returns the engine's dry-run plan
+(`status="plan"`) without mutating and without demanding confirmation
+(import-route precedent).
+
+**Disclose-then-confirm** (the shared `_confirm.py` helper A-6 #1263
+adopts next): a `project_shared` destination requires
+`confirm_project_shared` (Gate B, §5); a `user`-tier destination
+requires `allow_host_writes` (host path outside any project root,
+disclosed via `host_targets` — the `generate_all_settings` refusal
+shape). The first POST without the required flag performs no write and
+returns HTTP 200 `{status: "needs_confirmation", confirm: <flag>,
+reason, host_targets?, plan: {…dry-run result…}}`. `project_local`
+destinations have no gate (no host write, no git-tracked write).
+
+**Destination eligibility:** a project-tier destination whose
+discovered scope is not sync-eligible is refused 409 with the existing
+`resolve_writable_scope_root` reason-code shape (`sync_paused` /
+`sync_not_enrolled`, message verbatim) — **including the implicit
+destination** when `to_project_scope_id` is omitted but the *source*
+selector names a non-cwd discovered scope, so the implicit spelling of
+a destination can never write where the explicit spelling is refused
+(Codex design-gate finding). A cross-root project-tier destination
+without a `.memtomem/` store is refused 409 `no_memtomem_store` (the
+A-3 CLI gate, web-shaped).
+
+**Error envelope (campaign contract; B-1 #1284 retrofits old routes
+onto it):** every route-raised non-2xx detail is an object
+`{error_kind, message, reason_code?, …}`. `error_kind` vocabulary =
+the overview classifier four (`parse` / `permission` / `missing` /
+`internal`) plus three HTTP-semantic kinds: `validation` (bad
+input/combination, 400), `conflict` (the 409 state-refusal family,
+which also carries `reason_code` ∈ `sync_paused` / `sync_not_enrolled`
+/ `destination_exists` / `no_memtomem_store`), and `busy` (503
+lock/timeout). The one deliberate exception: `PrivacyScanError` keeps
+the standard project_shared block envelope (422, string detail) every
+sync surface emits. Engine errors map by TYPE, not message text — two
+typed `ClickException` subclasses exist for exactly this
+(`migrate.ArtifactNotFoundError` → 404, `transfer.TransferCollisionError`
+→ 409; message literals unchanged, so CLI/MCP/`migrate_scope` consumers
+are untouched).
+
+**Concurrency:** the handler runs the engine in a worker thread under
+the in-process `_gateway_lock` + `asyncio.timeout(60)`, passing
+`lock_timeout=30.0` — a whole-call deadline shared across both
+pair-lock acquisitions (`_acquire_pair_lock(timeout=…)`), so a
+cross-process lock holder makes the worker self-abort
+(`TimeoutError`, nothing acquired or committed) inside the request
+window instead of writing after the 503 (#1145 orphan-thread shape;
+`_SETTINGS_LOCK_BUDGET_S` / `_SKILLS_LOCK_BUDGET_S` precedent). The
+outer timeout can still expire while the worker is mid-write —
+`asyncio.to_thread` is un-cancellable — so the 503 wording makes no
+no-commit claim. The response serializes `TransferResult` verbatim
+(absolute paths; `src_project_scope_id` / `dst_project_scope_id`
+computed for project tiers so the UI can offer one-click follow-up
+sync; the §9 provenance triple on the wire for client matching).
+
 ## Backward compatibility
 
 - `migrate_scope` keeps its exact signature, result dataclass
@@ -355,9 +429,14 @@ transfer.
   frozen bytes).
 - Source anchors (grep the symbol if line numbers drift):
   `packages/memtomem/src/memtomem/context/transfer.py`
-  (`transfer_artifact`, `TransferResult`, `_stage_copy`,
-  `_rewrite_staged_manifest_name`),
+  (`transfer_artifact`, `TransferResult`, `TransferCollisionError`,
+  `_stage_copy`, `_rewrite_staged_manifest_name`),
   `packages/memtomem/src/memtomem/context/migrate.py`
-  (`_acquire_pair_lock`, `_stage_move`, `_promote_move`,
-  `_existing_fanout_targets`, `_remove_runtime_fanout_for` — two-root
-  split, `migrate_scope` wrapper).
+  (`_acquire_pair_lock` — pair-shared `timeout`, `_stage_move`,
+  `_promote_move`, `_existing_fanout_targets`,
+  `_remove_runtime_fanout_for` — two-root split, `migrate_scope`
+  wrapper, `ArtifactNotFoundError`),
+  `packages/memtomem/src/memtomem/web/routes/context_transfer.py`
+  (`transfer_context_artifact`, §10) and
+  `packages/memtomem/src/memtomem/web/routes/_confirm.py`
+  (`needs_confirmation_envelope`).

--- a/packages/memtomem/src/memtomem/context/migrate.py
+++ b/packages/memtomem/src/memtomem/context/migrate.py
@@ -38,6 +38,7 @@ import logging
 import os
 import secrets
 import shutil
+import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -84,6 +85,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "ASSET_DIR_FILENAMES",
     "MIGRATABLE_ASSET_TYPES",
+    "ArtifactNotFoundError",
     "MigratePartialError",
     "SCOPE_MIGRATABLE_KINDS",
     "MigrateResult",
@@ -119,6 +121,21 @@ class MigratePartialError(Exception):
         self.message = message
         self.src_path = src_path
         self.dst_path = dst_path
+
+
+class ArtifactNotFoundError(click.ClickException):
+    """Source artifact missing from the probed scope(s) (A-5 #1276).
+
+    Typed subclass so non-CLI surfaces can map "not found" to their
+    native shape (the web transfer route returns 404) without matching
+    on message text. Message literals are byte-identical to the plain
+    ``ClickException`` this replaces — every existing
+    ``except ClickException`` / ``str(exc)`` consumer (CLI verbs, MCP
+    actions, the ``migrate_scope`` wrapper contract) is untouched.
+    Raised only by the :func:`_detect_source_scope` not-found branches;
+    the multi-scope ambiguity raise stays a plain ``ClickException``
+    (the artifact exists — the selector is what's wrong).
+    """
 
 
 MigrateState = Literal[
@@ -697,7 +714,9 @@ class MigrateScopeResult:
 
 
 @contextmanager
-def _acquire_pair_lock(path_a: Path, path_b: Path) -> Iterator[None]:
+def _acquire_pair_lock(
+    path_a: Path, path_b: Path, *, timeout: float | None = None
+) -> Iterator[None]:
     """Acquire two sidecar locks in deterministic sorted order.
 
     Inverse migrations running concurrently (A: foo user→project_shared,
@@ -716,15 +735,39 @@ def _acquire_pair_lock(path_a: Path, path_b: Path) -> Iterator[None]:
     different project roots. ``sorted(key=str)`` over absolute lock
     paths is a total order there too, so every process — whatever pair
     of roots it works across — still acquires in one global sequence.
+
+    ``timeout`` is a WHOLE-CALL acquisition budget shared across both
+    locks (a monotonic deadline; the second acquisition gets whatever
+    the first left over), not a per-lock allowance — a caller bounding
+    its worst-case wait at N seconds must not discover it can stall for
+    2N. ``None`` (default) blocks indefinitely, the historical behavior
+    every CLI/MCP surface keeps. On expiry the underlying
+    :func:`memtomem.context._atomic._file_lock` raises ``TimeoutError``
+    having acquired nothing (the first lock, if already held, is
+    released by its own context manager on unwind), so a timed-out
+    caller has committed no filesystem change. Added for the web
+    transfer route (A-5 #1276), whose un-cancellable worker thread must
+    self-abort inside the route's ``asyncio.timeout`` window — the
+    #1145 orphan-thread shape ``_SETTINGS_LOCK_BUDGET_S`` /
+    ``_SKILLS_LOCK_BUDGET_S`` close for their engines.
     """
     lock_a = _lock_path_for(path_a)
     lock_b = _lock_path_for(path_b)
+    deadline = None if timeout is None else time.monotonic() + timeout
+
+    def _remaining() -> float | None:
+        # 0.0 (deadline already spent) still attempts each lock once
+        # non-blocking before raising — _file_lock's poll loop fails fast.
+        return None if deadline is None else max(0.0, deadline - time.monotonic())
+
     ordered = sorted([lock_a, lock_b], key=str)
     if ordered[0] == ordered[1]:
-        with _file_lock(ordered[0]):
+        with _file_lock(ordered[0], timeout=_remaining()):
             yield
         return
-    with _file_lock(ordered[0]), _file_lock(ordered[1]):
+    # ``with A, B`` enters A before evaluating B, so the second
+    # ``_remaining()`` reads the deadline AFTER the first wait finished.
+    with _file_lock(ordered[0], timeout=_remaining()), _file_lock(ordered[1], timeout=_remaining()):
         yield
 
 
@@ -1170,8 +1213,8 @@ def _detect_source_scope(
 
     if not candidates:
         if explicit_from is not None:
-            raise click.ClickException(f"{kind}/{name} not found at scope='{explicit_from}'.")
-        raise click.ClickException(
+            raise ArtifactNotFoundError(f"{kind}/{name} not found at scope='{explicit_from}'.")
+        raise ArtifactNotFoundError(
             f"{kind}/{name} not found in any scope (user / project_shared / project_local)."
         )
     if len(candidates) > 1:

--- a/packages/memtomem/src/memtomem/context/transfer.py
+++ b/packages/memtomem/src/memtomem/context/transfer.py
@@ -105,7 +105,26 @@ from memtomem.context.scope_resolver import ArtifactKind, canonical_artifact_dir
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["ProvenanceCarry", "TransferMode", "TransferResult", "transfer_artifact"]
+__all__ = [
+    "ProvenanceCarry",
+    "TransferCollisionError",
+    "TransferMode",
+    "TransferResult",
+    "transfer_artifact",
+]
+
+
+class TransferCollisionError(click.ClickException):
+    """Destination path already holds an artifact (ADR-0023 §6).
+
+    Typed subclass so non-CLI surfaces can map the collision to their
+    native shape (the web transfer route returns 409
+    ``destination_exists``) without matching on message text. Message
+    literals are byte-identical to the plain ``ClickException`` this
+    replaces, so every existing ``except ClickException`` / ``str(exc)``
+    consumer — CLI verbs, MCP migrate action, the ``migrate_scope``
+    wrapper's pinned wording — is untouched.
+    """
 
 
 TransferMode = Literal["move", "copy"]
@@ -641,6 +660,7 @@ def transfer_artifact(
     apply_: bool,
     surface: str = "cli_context_transfer",
     new_name: str | None = None,
+    lock_timeout: float | None = None,
 ) -> TransferResult:
     """Move or copy one canonical artifact between tiers and/or projects.
 
@@ -670,6 +690,14 @@ def transfer_artifact(
             ``validate_name``, and the staged manifest's frontmatter
             ``name:`` is rewritten to match
             (:func:`_rewrite_staged_manifest_name`).
+        lock_timeout: Whole-call acquisition budget (seconds) for the
+            artifact pair lock, shared across both sidecar acquisitions
+            (``_acquire_pair_lock``). ``None`` (default) blocks
+            indefinitely — the historical CLI/MCP behavior. The web
+            route passes a bound so its un-cancellable worker thread
+            self-aborts (``TimeoutError``, nothing acquired or
+            committed) inside the route's own ``asyncio.timeout``
+            window instead of writing after a 503 (#1145 shape).
 
     Apply sequence (move):
 
@@ -765,7 +793,7 @@ def transfer_artifact(
 
     # Pre-flight conflict check (also re-checked inside the lock).
     if dst_path.exists():
-        raise click.ClickException(
+        raise TransferCollisionError(
             f"destination already exists: {dst_path}. "
             "Resolve manually or remove the existing entry first. "
             "--force does not overwrite scope-tier targets in PR-E4 "
@@ -830,13 +858,13 @@ def transfer_artifact(
 
     # ── apply path ───────────────────────────────────────────────────
     notes: tuple[str, ...] = ()
-    with _acquire_pair_lock(src_path, dst_path):
+    with _acquire_pair_lock(src_path, dst_path, timeout=lock_timeout):
         # Re-check dst inside the lock window — some other process could
         # have created it between the dry-run preview and the apply
         # phase, even with our own lock-pair held (the writer would have
         # had to take the same lock, but check defensively).
         if dst_path.exists():
-            raise click.ClickException(f"destination appeared during lock acquire: {dst_path}.")
+            raise TransferCollisionError(f"destination appeared during lock acquire: {dst_path}.")
 
         # Provenance classification must run while the SOURCE tree still
         # exists (move staging consumes it). Read-only; the write half

--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -27,6 +27,7 @@ from memtomem.web.routes import (
     context_mcp_servers,
     context_projects,
     context_skills,
+    context_transfer,
     context_versions,
     decay,
     dedup,
@@ -101,6 +102,7 @@ _PROD_ROUTERS: list[ModuleType] = [
     context_commands,
     context_agents,
     context_mcp_servers,
+    context_transfer,
     context_versions,
     settings_sync,
 ]

--- a/packages/memtomem/src/memtomem/web/routes/_confirm.py
+++ b/packages/memtomem/src/memtomem/web/routes/_confirm.py
@@ -1,0 +1,52 @@
+"""Shared disclose-then-confirm envelope for consequential gateway writes.
+
+The shape is extracted from the ``settings_sync.py`` precedent (campaign
+#1270: A-5 and A-6 share one host-write confirmation helper; A-5 landed
+first and owns the extraction). Contract:
+
+- The first POST without the required opt-in flag performs **no write**
+  and returns HTTP 200 with ``status: "needs_confirmation"`` — consent
+  is an application state, not a transport error (the settings promote
+  route established the 200-with-status shape).
+- ``confirm`` names the exact request-body flag the client must re-POST
+  with after the user approves — machine-actionable, so the UI never
+  parses prose to find out *how* to proceed.
+- ``reason`` is the human disclosure. ``host_targets`` (host-write
+  gates only) lists the absolute paths outside any project root that
+  the confirmed request will write, mirroring
+  ``generate_all_settings``'s per-target disclosure.
+- Callers attach surface-specific context via ``extra`` (the transfer
+  route nests its dry-run preview under ``plan``).
+
+A-6 (#1263) migrates the settings-sync host-write refusals onto this
+helper; until then ``generate_all_settings`` keeps its engine-level
+per-generator ``needs_confirmation`` results.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+
+def needs_confirmation_envelope(
+    reason: str,
+    *,
+    confirm: str,
+    host_targets: Sequence[str] | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    """Build the ``needs_confirmation`` response body.
+
+    ``confirm`` is the request-body flag (e.g. ``confirm_project_shared``,
+    ``allow_host_writes``) whose ``true`` re-POST completes the round-trip.
+    """
+    payload: dict[str, Any] = {
+        "status": "needs_confirmation",
+        "confirm": confirm,
+        "reason": reason,
+    }
+    if host_targets is not None:
+        payload["host_targets"] = list(host_targets)
+    payload.update(extra)
+    return payload

--- a/packages/memtomem/src/memtomem/web/routes/context_transfer.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_transfer.py
@@ -1,0 +1,415 @@
+"""Context gateway — cross-project / cross-tier artifact transfer (A-5 #1276).
+
+One mutator: ``POST /api/context/{kind}/{name}/transfer`` — the web face
+of :func:`memtomem.context.transfer.transfer_artifact` (ADR-0023; move or
+copy one canonical artifact between tiers AND between projects). The
+dashboard's per-artifact "Move/Copy to…" action (B-6 #1289) is built on
+this endpoint.
+
+Contracts pinned in ADR-0023 §10:
+
+- **ADR-0015 §4d exception.** Every other create/update/delete/import
+  route is cwd-locked; this route accepts a destination project selector
+  in the request body (``to_project_scope_id``), bounded to exactly one
+  artifact per invocation, destinations restricted to the registered
+  discovery set (no typed-path consent valve — that is CLI-only), and
+  the two risky tiers gated behind a disclose-then-confirm round-trip.
+- **Two-step confirmation** (:mod:`memtomem.web.routes._confirm`):
+  a ``project_shared`` destination requires ``confirm_project_shared``
+  (Gate B), a ``user``-tier destination requires ``allow_host_writes``
+  (host path outside any project root). The first POST without the flag
+  writes nothing and returns the dry-run plan inside the
+  ``needs_confirmation`` envelope.
+- **Destination eligibility.** A project-tier destination whose
+  discovered scope is not sync-eligible is refused 409 with the
+  existing ``sync_paused`` / ``sync_not_enrolled`` reason-code shape —
+  including the IMPLICIT destination (``to_project_scope_id`` omitted)
+  when the *source* selector names a non-cwd discovered scope, so the
+  implicit spelling of a destination can never write where the explicit
+  spelling is refused.
+- **Error envelope.** Every route-raised non-2xx detail is an object
+  ``{error_kind, message, reason_code?, …}`` — the B-1 (#1284)
+  vocabulary (``parse`` / ``permission`` / ``missing`` / ``internal``)
+  plus the HTTP-semantic kinds ``validation`` (bad input/combination),
+  ``conflict`` (409 state-refusal family) and ``busy`` (503). The one
+  deliberate exception: ``PrivacyScanError`` keeps the standard
+  project_shared block envelope (422 with a string detail) that every
+  sync surface emits and the JS block path already renders.
+- **Engine offload.** The transfer core runs in a worker thread under
+  ``_gateway_lock`` + ``asyncio.timeout(60)``, with the engine's
+  pair-lock waits bounded by ``_TRANSFER_LOCK_BUDGET_S`` (whole-call
+  deadline, 30s < 60s) so a cross-process lock holder cannot leave an
+  un-cancellable worker writing after the 503 (#1145 shape). The outer
+  timeout can still expire mid-write — the 503 wording deliberately
+  makes no no-commit claim.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import click
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel
+
+from memtomem.config import TargetScope
+from memtomem.context._names import InvalidNameError, validate_name
+from memtomem.context.migrate import (
+    SCOPE_MIGRATABLE_KINDS,
+    ArtifactNotFoundError,
+    MigratePartialError,
+)
+from memtomem.context.privacy_scan import PrivacyScanError
+from memtomem.context.projects import ProjectScope, compute_scope_id
+from memtomem.context.scope_resolver import ArtifactKind
+from memtomem.context.transfer import (
+    TransferCollisionError,
+    TransferResult,
+    transfer_artifact,
+)
+from memtomem.web.routes._confirm import needs_confirmation_envelope
+from memtomem.web.routes._locks import _gateway_lock
+from memtomem.web.routes.context_gateway import _classify_exception, _redact_message
+from memtomem.web.routes.context_projects import (
+    _default_project_root,
+    _discover_for,
+    _resolve_selected_scope,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["context-transfer"])
+
+#: Whole-call pair-lock acquisition budget forwarded to the engine
+#: (``transfer_artifact(lock_timeout=…)``). Must stay below the route's
+#: ``asyncio.timeout(60)`` so the worker self-aborts inside the request
+#: window — the ``_SETTINGS_LOCK_BUDGET_S`` / ``_SKILLS_LOCK_BUDGET_S``
+#: precedent.
+_TRANSFER_LOCK_BUDGET_S = 30.0
+
+
+def _error(status_code: int, error_kind: str, message: str, **extra: Any) -> HTTPException:
+    """Object-envelope ``HTTPException`` (ADR-0023 §10 / B-1 #1284 shape)."""
+    return HTTPException(
+        status_code=status_code,
+        detail={"error_kind": error_kind, "message": message, **extra},
+    )
+
+
+class TransferRequest(BaseModel):
+    """Body for ``POST /context/{kind}/{name}/transfer`` (issue #1276)."""
+
+    mode: Literal["move", "copy"]
+    to_target_scope: TargetScope
+    to_project_scope_id: str | None = None
+    from_scope: TargetScope | None = None
+    as_name: str | None = None
+    confirm_project_shared: bool = False
+    allow_host_writes: bool = False
+
+
+def _resolve_source(
+    request: Request, project_scope_id: str | None, scope_id: str | None
+) -> tuple[Path, ProjectScope | None]:
+    """Source ``(root, scope record)`` from the standard query selectors.
+
+    Same resolution as the shared ``resolve_scope_root`` dependency
+    (``_resolve_selected_scope`` is the single implementation), but this
+    route needs the scope RECORD too — the implicit-destination
+    eligibility gate reads ``sync_eligible`` off it. The helper's plain
+    string 400/404 details are re-shaped into this route's object
+    envelope; status codes and message text are preserved exactly.
+    """
+    try:
+        scope = _resolve_selected_scope(request, project_scope_id, scope_id)
+    except HTTPException as exc:
+        kind = "missing" if exc.status_code == 404 else "validation"
+        raise _error(exc.status_code, kind, str(exc.detail)) from exc
+    if scope is None:
+        return _default_project_root(request), None
+    assert scope.root is not None  # _resolve_selected_scope 404s on a missing root
+    return scope.root, scope
+
+
+def _resolve_destination(
+    request: Request,
+    body: TransferRequest,
+    src_root: Path,
+    src_scope: ProjectScope | None,
+) -> tuple[Path, ProjectScope | None]:
+    """Destination ``(root, scope record)`` through the same discovery.
+
+    ``to_project_scope_id=None`` → the source project (cross-tier,
+    same-project transfer): the destination inherits the SOURCE's scope
+    record so the eligibility gate below sees a paused source project
+    even when the destination is only implicit. Message literals for
+    the 404s mirror ``_resolve_selected_scope`` verbatim.
+    """
+    if body.to_project_scope_id is None:
+        return src_root, src_scope
+    for scope in _discover_for(request):
+        if scope.scope_id != body.to_project_scope_id:
+            continue
+        if scope.root is None or scope.missing:
+            raise _error(
+                404,
+                "missing",
+                f"scope {body.to_project_scope_id!r} is registered but its root is missing",
+            )
+        return scope.root, scope
+    raise _error(404, "missing", f"unknown project_scope_id: {body.to_project_scope_id!r}")
+
+
+def _reject_ineligible_destination(scope: ProjectScope | None, to_scope: TargetScope) -> None:
+    """409 a project-tier destination in a non-sync-eligible project.
+
+    Same rule and reason-code shape as ``resolve_writable_scope_root``
+    (#1203 §1i), applied to the transfer destination: a paused or
+    never-enrolled project must not gain a canonical that can never fan
+    out there. ``scope is None`` is the server cwd (always eligible —
+    you cannot pause the running directory); user-tier destinations are
+    host writes, not project runtime, and are gated by
+    ``allow_host_writes`` instead.
+    """
+    if to_scope == "user" or scope is None or scope.sync_eligible:
+        return
+    paused = "known-projects" in scope.sources
+    raise HTTPException(
+        status_code=409,
+        detail={
+            "error_kind": "conflict",
+            "reason_code": "sync_paused" if paused else "sync_not_enrolled",
+            # Message wording verbatim from ``resolve_writable_scope_root`` —
+            # sibling trust-UX prose must not drift (the JS matches on the
+            # reason_code; the prose is what humans compare across surfaces).
+            "message": (
+                f"Project {scope.scope_id!r} is not enrolled for sync "
+                + (
+                    "(enrollment paused). Resume sync"
+                    if paused
+                    else "(discovery-only; never enrolled). Enroll the project"
+                )
+                + " from the Projects portal before writing to its runtime."
+            ),
+            "project_scope_id": scope.scope_id,
+        },
+    )
+
+
+def _required_confirm(body: TransferRequest) -> tuple[str, str] | None:
+    """``(flag, reason)`` for the gate the request still has to clear.
+
+    The two gates are tier-keyed and therefore mutually exclusive.
+    Gate B prose mirrors the CLI confirmation prompt; the host-write
+    prose mirrors ``generate_all_settings``'s refusal shape.
+    """
+    if body.to_target_scope == "project_shared" and not body.confirm_project_shared:
+        return (
+            "confirm_project_shared",
+            f"This will {body.mode} the canonical into the git-tracked "
+            f"project_shared tier. Re-POST with confirm_project_shared=true "
+            f"after confirming with the user.",
+        )
+    if body.to_target_scope == "user" and not body.allow_host_writes:
+        return (
+            "allow_host_writes",
+            "The destination is the user tier — a host path outside any "
+            "project root. Re-POST with allow_host_writes=true after "
+            "confirming with the user.",
+        )
+    return None
+
+
+def _scope_id_for(scope: TargetScope, root: Path | None) -> str | None:
+    """Project scope_id for a result side; ``None`` for the global user tier."""
+    if scope == "user" or root is None:
+        return None
+    return compute_scope_id(root)
+
+
+def _serialize(result: TransferResult) -> dict[str, Any]:
+    """Wire shape for one plan/apply result.
+
+    Paths are absolute strings — relativization is ambiguous when two
+    project roots (or a host path) are in play. ``dst_project_scope_id``
+    is the issue-pinned field the UI uses for one-click follow-up sync.
+    The provenance triple is the A-4 ``_skip_reasons`` contract: the
+    human ``provenance_reason`` for tooltips, the stable
+    ``provenance_reason_code`` for client matching.
+    """
+    return {
+        "transferred": result.transferred,
+        "kind": result.kind,
+        "name": result.name,
+        "dst_name": result.dst_name,
+        "mode": result.mode,
+        "from_scope": result.from_scope,
+        "to_scope": result.to_scope,
+        "layout": result.layout,
+        "src_path": str(result.src_path),
+        "dst_path": str(result.dst_path),
+        "src_project_scope_id": _scope_id_for(result.from_scope, result.src_project_root),
+        "dst_project_scope_id": _scope_id_for(result.to_scope, result.dst_project_root),
+        "fanout_planned": [str(p) for p in result.fanout_planned],
+        "fanout_cleaned": [str(p) for p in result.fanout_cleaned],
+        "fanout_backed_up": [str(p) for p in result.fanout_backed_up],
+        "needs_sync": result.needs_sync,
+        "sync_command": result.sync_command,
+        "notes": list(result.notes),
+        "provenance": result.provenance,
+        "provenance_reason": result.provenance_reason,
+        "provenance_reason_code": result.provenance_reason_code,
+    }
+
+
+@router.post("/context/{kind}/{name}/transfer")
+async def transfer_context_artifact(
+    kind: str,
+    name: str,
+    body: TransferRequest,
+    request: Request,
+    project_scope_id: str | None = Query(default=None),
+    scope_id: str | None = Query(default=None),
+    dry_run: bool = Query(
+        False,
+        description=(
+            "Preview the transfer without touching disk: returns the engine's "
+            "dry-run plan (status='plan') regardless of confirmation flags. "
+            "Mirrors the import routes' dry_run."
+        ),
+    ),
+) -> dict:
+    """Move or copy one canonical artifact between tiers and/or projects.
+
+    Source = ``{kind}/{name}`` under the ``?project_scope_id=`` project
+    (server cwd when omitted) at ``body.from_scope`` (auto-detected when
+    omitted). Destination = ``body.to_target_scope`` under
+    ``body.to_project_scope_id`` (the source project when omitted).
+    Responses: ``status="plan"`` (dry_run), ``status="needs_confirmation"``
+    (gate round-trip, plan nested under ``plan``), ``status="ok"``
+    (applied). See the module docstring for the gate and error contracts.
+    """
+    if kind not in SCOPE_MIGRATABLE_KINDS:
+        raise _error(
+            400,
+            "validation",
+            f"unsupported kind for artifact transfer: {kind!r} "
+            f"(use one of {SCOPE_MIGRATABLE_KINDS})",
+        )
+    kind_t = cast(ArtifactKind, kind)
+    try:
+        validate_name(name, kind=f"{kind[:-1]} name")
+        if body.as_name is not None:
+            validate_name(body.as_name, kind=f"{kind[:-1]} name")
+    except InvalidNameError as exc:
+        raise _error(400, "validation", str(exc)) from exc
+
+    if body.to_project_scope_id is not None and body.to_target_scope == "user":
+        raise _error(
+            400,
+            "validation",
+            "to_project_scope_id cannot be combined with to_target_scope='user': "
+            "the user tier is global (~/.memtomem), not per-project.",
+        )
+
+    src_root, src_scope = _resolve_source(request, project_scope_id, scope_id)
+    dst_root, dst_scope = _resolve_destination(request, body, src_root, src_scope)
+    _reject_ineligible_destination(dst_scope, body.to_target_scope)
+
+    if (
+        body.to_target_scope != "user"
+        and dst_root.resolve() != src_root.resolve()
+        and not (dst_root / ".memtomem").is_dir()
+    ):
+        # CLI-parity gate (#1274): a cross-project destination must already be
+        # a memtomem project — don't seed a half-initialized store into an
+        # arbitrary registered directory. Within-project transfers keep
+        # migrate's implicit-store behavior.
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error_kind": "conflict",
+                "reason_code": "no_memtomem_store",
+                "message": (
+                    f"destination project has no .memtomem/ store: {dst_root}. "
+                    f"Initialize it first: cd {dst_root} && mm context init"
+                ),
+                "project_scope_id": body.to_project_scope_id,
+            },
+        )
+
+    gate = None if dry_run else _required_confirm(body)
+    apply_ = not dry_run and gate is None
+
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                # Worker thread: the engine takes cross-process sidecar locks
+                # (the artifact pair lock) that would otherwise block the event
+                # loop AND keep the enclosing asyncio.timeout from firing. The
+                # engine-side lock budget (30s < 60s) bounds those waits — see
+                # the module docstring for the residual mid-write window.
+                result = await asyncio.to_thread(
+                    transfer_artifact,
+                    kind_t,
+                    name,
+                    src_project_root=src_root,
+                    from_scope=body.from_scope,
+                    dst_project_root=None if body.to_target_scope == "user" else dst_root,
+                    to_scope=body.to_target_scope,
+                    mode=body.mode,
+                    apply_=apply_,
+                    surface="web_context_transfer",
+                    new_name=body.as_name,
+                    lock_timeout=_TRANSFER_LOCK_BUDGET_S,
+                )
+    except TimeoutError:
+        # Either the route's own 60s window or the engine's lock budget.
+        # The lock-budget path commits nothing by construction; the outer
+        # window can expire mid-write, so no no-commit claim here.
+        raise _error(
+            503, "busy", "Transfer timed out — another sync or transfer may be in progress"
+        )
+    except PrivacyScanError as exc:
+        # The standard project_shared block envelope (string detail) every
+        # sync surface emits — issue-pinned exception to the object envelope.
+        raise HTTPException(422, exc.message) from exc
+    except ArtifactNotFoundError as exc:
+        raise _error(404, "missing", exc.message) from exc
+    except TransferCollisionError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error_kind": "conflict",
+                "reason_code": "destination_exists",
+                "message": exc.message,
+            },
+        ) from exc
+    except MigratePartialError as exc:
+        # Partial commit (EXDEV cleanup failure): the message carries the
+        # manual-recovery steps and is deliberately NOT redacted — the paths
+        # ARE the remediation, and the CLI prints the same text raw.
+        raise _error(500, "internal", exc.message) from exc
+    except InvalidNameError as exc:
+        raise _error(400, "validation", str(exc)) from exc
+    except click.ClickException as exc:
+        # Engine-validated combinations (same store, rename outside copy,
+        # multi-`name:` manifest, …) — bad request input, engine wording.
+        raise _error(400, "validation", exc.message) from exc
+    except Exception as exc:  # pragma: no cover - classified catch-all
+        logger.error("transfer %s/%s failed", kind, name, exc_info=True)
+        raise _error(500, _classify_exception(exc), _redact_message(str(exc))) from exc
+
+    if gate is not None:
+        flag, reason = gate
+        host_targets = [str(result.dst_path)] if flag == "allow_host_writes" else None
+        return needs_confirmation_envelope(
+            reason,
+            confirm=flag,
+            host_targets=host_targets,
+            plan=_serialize(result),
+        )
+    return {"status": "plan" if dry_run else "ok", **_serialize(result)}

--- a/packages/memtomem/tests/test_context_migrate_lock_order.py
+++ b/packages/memtomem/tests/test_context_migrate_lock_order.py
@@ -40,9 +40,9 @@ def _acquire_log(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
     log: list[Path] = []
     real = _file_lock
 
-    def wrapped(lock_path: Path):
+    def wrapped(lock_path: Path, *, timeout: float | None = None):
         log.append(lock_path)
-        return real(lock_path)
+        return real(lock_path, timeout=timeout)
 
     monkeypatch.setattr("memtomem.context.migrate._file_lock", wrapped)
     return log

--- a/packages/memtomem/tests/test_context_transfer.py
+++ b/packages/memtomem/tests/test_context_transfer.py
@@ -715,9 +715,9 @@ def test_pair_lock_held_across_both_roots_sorted(two_projects, monkeypatch):
     acquired: list[Path] = []
     real = _file_lock
 
-    def logging_lock(lock_path: Path):
+    def logging_lock(lock_path: Path, *, timeout: float | None = None):
         acquired.append(lock_path)
-        return real(lock_path)
+        return real(lock_path, timeout=timeout)
 
     # _acquire_pair_lock lives in (and reads) the migrate module namespace.
     monkeypatch.setattr("memtomem.context.migrate._file_lock", logging_lock)
@@ -749,8 +749,8 @@ def test_destination_appeared_during_lock(two_projects, monkeypatch):
     real_pair_lock = transfer_mod._acquire_pair_lock
 
     @contextlib.contextmanager
-    def racing_pair_lock(path_a: Path, path_b: Path):
-        with real_pair_lock(path_a, path_b):
+    def racing_pair_lock(path_a: Path, path_b: Path, *, timeout: float | None = None):
+        with real_pair_lock(path_a, path_b, timeout=timeout):
             dst_dir.mkdir(parents=True)
             (dst_dir / "agent.md").write_text("---\nname: foo\n---\n\nracer\n", encoding="utf-8")
             yield
@@ -1191,3 +1191,164 @@ def test_carry_provenance_digest_mismatch_refuses(two_projects):
     assert outcome[0] == "not_carried"
     assert outcome[2] == "dest_bytes_unverified"
     assert Lockfile.at(two_projects["b"]).read_entry("agents", "foo") is None
+
+
+# ── lock_timeout budget (A-5 #1276) ──────────────────────────────────
+
+
+def test_lock_timeout_self_aborts_with_nothing_committed(two_projects):
+    """A held destination sidecar lock + bounded budget → TimeoutError,
+    zero filesystem change (the web route's orphan-thread guard, #1145
+    shape). portalocker contends across separate fds in-process, so the
+    held lock below blocks the engine exactly like a foreign process."""
+    src_manifest = _write_canonical(
+        two_projects, "agents", "project_shared", "a", "foo", _AGENT_BODY_CLEAN
+    )
+    dst_dir = _canonical_root(two_projects, "agents", "project_shared", "b") / "foo"
+    dst_lock = _lock_path_for(dst_dir)
+
+    with _file_lock(dst_lock):
+        with pytest.raises(TimeoutError, match="held by another process"):
+            transfer_artifact(
+                "agents",
+                "foo",
+                src_project_root=two_projects["a"],
+                from_scope="project_shared",
+                dst_project_root=two_projects["b"],
+                to_scope="project_shared",
+                mode="move",
+                apply_=True,
+                lock_timeout=0.2,
+            )
+
+    # Nothing acquired → nothing staged or committed; source untouched.
+    assert src_manifest.read_text(encoding="utf-8") == _AGENT_BODY_CLEAN
+    assert not dst_dir.exists()
+    assert not list(dst_dir.parent.glob(".migrate-*"))
+
+
+def test_lock_timeout_budget_shared_across_pair(two_projects, monkeypatch):
+    """The budget is a whole-call deadline: the second acquisition gets the
+    remainder, not a fresh allowance (worst case N, not 2N)."""
+    import contextlib as _ctx
+    import time as _time
+
+    import memtomem.context.migrate as migrate_mod
+
+    _write_canonical(two_projects, "agents", "project_shared", "a", "foo", _AGENT_BODY_CLEAN)
+    seen: list[float | None] = []
+    real = _file_lock
+
+    @_ctx.contextmanager
+    def slow_lock(lock_path: Path, *, timeout: float | None = None):
+        seen.append(timeout)
+        _time.sleep(0.1)  # consume budget while "acquiring"
+        with real(lock_path, timeout=timeout):
+            yield
+
+    monkeypatch.setattr(migrate_mod, "_file_lock", slow_lock)
+
+    transfer_artifact(
+        "agents",
+        "foo",
+        src_project_root=two_projects["a"],
+        from_scope="project_shared",
+        dst_project_root=two_projects["b"],
+        to_scope="project_shared",
+        mode="copy",
+        apply_=True,
+        lock_timeout=5.0,
+    )
+
+    assert len(seen) == 2
+    assert all(t is not None for t in seen)
+    assert seen[0] <= 5.0
+    # The 0.1s spent inside the first acquisition must come off the
+    # second's allowance.
+    assert seen[1] <= seen[0] - 0.05
+
+
+def test_lock_timeout_default_none_passes_unbounded(two_projects, monkeypatch):
+    """Default ``lock_timeout=None`` keeps the historical blocking waits —
+    every CLI/MCP call site is byte-for-byte unaffected."""
+    import memtomem.context.migrate as migrate_mod
+
+    _write_canonical(two_projects, "agents", "project_shared", "a", "foo", _AGENT_BODY_CLEAN)
+    seen: list[float | None] = []
+    real = _file_lock
+
+    def logging_lock(lock_path: Path, *, timeout: float | None = None):
+        seen.append(timeout)
+        return real(lock_path, timeout=timeout)
+
+    monkeypatch.setattr(migrate_mod, "_file_lock", logging_lock)
+
+    transfer_artifact(
+        "agents",
+        "foo",
+        src_project_root=two_projects["a"],
+        from_scope="project_shared",
+        dst_project_root=two_projects["b"],
+        to_scope="project_shared",
+        mode="copy",
+        apply_=True,
+    )
+
+    assert seen == [None, None]
+
+
+# ── typed engine exceptions (A-5 #1276) ──────────────────────────────
+
+
+def test_source_not_found_is_typed_with_pinned_literal(two_projects):
+    """``ArtifactNotFoundError`` is a ClickException subclass with the
+    byte-identical historical message — CLI/MCP/migrate consumers see no
+    change; the web route maps the TYPE to 404. Full-equality pin, not a
+    substring search (Codex review: an unanchored match would let most of
+    the literal drift)."""
+    from memtomem.context.migrate import ArtifactNotFoundError
+
+    with pytest.raises(ArtifactNotFoundError) as excinfo:
+        transfer_artifact(
+            "agents",
+            "ghost",
+            src_project_root=two_projects["a"],
+            from_scope=None,
+            dst_project_root=two_projects["b"],
+            to_scope="project_shared",
+            mode="move",
+            apply_=False,
+        )
+    assert isinstance(excinfo.value, click.ClickException)
+    assert excinfo.value.message == (
+        "agents/ghost not found in any scope (user / project_shared / project_local)."
+    )
+
+
+def test_collision_is_typed_with_pinned_literal(two_projects):
+    """``TransferCollisionError`` carries the historical Row-15 wording —
+    pinned by full equality including the remediation sentences."""
+    from memtomem.context.transfer import TransferCollisionError
+
+    _write_canonical(two_projects, "agents", "project_shared", "a", "foo", _AGENT_BODY_CLEAN)
+    _write_canonical(two_projects, "agents", "project_shared", "b", "foo", _AGENT_BODY_CLEAN)
+    dst_path = _canonical_root(two_projects, "agents", "project_shared", "b") / "foo"
+
+    with pytest.raises(TransferCollisionError) as excinfo:
+        transfer_artifact(
+            "agents",
+            "foo",
+            src_project_root=two_projects["a"],
+            from_scope="project_shared",
+            dst_project_root=two_projects["b"],
+            to_scope="project_shared",
+            mode="move",
+            apply_=False,
+        )
+    assert isinstance(excinfo.value, click.ClickException)
+    assert excinfo.value.message == (
+        f"destination already exists: {dst_path}. "
+        "Resolve manually or remove the existing entry first. "
+        "--force does not overwrite scope-tier targets in PR-E4 "
+        "(replace verb is a follow-up)."
+    )

--- a/packages/memtomem/tests/test_web_invariants_registry.py
+++ b/packages/memtomem/tests/test_web_invariants_registry.py
@@ -82,6 +82,7 @@ _CSRF_PROTECTED: frozenset[str] = frozenset(
         "context_skills.import_skills",
         "context_skills.sync_skills",
         "context_skills.update_skill",
+        "context_transfer.transfer_context_artifact",
         "context_versions.create_artifact_version",
         "context_versions.delete_artifact_label",
         "context_versions.enable_artifact_versioning",
@@ -188,6 +189,10 @@ _REDACTION_EXEMPT: dict[str, str] = {
     "context_skills.import_skill": "structured artifact import",
     "context_skills.import_skills": "bulk structured artifact import",
     "context_skills.sync_skills": "filesystem-driven sync",
+    "context_transfer.transfer_context_artifact": (
+        "no content payload — moves/copies existing canonical bytes between "
+        "stores; project_shared landings run Gate A in-engine on the staged tree"
+    ),
     "context_projects.add_known_project": "path/label only, no prose",
     "context_projects.update_known_project": "label/enabled update, no prose",
     # Versioning: the snapshot bytes are the already-canonical working file,

--- a/packages/memtomem/tests/test_web_routes_context_transfer.py
+++ b/packages/memtomem/tests/test_web_routes_context_transfer.py
@@ -1,0 +1,565 @@
+"""HTTP-layer tests for ``POST /api/context/{kind}/{name}/transfer`` (A-5 #1276).
+
+The engine matrix (cross-project move/copy, Gate A residue, rollback,
+provenance carry-over) is pinned by ``test_context_transfer.py``; this file
+covers what the WEB surface adds (ADR-0023 §10):
+
+- destination resolution through project discovery (404 unknown,
+  409 ``sync_paused`` incl. the implicit same-project destination,
+  409 ``no_memtomem_store``);
+- the disclose-then-confirm round-trips (Gate B ``confirm_project_shared``,
+  user-tier ``allow_host_writes`` with ``host_targets``);
+- the object error envelope (``error_kind`` + ``reason_code``) and the
+  issue-pinned string 422 for ``PrivacyScanError``;
+- ``dry_run`` plan responses and the provenance triple on the wire.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from memtomem.config import ContextGatewayConfig, Mem2MemConfig
+from memtomem.context.lockfile import Lockfile, utcnow_iso8601_z
+from memtomem.web.app import create_app
+from .helpers import set_home
+
+_AGENT_BODY = "---\nname: foo\ndescription: a clean test agent\n---\n\nhello\n"
+_SECRET_BODY = "---\nname: foo\ndescription: leaky\n---\n\nkey=AKIA1234567890ABCDEF\n"
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def cwd_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Sandbox HOME; return the cwd project root with markers + store."""
+    set_home(monkeypatch, tmp_path / "home")
+    (tmp_path / "home").mkdir()
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    (cwd / ".claude").mkdir()
+    (cwd / ".memtomem").mkdir()
+    return cwd
+
+
+@pytest.fixture
+def known_projects_path(tmp_path: Path) -> Path:
+    return tmp_path / "kp.json"
+
+
+@pytest.fixture
+def app(cwd_root: Path, known_projects_path: Path):
+    application = create_app(lifespan=None, mode="dev")
+    application.state.project_root = cwd_root
+    application.state.storage = AsyncMock()
+    config = Mem2MemConfig()
+    config.context_gateway = ContextGatewayConfig(
+        known_projects_path=known_projects_path,
+        experimental_claude_projects_scan=False,
+    )
+    application.state.config = config
+    application.state.search_pipeline = None
+    application.state.index_engine = None
+    application.state.embedder = None
+    application.state.dedup_scanner = None
+    application.state.last_reload_error = None
+    return application
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _write_agent(store_root: Path, name: str, body: str = _AGENT_BODY) -> Path:
+    """Dir-layout canonical agent under *store_root* (an ``agents`` dir)."""
+    artifact = store_root / name
+    artifact.mkdir(parents=True, exist_ok=True)
+    manifest = artifact / "agent.md"
+    manifest.write_text(body, encoding="utf-8")
+    return manifest
+
+
+def _shared_agents(root: Path) -> Path:
+    return root / ".memtomem" / "agents"
+
+
+def _local_agents(root: Path) -> Path:
+    return root / ".memtomem" / "agents.local"
+
+
+async def _register(client, root: Path, *, enabled: bool | None = None) -> str:
+    """Register *root* as a known project; optionally flip enrollment."""
+    resp = await client.post("/api/context/known-projects", json={"root": str(root)})
+    assert resp.status_code == 200, resp.text
+    scope_id = resp.json()["project_scope_id"]
+    if enabled is not None:
+        resp = await client.patch(
+            f"/api/context/known-projects/{scope_id}", json={"enabled": enabled}
+        )
+        assert resp.status_code == 200, resp.text
+    return scope_id
+
+
+def _other_project(tmp_path: Path, name: str = "proj-b", *, store: bool = True) -> Path:
+    other = tmp_path / name
+    other.mkdir()
+    (other / ".claude").mkdir()
+    if store:
+        (other / ".memtomem").mkdir()
+    return other
+
+
+# ── apply: cross-project move / copy ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cross_project_move_ok(client, cwd_root: Path, tmp_path: Path) -> None:
+    """shared→shared move A→B: 200 ok + result fields the UI builds on."""
+    src_manifest = _write_agent(_shared_agents(cwd_root), "foo")
+    other = _other_project(tmp_path)
+    scope_b = await _register(client, other)
+
+    resp = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={
+            "mode": "move",
+            "to_target_scope": "project_shared",
+            "to_project_scope_id": scope_b,
+            "confirm_project_shared": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["transferred"] is True
+    assert data["mode"] == "move"
+    assert data["from_scope"] == "project_shared"
+    assert data["to_scope"] == "project_shared"
+    # One-click follow-up sync contract: the destination scope_id + the
+    # engine's exact cd-prefixed command.
+    assert data["dst_project_scope_id"] == scope_b
+    assert data["needs_sync"] is True
+    assert data["sync_command"].startswith("cd ")
+    assert "mm context sync --scope project_shared" in data["sync_command"]
+    # Provenance triple is on the wire even in the quiet case.
+    assert data["provenance"] == "not_applicable"
+    assert data["provenance_reason"] is None
+    assert data["provenance_reason_code"] is None
+
+    assert not src_manifest.parent.exists()
+    dst_manifest = _shared_agents(other) / "foo" / "agent.md"
+    assert dst_manifest.read_text(encoding="utf-8") == _AGENT_BODY
+
+
+@pytest.mark.asyncio
+async def test_cross_project_copy_keeps_source(client, cwd_root: Path, tmp_path: Path) -> None:
+    src_manifest = _write_agent(_shared_agents(cwd_root), "foo")
+    other = _other_project(tmp_path)
+    scope_b = await _register(client, other)
+
+    resp = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={
+            "mode": "copy",
+            "to_target_scope": "project_shared",
+            "to_project_scope_id": scope_b,
+            "confirm_project_shared": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "ok"
+    assert src_manifest.read_text(encoding="utf-8") == _AGENT_BODY
+    assert (_shared_agents(other) / "foo" / "agent.md").is_file()
+
+
+@pytest.mark.asyncio
+async def test_copy_rename_surfaces_provenance_reason_code(
+    client, cwd_root: Path, tmp_path: Path
+) -> None:
+    """A renamed shared→shared copy of a wiki-tracked source never carries
+    provenance — the response must surface the typed reason code (the A-4
+    ``_skip_reasons`` contract this surface exists to expose)."""
+    _write_agent(_shared_agents(cwd_root), "foo")
+    Lockfile.at(cwd_root).upsert_entry(
+        "agents", "foo", wiki_commit="abc123", installed_at=utcnow_iso8601_z()
+    )
+    other = _other_project(tmp_path)
+    scope_b = await _register(client, other)
+
+    resp = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={
+            "mode": "copy",
+            "to_target_scope": "project_shared",
+            "to_project_scope_id": scope_b,
+            "as_name": "bar",
+            "confirm_project_shared": True,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["dst_name"] == "bar"
+    assert data["provenance"] == "not_carried"
+    assert data["provenance_reason_code"] == "renamed_copy"
+    assert "lock.json entries are keyed by wiki asset name" in data["provenance_reason"]
+    assert (_shared_agents(other) / "bar" / "agent.md").is_file()
+
+
+# ── destination refusals ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_collision_409_destination_exists(client, cwd_root: Path, tmp_path: Path) -> None:
+    _write_agent(_shared_agents(cwd_root), "foo")
+    other = _other_project(tmp_path)
+    _write_agent(_shared_agents(other), "foo", "---\nname: foo\n---\n\nresident\n")
+    scope_b = await _register(client, other)
+
+    resp = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={
+            "mode": "move",
+            "to_target_scope": "project_shared",
+            "to_project_scope_id": scope_b,
+            "confirm_project_shared": True,
+        },
+    )
+    assert resp.status_code == 409, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error_kind"] == "conflict"
+    assert detail["reason_code"] == "destination_exists"
+    assert "destination already exists" in detail["message"]
+
+
+@pytest.mark.asyncio
+async def test_paused_destination_409_sync_paused(client, cwd_root: Path, tmp_path: Path) -> None:
+    _write_agent(_shared_agents(cwd_root), "foo")
+    other = _other_project(tmp_path)
+    scope_b = await _register(client, other, enabled=False)
+
+    resp = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={
+            "mode": "move",
+            "to_target_scope": "project_shared",
+            "to_project_scope_id": scope_b,
+            "confirm_project_shared": True,
+        },
+    )
+    assert resp.status_code == 409, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error_kind"] == "conflict"
+    assert detail["reason_code"] == "sync_paused"
+    assert detail["project_scope_id"] == scope_b
+    # Nothing moved.
+    assert (_shared_agents(cwd_root) / "foo" / "agent.md").is_file()
+
+
+@pytest.mark.asyncio
+async def test_implicit_destination_in_paused_source_project_409(
+    client, cwd_root: Path, tmp_path: Path
+) -> None:
+    """Codex design-gate Major-2 pin: omitting ``to_project_scope_id`` must
+    not write a project tier the explicit spelling of the same destination
+    refuses. Source selector names a paused project; destination implicit."""
+    other = _other_project(tmp_path)
+    _write_agent(_shared_agents(other), "foo")
+    scope_b = await _register(client, other, enabled=False)
+
+    resp = await client.post(
+        f"/api/context/agents/foo/transfer?project_scope_id={scope_b}",
+        json={"mode": "move", "to_target_scope": "project_local"},
+    )
+    assert resp.status_code == 409, resp.text
+    detail = resp.json()["detail"]
+    assert detail["reason_code"] == "sync_paused"
+    assert (_shared_agents(other) / "foo" / "agent.md").is_file()
+
+
+@pytest.mark.asyncio
+async def test_user_tier_from_paused_source_project_not_gated_by_eligibility(
+    client, cwd_root: Path, tmp_path: Path
+) -> None:
+    """User-tier destination is a host write, not the paused project's
+    runtime — eligibility must not refuse it (allow_host_writes gates it)."""
+    other = _other_project(tmp_path)
+    _write_agent(_shared_agents(other), "foo")
+    scope_b = await _register(client, other, enabled=False)
+
+    resp = await client.post(
+        f"/api/context/agents/foo/transfer?project_scope_id={scope_b}",
+        json={"mode": "move", "to_target_scope": "user", "allow_host_writes": True},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "ok"
+    assert (Path.home() / ".memtomem" / "agents" / "foo" / "agent.md").is_file()
+
+
+@pytest.mark.asyncio
+async def test_unknown_destination_scope_404(client, cwd_root: Path) -> None:
+    _write_agent(_shared_agents(cwd_root), "foo")
+    resp = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={
+            "mode": "move",
+            "to_target_scope": "project_shared",
+            "to_project_scope_id": "p-deadbeef0000",
+            "confirm_project_shared": True,
+        },
+    )
+    assert resp.status_code == 404, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error_kind"] == "missing"
+    assert "unknown project_scope_id" in detail["message"]
+
+
+@pytest.mark.asyncio
+async def test_destination_without_store_409(client, cwd_root: Path, tmp_path: Path) -> None:
+    _write_agent(_shared_agents(cwd_root), "foo")
+    bare = _other_project(tmp_path, "bare", store=False)
+    scope_b = await _register(client, bare)
+
+    resp = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={
+            "mode": "copy",
+            "to_target_scope": "project_shared",
+            "to_project_scope_id": scope_b,
+            "confirm_project_shared": True,
+        },
+    )
+    assert resp.status_code == 409, resp.text
+    detail = resp.json()["detail"]
+    assert detail["reason_code"] == "no_memtomem_store"
+    assert "mm context init" in detail["message"]
+
+
+@pytest.mark.asyncio
+async def test_source_not_found_404(client, cwd_root: Path) -> None:
+    resp = await client.post(
+        "/api/context/agents/ghost/transfer",
+        json={"mode": "move", "to_target_scope": "project_local"},
+    )
+    assert resp.status_code == 404, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error_kind"] == "missing"
+    assert "not found in any scope" in detail["message"]
+
+
+# ── disclose-then-confirm round-trips ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_gate_b_round_trip(client, cwd_root: Path) -> None:
+    """project_shared destination: disclose (no write) → confirmed re-POST."""
+    src_manifest = _write_agent(_local_agents(cwd_root), "foo")
+
+    first = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={"mode": "move", "to_target_scope": "project_shared"},
+    )
+    assert first.status_code == 200, first.text
+    data = first.json()
+    assert data["status"] == "needs_confirmation"
+    assert data["confirm"] == "confirm_project_shared"
+    assert "host_targets" not in data
+    plan = data["plan"]
+    assert plan["transferred"] is False
+    assert plan["dst_path"].endswith("foo")
+    # Disclosure performed no write.
+    assert src_manifest.is_file()
+    assert not (_shared_agents(cwd_root) / "foo").exists()
+
+    second = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={
+            "mode": "move",
+            "to_target_scope": "project_shared",
+            "confirm_project_shared": True,
+        },
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["status"] == "ok"
+    assert (_shared_agents(cwd_root) / "foo" / "agent.md").is_file()
+    assert not src_manifest.parent.exists()
+
+
+@pytest.mark.asyncio
+async def test_host_write_round_trip(client, cwd_root: Path) -> None:
+    """user-tier destination: host paths disclosed → allow_host_writes re-POST."""
+    src_manifest = _write_agent(_shared_agents(cwd_root), "foo")
+    host_dst = Path.home() / ".memtomem" / "agents" / "foo"
+
+    first = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={"mode": "move", "to_target_scope": "user"},
+    )
+    assert first.status_code == 200, first.text
+    data = first.json()
+    assert data["status"] == "needs_confirmation"
+    assert data["confirm"] == "allow_host_writes"
+    assert data["host_targets"] == [str(host_dst)]
+    assert data["plan"]["dst_project_scope_id"] is None
+    assert src_manifest.is_file()
+    assert not host_dst.exists()
+
+    second = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={"mode": "move", "to_target_scope": "user", "allow_host_writes": True},
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["status"] == "ok"
+    assert (host_dst / "agent.md").read_text(encoding="utf-8") == _AGENT_BODY
+    assert not src_manifest.parent.exists()
+
+
+@pytest.mark.asyncio
+async def test_dry_run_plans_without_confirmation(client, cwd_root: Path) -> None:
+    src_manifest = _write_agent(_local_agents(cwd_root), "foo")
+    resp = await client.post(
+        "/api/context/agents/foo/transfer?dry_run=true",
+        json={"mode": "move", "to_target_scope": "project_shared"},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["status"] == "plan"
+    assert data["transferred"] is False
+    assert src_manifest.is_file()
+    assert not (_shared_agents(cwd_root) / "foo").exists()
+
+
+# ── Gate A / privacy envelope ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_privacy_scan_blocks_with_standard_string_envelope(client, cwd_root: Path) -> None:
+    """Secret bytes landing in project_shared → the standard 422 STRING
+    envelope (issue-pinned), zero residue at the destination. Copy mode
+    carries the transfer-native source-anchored remediation hint (a
+    same-root move keeps migrate's historical Gate A wording — engine
+    contract, pinned in test_context_transfer.py)."""
+    src_manifest = _write_agent(_local_agents(cwd_root), "foo", _SECRET_BODY)
+
+    resp = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={
+            "mode": "copy",
+            "to_target_scope": "project_shared",
+            "confirm_project_shared": True,
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    assert isinstance(detail, str)
+    assert "Offending file" in detail
+    # The hint re-anchors onto the SOURCE manifest (the transient staging
+    # path is gone after rollback).
+    assert str(src_manifest) in detail
+    # Zero residue at the destination; copy never touched the source.
+    assert not (_shared_agents(cwd_root) / "foo").exists()
+    assert src_manifest.read_text(encoding="utf-8") == _SECRET_BODY
+
+
+# ── validation 400s ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_user_destination_with_project_selector_400(client, cwd_root: Path) -> None:
+    _write_agent(_shared_agents(cwd_root), "foo")
+    resp = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={
+            "mode": "move",
+            "to_target_scope": "user",
+            "to_project_scope_id": "p-cafecafe0000",
+            "allow_host_writes": True,
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error_kind"] == "validation"
+    assert "user tier is global" in detail["message"]
+
+
+@pytest.mark.asyncio
+async def test_rename_with_move_400(client, cwd_root: Path) -> None:
+    _write_agent(_shared_agents(cwd_root), "foo")
+    resp = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={
+            "mode": "move",
+            "to_target_scope": "project_local",
+            "as_name": "bar",
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error_kind"] == "validation"
+    assert "copy mode only" in detail["message"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_name_400(client, cwd_root: Path) -> None:
+    """Name validation fires before any path math (CLI-parity). A
+    slash-bearing traversal shape can't even reach the handler — the
+    router 404s a path-param slash — so the reachable invalid class is
+    charset violations."""
+    resp = await client.post(
+        "/api/context/agents/foo$/transfer",
+        json={"mode": "move", "to_target_scope": "project_local"},
+    )
+    assert resp.status_code == 400, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error_kind"] == "validation"
+    assert "invalid agent name" in detail["message"]
+
+
+@pytest.mark.asyncio
+async def test_unsupported_kind_400(client, cwd_root: Path) -> None:
+    resp = await client.post(
+        "/api/context/mcp-servers/foo/transfer",
+        json={"mode": "move", "to_target_scope": "project_local"},
+    )
+    assert resp.status_code == 400, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error_kind"] == "validation"
+    assert "unsupported kind for artifact transfer" in detail["message"]
+
+
+# ── timeout envelope ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_timeout_503_busy_with_bounded_lock_budget(
+    client, cwd_root: Path, monkeypatch
+) -> None:
+    """Engine lock-budget TimeoutError → 503 busy. The fake also records the
+    call kwargs: the route MUST pass the bounded ``lock_timeout`` — an
+    unbounded (None) engine wait would silently reopen the #1145
+    orphan-worker shape while this test kept passing (Codex review)."""
+    import memtomem.web.routes.context_transfer as route_mod
+
+    _write_agent(_shared_agents(cwd_root), "foo")
+    seen_kwargs: dict = {}
+
+    def hung_transfer(*args, **kwargs):
+        seen_kwargs.update(kwargs)
+        raise TimeoutError("could not acquire .lock within 30s (held by another process)")
+
+    monkeypatch.setattr(route_mod, "transfer_artifact", hung_transfer)
+    resp = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={"mode": "move", "to_target_scope": "project_local"},
+    )
+    assert resp.status_code == 503, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error_kind"] == "busy"
+    assert "Transfer timed out" in detail["message"]
+    assert seen_kwargs["lock_timeout"] == route_mod._TRANSFER_LOCK_BUDGET_S


### PR DESCRIPTION
The web UI had zero move/copy surface — the ADR-0023 transfer engine (A-2 #1298)
had CLI verbs (A-3 #1299) and provenance carry-over (A-4 #1300) but no endpoint
for the dashboard's per-artifact "Move/Copy to…" action (B-6 #1289, blocked on
this). `POST /api/context/{kind}/{name}/transfer` is that endpoint; the contract
is pinned in ADR-0023 §10 and ADR-0015 §4d gets the dated rider for the one
non-sync mutator that accepts a project selector.

### Route (`web/routes/context_transfer.py`)

- Source = path `{kind}/{name}` + the standard `?project_scope_id=`/`?scope_id=`
  selector (server cwd default) + optional body `from_scope` (auto-detect when
  omitted). Destination = body `to_target_scope` + optional body
  `to_project_scope_id` (source project when omitted), resolved through the same
  project discovery as every read route: 404 unknown/stale, 409
  `sync_paused`/`sync_not_enrolled` (existing reason-code shape, message
  verbatim from `resolve_writable_scope_root`) for project-tier destinations —
  **including the implicit same-project destination** when the source selector
  names a non-cwd scope, so omitting `to_project_scope_id` can never write
  where the explicit spelling is refused (Codex design-gate finding). Cross-root
  destinations without a `.memtomem/` store → 409 `no_memtomem_store` (A-3 CLI
  gate parity).
- **Disclose-then-confirm round-trip** (the `settings_sync.py` shape, extracted
  to `web/routes/_confirm.py` — the helper A-6 #1263 adopts next): destination
  `project_shared` requires `confirm_project_shared` (Gate B), destination
  `user` requires `allow_host_writes` with the host path disclosed via
  `host_targets`. The first POST without the flag writes nothing and returns
  the engine dry-run plan nested under `plan`. `?dry_run=true` returns the plan
  unconditionally (import-route precedent; gives B-6 its preview).
- Runs under `_gateway_lock` with the engine offloaded to a worker thread
  (`asyncio.timeout(60)`, import-route precedent).
- Response carries `fanout_cleaned`/`fanout_backed_up`, `needs_sync` + the
  engine's exact cd-prefixed `sync_command`, and `dst_project_scope_id` so the
  UI can offer one-click follow-up sync — plus the A-4 provenance triple
  (`provenance` / `provenance_reason` / `provenance_reason_code`) so clients
  match on the stable code (`renamed_copy`, `source_dirty`, …) per the
  `_skip_reasons` contract.
- **Error envelope adopts the unified `error_kind` taxonomy from day one**
  (coordinated with B-1 #1284, which retrofits old routes onto the same
  vocabulary): every route-raised non-2xx detail is an object
  `{error_kind, message, reason_code?, …}` — the overview classifier four plus
  `validation` (400), `conflict` (409 family, with `reason_code`), `busy`
  (503). The one deliberate exception per the issue's acceptance criteria:
  `PrivacyScanError` keeps the standard project_shared block envelope
  (422, string detail).

### Engine (additive, byte-compatible)

- `transfer_artifact(..., lock_timeout=None)` → `_acquire_pair_lock(timeout=…)`:
  a **whole-call deadline shared across both sidecar acquisitions** (worst case
  N seconds, not 2N; monotonic remainder math). The web route passes 30s so a
  cross-process lock holder makes the un-cancellable worker self-abort inside
  the route's 60s window instead of writing after the 503 — the #1145
  orphan-thread shape `_SETTINGS_LOCK_BUDGET_S`/`_SKILLS_LOCK_BUDGET_S` close
  for their engines. Default `None` keeps the historical blocking waits for
  every CLI/MCP call site (pinned by test).
- Two typed `ClickException` subclasses so surfaces map errors by TYPE, not
  message text: `migrate.ArtifactNotFoundError` (→ 404) and
  `transfer.TransferCollisionError` (→ 409 `destination_exists`). Message
  literals are byte-identical to the plain exceptions they replace — pinned by
  tests, so CLI/MCP/`migrate_scope` consumers are untouched.

### Tests

`test_web_routes_context_transfer.py` (19): cross-project move/copy, the
collision 409, paused-destination 409 (explicit AND implicit spelling, plus the
user-tier-not-gated counter-case), unknown-destination 404, both two-step
confirmation round-trips (disclosure performs no write), `dry_run` plan,
privacy-block 422 string envelope with zero destination residue, the renamed-copy
provenance reason-code surfacing, validation 400s, timeout 503.
`test_context_transfer.py` (+5): lock-timeout self-abort with nothing committed,
budget shared across the pair, default-None unbounded pin, typed-exception
byte-literal pins. Existing lock-wrapper test doubles updated for the new
keyword (signature-compatible delegation only).

Part of #1270 (campaign item A-5). Closes #1276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
