### PR TITLE
feat(context): accept target_scope=user on artifact write/sync routes (#1263)

### DIFF
--- a/docs/adr/0015-context-gateway-scope-vocabulary.md
+++ b/docs/adr/0015-context-gateway-scope-vocabulary.md
@@ -270,6 +270,31 @@ batch.
 > list/read routes accept the full tier set. The engine already supports
 > user-tier sync (ADR-0011 PR-E3); exposing it through the web write
 > routes is tracked in #1263.
+>
+> **2026-06 (#1263):** Shipped — the skills / commands / agents write
+> routes (create / update / delete / import / sync) now accept
+> `target_scope=user`, completed only through a disclose-then-confirm
+> round-trip: the first unconfirmed request performs no write and
+> returns the `_confirm.py` `needs_confirmation` envelope (ADR-0023 §10
+> shape) listing the pending `host_targets` (`~/.memtomem/<kind>/`
+> canonicals, `~/.claude`-family fan-out roots). For sync, that list is
+> an upper bound resolved from the parsed frontmatter names the engine
+> fans out under: later engine preflight (Gate A, override errors,
+> target conflicts, lock timeouts) can only shrink the written set below
+> the disclosure, never relocate it. Re-sending with
+> `allow_host_writes=true` (body field on POST/PUT, query parameter on
+> DELETE) applies it. The gate fires only when the request has pending
+> host writes — no-op requests (idempotent deletes, nothing-to-import
+> imports, empty canonical sets) and requests refused by cheaper checks
+> (duplicate create, stale mtime) never prompt. Import routes disclose
+> via an engine dry-run nested under `plan` (transfer-route parity).
+> `project_local` writes stay 400 (no fan-out, ADR-0011 §3); mcp-servers
+> stay project_shared-only by design (ADR-0011 §1); version routes
+> (ADR-0022) stay project_shared-only. The sync-eligibility 409
+> (#1203 §1i) still precedes the tier gate for selected paused projects.
+> Web UI affordance (tier-aware write buttons + confirm dialog) is the
+> #1263 follow-up; until it lands the dashboard keeps its client-side
+> write block on non-shared tiers.
 
 #### 4d. Mutator routes accepting `project_scope_id` — Option C (sync only)
 

--- a/packages/memtomem/src/memtomem/web/routes/_confirm.py
+++ b/packages/memtomem/src/memtomem/web/routes/_confirm.py
@@ -18,15 +18,22 @@ first and owns the extraction). Contract:
 - Callers attach surface-specific context via ``extra`` (the transfer
   route nests its dry-run preview under ``plan``).
 
-A-6 (#1263) migrates the settings-sync host-write refusals onto this
-helper; until then ``generate_all_settings`` keeps its engine-level
-per-generator ``needs_confirmation`` results.
+The artifact write/sync routes (skills / commands / agents, #1263)
+gate their ``target_scope=user`` writes through :func:`host_write_gate`
+below. Settings sync is the one deliberate hold-out: its refusal is
+engine-level and per-generator (``generate_all_settings`` returns a
+``needs_confirmation`` *result row* per runtime target, consumed by the
+CLI prompt, the web route, and the dashboard's Sync All summary), so
+migrating it onto this envelope is a behavior-visible refactor tracked
+separately — not part of #1263.
 """
 
 from __future__ import annotations
 
 from collections.abc import Sequence
 from typing import Any
+
+from memtomem.config import TargetScope
 
 
 def needs_confirmation_envelope(
@@ -50,3 +57,43 @@ def needs_confirmation_envelope(
         payload["host_targets"] = list(host_targets)
     payload.update(extra)
     return payload
+
+
+def host_write_gate(
+    target_scope: TargetScope,
+    allow_host_writes: bool,
+    *,
+    action: str,
+    host_targets: Sequence[str],
+    **extra: Any,
+) -> dict[str, Any] | None:
+    """``needs_confirmation`` envelope for an unconfirmed user-tier write, else ``None``.
+
+    The #1263 contract for the artifact write/sync routes: a
+    ``target_scope=user`` request whose pending writes land on host paths
+    (the ``~/.memtomem/<kind>/`` canonicals and the ``~/.claude/...``-family
+    fan-out roots both live outside any project root) must disclose those
+    paths and complete only on a confirmed re-request. Callers compute
+    ``host_targets`` from the *pending* mutation — an empty sequence means
+    the request would not write anything, and the gate stays open
+    (``None``) so no-op requests (idempotent deletes, nothing-to-import
+    imports, empty canonical sets) never prompt; cheap conflict checks
+    (409 duplicate create, 404 missing update) likewise belong *before*
+    this gate so a request that cannot succeed is refused, not confirmed.
+
+    ``allow_host_writes`` is the request's opt-in flag: a body field on
+    POST/PUT routes, a query parameter on DELETE (bodies on DELETE are
+    client-hostile). The reason prose therefore says "re-send", not
+    "re-POST". Project tiers pass through untouched (``None``) — their
+    write policy is the caller's business.
+    """
+    if target_scope != "user" or allow_host_writes or not host_targets:
+        return None
+    return needs_confirmation_envelope(
+        f"{action} targets the user tier — host paths outside any project "
+        f"root. Re-send the request with allow_host_writes=true after "
+        f"confirming with the user.",
+        confirm="allow_host_writes",
+        host_targets=host_targets,
+        **extra,
+    )

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -15,12 +15,14 @@ from memtomem.config import TargetScope
 from memtomem.context import versioning
 from memtomem.context._atomic import atomic_write_text
 from memtomem.context._names import InvalidNameError, validate_name
+from memtomem.context._runtime_targets import KNOWN_RUNTIMES, runtime_fanout_root
 from memtomem.context.agents import (
     AGENT_DIR_FILENAME,
     AGENT_GENERATORS,
     CANONICAL_AGENT_ROOT,
     ON_DROP_LEVELS,
     AgentParseError,
+    ExtractResult,
     StrictDropError,
     SubAgent,
     _parse_canonical_agent_text,
@@ -46,6 +48,7 @@ from memtomem.web.routes.context_projects import (
     resolve_writable_scope_root,
 )
 from memtomem.web.routes.context_versions import include_has, version_summary
+from memtomem.web.routes._confirm import host_write_gate
 from memtomem.web.routes._locks import _gateway_lock
 
 # Flat list of project-relative runtime scan paths reported on list / import
@@ -77,20 +80,67 @@ def _resolve_existing_agent(
     return name, resolve_canonical_agent(project_root, name, scope=scope)
 
 
-def _reject_non_shared_write(target_scope: TargetScope, action: str) -> None:
-    """Reject writes on non-``project_shared`` tiers with HTTP 400.
+def _reject_project_local_write(target_scope: TargetScope, action: str) -> None:
+    """Reject writes on the ``project_local`` tier with HTTP 400.
 
-    See context_skills.py:_reject_non_shared_write for the rationale.
-    Mirrored here so each route file stays self-contained.
+    See context_skills.py:_reject_project_local_write for the rationale
+    (user accepted behind the #1263 host-write confirm; project_local
+    deferred per ADR-0011 §3). Mirrored here so each route file stays
+    self-contained.
     """
-    if target_scope != "project_shared":
+    if target_scope == "project_local":
         raise HTTPException(
             status_code=400,
             detail=(
-                f"{action} is supported only on project_shared in this release; "
-                f"got target_scope={target_scope!r}."
+                f"{action} is supported on the project_shared and user tiers; "
+                f"project_local is a draft tier with no runtime fan-out "
+                f"(ADR-0011 §3)."
             ),
         )
+
+
+def _user_scan_dirs() -> list[str]:
+    """User-tier runtime roots the import scan reads (absolute, expanded).
+
+    Mirrors context_skills._user_scan_dirs — the project-relative
+    ``_AGENT_SCAN_DIRS`` hint would lie on ``target_scope=user``.
+    """
+    dirs: list[str] = []
+    for runtime in KNOWN_RUNTIMES:
+        root = runtime_fanout_root("agents", runtime, "user", None)
+        if root is not None:
+            dirs.append(str(root))
+    return sorted(set(dirs))
+
+
+def _scanned_dirs_for(target_scope: TargetScope) -> list[str]:
+    return _user_scan_dirs() if target_scope == "user" else _AGENT_SCAN_DIRS
+
+
+def _user_sync_host_targets(project_root: Path) -> list[str]:
+    """Pending user-tier fan-out destinations for the sync confirm gate.
+
+    Upper bound on the confirmed sync's writes, resolved from the PARSED
+    frontmatter name: ``sync_atomic_artifact`` fans out under
+    ``adapter.name_of(parse(...))``, not the canonical filename, so a
+    filename-derived disclosure could confirm one path while the engine
+    writes another (#1263 review Blocker). Canonicals the engine would
+    skip at read/parse time are excluded the same way; later preflight
+    skips (Gate A, override errors, conflicts, lock timeouts) only
+    shrink the actual write set below this disclosure.
+    """
+    targets: set[str] = set()
+    for agent_path, layout in list_canonical_agents(project_root, scope="user"):
+        try:
+            text = agent_path.read_bytes().decode("utf-8", errors="replace")
+            parsed = _parse_canonical_agent_text(text, source=agent_path, layout=layout)
+        except (OSError, AgentParseError):
+            continue  # the engine skips these too
+        for gen in AGENT_GENERATORS.values():
+            dst = gen.target_file(project_root, parsed.name, scope="user")
+            if dst is not None:
+                targets.add(str(dst))
+    return sorted(targets)
 
 
 def _agent_to_dict(agent: SubAgent) -> dict:
@@ -286,6 +336,10 @@ async def rendered_agent(
 class AgentCreateRequest(BaseModel):
     name: str
     content: str
+    # #1263 host-write opt-in: required true for target_scope=user (the
+    # canonical lands under ~/.memtomem/, outside any project root). The
+    # first POST without it returns the needs_confirmation envelope.
+    allow_host_writes: bool = False
 
 
 @router.post("/context/agents")
@@ -294,11 +348,32 @@ async def create_agent(
     project_root: Path = Depends(resolve_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
-        description="Canonical-residency tier to create in. Non-shared tiers rejected (ADR-0011).",
+        description=(
+            "Canonical-residency tier to create in. user requires the "
+            "allow_host_writes confirm round-trip; project_local rejected (ADR-0011 §3)."
+        ),
     ),
 ) -> dict:
-    _reject_non_shared_write(target_scope, "Create agent")
+    _reject_project_local_write(target_scope, "Create agent")
     name = validate_name(body.name, kind="agent")
+
+    # Unlocked pre-checks so a duplicate is refused (409) rather than
+    # confirmed, and the gate discloses the exact artifact dir. The locked
+    # re-checks below stay authoritative for create races.
+    artifact_dir_unlocked = _agents_root(project_root, scope=target_scope) / name
+    if (
+        resolve_canonical_agent(project_root, name, scope=target_scope) is not None
+        or artifact_dir_unlocked.exists()
+    ):
+        raise HTTPException(409, detail=f"Agent '{name}' already exists")
+    gate = host_write_gate(
+        target_scope,
+        body.allow_host_writes,
+        action="Create agent",
+        host_targets=[str(artifact_dir_unlocked)],
+    )
+    if gate is not None:
+        return gate
 
     try:
         async with asyncio.timeout(60):
@@ -345,7 +420,7 @@ async def create_agent(
                     raise
     except TimeoutError:
         raise HTTPException(503, "Agent create timed out — another sync may be in progress")
-    return {"name": name, "canonical_path": str(agent_path.relative_to(project_root))}
+    return {"name": name, "canonical_path": _safe_rel(agent_path, project_root)}
 
 
 # ── Update ───────────────────────────────────────────────────────────────
@@ -360,6 +435,22 @@ class AgentUpdateRequest(BaseModel):
     # (see issue #763); every force-save emits a WARNING with both mtime
     # values for the audit trail.
     force: bool = False
+    # #1263 host-write opt-in for target_scope=user (see AgentCreateRequest).
+    allow_host_writes: bool = False
+
+
+_MTIME_CONFLICT_REASON = "File was modified by another process. Reload and retry."
+
+
+def _mtime_conflict_response(current_mtime_ns: int) -> JSONResponse:
+    return JSONResponse(
+        status_code=409,
+        content={
+            "status": "aborted",
+            "reason": _MTIME_CONFLICT_REASON,
+            "mtime_ns": str(current_mtime_ns),
+        },
+    )
 
 
 @router.put("/context/agents/{name}")
@@ -369,10 +460,13 @@ async def update_agent(
     project_root: Path = Depends(resolve_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
-        description="Canonical-residency tier to update. Non-shared tiers rejected (ADR-0011).",
+        description=(
+            "Canonical-residency tier to update. user requires the "
+            "allow_host_writes confirm round-trip; project_local rejected (ADR-0011 §3)."
+        ),
     ),
 ) -> JSONResponse:
-    _reject_non_shared_write(target_scope, "Update agent")
+    _reject_project_local_write(target_scope, "Update agent")
     name, resolved = _resolve_existing_agent(project_root, name, scope=target_scope)
     if resolved is None:
         raise KeyError(name)
@@ -383,22 +477,27 @@ async def update_agent(
     except ValueError:
         raise HTTPException(422, f"Invalid mtime_ns: {body.mtime_ns!r}")
 
+    # Unlocked pre-check before the host-write gate — a stale request is
+    # refused, never confirmed (see context_skills.update_skill).
+    pre_mtime_ns = agent_path.stat().st_mtime_ns
+    if pre_mtime_ns != body_mtime_ns and not body.force:
+        return _mtime_conflict_response(pre_mtime_ns)
+    gate = host_write_gate(
+        target_scope,
+        body.allow_host_writes,
+        action="Update agent",
+        host_targets=[str(agent_path)],
+    )
+    if gate is not None:
+        return JSONResponse(content=gate)
+
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
                 current_mtime_ns = agent_path.stat().st_mtime_ns
                 if current_mtime_ns != body_mtime_ns:
                     if not body.force:
-                        return JSONResponse(
-                            status_code=409,
-                            content={
-                                "status": "aborted",
-                                "reason": (
-                                    "File was modified by another process. Reload and retry."
-                                ),
-                                "mtime_ns": str(current_mtime_ns),
-                            },
-                        )
+                        return _mtime_conflict_response(current_mtime_ns)
                     logger.warning(
                         "force-save bypassed mtime check on %s "
                         "(client_mtime_ns=%s server_mtime_ns=%s)",
@@ -430,11 +529,40 @@ async def delete_agent(
     project_root: Path = Depends(resolve_scope_root_cascade_gated),
     target_scope: TargetScope = Query(
         "project_shared",
-        description="Canonical-residency tier to delete from. Non-shared tiers rejected (ADR-0011).",
+        description=(
+            "Canonical-residency tier to delete from. user requires the "
+            "allow_host_writes confirm round-trip; project_local rejected (ADR-0011 §3)."
+        ),
+    ),
+    allow_host_writes: bool = Query(
+        False,
+        description=(
+            "#1263 host-write opt-in for target_scope=user. Query parameter "
+            "(not a body field) because DELETE bodies are client-hostile; "
+            "the needs_confirmation envelope names the same flag."
+        ),
     ),
 ) -> dict:
-    _reject_non_shared_write(target_scope, "Delete agent")
+    _reject_project_local_write(target_scope, "Delete agent")
     name, resolved = _resolve_existing_agent(project_root, name, scope=target_scope)
+
+    # Pending deletions, computed unlocked (see delete_skill): cascade
+    # targets resolve AT THIS TIER — scope= is load-bearing for user-tier
+    # cascades. Idempotent no-ops skip the gate.
+    pending: list[Path] = [resolved[0]] if resolved is not None else []
+    if cascade:
+        for gen in AGENT_GENERATORS.values():
+            target = gen.target_file(project_root, name, scope=target_scope)
+            if target is not None and target.is_file():
+                pending.append(target)
+    gate = host_write_gate(
+        target_scope,
+        allow_host_writes,
+        action="Delete agent",
+        host_targets=[str(p) for p in pending],
+    )
+    if gate is not None:
+        return gate
 
     try:
         async with asyncio.timeout(60):
@@ -452,7 +580,7 @@ async def delete_agent(
 
                 if cascade:
                     for gen in AGENT_GENERATORS.values():
-                        target = gen.target_file(project_root, name)
+                        target = gen.target_file(project_root, name, scope=target_scope)
                         if target is None:
                             continue
                         if not target.is_file():
@@ -571,6 +699,8 @@ async def diff_agent(
 
 class SyncRequest(BaseModel):
     on_drop: str = "warn"
+    # #1263 host-write opt-in for target_scope=user (see AgentCreateRequest).
+    allow_host_writes: bool = False
 
     # An out-of-vocabulary value used to slip through to the engine, where it
     # silently behaved as "ignore" (#1247 id 47) — reject at the boundary
@@ -592,16 +722,32 @@ async def sync_agents(
     project_root: Path = Depends(resolve_writable_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
-        description="Canonical-residency tier to fan out. Non-shared tiers rejected (ADR-0011).",
+        description=(
+            "Canonical-residency tier to fan out. user fans out to the host "
+            "~/.claude-family roots behind the allow_host_writes confirm "
+            "round-trip (#1263); project_local rejected — no runtime fan-out "
+            "per ADR-0011 §3."
+        ),
     ),
 ) -> dict:
-    _reject_non_shared_write(target_scope, "Sync agents")
+    _reject_project_local_write(target_scope, "Sync agents")
     on_drop = body.on_drop if body else "warn"
+    gate = host_write_gate(
+        target_scope,
+        body.allow_host_writes if body else False,
+        action="Sync agents",
+        host_targets=_user_sync_host_targets(project_root),
+    )
+    if gate is not None:
+        return gate
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
                 result = generate_all_agents(
-                    project_root, on_drop=on_drop, surface="web_context_agents_sync"
+                    project_root,
+                    on_drop=on_drop,
+                    scope=target_scope,
+                    surface="web_context_agents_sync",
                 )
     except TimeoutError:
         raise HTTPException(503, "Agents sync timed out — another sync may be in progress")
@@ -649,43 +795,27 @@ async def sync_agents(
 
 class ImportRequest(BaseModel):
     overwrite: bool = False
+    # #1263 host-write opt-in for target_scope=user (the canonical
+    # destination is ~/.memtomem/agents/, outside any project root).
+    allow_host_writes: bool = False
 
 
-@router.post("/context/agents/import")
-async def import_agents(
-    body: ImportRequest | None = None,
-    project_root: Path = Depends(resolve_scope_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to import into. Non-shared tiers rejected (ADR-0011).",
-    ),
-    dry_run: bool = Query(
-        False,
-        description=(
-            "Preview the import without writing to canonical (rank-10): runs the "
-            "full scan + privacy walk + dedup and returns the would-import / would-"
-            "skip counts, leaving disk untouched."
-        ),
-    ),
+def _import_payload(
+    result: ExtractResult,
+    project_root: Path,
+    target_scope: TargetScope,
+    dry_run: bool | None,
 ) -> dict:
-    _reject_non_shared_write(target_scope, "Import agents")
-    overwrite = body.overwrite if body else False
-    try:
-        async with asyncio.timeout(60):
-            async with _gateway_lock:
-                result = extract_agents_to_canonical(
-                    project_root,
-                    overwrite=overwrite,
-                    dry_run=dry_run,
-                    surface="web_context_agents_import",
-                )
-    except TimeoutError:
-        raise HTTPException(503, "Agents import timed out — another sync may be in progress")
-    return {
+    """Wire shape shared by both import routes (and the gate's nested plan).
+
+    Mirrors context_skills._import_payload — ``dry_run=None`` omits the
+    key, ``_safe_rel`` keeps user-tier ``~/.memtomem`` paths encodable.
+    """
+    payload: dict = {
         "imported": [
             {
                 "name": canonical_agent_name(p, layout),
-                "canonical_path": str(p.relative_to(project_root)),
+                "canonical_path": _safe_rel(p, project_root),
             }
             for p, layout in result.imported
         ],
@@ -694,9 +824,67 @@ async def import_agents(
             for name, reason, code in result.skipped
         ],
         "project_root": str(project_root),
-        "scanned_dirs": _AGENT_SCAN_DIRS,
-        "dry_run": dry_run,
+        "scanned_dirs": _scanned_dirs_for(target_scope),
     }
+    if dry_run is not None:
+        payload["dry_run"] = dry_run
+    return payload
+
+
+@router.post("/context/agents/import")
+async def import_agents(
+    body: ImportRequest | None = None,
+    project_root: Path = Depends(resolve_scope_root),
+    target_scope: TargetScope = Query(
+        "project_shared",
+        description=(
+            "Canonical-residency tier to import into. user requires the "
+            "allow_host_writes confirm round-trip; project_local rejected (ADR-0011 §3)."
+        ),
+    ),
+    dry_run: bool = Query(
+        False,
+        description=(
+            "Preview the import without writing to canonical (rank-10): runs the "
+            "full scan + privacy walk + dedup and returns the would-import / would-"
+            "skip counts, leaving disk untouched. Returned regardless of "
+            "confirmation flags (mirrors the transfer route's dry_run)."
+        ),
+    ),
+) -> dict:
+    _reject_project_local_write(target_scope, "Import agents")
+    overwrite = body.overwrite if body else False
+    allow_host_writes = body.allow_host_writes if body else False
+
+    async def _run(dry: bool) -> ExtractResult:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                return extract_agents_to_canonical(
+                    project_root,
+                    overwrite=overwrite,
+                    dry_run=dry,
+                    scope=target_scope,
+                    surface="web_context_agents_import",
+                )
+
+    try:
+        if not dry_run and target_scope == "user" and not allow_host_writes:
+            # Gate disclosure needs the engine's scan — dry-run preview,
+            # nested as ``plan`` (see context_skills.import_skills).
+            preview = await _run(dry=True)
+            gate = host_write_gate(
+                target_scope,
+                allow_host_writes,
+                action="Import agents",
+                host_targets=[str(p) for p, _layout in preview.imported],
+                plan=_import_payload(preview, project_root, target_scope, dry_run=True),
+            )
+            if gate is not None:
+                return gate
+        result = await _run(dry=dry_run)
+    except TimeoutError:
+        raise HTTPException(503, "Agents import timed out — another sync may be in progress")
+    return _import_payload(result, project_root, target_scope, dry_run=dry_run)
 
 
 @router.post("/context/agents/{name}/import")
@@ -706,46 +894,57 @@ async def import_agent(
     project_root: Path = Depends(resolve_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
-        description="Canonical-residency tier to import into. Non-shared tiers rejected (ADR-0011).",
+        description=(
+            "Canonical-residency tier to import into. user requires the "
+            "allow_host_writes confirm round-trip; project_local rejected (ADR-0011 §3)."
+        ),
     ),
 ) -> dict:
-    """Import a single runtime agent into ``.memtomem/agents/``.
+    """Import a single runtime agent into the scoped canonical dir.
 
     Same response shape as the section-level import so the web UI can reuse
     its rendering. 404 when no runtime file matches the name (the section
     import would silently report 0 imported, which is the wrong shape of
-    feedback for "you clicked a specific item that doesn't exist").
+    feedback for "you clicked a specific item that doesn't exist") — pinned
+    on the gate's dry-run preview too.
     """
-    _reject_non_shared_write(target_scope, "Import agent")
+    _reject_project_local_write(target_scope, "Import agent")
     try:
         validate_name(name, kind="agent name")
     except InvalidNameError as exc:
         raise HTTPException(400, f"Invalid agent name: {exc}")
     overwrite = body.overwrite if body else False
-    try:
+    allow_host_writes = body.allow_host_writes if body else False
+
+    async def _run(dry: bool) -> ExtractResult:
         async with asyncio.timeout(60):
             async with _gateway_lock:
-                result = extract_agents_to_canonical(
+                return extract_agents_to_canonical(
                     project_root,
                     overwrite=overwrite,
                     only_name=name,
+                    dry_run=dry,
+                    scope=target_scope,
                     surface="web_context_agents_import",
                 )
+
+    try:
+        if target_scope == "user" and not allow_host_writes:
+            preview = await _run(dry=True)
+            if not preview.imported and not preview.skipped:
+                raise HTTPException(404, f"No runtime agent named {name!r} to import")
+            gate = host_write_gate(
+                target_scope,
+                allow_host_writes,
+                action="Import agent",
+                host_targets=[str(p) for p, _layout in preview.imported],
+                plan=_import_payload(preview, project_root, target_scope, dry_run=None),
+            )
+            if gate is not None:
+                return gate
+        result = await _run(dry=False)
     except TimeoutError:
         raise HTTPException(503, "Agent import timed out — another sync may be in progress")
     if not result.imported and not result.skipped:
         raise HTTPException(404, f"No runtime agent named {name!r} to import")
-    return {
-        "imported": [
-            {
-                "name": canonical_agent_name(p, layout),
-                "canonical_path": str(p.relative_to(project_root)),
-            }
-            for p, layout in result.imported
-        ],
-        "skipped": [
-            {"name": n, "reason": reason, "reason_code": code} for n, reason, code in result.skipped
-        ],
-        "project_root": str(project_root),
-        "scanned_dirs": _AGENT_SCAN_DIRS,
-    }
+    return _import_payload(result, project_root, target_scope, dry_run=None)

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -15,6 +15,7 @@ from memtomem.config import TargetScope
 from memtomem.context import versioning
 from memtomem.context._atomic import atomic_write_text
 from memtomem.context._names import InvalidNameError, validate_name
+from memtomem.context._runtime_targets import KNOWN_RUNTIMES, runtime_fanout_root
 from memtomem.context.commands import (
     _parse_canonical_command_text,
     CANONICAL_COMMAND_ROOT,
@@ -22,6 +23,7 @@ from memtomem.context.commands import (
     COMMAND_GENERATORS,
     ON_DROP_LEVELS,
     CommandParseError,
+    ExtractResult,
     StrictDropError,
     canonical_command_name,
     diff_commands,
@@ -45,6 +47,7 @@ from memtomem.web.routes.context_projects import (
     resolve_writable_scope_root,
 )
 from memtomem.web.routes.context_versions import include_has, version_summary
+from memtomem.web.routes._confirm import host_write_gate
 from memtomem.web.routes._locks import _gateway_lock
 
 # Flat list of project-relative runtime scan paths reported on list / import
@@ -73,18 +76,21 @@ def _resolve_existing_command(
     return name, resolve_canonical_command(project_root, name, scope=scope)
 
 
-def _reject_non_shared_write(target_scope: TargetScope, action: str) -> None:
-    """Reject writes on non-``project_shared`` tiers with HTTP 400.
+def _reject_project_local_write(target_scope: TargetScope, action: str) -> None:
+    """Reject writes on the ``project_local`` tier with HTTP 400.
 
-    See context_skills.py:_reject_non_shared_write for the rationale.
-    Mirrored here so each route file stays self-contained.
+    See context_skills.py:_reject_project_local_write for the rationale
+    (user accepted behind the #1263 host-write confirm; project_local
+    deferred per ADR-0011 §3). Mirrored here so each route file stays
+    self-contained.
     """
-    if target_scope != "project_shared":
+    if target_scope == "project_local":
         raise HTTPException(
             status_code=400,
             detail=(
-                f"{action} is supported only on project_shared in this release; "
-                f"got target_scope={target_scope!r}."
+                f"{action} is supported on the project_shared and user tiers; "
+                f"project_local is a draft tier with no runtime fan-out "
+                f"(ADR-0011 §3)."
             ),
         )
 
@@ -94,6 +100,50 @@ def _safe_rel(p: Path, project_root: Path) -> str:
         return p.relative_to(project_root).as_posix()
     except ValueError:
         return p.as_posix()
+
+
+def _user_scan_dirs() -> list[str]:
+    """User-tier runtime roots the import scan reads (absolute, expanded).
+
+    Mirrors context_skills._user_scan_dirs — the project-relative
+    ``_COMMAND_SCAN_DIRS`` hint would lie on ``target_scope=user``.
+    """
+    dirs: list[str] = []
+    for runtime in KNOWN_RUNTIMES:
+        root = runtime_fanout_root("commands", runtime, "user", None)
+        if root is not None:
+            dirs.append(str(root))
+    return sorted(set(dirs))
+
+
+def _scanned_dirs_for(target_scope: TargetScope) -> list[str]:
+    return _user_scan_dirs() if target_scope == "user" else _COMMAND_SCAN_DIRS
+
+
+def _user_sync_host_targets(project_root: Path) -> list[str]:
+    """Pending user-tier fan-out destinations for the sync confirm gate.
+
+    Upper bound on the confirmed sync's writes, resolved from the PARSED
+    frontmatter name: ``sync_atomic_artifact`` fans out under
+    ``adapter.name_of(parse(...))``, not the canonical filename, so a
+    filename-derived disclosure could confirm one path while the engine
+    writes another (#1263 review Blocker). Canonicals the engine would
+    skip at read/parse time are excluded the same way; later preflight
+    skips (Gate A, override errors, conflicts, lock timeouts) only
+    shrink the actual write set below this disclosure.
+    """
+    targets: set[str] = set()
+    for cmd_path, layout in list_canonical_commands(project_root, scope="user"):
+        try:
+            text = cmd_path.read_bytes().decode("utf-8", errors="replace")
+            parsed = _parse_canonical_command_text(text, source=cmd_path, layout=layout)
+        except (OSError, CommandParseError):
+            continue  # the engine skips these too
+        for gen in COMMAND_GENERATORS.values():
+            dst = gen.target_file(project_root, parsed.name, scope="user")
+            if dst is not None:
+                targets.add(str(dst))
+    return sorted(targets)
 
 
 # ── List ─────────────────────────────────────────────────────────────────
@@ -286,6 +336,10 @@ async def rendered_command(
 class CommandCreateRequest(BaseModel):
     name: str
     content: str
+    # #1263 host-write opt-in: required true for target_scope=user (the
+    # canonical lands under ~/.memtomem/, outside any project root). The
+    # first POST without it returns the needs_confirmation envelope.
+    allow_host_writes: bool = False
 
 
 @router.post("/context/commands")
@@ -294,11 +348,32 @@ async def create_command(
     project_root: Path = Depends(resolve_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
-        description="Canonical-residency tier to create in. Non-shared tiers rejected (ADR-0011).",
+        description=(
+            "Canonical-residency tier to create in. user requires the "
+            "allow_host_writes confirm round-trip; project_local rejected (ADR-0011 §3)."
+        ),
     ),
 ) -> dict:
-    _reject_non_shared_write(target_scope, "Create command")
+    _reject_project_local_write(target_scope, "Create command")
     name = validate_name(body.name, kind="command")
+
+    # Unlocked pre-checks so a duplicate is refused (409) rather than
+    # confirmed, and the gate discloses the exact artifact dir. The locked
+    # re-checks below stay authoritative for create races.
+    artifact_dir_unlocked = _commands_root(project_root, scope=target_scope) / name
+    if (
+        resolve_canonical_command(project_root, name, scope=target_scope) is not None
+        or artifact_dir_unlocked.exists()
+    ):
+        raise HTTPException(409, detail=f"Command '{name}' already exists")
+    gate = host_write_gate(
+        target_scope,
+        body.allow_host_writes,
+        action="Create command",
+        host_targets=[str(artifact_dir_unlocked)],
+    )
+    if gate is not None:
+        return gate
 
     try:
         async with asyncio.timeout(60):
@@ -345,7 +420,7 @@ async def create_command(
                     raise
     except TimeoutError:
         raise HTTPException(503, "Command create timed out — another sync may be in progress")
-    return {"name": name, "canonical_path": str(cmd_path.relative_to(project_root))}
+    return {"name": name, "canonical_path": _safe_rel(cmd_path, project_root)}
 
 
 # ── Update ───────────────────────────────────────────────────────────────
@@ -360,6 +435,22 @@ class CommandUpdateRequest(BaseModel):
     # (see issue #763); every force-save emits a WARNING with both mtime
     # values for the audit trail.
     force: bool = False
+    # #1263 host-write opt-in for target_scope=user (see CommandCreateRequest).
+    allow_host_writes: bool = False
+
+
+_MTIME_CONFLICT_REASON = "File was modified by another process. Reload and retry."
+
+
+def _mtime_conflict_response(current_mtime_ns: int) -> JSONResponse:
+    return JSONResponse(
+        status_code=409,
+        content={
+            "status": "aborted",
+            "reason": _MTIME_CONFLICT_REASON,
+            "mtime_ns": str(current_mtime_ns),
+        },
+    )
 
 
 @router.put("/context/commands/{name}")
@@ -369,10 +460,13 @@ async def update_command(
     project_root: Path = Depends(resolve_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
-        description="Canonical-residency tier to update. Non-shared tiers rejected (ADR-0011).",
+        description=(
+            "Canonical-residency tier to update. user requires the "
+            "allow_host_writes confirm round-trip; project_local rejected (ADR-0011 §3)."
+        ),
     ),
 ) -> JSONResponse:
-    _reject_non_shared_write(target_scope, "Update command")
+    _reject_project_local_write(target_scope, "Update command")
     name, resolved = _resolve_existing_command(project_root, name, scope=target_scope)
     if resolved is None:
         raise KeyError(name)
@@ -383,22 +477,27 @@ async def update_command(
     except ValueError:
         raise HTTPException(422, f"Invalid mtime_ns: {body.mtime_ns!r}")
 
+    # Unlocked pre-check before the host-write gate — a stale request is
+    # refused, never confirmed (see context_skills.update_skill).
+    pre_mtime_ns = cmd_path.stat().st_mtime_ns
+    if pre_mtime_ns != body_mtime_ns and not body.force:
+        return _mtime_conflict_response(pre_mtime_ns)
+    gate = host_write_gate(
+        target_scope,
+        body.allow_host_writes,
+        action="Update command",
+        host_targets=[str(cmd_path)],
+    )
+    if gate is not None:
+        return JSONResponse(content=gate)
+
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
                 current_mtime_ns = cmd_path.stat().st_mtime_ns
                 if current_mtime_ns != body_mtime_ns:
                     if not body.force:
-                        return JSONResponse(
-                            status_code=409,
-                            content={
-                                "status": "aborted",
-                                "reason": (
-                                    "File was modified by another process. Reload and retry."
-                                ),
-                                "mtime_ns": str(current_mtime_ns),
-                            },
-                        )
+                        return _mtime_conflict_response(current_mtime_ns)
                     logger.warning(
                         "force-save bypassed mtime check on %s "
                         "(client_mtime_ns=%s server_mtime_ns=%s)",
@@ -423,11 +522,40 @@ async def delete_command(
     project_root: Path = Depends(resolve_scope_root_cascade_gated),
     target_scope: TargetScope = Query(
         "project_shared",
-        description="Canonical-residency tier to delete from. Non-shared tiers rejected (ADR-0011).",
+        description=(
+            "Canonical-residency tier to delete from. user requires the "
+            "allow_host_writes confirm round-trip; project_local rejected (ADR-0011 §3)."
+        ),
+    ),
+    allow_host_writes: bool = Query(
+        False,
+        description=(
+            "#1263 host-write opt-in for target_scope=user. Query parameter "
+            "(not a body field) because DELETE bodies are client-hostile; "
+            "the needs_confirmation envelope names the same flag."
+        ),
     ),
 ) -> dict:
-    _reject_non_shared_write(target_scope, "Delete command")
+    _reject_project_local_write(target_scope, "Delete command")
     name, resolved = _resolve_existing_command(project_root, name, scope=target_scope)
+
+    # Pending deletions, computed unlocked (see delete_skill): cascade
+    # targets resolve AT THIS TIER — scope= is load-bearing for user-tier
+    # cascades. Idempotent no-ops skip the gate.
+    pending: list[Path] = [resolved[0]] if resolved is not None else []
+    if cascade:
+        for gen in COMMAND_GENERATORS.values():
+            target = gen.target_file(project_root, name, scope=target_scope)
+            if target is not None and target.is_file():
+                pending.append(target)
+    gate = host_write_gate(
+        target_scope,
+        allow_host_writes,
+        action="Delete command",
+        host_targets=[str(p) for p in pending],
+    )
+    if gate is not None:
+        return gate
 
     try:
         async with asyncio.timeout(60):
@@ -449,7 +577,7 @@ async def delete_command(
                 # (#1247 id 46). Matches delete_agent / delete_skill.
                 if cascade:
                     for gen in COMMAND_GENERATORS.values():
-                        target = gen.target_file(project_root, name)
+                        target = gen.target_file(project_root, name, scope=target_scope)
                         if target is None:
                             continue
                         if not target.is_file():
@@ -566,6 +694,8 @@ async def diff_command(
 
 class SyncRequest(BaseModel):
     on_drop: str = "warn"
+    # #1263 host-write opt-in for target_scope=user (see CommandCreateRequest).
+    allow_host_writes: bool = False
 
     # An out-of-vocabulary value used to slip through to the engine, where it
     # silently behaved as "ignore" (#1247 id 47) — reject at the boundary
@@ -587,16 +717,32 @@ async def sync_commands(
     project_root: Path = Depends(resolve_writable_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
-        description="Canonical-residency tier to fan out. Non-shared tiers rejected (ADR-0011).",
+        description=(
+            "Canonical-residency tier to fan out. user fans out to the host "
+            "~/.claude-family roots behind the allow_host_writes confirm "
+            "round-trip (#1263); project_local rejected — no runtime fan-out "
+            "per ADR-0011 §3."
+        ),
     ),
 ) -> dict:
-    _reject_non_shared_write(target_scope, "Sync commands")
+    _reject_project_local_write(target_scope, "Sync commands")
     on_drop = body.on_drop if body else "warn"
+    gate = host_write_gate(
+        target_scope,
+        body.allow_host_writes if body else False,
+        action="Sync commands",
+        host_targets=_user_sync_host_targets(project_root),
+    )
+    if gate is not None:
+        return gate
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
                 result = generate_all_commands(
-                    project_root, on_drop=on_drop, surface="web_context_commands_sync"
+                    project_root,
+                    on_drop=on_drop,
+                    scope=target_scope,
+                    surface="web_context_commands_sync",
                 )
     except TimeoutError:
         raise HTTPException(503, "Commands sync timed out — another sync may be in progress")
@@ -639,43 +785,27 @@ async def sync_commands(
 
 class ImportRequest(BaseModel):
     overwrite: bool = False
+    # #1263 host-write opt-in for target_scope=user (the canonical
+    # destination is ~/.memtomem/commands/, outside any project root).
+    allow_host_writes: bool = False
 
 
-@router.post("/context/commands/import")
-async def import_commands(
-    body: ImportRequest | None = None,
-    project_root: Path = Depends(resolve_scope_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to import into. Non-shared tiers rejected (ADR-0011).",
-    ),
-    dry_run: bool = Query(
-        False,
-        description=(
-            "Preview the import without writing to canonical (rank-10): runs the "
-            "full scan + privacy walk + dedup and returns the would-import / would-"
-            "skip counts, leaving disk untouched."
-        ),
-    ),
+def _import_payload(
+    result: ExtractResult,
+    project_root: Path,
+    target_scope: TargetScope,
+    dry_run: bool | None,
 ) -> dict:
-    _reject_non_shared_write(target_scope, "Import commands")
-    overwrite = body.overwrite if body else False
-    try:
-        async with asyncio.timeout(60):
-            async with _gateway_lock:
-                result = extract_commands_to_canonical(
-                    project_root,
-                    overwrite=overwrite,
-                    dry_run=dry_run,
-                    surface="web_context_commands_import",
-                )
-    except TimeoutError:
-        raise HTTPException(503, "Commands import timed out — another sync may be in progress")
-    return {
+    """Wire shape shared by both import routes (and the gate's nested plan).
+
+    Mirrors context_skills._import_payload — ``dry_run=None`` omits the
+    key, ``_safe_rel`` keeps user-tier ``~/.memtomem`` paths encodable.
+    """
+    payload: dict = {
         "imported": [
             {
                 "name": canonical_command_name(p, layout),
-                "canonical_path": str(p.relative_to(project_root)),
+                "canonical_path": _safe_rel(p, project_root),
             }
             for p, layout in result.imported
         ],
@@ -684,9 +814,67 @@ async def import_commands(
             for name, reason, code in result.skipped
         ],
         "project_root": str(project_root),
-        "scanned_dirs": _COMMAND_SCAN_DIRS,
-        "dry_run": dry_run,
+        "scanned_dirs": _scanned_dirs_for(target_scope),
     }
+    if dry_run is not None:
+        payload["dry_run"] = dry_run
+    return payload
+
+
+@router.post("/context/commands/import")
+async def import_commands(
+    body: ImportRequest | None = None,
+    project_root: Path = Depends(resolve_scope_root),
+    target_scope: TargetScope = Query(
+        "project_shared",
+        description=(
+            "Canonical-residency tier to import into. user requires the "
+            "allow_host_writes confirm round-trip; project_local rejected (ADR-0011 §3)."
+        ),
+    ),
+    dry_run: bool = Query(
+        False,
+        description=(
+            "Preview the import without writing to canonical (rank-10): runs the "
+            "full scan + privacy walk + dedup and returns the would-import / would-"
+            "skip counts, leaving disk untouched. Returned regardless of "
+            "confirmation flags (mirrors the transfer route's dry_run)."
+        ),
+    ),
+) -> dict:
+    _reject_project_local_write(target_scope, "Import commands")
+    overwrite = body.overwrite if body else False
+    allow_host_writes = body.allow_host_writes if body else False
+
+    async def _run(dry: bool) -> ExtractResult:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                return extract_commands_to_canonical(
+                    project_root,
+                    overwrite=overwrite,
+                    dry_run=dry,
+                    scope=target_scope,
+                    surface="web_context_commands_import",
+                )
+
+    try:
+        if not dry_run and target_scope == "user" and not allow_host_writes:
+            # Gate disclosure needs the engine's scan — dry-run preview,
+            # nested as ``plan`` (see context_skills.import_skills).
+            preview = await _run(dry=True)
+            gate = host_write_gate(
+                target_scope,
+                allow_host_writes,
+                action="Import commands",
+                host_targets=[str(p) for p, _layout in preview.imported],
+                plan=_import_payload(preview, project_root, target_scope, dry_run=True),
+            )
+            if gate is not None:
+                return gate
+        result = await _run(dry=dry_run)
+    except TimeoutError:
+        raise HTTPException(503, "Commands import timed out — another sync may be in progress")
+    return _import_payload(result, project_root, target_scope, dry_run=dry_run)
 
 
 @router.post("/context/commands/{name}/import")
@@ -696,46 +884,57 @@ async def import_command(
     project_root: Path = Depends(resolve_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
-        description="Canonical-residency tier to import into. Non-shared tiers rejected (ADR-0011).",
+        description=(
+            "Canonical-residency tier to import into. user requires the "
+            "allow_host_writes confirm round-trip; project_local rejected (ADR-0011 §3)."
+        ),
     ),
 ) -> dict:
-    """Import a single runtime command into ``.memtomem/commands/``.
+    """Import a single runtime command into the scoped canonical dir.
 
     Same response shape as the section-level import so the web UI can reuse
     its rendering. 404 when no runtime file matches the name (the section
     import would silently report 0 imported, which is the wrong shape of
-    feedback for "you clicked a specific item that doesn't exist").
+    feedback for "you clicked a specific item that doesn't exist") — pinned
+    on the gate's dry-run preview too.
     """
-    _reject_non_shared_write(target_scope, "Import command")
+    _reject_project_local_write(target_scope, "Import command")
     try:
         validate_name(name, kind="command name")
     except InvalidNameError as exc:
         raise HTTPException(400, f"Invalid command name: {exc}")
     overwrite = body.overwrite if body else False
-    try:
+    allow_host_writes = body.allow_host_writes if body else False
+
+    async def _run(dry: bool) -> ExtractResult:
         async with asyncio.timeout(60):
             async with _gateway_lock:
-                result = extract_commands_to_canonical(
+                return extract_commands_to_canonical(
                     project_root,
                     overwrite=overwrite,
                     only_name=name,
+                    dry_run=dry,
+                    scope=target_scope,
                     surface="web_context_commands_import",
                 )
+
+    try:
+        if target_scope == "user" and not allow_host_writes:
+            preview = await _run(dry=True)
+            if not preview.imported and not preview.skipped:
+                raise HTTPException(404, f"No runtime command named {name!r} to import")
+            gate = host_write_gate(
+                target_scope,
+                allow_host_writes,
+                action="Import command",
+                host_targets=[str(p) for p, _layout in preview.imported],
+                plan=_import_payload(preview, project_root, target_scope, dry_run=None),
+            )
+            if gate is not None:
+                return gate
+        result = await _run(dry=False)
     except TimeoutError:
         raise HTTPException(503, "Command import timed out — another sync may be in progress")
     if not result.imported and not result.skipped:
         raise HTTPException(404, f"No runtime command named {name!r} to import")
-    return {
-        "imported": [
-            {
-                "name": canonical_command_name(p, layout),
-                "canonical_path": str(p.relative_to(project_root)),
-            }
-            for p, layout in result.imported
-        ],
-        "skipped": [
-            {"name": n, "reason": reason, "reason_code": code} for n, reason, code in result.skipped
-        ],
-        "project_root": str(project_root),
-        "scanned_dirs": _COMMAND_SCAN_DIRS,
-    }
+    return _import_payload(result, project_root, target_scope, dry_run=None)

--- a/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
@@ -49,16 +49,20 @@ def _safe_rel(p: Path, project_root: Path) -> str:
 def _reject_non_shared_write(target_scope: TargetScope, action: str) -> None:
     """Guard a *write* (create/update/delete/sync) to project_shared only.
 
-    Writes reject non-shared tiers because an MCP server canonical can only
-    live in project_shared. Reads intentionally do NOT call this — they return
-    an empty/absent result for other tiers instead (see ``list_mcp_servers``),
-    so a tier switch never turns the panel into a load-failed state.
+    Writes reject non-shared tiers **by design** (ADR-0011 §1 table note):
+    an MCP server canonical can only live in project_shared — unlike the
+    skills/commands/agents routes, which #1263 opened to ``user`` behind
+    the host-write confirm, this is not a deferred v1 narrowing. Reads
+    intentionally do NOT call this — they return an empty/absent result
+    for other tiers instead (see ``list_mcp_servers``), so a tier switch
+    never turns the panel into a load-failed state.
     """
     if target_scope != "project_shared":
         raise HTTPException(
             status_code=400,
             detail=(
-                f"{action} is supported only on project_shared in this release; "
+                f"{action} is supported only on project_shared — MCP server "
+                f"canonicals are project_shared-only by design (ADR-0011 §1); "
                 f"got target_scope={target_scope!r}."
             ),
         )

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -14,12 +14,14 @@ from pydantic import BaseModel
 
 from memtomem.context._atomic import atomic_write_text
 from memtomem.context._names import InvalidNameError, validate_name
+from memtomem.context._runtime_targets import KNOWN_RUNTIMES, runtime_fanout_root
 from memtomem.context.detector import SKILL_DIRS
 from memtomem.context.privacy_scan import PrivacyScanError
 from memtomem.context.skills import (
     CANONICAL_SKILL_ROOT,
     SKILL_GENERATORS,
     SKILL_MANIFEST,
+    ExtractResult,
     canonical_skills_root,
     diff_skills,
     extract_skills_to_canonical,
@@ -27,6 +29,7 @@ from memtomem.context.skills import (
     list_canonical_skills,
 )
 from memtomem.config import TargetScope
+from memtomem.web.routes._confirm import host_write_gate
 from memtomem.web.routes._locks import _gateway_lock
 from memtomem.web.routes.context_gateway import delete_skip_entry, sanitize_diff_reason
 from memtomem.web.routes.context_projects import (
@@ -60,27 +63,73 @@ def _canonical_skill_dir(
     return canonical_skills_root(project_root, scope=scope) / name
 
 
-def _reject_non_shared_write(target_scope: TargetScope, action: str) -> None:
-    """Reject writes on non-``project_shared`` tiers with HTTP 400.
+def _reject_project_local_write(target_scope: TargetScope, action: str) -> None:
+    """Reject writes on the ``project_local`` tier with HTTP 400.
 
-    Reads honor every tier (the canonical content differs per scope), but
-    write/sync/import endpoints stay on ``project_shared`` for v1 — the
-    multi-scope write contract is intentionally deferred to a follow-up so
-    each tier's authoring policy (draft vs runtime fan-out vs user-share)
-    can be designed deliberately. Passing the param explicitly + rejecting
-    here is preferred over silently overriding the client's selection,
-    because silent override is exactly the cross-tier crossover (ADR-0011) P1
-    flagged ("mutates a same-named project_shared artifact while the UI is
-    showing a user/local row").
+    Reads honor every tier (the canonical content differs per scope).
+    Writes accept ``project_shared`` (ungated, today's default) and —
+    since #1263 — ``user``, whose host-path writes complete only through
+    the ``allow_host_writes`` disclose-then-confirm round-trip
+    (:func:`memtomem.web.routes._confirm.host_write_gate`).
+    ``project_local`` stays rejected: it is a gitignored draft tier with
+    no runtime fan-out (ADR-0011 §3), so sync would be a no-op and its
+    authoring policy is still deliberately deferred. Rejecting the
+    explicit param is preferred over silently overriding the client's
+    selection — silent override is exactly the cross-tier crossover
+    (ADR-0011) P1 flagged ("mutates a same-named project_shared artifact
+    while the UI is showing a user/local row").
     """
-    if target_scope != "project_shared":
+    if target_scope == "project_local":
         raise HTTPException(
             status_code=400,
             detail=(
-                f"{action} is supported only on project_shared in this release; "
-                f"got target_scope={target_scope!r}."
+                f"{action} is supported on the project_shared and user tiers; "
+                f"project_local is a draft tier with no runtime fan-out "
+                f"(ADR-0011 §3)."
             ),
         )
+
+
+def _user_scan_dirs() -> list[str]:
+    """User-tier runtime roots the import scan reads (absolute, expanded).
+
+    The project-relative ``_SKILL_SCAN_DIRS`` hint would lie on
+    ``target_scope=user`` — the engine's user-tier import reads
+    ``~/.claude/skills`` etc. via ``runtime_fanout_root``, not the
+    project's runtime dirs.
+    """
+    dirs: list[str] = []
+    for runtime in KNOWN_RUNTIMES:
+        root = runtime_fanout_root("skills", runtime, "user", None)
+        if root is not None:
+            dirs.append(str(root))
+    return sorted(set(dirs))
+
+
+def _scanned_dirs_for(target_scope: TargetScope) -> list[str]:
+    return _user_scan_dirs() if target_scope == "user" else _SKILL_SCAN_DIRS
+
+
+def _user_sync_host_targets(project_root: Path) -> list[str]:
+    """Pending user-tier fan-out destinations for the sync confirm gate.
+
+    Upper bound on the confirmed sync's writes. Skill fan-out is keyed by
+    the canonical DIRECTORY name (skills are opaque to the canonical
+    layer — no parsed-frontmatter rename axis, unlike agents/commands),
+    so the names here are exact; the engine's per-destination preflight
+    (target conflicts, unreadable canonicals/overrides, privacy blocks,
+    lock timeouts) can only shrink the actual write set below this
+    disclosure, never move it elsewhere. Empty when there are no
+    user-tier canonicals — the gate stays open and the engine returns
+    its normal ``no canonical skills`` skip.
+    """
+    targets: list[str] = []
+    for skill_dir in list_canonical_skills(project_root, scope="user"):
+        for gen in SKILL_GENERATORS.values():
+            dst = gen.target_dir(project_root, skill_dir.name, scope="user")
+            if dst is not None:
+                targets.append(str(dst))
+    return sorted(targets)
 
 
 def _safe_rel(p: Path, project_root: Path) -> str:
@@ -253,6 +302,10 @@ async def read_skill(
 class SkillCreateRequest(BaseModel):
     name: str
     content: str
+    # #1263 host-write opt-in: required true for target_scope=user (the
+    # canonical lands under ~/.memtomem/, outside any project root). The
+    # first POST without it returns the needs_confirmation envelope.
+    allow_host_writes: bool = False
 
 
 @router.post("/context/skills")
@@ -261,12 +314,29 @@ async def create_skill(
     project_root: Path = Depends(resolve_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
-        description="Canonical-residency tier to create in. Non-shared tiers rejected (ADR-0011).",
+        description=(
+            "Canonical-residency tier to create in. user requires the "
+            "allow_host_writes confirm round-trip; project_local rejected (ADR-0011 §3)."
+        ),
     ),
 ) -> dict:
     """Create a new canonical skill."""
-    _reject_non_shared_write(target_scope, "Create skill")
+    _reject_project_local_write(target_scope, "Create skill")
     skill_dir = _canonical_skill_dir(project_root, body.name, scope=target_scope)
+
+    # Unlocked pre-checks so a request that cannot succeed is refused
+    # (409) rather than confirmed, and a no-op never prompts. The locked
+    # re-check below stays authoritative for create races.
+    if skill_dir.exists():
+        raise HTTPException(409, detail=f"Skill '{body.name}' already exists")
+    gate = host_write_gate(
+        target_scope,
+        body.allow_host_writes,
+        action="Create skill",
+        host_targets=[str(skill_dir / SKILL_MANIFEST)],
+    )
+    if gate is not None:
+        return gate
 
     try:
         async with asyncio.timeout(60):
@@ -282,7 +352,7 @@ async def create_skill(
                 atomic_write_text(manifest, body.content)
     except TimeoutError:
         raise HTTPException(503, "Skill create timed out — another sync may be in progress")
-    return {"name": body.name, "canonical_path": str(skill_dir.relative_to(project_root))}
+    return {"name": body.name, "canonical_path": _safe_rel(skill_dir, project_root)}
 
 
 # ── Update ───────────────────────────────────────────────────────────────
@@ -297,6 +367,22 @@ class SkillUpdateRequest(BaseModel):
     # (see issue #763); every force-save emits a WARNING with both mtime
     # values for the audit trail.
     force: bool = False
+    # #1263 host-write opt-in for target_scope=user (see SkillCreateRequest).
+    allow_host_writes: bool = False
+
+
+_MTIME_CONFLICT_REASON = "File was modified by another process. Reload and retry."
+
+
+def _mtime_conflict_response(current_mtime_ns: int) -> JSONResponse:
+    return JSONResponse(
+        status_code=409,
+        content={
+            "status": "aborted",
+            "reason": _MTIME_CONFLICT_REASON,
+            "mtime_ns": str(current_mtime_ns),
+        },
+    )
 
 
 @router.put("/context/skills/{name}")
@@ -306,11 +392,14 @@ async def update_skill(
     project_root: Path = Depends(resolve_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
-        description="Canonical-residency tier to update. Non-shared tiers rejected (ADR-0011).",
+        description=(
+            "Canonical-residency tier to update. user requires the "
+            "allow_host_writes confirm round-trip; project_local rejected (ADR-0011 §3)."
+        ),
     ),
 ) -> JSONResponse:
     """Update a canonical skill's SKILL.md (mtime-guarded, atomic, locked)."""
-    _reject_non_shared_write(target_scope, "Update skill")
+    _reject_project_local_write(target_scope, "Update skill")
     skill_dir = _canonical_skill_dir(project_root, name, scope=target_scope)
     manifest = skill_dir / SKILL_MANIFEST
     if not manifest.is_file():
@@ -321,22 +410,30 @@ async def update_skill(
     except ValueError:
         raise HTTPException(422, f"Invalid mtime_ns: {body.mtime_ns!r}")
 
+    # Unlocked pre-check: a stale-mtime request is refused (same 409 shape
+    # as the locked check) BEFORE the host-write gate, so the user is never
+    # asked to confirm a write that would only abort. The locked re-check
+    # below stays authoritative; force=True falls through so the locked
+    # path keeps emitting its audit WARNING exactly once.
+    pre_mtime_ns = manifest.stat().st_mtime_ns
+    if pre_mtime_ns != body_mtime_ns and not body.force:
+        return _mtime_conflict_response(pre_mtime_ns)
+    gate = host_write_gate(
+        target_scope,
+        body.allow_host_writes,
+        action="Update skill",
+        host_targets=[str(manifest)],
+    )
+    if gate is not None:
+        return JSONResponse(content=gate)
+
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
                 current_mtime_ns = manifest.stat().st_mtime_ns
                 if current_mtime_ns != body_mtime_ns:
                     if not body.force:
-                        return JSONResponse(
-                            status_code=409,
-                            content={
-                                "status": "aborted",
-                                "reason": (
-                                    "File was modified by another process. Reload and retry."
-                                ),
-                                "mtime_ns": str(current_mtime_ns),
-                            },
-                        )
+                        return _mtime_conflict_response(current_mtime_ns)
                     logger.warning(
                         "force-save bypassed mtime check on %s "
                         "(client_mtime_ns=%s server_mtime_ns=%s)",
@@ -361,15 +458,45 @@ async def delete_skill(
     project_root: Path = Depends(resolve_scope_root_cascade_gated),
     target_scope: TargetScope = Query(
         "project_shared",
-        description="Canonical-residency tier to delete from. Non-shared tiers rejected (ADR-0011).",
+        description=(
+            "Canonical-residency tier to delete from. user requires the "
+            "allow_host_writes confirm round-trip; project_local rejected (ADR-0011 §3)."
+        ),
+    ),
+    allow_host_writes: bool = Query(
+        False,
+        description=(
+            "#1263 host-write opt-in for target_scope=user. Query parameter "
+            "(not a body field) because DELETE bodies are client-hostile; "
+            "the needs_confirmation envelope names the same flag."
+        ),
     ),
 ) -> dict:
     """Delete a canonical skill, optionally cascading to runtime copies.
 
     Idempotent: missing canonical directory returns ``deleted: []``.
     """
-    _reject_non_shared_write(target_scope, "Delete skill")
+    _reject_project_local_write(target_scope, "Delete skill")
     skill_dir = _canonical_skill_dir(project_root, name, scope=target_scope)
+
+    # Pending deletions, computed unlocked: the canonical dir plus — on
+    # cascade — the runtime copies AT THIS TIER (scope= is load-bearing:
+    # a user-tier cascade must resolve ~/.claude/... copies, never the
+    # project's). Idempotent no-ops (nothing exists) skip the gate.
+    pending: list[Path] = [skill_dir] if skill_dir.exists() else []
+    if cascade:
+        for gen in SKILL_GENERATORS.values():
+            target = gen.target_dir(project_root, name, scope=target_scope)
+            if target is not None and target.exists():
+                pending.append(target)
+    gate = host_write_gate(
+        target_scope,
+        allow_host_writes,
+        action="Delete skill",
+        host_targets=[str(p) for p in pending],
+    )
+    if gate is not None:
+        return gate
 
     try:
         async with asyncio.timeout(60):
@@ -386,7 +513,7 @@ async def delete_skill(
 
                 if cascade:
                     for gen in SKILL_GENERATORS.values():
-                        target = gen.target_dir(project_root, name)
+                        target = gen.target_dir(project_root, name, scope=target_scope)
                         if target is None:
                             continue
                         if not target.exists():
@@ -468,20 +595,40 @@ async def diff_skill(
 # ── Sync (fan-out) ──────────────────────────────────────────────────────
 
 
+class SyncRequest(BaseModel):
+    """Optional body for the sync routes (#1263).
+
+    Absent body keeps the historical no-body POST working; the only field
+    is the user-tier host-write opt-in.
+    """
+
+    allow_host_writes: bool = False
+
+
 @router.post("/context/skills/sync")
 async def sync_skills(
+    body: SyncRequest | None = None,
     project_root: Path = Depends(resolve_writable_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
         description=(
-            "Canonical-residency tier to fan out. Non-shared rejected — "
-            "project_local has no runtime fan-out per ADR-0011 §3, and user-tier "
-            "sync is deferred to a follow-up (ADR-0016)."
+            "Canonical-residency tier to fan out. user fans out to the host "
+            "~/.claude-family roots behind the allow_host_writes confirm "
+            "round-trip (#1263); project_local rejected — no runtime fan-out "
+            "per ADR-0011 §3."
         ),
     ),
 ) -> dict:
     """Fan out canonical skills to all runtimes."""
-    _reject_non_shared_write(target_scope, "Sync skills")
+    _reject_project_local_write(target_scope, "Sync skills")
+    gate = host_write_gate(
+        target_scope,
+        body.allow_host_writes if body else False,
+        action="Sync skills",
+        host_targets=_user_sync_host_targets(project_root),
+    )
+    if gate is not None:
+        return gate
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
@@ -497,7 +644,10 @@ async def sync_skills(
                 # waits, so a timed-out request cannot orphan a worker
                 # thread that writes after the 503 already went out.
                 result = await asyncio.to_thread(
-                    generate_all_skills, project_root, surface="web_context_skills_sync"
+                    generate_all_skills,
+                    project_root,
+                    scope=target_scope,
+                    surface="web_context_skills_sync",
                 )
     except TimeoutError:
         raise HTTPException(503, "Skills sync timed out — another sync may be in progress")
@@ -520,6 +670,38 @@ async def sync_skills(
 
 class ImportRequest(BaseModel):
     overwrite: bool = False
+    # #1263 host-write opt-in for target_scope=user (the canonical
+    # destination is ~/.memtomem/skills/, outside any project root).
+    allow_host_writes: bool = False
+
+
+def _import_payload(
+    result: ExtractResult,
+    project_root: Path,
+    target_scope: TargetScope,
+    dry_run: bool | None,
+) -> dict:
+    """Wire shape shared by both import routes (and the gate's nested plan).
+
+    ``dry_run=None`` omits the key — the single-import response never
+    carried one. ``_safe_rel`` (not bare ``relative_to``) because user-tier
+    canonical paths live under ``~/.memtomem/`` and would otherwise raise
+    out of the response encoder.
+    """
+    payload: dict = {
+        "imported": [
+            {"name": p.name, "canonical_path": _safe_rel(p, project_root)} for p in result.imported
+        ],
+        "skipped": [
+            {"name": name, "reason": reason, "reason_code": code}
+            for name, reason, code in result.skipped
+        ],
+        "project_root": str(project_root),
+        "scanned_dirs": _scanned_dirs_for(target_scope),
+    }
+    if dry_run is not None:
+        payload["dry_run"] = dry_run
+    return payload
 
 
 @router.post("/context/skills/import")
@@ -528,49 +710,64 @@ async def import_skills(
     project_root: Path = Depends(resolve_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
-        description="Canonical-residency tier to import into. Non-shared tiers rejected (ADR-0011).",
+        description=(
+            "Canonical-residency tier to import into. user requires the "
+            "allow_host_writes confirm round-trip; project_local rejected (ADR-0011 §3)."
+        ),
     ),
     dry_run: bool = Query(
         False,
         description=(
             "Preview the import without writing to canonical (rank-10): runs the "
             "full scan + privacy walk + dedup and returns the would-import / would-"
-            "skip counts, leaving disk untouched."
+            "skip counts, leaving disk untouched. Returned regardless of "
+            "confirmation flags (mirrors the transfer route's dry_run)."
         ),
     ),
 ) -> dict:
-    """Import runtime skills into canonical .memtomem/skills/."""
-    _reject_non_shared_write(target_scope, "Import skills")
+    """Import runtime skills into the scoped canonical directory."""
+    _reject_project_local_write(target_scope, "Import skills")
     overwrite = body.overwrite if body else False
-    try:
+    allow_host_writes = body.allow_host_writes if body else False
+
+    async def _run(dry: bool) -> ExtractResult:
         async with asyncio.timeout(60):
             async with _gateway_lock:
                 # Thread offload (#1247 id 18): the import engine now blocks
                 # on the destination sidecar flock (budget-bounded), and
                 # ``asyncio.timeout`` cannot fire while the loop thread
                 # itself is blocked — same shape as the sync route above.
-                result = await asyncio.to_thread(
+                return await asyncio.to_thread(
                     extract_skills_to_canonical,
                     project_root,
                     overwrite=overwrite,
-                    dry_run=dry_run,
+                    dry_run=dry,
+                    scope=target_scope,
                     surface="web_context_skills_import",
                 )
+
+    try:
+        if not dry_run and target_scope == "user" and not allow_host_writes:
+            # The gate needs the pending destination paths, which only the
+            # engine's scan knows — preview via dry_run, disclose, and nest
+            # the plan (A-5 transfer-route parity). An empty would-import
+            # set keeps the gate open (the confirmed run writes nothing);
+            # the dry-run→apply gap is the same accepted TOCTOU window the
+            # transfer route documents.
+            preview = await _run(dry=True)
+            gate = host_write_gate(
+                target_scope,
+                allow_host_writes,
+                action="Import skills",
+                host_targets=[str(p) for p in preview.imported],
+                plan=_import_payload(preview, project_root, target_scope, dry_run=True),
+            )
+            if gate is not None:
+                return gate
+        result = await _run(dry=dry_run)
     except TimeoutError:
         raise HTTPException(503, "Skills import timed out — another sync may be in progress")
-    return {
-        "imported": [
-            {"name": p.name, "canonical_path": str(p.relative_to(project_root))}
-            for p in result.imported
-        ],
-        "skipped": [
-            {"name": name, "reason": reason, "reason_code": code}
-            for name, reason, code in result.skipped
-        ],
-        "project_root": str(project_root),
-        "scanned_dirs": _SKILL_SCAN_DIRS,
-        "dry_run": dry_run,
-    }
+    return _import_payload(result, project_root, target_scope, dry_run=dry_run)
 
 
 @router.post("/context/skills/{name}/import")
@@ -580,45 +777,60 @@ async def import_skill(
     project_root: Path = Depends(resolve_scope_root),
     target_scope: TargetScope = Query(
         "project_shared",
-        description="Canonical-residency tier to import into. Non-shared tiers rejected (ADR-0011).",
+        description=(
+            "Canonical-residency tier to import into. user requires the "
+            "allow_host_writes confirm round-trip; project_local rejected (ADR-0011 §3)."
+        ),
     ),
 ) -> dict:
-    """Import a single runtime skill into ``.memtomem/skills/``.
+    """Import a single runtime skill into the scoped canonical directory.
 
     Same response shape as the section-level import so the web UI can reuse
     its rendering. 404 when no runtime directory matches the name (the
     section import would silently report 0 imported, which is the wrong
-    shape of feedback for "you clicked a specific item that doesn't exist").
+    shape of feedback for "you clicked a specific item that doesn't exist")
+    — pinned on the gate's dry-run preview too, so a misnamed user-tier
+    import 404s instead of asking for confirmation.
     """
-    _reject_non_shared_write(target_scope, "Import skill")
+    _reject_project_local_write(target_scope, "Import skill")
     try:
         validate_name(name, kind="skill name")
     except InvalidNameError as exc:
         raise HTTPException(400, f"Invalid skill name: {exc}")
     overwrite = body.overwrite if body else False
-    try:
+    allow_host_writes = body.allow_host_writes if body else False
+
+    async def _run(dry: bool) -> ExtractResult:
         async with asyncio.timeout(60):
             async with _gateway_lock:
                 # Thread offload (#1247 id 18): see import_skills above.
-                result = await asyncio.to_thread(
+                return await asyncio.to_thread(
                     extract_skills_to_canonical,
                     project_root,
                     overwrite=overwrite,
                     only_name=name,
+                    dry_run=dry,
+                    scope=target_scope,
                     surface="web_context_skills_import",
                 )
+
+    try:
+        if target_scope == "user" and not allow_host_writes:
+            preview = await _run(dry=True)
+            if not preview.imported and not preview.skipped:
+                raise HTTPException(404, f"No runtime skill named {name!r} to import")
+            gate = host_write_gate(
+                target_scope,
+                allow_host_writes,
+                action="Import skill",
+                host_targets=[str(p) for p in preview.imported],
+                plan=_import_payload(preview, project_root, target_scope, dry_run=None),
+            )
+            if gate is not None:
+                return gate
+        result = await _run(dry=False)
     except TimeoutError:
         raise HTTPException(503, "Skill import timed out — another sync may be in progress")
     if not result.imported and not result.skipped:
         raise HTTPException(404, f"No runtime skill named {name!r} to import")
-    return {
-        "imported": [
-            {"name": p.name, "canonical_path": str(p.relative_to(project_root))}
-            for p in result.imported
-        ],
-        "skipped": [
-            {"name": n, "reason": reason, "reason_code": code} for n, reason, code in result.skipped
-        ],
-        "project_root": str(project_root),
-        "scanned_dirs": _SKILL_SCAN_DIRS,
-    }
+    return _import_payload(result, project_root, target_scope, dry_run=None)

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -773,14 +773,17 @@ function _ctxWireShowAllScopes(type, listEl) {
 
 // -- Tier-aware write-block gate (issue #943) ---------------------------------
 //
-// ADR-0011 / #940 wired ``target_scope`` through every artifact route, with
-// ``_reject_non_shared_write`` 400-rejecting create/update/delete/sync/import
-// on user and project_local tiers. Without a matching UI affordance, users
-// who switch the tier filter to ``user`` or ``project_local`` see the same
-// write buttons as on ``project_shared`` and only learn the operation is
-// blocked when the route surfaces a generic toast. #943 closes that UX
-// gap by tagging every web-write affordance with
-// ``data-write-blocked="<tier>"`` so:
+// ADR-0011 / #940 wired ``target_scope`` through every artifact route. The
+// server gate is now split (#1263): ``project_local`` writes 400 via
+// ``_reject_project_local_write`` (mcp-servers/versions keep the stricter
+// ``_reject_non_shared_write``), while unconfirmed ``user``-tier writes on
+// skills/commands/agents return a 200 ``needs_confirmation`` envelope this
+// UI does not yet re-send with ``allow_host_writes`` — so the client-side
+// block below still covers BOTH non-shared tiers until the confirm dialog
+// ships (#1263 follow-up). Without the affordance, users who switch the
+// tier filter would only learn the operation is blocked from a generic
+// toast. #943 closed that UX gap by tagging every web-write affordance
+// with ``data-write-blocked="<tier>"`` so:
 //
 //   (1) CSS dims the button (``[data-write-blocked]`` selector in style.css),
 //   (2) ``aria-disabled="true"`` announces the state to screen readers,
@@ -810,9 +813,10 @@ const _CTX_WRITE_BUTTON_SELECTOR = (
   // stay un-gated, as they were before).
   + '.ctx-portal-sync, '
   // The single-item runtime-only import route (#940 import_<type>)
-  // also flows through ``_reject_non_shared_write``, so the per-detail
-  // "Import this <type>" button minted by ``_ctxLoadRuntimeOnlyDetail``
-  // belongs in the same write-blocked sweep.
+  // also flows through the tier gate (project_local 400, unconfirmed
+  // user-tier → needs_confirmation), so the per-detail "Import this
+  // <type>" button minted by ``_ctxLoadRuntimeOnlyDetail`` belongs in
+  // the same write-blocked sweep.
   + '.ctx-runtime-only-import, '
   // ADR-0022 version-store writes (enable / freeze / promote / delete-label)
   // are project_shared-only canonical writes, so they ride the same tier gate.
@@ -2924,9 +2928,10 @@ async function _loadScopeGroupItems(type, scope, container, seq) {
     // Cards on the active project scope are clickable across all tiers — the detail /
     // rendered / diff / edit / delete endpoints now accept ``target_scope=``
     // (#940 r3), so a click on a project_local draft opens the project_local
-    // canonical, not a same-named project_shared one. Writes on non-shared
-    // tiers are rejected at the server with HTTP 400 (the route's
-    // ``_reject_non_shared_write`` helper); the JS surfaces those as
+    // canonical, not a same-named project_shared one. project_local writes
+    // are rejected at the server with HTTP 400 (``_reject_project_local_write``)
+    // and unconfirmed user-tier writes return a needs_confirmation envelope
+    // this UI doesn't yet act on (#1263); the JS surfaces the 400s as
     // toasts via the existing ``err.detail`` path.
     const clickable = _ctxScopeIsActive(scope);
     container.innerHTML = _ctxRenderItemsHtml(

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -4360,7 +4360,8 @@ button.ctx-runtime-chip--greyed:focus-visible {
    reach the per-button handler. Mirrors the #ctx-sync-all-btn
    data-runtime-only pattern — clicks still fire a toast so the user
    understands why the affordance is dim, rather than getting a
-   generic 400 from the route's _reject_non_shared_write guard. */
+   generic 400 (project_local) or an unhandled needs_confirmation
+   envelope (user tier, #1263) from the route's tier gate. */
 [data-write-blocked] {
   opacity: 0.45;
   cursor: not-allowed;

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -1962,9 +1962,11 @@ class TestImportOneAgent:
 # target_scope plumbing through item routes (#940 r3)
 #
 # Reads honor every tier; writes (create/update/delete/sync/import) accept
-# the param but reject anything other than ``project_shared`` with HTTP 400
-# via ``_reject_non_shared_write``. Pins the contract from both sides so a
-# regression on either gate shows up immediately.
+# the param, 400-reject ``project_local`` via ``_reject_project_local_write``,
+# and since #1263 accept ``user`` behind the allow_host_writes confirm
+# round-trip (pinned in test_web_routes_context_user_tier.py). Pins the
+# contract from both sides so a regression on either gate shows up
+# immediately.
 # ---------------------------------------------------------------------------
 
 
@@ -2020,9 +2022,11 @@ class TestSkillTargetScopePlumbing:
         assert "project_shared" in r.json()["detail"]
 
     @pytest.mark.anyio
-    async def test_sync_rejects_non_shared(self, client: AsyncClient):
-        r = await client.post("/api/context/skills/sync", params={"target_scope": "user"})
+    async def test_sync_rejects_project_local(self, client: AsyncClient):
+        """user-tier sync is open since #1263 — project_local stays 400."""
+        r = await client.post("/api/context/skills/sync", params={"target_scope": "project_local"})
         assert r.status_code == 400
+        assert "project_shared" in r.json()["detail"]
 
 
 class TestAgentTargetScopePlumbing:
@@ -2075,15 +2079,17 @@ class TestCommandTargetScopePlumbing:
         assert "local draft cmd" in local.json()["content"]
 
     @pytest.mark.anyio
-    async def test_update_rejects_non_shared(self, client: AsyncClient, tmp_path: Path):
+    async def test_update_rejects_project_local(self, client: AsyncClient, tmp_path: Path):
+        """user-tier update is open since #1263 — project_local stays 400."""
         _make_local_command(tmp_path, "draft")
         # Need an mtime_ns; doesn't matter — the gate fires before mtime check.
         r = await client.put(
             "/api/context/commands/draft",
-            params={"target_scope": "user"},
+            params={"target_scope": "project_local"},
             json={"content": "# x\n", "mtime_ns": "0"},
         )
         assert r.status_code == 400
+        assert "project_shared" in r.json()["detail"]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/memtomem/tests/test_web_routes_context_user_tier.py
+++ b/packages/memtomem/tests/test_web_routes_context_user_tier.py
@@ -1,0 +1,710 @@
+"""User-tier write/sync routes behind the host-write confirm gate (#1263).
+
+Pins the A-6 contract on the skills / commands / agents web routes:
+
+- ``target_scope=user`` + no ``allow_host_writes`` → HTTP 200
+  ``needs_confirmation`` envelope (full-equality literals, including the
+  exact reason prose and the disclosed ``host_targets``), with **no**
+  disk mutation and **no** engine apply call.
+- The confirmed re-request applies, passing ``scope="user"`` through to
+  the engine (monkeypatched-engine tests pin the pass-through kwargs —
+  the campaign's false-pass lesson).
+- The gate never fires for requests that would not write: idempotent
+  deletes, nothing-to-import imports, empty canonical sets, and requests
+  refused by cheaper checks (duplicate create 409, missing update 404,
+  stale-mtime 409).
+- Cascade deletes resolve runtime copies AT the requested tier: a
+  user-tier cascade removes ``~/.claude/...`` copies and leaves the
+  project's runtime copies untouched (the design-gate Blocker).
+- ``project_local`` writes stay 400; the explicit ``?dry_run=true``
+  import preview stays flag-free.
+
+Every test isolates HOME via ``set_home`` — user-tier paths
+(``~/.memtomem``, ``~/.claude``, …) must never touch the real home.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from memtomem.context.skills import SKILL_MANIFEST, SkillSyncResult
+from memtomem.web.app import create_app
+
+from .helpers import set_home
+
+_HOST_REASON = (
+    "{action} targets the user tier — host paths outside any project "
+    "root. Re-send the request with allow_host_writes=true after "
+    "confirming with the user."
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def proj(tmp_path: Path) -> Path:
+    """Project root as a SIBLING of the fake home — ``~/.memtomem`` must
+    not live under the project root, or ``_safe_rel`` legitimately
+    relativizes user-tier paths and the absolute-path pins go soft."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    return proj
+
+
+@pytest.fixture
+def ctx_app(proj: Path):
+    """App with project_root pointing to a temp directory."""
+    from memtomem.config import Mem2MemConfig
+
+    application = create_app(lifespan=None, mode="dev")
+    application.state.project_root = proj
+    application.state.storage = AsyncMock()
+    application.state.config = Mem2MemConfig()
+    application.state.search_pipeline = None
+    application.state.index_engine = None
+    application.state.embedder = None
+    application.state.dedup_scanner = None
+    return application
+
+
+@pytest.fixture
+async def client(ctx_app):
+    transport = ASGITransport(app=ctx_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolated fake home; resolved so expectations match engine paths.
+
+    The engine resolves user-tier paths via ``expanduser().resolve()`` —
+    resolve here too so macOS ``/var`` → ``/private/var`` symlinks can't
+    desync the full-equality envelope pins.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    set_home(monkeypatch, home)
+    return home.resolve()
+
+
+def _make_user_skill(home: Path, name: str, content: str = "# User skill\n") -> Path:
+    skill_dir = home / ".memtomem" / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / SKILL_MANIFEST).write_text(content, encoding="utf-8")
+    return skill_dir
+
+
+def _make_user_command(home: Path, name: str, content: str = "# User command\n") -> Path:
+    cmd_dir = home / ".memtomem" / "commands"
+    cmd_dir.mkdir(parents=True, exist_ok=True)
+    cmd_file = cmd_dir / f"{name}.md"
+    cmd_file.write_text(content, encoding="utf-8")
+    return cmd_file
+
+
+_AGENT_CONTENT = """---
+name: uagent
+description: User-tier agent
+---
+You are a user-tier agent.
+"""
+
+
+def _make_user_agent(home: Path, name: str, content: str = _AGENT_CONTENT) -> Path:
+    agent_dir = home / ".memtomem" / "agents"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    agent_file = agent_dir / f"{name}.md"
+    agent_file.write_text(content, encoding="utf-8")
+    return agent_file
+
+
+# ---------------------------------------------------------------------------
+# Sync — envelope literal, engine pass-through, empty-set bypass
+# ---------------------------------------------------------------------------
+
+
+class TestUserTierSync:
+    @pytest.mark.anyio
+    async def test_no_flag_returns_envelope_literal_and_never_calls_engine(
+        self, client: AsyncClient, home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _make_user_skill(home, "uskill")
+
+        def _boom(*a, **k):  # engine must not run on the disclose leg
+            raise AssertionError("generate_all_skills must not be called before confirmation")
+
+        monkeypatch.setattr("memtomem.web.routes.context_skills.generate_all_skills", _boom)
+        r = await client.post("/api/context/skills/sync", params={"target_scope": "user"})
+        assert r.status_code == 200
+        assert r.json() == {
+            "status": "needs_confirmation",
+            "confirm": "allow_host_writes",
+            "reason": _HOST_REASON.format(action="Sync skills"),
+            "host_targets": [
+                str(home / ".agents" / "skills" / "uskill"),
+                str(home / ".claude" / "skills" / "uskill"),
+                str(home / ".gemini" / "skills" / "uskill"),
+                str(home / ".kimi" / "skills" / "uskill"),
+            ],
+        }
+        assert not (home / ".claude" / "skills").exists()
+
+    @pytest.mark.anyio
+    async def test_confirmed_passes_scope_kwarg_to_engine(
+        self, client: AsyncClient, home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        _make_user_skill(home, "uskill")
+        calls: list[tuple[tuple, dict]] = []
+
+        def _spy(*args, **kwargs):
+            calls.append((args, kwargs))
+            return SkillSyncResult(generated=[], skipped=[])
+
+        monkeypatch.setattr("memtomem.web.routes.context_skills.generate_all_skills", _spy)
+        r = await client.post(
+            "/api/context/skills/sync",
+            params={"target_scope": "user"},
+            json={"allow_host_writes": True},
+        )
+        assert r.status_code == 200
+        # Pin the pass-through kwargs in full — a monkeypatched engine that
+        # ignores them would false-pass a route that dropped scope=.
+        assert calls == [
+            (
+                (Path(client._transport.app.state.project_root),),
+                {"scope": "user", "surface": "web_context_skills_sync"},
+            )  # type: ignore[attr-defined]
+        ]
+
+    @pytest.mark.anyio
+    async def test_no_user_canonicals_skips_gate(self, client: AsyncClient, home: Path):
+        """Empty user canonical set → nothing to disclose → engine no-op runs."""
+        r = await client.post("/api/context/skills/sync", params={"target_scope": "user"})
+        assert r.status_code == 200
+        body = r.json()
+        assert "status" not in body  # not an envelope
+        assert body["generated"] == []
+        assert body["skipped"][0]["reason_code"] == "no_canonical_root"
+
+    @pytest.mark.anyio
+    async def test_confirmed_sync_writes_user_runtime_roots(
+        self, client: AsyncClient, home: Path, proj: Path
+    ):
+        _make_user_skill(home, "uskill", content="# Fan me out\n")
+        r = await client.post(
+            "/api/context/skills/sync",
+            params={"target_scope": "user"},
+            json={"allow_host_writes": True},
+        )
+        assert r.status_code == 200
+        assert (home / ".claude" / "skills" / "uskill" / SKILL_MANIFEST).is_file()
+        assert (home / ".gemini" / "skills" / "uskill" / SKILL_MANIFEST).is_file()
+        # The project's runtime tree is untouched by a user-tier sync.
+        assert not (proj / ".claude" / "skills").exists()
+
+    @pytest.mark.anyio
+    async def test_agents_and_commands_sync_pass_scope_kwarg(
+        self, client: AsyncClient, home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        from memtomem.context.agents import AgentSyncResult
+        from memtomem.context.commands import CommandSyncResult
+
+        _make_user_agent(home, "uagent")
+        _make_user_command(home, "ucmd")
+        agent_calls: list[dict] = []
+        cmd_calls: list[dict] = []
+
+        def _agent_spy(*args, **kwargs):
+            agent_calls.append(kwargs)
+            return AgentSyncResult(generated=[], dropped=[], skipped=[])
+
+        def _cmd_spy(*args, **kwargs):
+            cmd_calls.append(kwargs)
+            return CommandSyncResult(generated=[], dropped=[], skipped=[])
+
+        monkeypatch.setattr("memtomem.web.routes.context_agents.generate_all_agents", _agent_spy)
+        monkeypatch.setattr("memtomem.web.routes.context_commands.generate_all_commands", _cmd_spy)
+        ra = await client.post(
+            "/api/context/agents/sync",
+            params={"target_scope": "user"},
+            json={"allow_host_writes": True},
+        )
+        rc = await client.post(
+            "/api/context/commands/sync",
+            params={"target_scope": "user"},
+            json={"allow_host_writes": True},
+        )
+        assert ra.status_code == 200 and rc.status_code == 200
+        assert agent_calls == [
+            {"on_drop": "warn", "scope": "user", "surface": "web_context_agents_sync"}
+        ]
+        assert cmd_calls == [
+            {"on_drop": "warn", "scope": "user", "surface": "web_context_commands_sync"}
+        ]
+
+    @pytest.mark.anyio
+    async def test_agents_sync_no_flag_envelope_targets(self, client: AsyncClient, home: Path):
+        """Agent fan-out targets are per-runtime files at the user tier."""
+        _make_user_agent(home, "uagent")
+        r = await client.post("/api/context/agents/sync", params={"target_scope": "user"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "needs_confirmation"
+        assert body["confirm"] == "allow_host_writes"
+        assert str(home / ".claude" / "agents" / "uagent.md") in body["host_targets"]
+        assert all(str(home) in t for t in body["host_targets"])
+
+    @pytest.mark.anyio
+    async def test_sync_disclosure_uses_parsed_name_not_filename(
+        self, client: AsyncClient, home: Path
+    ):
+        """Disclosure-vs-mutation parity (review Blocker): the engine fans
+        out under the PARSED frontmatter ``name``, so the envelope must
+        disclose that name's paths — a filename-keyed disclosure would
+        confirm ``benign.md`` while the engine writes ``surprise.md``."""
+        _make_user_agent(
+            home,
+            "benign",
+            content="---\nname: surprise\ndescription: Renamed\n---\nBody.\n",
+        )
+        r = await client.post("/api/context/agents/sync", params={"target_scope": "user"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "needs_confirmation"
+        assert str(home / ".claude" / "agents" / "surprise.md") in body["host_targets"]
+        assert not any("benign" in t for t in body["host_targets"])
+
+    @pytest.mark.anyio
+    async def test_command_sync_disclosure_uses_parsed_name_not_filename(
+        self, client: AsyncClient, home: Path
+    ):
+        """Commands share the sync_atomic_artifact parsed-name fan-out, so
+        the same Blocker pin applies to their disclosure helper."""
+        _make_user_command(
+            home,
+            "benign",
+            content="---\nname: surprise\ndescription: Renamed\n---\nBody.\n",
+        )
+        r = await client.post("/api/context/commands/sync", params={"target_scope": "user"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "needs_confirmation"
+        assert str(home / ".claude" / "commands" / "surprise.md") in body["host_targets"]
+        assert not any("benign" in t for t in body["host_targets"])
+
+    @pytest.mark.anyio
+    async def test_sync_disclosure_excludes_unparseable_canonicals(
+        self, client: AsyncClient, home: Path
+    ):
+        """A canonical the engine would parse-skip is not disclosed; with
+        nothing else pending the gate stays open (engine no-ops)."""
+        _make_user_agent(home, "broken", content="---\nname: [unclosed\n---\nBody.\n")
+        r = await client.post("/api/context/agents/sync", params={"target_scope": "user"})
+        assert r.status_code == 200
+        body = r.json()
+        assert "status" not in body  # no envelope — nothing would be written
+        assert body["generated"] == []
+
+    @pytest.mark.anyio
+    async def test_command_sync_disclosure_excludes_unparseable_canonicals(
+        self, client: AsyncClient, home: Path
+    ):
+        _make_user_command(home, "broken", content="---\nname: [unclosed\n---\nBody.\n")
+        r = await client.post("/api/context/commands/sync", params={"target_scope": "user"})
+        assert r.status_code == 200
+        body = r.json()
+        assert "status" not in body
+        assert body["generated"] == []
+
+
+# ---------------------------------------------------------------------------
+# Create — pre-checks before gate, absolute canonical_path, real write
+# ---------------------------------------------------------------------------
+
+
+class TestUserTierCreate:
+    @pytest.mark.anyio
+    async def test_no_flag_returns_envelope_literal(self, client: AsyncClient, home: Path):
+        r = await client.post(
+            "/api/context/skills",
+            params={"target_scope": "user"},
+            json={"name": "newskill", "content": "# x\n"},
+        )
+        assert r.status_code == 200
+        assert r.json() == {
+            "status": "needs_confirmation",
+            "confirm": "allow_host_writes",
+            "reason": _HOST_REASON.format(action="Create skill"),
+            "host_targets": [str(home / ".memtomem" / "skills" / "newskill" / SKILL_MANIFEST)],
+        }
+        assert not (home / ".memtomem" / "skills" / "newskill").exists()
+
+    @pytest.mark.anyio
+    async def test_confirmed_writes_user_canonical_and_returns_absolute_path(
+        self, client: AsyncClient, home: Path
+    ):
+        r = await client.post(
+            "/api/context/skills",
+            params={"target_scope": "user"},
+            json={"name": "newskill", "content": "# x\n", "allow_host_writes": True},
+        )
+        assert r.status_code == 200
+        manifest = home / ".memtomem" / "skills" / "newskill" / SKILL_MANIFEST
+        assert manifest.is_file()
+        # Regression: bare relative_to(project_root) 500'd on user-tier paths.
+        assert r.json()["canonical_path"] == str(manifest.parent)
+
+    @pytest.mark.anyio
+    async def test_duplicate_is_409_not_confirmation_prompt(self, client: AsyncClient, home: Path):
+        _make_user_skill(home, "dup")
+        r = await client.post(
+            "/api/context/skills",
+            params={"target_scope": "user"},
+            json={"name": "dup", "content": "# x\n"},
+        )
+        assert r.status_code == 409
+
+    @pytest.mark.anyio
+    async def test_agent_create_confirmed_uses_versioned_layout(
+        self, client: AsyncClient, home: Path
+    ):
+        r = await client.post(
+            "/api/context/agents",
+            params={"target_scope": "user"},
+            json={"name": "uagent", "content": _AGENT_CONTENT, "allow_host_writes": True},
+        )
+        assert r.status_code == 200
+        agent_md = home / ".memtomem" / "agents" / "uagent" / "agent.md"
+        assert agent_md.is_file()
+        assert r.json()["canonical_path"] == agent_md.as_posix()
+
+    @pytest.mark.anyio
+    async def test_agent_duplicate_flat_user_canonical_is_409(
+        self, client: AsyncClient, home: Path
+    ):
+        """The unlocked duplicate pre-check resolves flat layout too."""
+        _make_user_agent(home, "uagent")
+        r = await client.post(
+            "/api/context/agents",
+            params={"target_scope": "user"},
+            json={"name": "uagent", "content": _AGENT_CONTENT},
+        )
+        assert r.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# Update — refusals win over the gate
+# ---------------------------------------------------------------------------
+
+
+class TestUserTierUpdate:
+    @pytest.mark.anyio
+    async def test_missing_is_404_not_confirmation_prompt(self, client: AsyncClient, home: Path):
+        r = await client.put(
+            "/api/context/commands/ghost",
+            params={"target_scope": "user"},
+            json={"content": "# x\n", "mtime_ns": "0"},
+        )
+        assert r.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_stale_mtime_is_409_not_confirmation_prompt(
+        self, client: AsyncClient, home: Path
+    ):
+        _make_user_command(home, "ucmd")
+        r = await client.put(
+            "/api/context/commands/ucmd",
+            params={"target_scope": "user"},
+            json={"content": "# y\n", "mtime_ns": "1"},
+        )
+        assert r.status_code == 409
+        assert r.json()["status"] == "aborted"
+
+    @pytest.mark.anyio
+    async def test_fresh_mtime_no_flag_returns_envelope(self, client: AsyncClient, home: Path):
+        cmd_file = _make_user_command(home, "ucmd")
+        mtime_ns = str(cmd_file.stat().st_mtime_ns)
+        r = await client.put(
+            "/api/context/commands/ucmd",
+            params={"target_scope": "user"},
+            json={"content": "# y\n", "mtime_ns": mtime_ns},
+        )
+        assert r.status_code == 200
+        assert r.json() == {
+            "status": "needs_confirmation",
+            "confirm": "allow_host_writes",
+            "reason": _HOST_REASON.format(action="Update command"),
+            "host_targets": [str(cmd_file)],
+        }
+        assert cmd_file.read_text(encoding="utf-8") == "# User command\n"
+
+    @pytest.mark.anyio
+    async def test_confirmed_update_writes(self, client: AsyncClient, home: Path):
+        cmd_file = _make_user_command(home, "ucmd")
+        mtime_ns = str(cmd_file.stat().st_mtime_ns)
+        r = await client.put(
+            "/api/context/commands/ucmd",
+            params={"target_scope": "user"},
+            json={"content": "# y\n", "mtime_ns": mtime_ns, "allow_host_writes": True},
+        )
+        assert r.status_code == 200
+        assert cmd_file.read_text(encoding="utf-8") == "# y\n"
+
+
+# ---------------------------------------------------------------------------
+# Delete — idempotent no-ops never prompt; cascade is tier-scoped
+# ---------------------------------------------------------------------------
+
+
+class TestUserTierDelete:
+    @pytest.mark.anyio
+    async def test_missing_is_idempotent_no_prompt(self, client: AsyncClient, home: Path):
+        r = await client.delete("/api/context/skills/ghost", params={"target_scope": "user"})
+        assert r.status_code == 200
+        assert r.json() == {"deleted": [], "skipped": []}
+
+    @pytest.mark.anyio
+    async def test_no_flag_returns_envelope_with_pending_targets(
+        self, client: AsyncClient, home: Path
+    ):
+        skill_dir = _make_user_skill(home, "uskill")
+        r = await client.delete("/api/context/skills/uskill", params={"target_scope": "user"})
+        assert r.status_code == 200
+        assert r.json() == {
+            "status": "needs_confirmation",
+            "confirm": "allow_host_writes",
+            "reason": _HOST_REASON.format(action="Delete skill"),
+            "host_targets": [str(skill_dir)],
+        }
+        assert skill_dir.exists()
+
+    @pytest.mark.anyio
+    async def test_cascade_envelope_lists_user_runtime_copies_only(
+        self, client: AsyncClient, home: Path, proj: Path
+    ):
+        skill_dir = _make_user_skill(home, "uskill")
+        user_copy = home / ".claude" / "skills" / "uskill"
+        user_copy.mkdir(parents=True)
+        (user_copy / SKILL_MANIFEST).write_text("# copy\n", encoding="utf-8")
+        project_copy = proj / ".claude" / "skills" / "uskill"
+        project_copy.mkdir(parents=True)
+        (project_copy / SKILL_MANIFEST).write_text("# project copy\n", encoding="utf-8")
+
+        r = await client.delete(
+            "/api/context/skills/uskill",
+            params={"target_scope": "user", "cascade": "true"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "needs_confirmation"
+        assert body["host_targets"] == [str(skill_dir), str(user_copy)]
+        assert str(project_copy) not in body["host_targets"]
+
+    @pytest.mark.anyio
+    async def test_confirmed_cascade_spares_project_runtime_copies(
+        self, client: AsyncClient, home: Path, proj: Path
+    ):
+        """The design-gate Blocker: user-tier cascade must not touch the
+        project's runtime fan-out (and the disclosure above must match
+        what is actually removed)."""
+        _make_user_skill(home, "uskill")
+        user_copy = home / ".claude" / "skills" / "uskill"
+        user_copy.mkdir(parents=True)
+        (user_copy / SKILL_MANIFEST).write_text("# copy\n", encoding="utf-8")
+        project_copy = proj / ".claude" / "skills" / "uskill"
+        project_copy.mkdir(parents=True)
+        (project_copy / SKILL_MANIFEST).write_text("# project copy\n", encoding="utf-8")
+
+        r = await client.delete(
+            "/api/context/skills/uskill",
+            params={
+                "target_scope": "user",
+                "cascade": "true",
+                "allow_host_writes": "true",
+            },
+        )
+        assert r.status_code == 200
+        assert not (home / ".memtomem" / "skills" / "uskill").exists()
+        assert not user_copy.exists()
+        assert project_copy.exists()  # project runtime copy survives
+
+    @pytest.mark.anyio
+    async def test_agent_confirmed_cascade_spares_project_runtime_copies(
+        self, client: AsyncClient, home: Path, proj: Path
+    ):
+        """File-shaped sibling of the skills cascade pin (agents/commands
+        share the target_file cascade loop)."""
+        _make_user_agent(home, "uagent")
+        user_copy = home / ".claude" / "agents" / "uagent.md"
+        user_copy.parent.mkdir(parents=True)
+        user_copy.write_text(_AGENT_CONTENT, encoding="utf-8")
+        project_copy = proj / ".claude" / "agents" / "uagent.md"
+        project_copy.parent.mkdir(parents=True)
+        project_copy.write_text(_AGENT_CONTENT, encoding="utf-8")
+
+        r = await client.delete(
+            "/api/context/agents/uagent",
+            params={
+                "target_scope": "user",
+                "cascade": "true",
+                "allow_host_writes": "true",
+            },
+        )
+        assert r.status_code == 200
+        assert not (home / ".memtomem" / "agents" / "uagent.md").exists()
+        assert not user_copy.exists()
+        assert project_copy.exists()
+
+    @pytest.mark.anyio
+    async def test_project_shared_cascade_unaffected(
+        self, client: AsyncClient, home: Path, proj: Path
+    ):
+        """Behavior pin: shared-tier cascade still removes project copies
+        and never prompts (scope= addition must be a no-op there)."""
+        skill_dir = proj / ".memtomem" / "skills" / "pskill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / SKILL_MANIFEST).write_text("# p\n", encoding="utf-8")
+        project_copy = proj / ".claude" / "skills" / "pskill"
+        project_copy.mkdir(parents=True)
+        (project_copy / SKILL_MANIFEST).write_text("# p\n", encoding="utf-8")
+
+        r = await client.delete("/api/context/skills/pskill", params={"cascade": "true"})
+        assert r.status_code == 200
+        assert not skill_dir.exists()
+        assert not project_copy.exists()
+
+
+# ---------------------------------------------------------------------------
+# Import — dry-run-backed disclosure, 404 contract, dry_run stays flag-free
+# ---------------------------------------------------------------------------
+
+
+class TestUserTierImport:
+    def _seed_user_runtime_skill(self, home: Path, name: str) -> Path:
+        runtime_dir = home / ".claude" / "skills" / name
+        runtime_dir.mkdir(parents=True)
+        (runtime_dir / SKILL_MANIFEST).write_text("# runtime skill\n", encoding="utf-8")
+        return runtime_dir
+
+    @pytest.mark.anyio
+    async def test_no_flag_returns_envelope_with_plan(self, client: AsyncClient, home: Path):
+        self._seed_user_runtime_skill(home, "imp1")
+        r = await client.post("/api/context/skills/import", params={"target_scope": "user"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "needs_confirmation"
+        assert body["confirm"] == "allow_host_writes"
+        assert body["reason"] == _HOST_REASON.format(action="Import skills")
+        assert body["host_targets"] == [str(home / ".memtomem" / "skills" / "imp1")]
+        assert body["plan"]["dry_run"] is True
+        assert [i["name"] for i in body["plan"]["imported"]] == ["imp1"]
+        # The user-tier scan hint names the host runtime roots, not the
+        # project-relative detector dirs.
+        assert str(home / ".claude" / "skills") in body["plan"]["scanned_dirs"]
+        assert not (home / ".memtomem" / "skills").exists()
+
+    @pytest.mark.anyio
+    async def test_confirmed_import_writes_user_canonical(self, client: AsyncClient, home: Path):
+        self._seed_user_runtime_skill(home, "imp1")
+        r = await client.post(
+            "/api/context/skills/import",
+            params={"target_scope": "user"},
+            json={"allow_host_writes": True},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        canonical = home / ".memtomem" / "skills" / "imp1"
+        assert (canonical / SKILL_MANIFEST).is_file()
+        # Regression: bare relative_to(project_root) 500'd on user-tier paths.
+        assert body["imported"] == [{"name": "imp1", "canonical_path": str(canonical)}]
+        assert body["dry_run"] is False
+
+    @pytest.mark.anyio
+    async def test_nothing_to_import_skips_gate(self, client: AsyncClient, home: Path):
+        r = await client.post("/api/context/skills/import", params={"target_scope": "user"})
+        assert r.status_code == 200
+        body = r.json()
+        assert "status" not in body
+        assert body["imported"] == []
+
+    @pytest.mark.anyio
+    async def test_explicit_dry_run_needs_no_flag(self, client: AsyncClient, home: Path):
+        self._seed_user_runtime_skill(home, "imp1")
+        r = await client.post(
+            "/api/context/skills/import",
+            params={"target_scope": "user", "dry_run": "true"},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert "status" not in body
+        assert body["dry_run"] is True
+        assert not (home / ".memtomem" / "skills").exists()
+
+    @pytest.mark.anyio
+    async def test_single_import_unknown_name_404_not_prompt(self, client: AsyncClient, home: Path):
+        r = await client.post("/api/context/skills/ghost/import", params={"target_scope": "user"})
+        assert r.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_single_import_envelope_then_confirmed(self, client: AsyncClient, home: Path):
+        self._seed_user_runtime_skill(home, "imp1")
+        first = await client.post(
+            "/api/context/skills/imp1/import", params={"target_scope": "user"}
+        )
+        assert first.status_code == 200
+        body = first.json()
+        assert body["status"] == "needs_confirmation"
+        assert body["host_targets"] == [str(home / ".memtomem" / "skills" / "imp1")]
+        assert "dry_run" not in body["plan"]  # single-import shape has no key
+
+        second = await client.post(
+            "/api/context/skills/imp1/import",
+            params={"target_scope": "user"},
+            json={"allow_host_writes": True},
+        )
+        assert second.status_code == 200
+        assert (home / ".memtomem" / "skills" / "imp1" / SKILL_MANIFEST).is_file()
+
+    @pytest.mark.anyio
+    async def test_import_project_local_still_400(self, client: AsyncClient, home: Path):
+        r = await client.post(
+            "/api/context/skills/import", params={"target_scope": "project_local"}
+        )
+        assert r.status_code == 400
+        assert "project_shared" in r.json()["detail"]
+
+    @pytest.mark.anyio
+    async def test_import_passes_scope_kwargs_to_engine(
+        self, client: AsyncClient, home: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        from memtomem.context.skills import ExtractResult
+
+        calls: list[dict] = []
+
+        def _spy(*args, **kwargs):
+            calls.append(kwargs)
+            return ExtractResult(imported=[], skipped=[])
+
+        monkeypatch.setattr("memtomem.web.routes.context_skills.extract_skills_to_canonical", _spy)
+        r = await client.post(
+            "/api/context/skills/import",
+            params={"target_scope": "user"},
+            json={"allow_host_writes": True},
+        )
+        assert r.status_code == 200
+        assert calls == [
+            {
+                "overwrite": False,
+                "dry_run": False,
+                "scope": "user",
+                "surface": "web_context_skills_import",
+            }
+        ]

--- a/packages/memtomem/tests/test_web_sync_write_guard.py
+++ b/packages/memtomem/tests/test_web_sync_write_guard.py
@@ -235,7 +235,7 @@ async def test_scan_only_never_enrolled_rejected(
 # ── Both project-runtime tiers gated; user tier exempt ───────────────────
 
 # The settings-sync routes legitimately accept ``project_local`` (they have NO
-# ``_reject_non_shared_write`` tier backstop), so the guard — not the route —
+# ``_reject_project_local_write`` tier backstop), so the guard — not the route —
 # is the only thing standing between a paused project and a ``project_local``
 # runtime write.
 _SETTINGS_RUNTIME_WRITES = [e for e in GATED_ENDPOINTS if e[0].startswith("settings_")]
@@ -249,7 +249,7 @@ async def test_settings_project_local_on_paused_rejected(
 ) -> None:
     """Regression (review blocker): ``project_local`` is a project-runtime write
     (``<root>/.claude/settings.local.json``). The settings routes have no
-    ``_reject_non_shared_write`` backstop, so the guard must 409 ``project_local``
+    ``_reject_project_local_write`` backstop, so the guard must 409 ``project_local``
     on a paused project — and nothing may be written under ``proj/.claude/``.
     """
     proj = tmp_path / "proj"


### PR DESCRIPTION
## Summary

Implements the API half of #1263 (campaign #1270 A-6): the skills / commands / agents web write routes (create / update / delete / import / sync) now accept `target_scope=user`, completed only through the `_confirm.py` disclose-then-confirm round-trip that A-5's transfer route (#1301) established.

**Contract** (pinned in the ADR-0015 §4c rider):

- First unconfirmed request → HTTP 200 `{status: "needs_confirmation", confirm: "allow_host_writes", reason, host_targets}` — no write. Re-send with `allow_host_writes=true` (body field on POST/PUT, query param on DELETE) to apply.
- The gate fires **only when a write is pending**: duplicate-create 409, missing-update 404, stale-mtime 409, idempotent deletes, nothing-to-import imports, and empty canonical sets all resolve before it.
- **Sync disclosure uses the parsed frontmatter name** (the name `sync_atomic_artifact` actually fans out under), not the canonical filename — a filename-keyed disclosure could confirm `benign.md` while the engine writes `surprise.md`. Disclosed set is a documented upper bound; engine preflight only shrinks it.
- **Cascade deletes are tier-scoped** (`scope=target_scope` on the runtime-target resolution): a confirmed user-tier cascade removes `~/.claude/...` copies and leaves the project's runtime fan-out untouched.
- Import routes disclose via an engine `dry_run` nested under `plan` (transfer parity); single-import keeps its 404 contract on the preview leg; explicit `?dry_run=true` stays flag-free; `scanned_dirs` reports user-tier runtime roots at that tier.
- `project_local` writes stay 400 (no fan-out, ADR-0011 §3). mcp-servers writes stay project_shared-only **by design** (ADR-0011 §1; message no longer says "in this release"). Version routes (ADR-0022) stay project_shared-only — not in #1263's checklist.
- Sync-eligibility 409 (#1203 §1i) ordering unchanged for selected paused projects.

Also fixes a latent 500: create/import responses used bare `relative_to(project_root)`, which raises on user-tier paths — now `_safe_rel` (absolute string outside the root).

## Out of scope (issue stays open)

- **Web UI affordance** — un-blocking the user-tier write buttons + the `needs_confirmation` dialog (`host_targets` display → re-send). The dashboard keeps its client-side write block on non-shared tiers until that follow-up, so this PR is API-surface only. JS/CSS changes here are comment-accuracy only.
- Migrating settings-sync's engine-level per-generator `needs_confirmation` rows onto `_confirm.py` (the old `_confirm.py` docstring over-promised this for A-6; reworded).

## Review

Codex design gate + two implementation passes; all findings folded: cascade tier-scoping (Blocker), parsed-name disclosure (Blocker), paused-project 409 ordering, single-import 404 preservation, no-prompt-on-no-op, commands-side regression tests, ADR upper-bound sentence. Documented-upper-bound disclosure accepted in lieu of an engine dry-run planner.

## Tests

- New `test_web_routes_context_user_tier.py` (33 tests): envelope literals by full equality (reason prose + host_targets), monkeypatched-engine pass-through kwarg pins (`scope=`, `surface=`), parsed-name disclosure for agents AND commands, unparseable-canonical exclusion, cascade tier-scoping (project copies survive), no-prompt-on-no-op matrix, `_safe_rel` regressions, dry-run/404 contracts. All HOME-isolated via `set_home`.
- Flipped 2 legacy pins (user-tier sync/update 400 → new contract); project_local pins retained with message literals.
- `uv run pytest` web-context suite: 433 passed locally; `ruff check` + `ruff format --check` clean; tests-js vitest 36 files / 182 tests green (Test Files line verified). `test_web_routes_extended.py::TestConfigPatch::test_save_config` fails identically on clean main here (machine-env, stash-verified). mypy: 2 pre-existing lambda errors, same on main.

Closes nothing yet — #1263 stays open for the UI follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
