### PR TITLE
feat(context): cross-project bulk sync — --all-projects + POST /api/context/sync-all-projects (#1279)

### DIFF
--- a/docs/adr/0021-context-portal.md
+++ b/docs/adr/0021-context-portal.md
@@ -98,15 +98,19 @@ stands.
    adds listing, switching, and lifecycle management (label, unregister) across
    the registered set — resolving the read/management half of the
    `registered_roots` shape ADR-0009 deferred to #829. **Mutations remain
-   single active-project per invocation.** **Artifact** writes (Sync All)
+   single active-project per invocation.** *Narrowly superseded for SYNC
+   ORCHESTRATION by ADR-0025 (#1279): a bulk-sync invocation may sequence N
+   single-project syncs, each still targeting exactly one
+   `(project_root, target_scope)`; every other mutation class keeps this
+   clause.* **Artifact** writes (Sync All)
    target exactly one `(project_root, target_scope)` — preserving ADR-0016 §5
    ("writes land in exactly one tier per invocation") and ADR-0001's
    per-project pipeline unchanged. **Registry-lifecycle** mutations (unregister,
    label edit) mutate `known_projects.json` for a single `project_scope_id`,
    carry **no artifact-tier dimension** (ADR-0015 classifies project-discovery
    routes as project-root-only), and therefore sit **outside** ADR-0016's
-   artifact-tier write rule. Cross-project *bulk* sync is explicitly deferred
-   (Open questions).
+   artifact-tier write rule. Cross-project *bulk* sync was explicitly deferred
+   here; *deferral resolved by ADR-0025* (#1279).
 
 2. **Read-only info surface → bounded actionable surface.** The dashboard may
    now host actions that are (a) **push-only from canonical** (Sync All —

--- a/docs/adr/0025-cross-project-sync-orchestration.md
+++ b/docs/adr/0025-cross-project-sync-orchestration.md
@@ -1,0 +1,217 @@
+# ADR-0025: Cross-project sync orchestration — bulk sync over the project registry
+
+**Status:** Accepted (narrowly supersedes ADR-0021 §"Relationship to
+ADR-0009" item 1's "Mutations remain single active-project per
+invocation" clause, for sync orchestration only; resolves that
+section's "Cross-project *bulk* sync is explicitly deferred" note)
+**Date:** 2026-06-12
+**Context:** Context Gateway completion campaign, mechanism track #1270
+item A-9 (#1279). Keeping several registered projects' runtime files
+fresh after canonical edits required running sync once per project by
+hand. ADR-0021 deferred cross-project bulk sync pending a need signal;
+the campaign owner has signaled it. ADR-0023 §3 (bounded two-roots
+transfer exception) explicitly delegated the ADR-0021
+single-project-mutation supersession to this ADR.
+
+## Decision
+
+### 1. Bounded supersession — a batch is sequenced single-project syncs
+
+A bulk-sync invocation (`mm context sync --all-projects`,
+`POST /api/context/sync-all-projects`) may write N projects' runtimes.
+The superseded ADR-0021 clause narrows only in the *per-invocation*
+dimension; everything it protected per write is preserved by
+construction:
+
+- each per-project execution is the UNCHANGED single-project pipeline
+  targeting exactly one `(project_root, target_scope=project_shared)` —
+  ADR-0016 §5 ("writes land in exactly one tier per invocation") holds
+  per write;
+- no new cross-project write primitive exists — the batch surfaces loop
+  the existing per-project entry points (the CLI sync legs; the five
+  ADR-0024 `_sync_*_core` phases);
+- registry-lifecycle mutations and every non-sync artifact mutation
+  remain single-active-project per invocation — this supersession covers
+  sync orchestration ONLY. (ADR-0023 §3's two-roots transfer exception
+  is the only other bounded carve-out.)
+
+### 2. Loop set + skip semantics — batch reports, never refuses
+
+Both surfaces iterate the discovered project scopes
+(`discover_project_scopes`, display order: server-cwd first, dedup by
+resolved path) and execute a scope iff it passes
+`context.projects.sync_skip_reason` — one shared derivation so the CLI
+and web cannot drift on WHICH scopes execute. Non-executed scopes are
+REPORTED as skipped rows with a reason code; where the single-project
+route 409s on an ineligible explicit selector, the batch records and
+proceeds (the `_run_update_all` precedent):
+
+- `missing_root` — registered root no longer a directory (checked
+  first: physical absence trumps enrollment state);
+- `sync_paused` / `sync_not_enrolled` — `sync_eligible` is False
+  (mirrors the web resolver's eligibility-409 split);
+- `stale_project` — root exists but has no `.memtomem/` store.
+  **Batch-only gate**: bulk-syncing a tree the user never initialized
+  would at best no-op every phase and at worst seed `.memtomem/`
+  bookkeeping; the per-type single routes stay ungated on stale.
+  Remediation (run `mm context init` there) is in the row message.
+
+Each surface owns its remediation prose (portal verbs on the web, `mm`
+verbs on the CLI); the codes are the shared contract. Zero eligible
+projects is a no-op success: CLI exits 0 informationally (cron safety),
+web returns 200 with an all-skipped report.
+
+CLI batch discovery anchors at `find_project_root()` — NOT raw
+`Path.cwd()` like `mm context projects list` — so a run from a project
+subdirectory treats that project as the cwd scope, matching both
+single-sync semantics (which walks up) and the web lifespan anchor.
+
+### 3. Per-project isolation; per-project lock window (web)
+
+One project's failure — engine error, privacy refusal, lock timeout —
+converts to a failed row and the batch proceeds. This extends ADR-0024
+§1 (per-phase proceed-past-failure) one level up, and cross-project
+rollback is rejected for the same reason cross-type rollback was:
+project stores are independent; there is no cross-project snapshot
+invariant to restore.
+
+The web batch wraps EACH project's five phases in its own
+`_gateway_lock` + `asyncio.timeout(300)` window, released between
+projects:
+
+- the invariant the ADR-0024 window protects — no per-type mutator
+  interleaving between ONE project's phases — holds per window;
+  cross-project interleaving by other mutators is harmless;
+- a batch-wide window would starve every other gateway mutator for
+  N×5 phases.
+
+A project-level timeout / unexpected error yields a failed entry with
+the `error` envelope attached and the completed phases kept (their
+writes are real); `summary` is present iff the project's phase loop
+completed. There is deliberately NO batch-level timeout: it would
+discard completed projects' reports mid-flight — the failure shape the
+per-phase report exists to avoid. The worst-case N×300s serial run is
+the honest cost of a serial batch.
+
+### 4. Tier policy — project_shared only
+
+Web: the same two 400s as ADR-0024 §4, raised by the shared
+`_reject_ineligible_tier` gate (one source for the issue-pinned
+literals). CLI: `--all-projects` combined with `--scope user` or
+`--scope project_local` is a usage error.
+
+The CLI batch passes an explicit `scope_flag="project_shared"` into the
+sync legs so the settings leg's `_resolve_cli_scope` cannot fall through
+to `cfg.hooks.target_scope` — a config-pinned `user` value would fan the
+SAME host files (`~/.claude/settings.json`, …) out once per project. On
+project_shared every settings target resolves inside the project root,
+so the host-write confirmation is vacuous (kept as defense in depth).
+The user tier remains reachable only through the per-project, per-type
+paths with their host-write confirmation — the batch cannot become a
+confirmation-bypass multiplier.
+
+### 5. Report shapes
+
+**Web** — HTTP 200 whenever the loop ran (mixed results cannot map to
+one HTTP code; ADR-0024 precedent). Non-2xx only pre-run: 400 tier
+gate, 403 CSRF.
+
+```jsonc
+{
+  "projects": [
+    {"project_scope_id": "p-…", "label": "…", "root": "/abs/path",
+     "status": "ok|partial|failed",          // = its ADR-0024 summary.status
+     "phases": [...], "summary": {...}},      // ADR-0024 report, verbatim
+    {"project_scope_id": "p-…", "label": "…", "root": "/abs/path",
+     "status": "skipped", "reason_code": "sync_paused", "message": "…"}
+  ],
+  "summary": {"status": "ok|partial|failed", "projects_total": 4,
+              "executed": 2, "ok": 1, "partial": 0, "failed": 1,
+              "skipped": 2, "generated_total": 9, "skipped_rows_total": 3}
+}
+```
+
+- Executed entries embed the ADR-0024 single-project report verbatim
+  under the project identity; skip-row classification stays client-side
+  (#1262) and the totals are counts, not classifications.
+- Batch `summary.status`: `failed` = every EXECUTED project failed;
+  `ok` = no executed project failed or partial — an all-skipped batch
+  is `ok` with `executed: 0` visible (skipping paused projects is the
+  designed outcome; unattended callers need the no-op run to read as
+  success; a `failed == executed` check alone would mark 0/0 failed);
+  else `partial`.
+- Version snapshots carry `surface="web_context_sync_all_projects"` /
+  `"cli_context_sync_all_projects"` — the audit trail names the batch
+  orchestrator (ADR-0024 precedent).
+
+**CLI** — cloned from the `_run_update_all` flow: discover → classify
+(eligibility/health, NOT a dirty-diff preview — running four diff
+engines × N projects for a preview is heavy and still racy) → preview
+table → confirm (`--yes` skips) → serial execute printing the same
+per-leg output single sync prints under a per-project header → summary
+(`N synced, M failed, K skipped`) → exit 1 if any project failed.
+
+Include semantics are UNCHANGED: the default include set stays the
+project-memory leg only (each project's `context.md` → its agent
+files); `--include skills,agents,commands,settings` adds the artifact
+legs. The flag multiplies the existing command across projects — it
+does not change what one project's sync means. A missing `context.md`
+in a batch row is a yellow note, not a failure (a registered project
+without project memory is normal at batch scope). `--strict` /
+`--on-drop` / `--label` thread through per project; a label missing in
+one project fails that row only.
+
+## Consequences
+
+- ADR-0021 §"Relationship to ADR-0009" item 1 gets an in-place
+  superseded-by rider (this clause only; the Portal's read/management
+  scope and registry-lifecycle rules are untouched). No TRACKER row —
+  nothing is deferred here.
+- The front-end Sync-All-Projects switchover (a dashboard affordance
+  over the batch route) is a follow-up, B-track concern; this ADR ships
+  the API + CLI only. MCP parity remains out of scope (ADR-0021
+  §"Open questions" §5 v1 scope-out, unchanged).
+- New web mutator bookkeeping: `context_sync_all.sync_all_projects_context`
+  is classified in `_CSRF_PROTECTED` and `_REDACTION_EXEMPT`
+  (`tests/test_web_invariants_registry.py`).
+- `_run_phase` gained a `surface` keyword (default preserves the A-8
+  attribution) and the CLI `_print_*_generate` helpers gained the same
+  pass-through; the single-project surfaces are unchanged.
+
+## Alternatives considered
+
+- **One batch-wide lock window.** Rejected — starves every other
+  mutator for N×5 phases and protects no cross-project invariant
+  (stores are independent).
+- **Batch-wide outer timeout.** Rejected — discards completed projects'
+  reports mid-flight; the per-project 300s window bounds each unit.
+- **Executing stale projects.** Rejected for the batch — would seed
+  `.memtomem/` bookkeeping into never-initialized trees; cheap to flip
+  later if a real workflow wants it (the per-type single routes already
+  allow it deliberately).
+- **`--all-projects` defaulting the include set to all four kinds.**
+  Rejected — silently multiplies a default that today touches only the
+  memory leg; explicit `--include` keeps single↔batch symmetry.
+- **A separate `mm context sync-all` command.** Rejected — the flag
+  form shares the include/strict/on-drop/label plumbing and keeps one
+  sync surface.
+- **Refusing (409/exit-1) on ineligible scopes instead of skip rows.**
+  Rejected — a batch over a registry where pausing is a feature must
+  treat paused projects as a reported skip, not an error
+  (`_run_update_all` precedent).
+
+## References
+
+- ADR-0021 (Portal — the superseded clause carries the rider),
+  ADR-0024 (per-phase sync-all this batch loops), ADR-0023 §3 (bounded
+  two-roots transfer exception; delegated this supersession),
+  ADR-0016 §5 (one tier per write — preserved per-write), ADR-0011 §3
+  (project_local has no fan-out), ADR-0023 §10 (error envelope).
+- Issue #1279 (A-9), umbrella #1270; #1262 (skip-row classification
+  stays client-side); #1263 (user tier is the per-type confirm path).
+- Implementation: `web/routes/context_sync_all.py`
+  (`sync_all_projects_context`, `_project_skip`, `_summarize_projects`),
+  `cli/context_cmd.py` (`_run_sync_all_projects`, `_run_sync_legs`),
+  `context/projects.py` (`sync_skip_reason`);
+  `tests/test_web_routes_context_sync_all_projects.py`,
+  `tests/test_cli_context_sync_all_projects.py`.

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -1212,6 +1212,7 @@ mm context sync                        # sync context.md → agent files (projec
 mm context sync --scope user           # fan out from ~/.memtomem/... → ~/.{claude,gemini,codex}/...
 mm context sync --include=skills --scope project_local   # NO_FANOUT skip (no runtime per ADR §3)
 mm context sync --include=agents,commands --label production # sync using the 'production' labeled version (agents/commands only)
+mm context sync --all-projects --yes   # batch over every enrolled on-disk project (project_shared only, ADR-0025)
 mm context generate --include=settings # merge hooks → ~/.claude/settings.json
 mm context diff --include=settings     # check hook sync status
 

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -72,6 +72,7 @@ from memtomem.context.projects import (
     compute_scope_id,
     discover_project_scopes,
     resolve_project_selector,
+    sync_skip_reason,
 )
 from memtomem.context.lockfile import LockfileError
 from memtomem.context.status import classify_status, load_with_recovery, scan_user_artifacts
@@ -223,9 +224,10 @@ def _print_skills_generate(
     root: Path,
     *,
     scope: TargetScope = "project_shared",
+    surface: str = "cli_context_sync",
 ) -> None:
     try:
-        result = generate_all_skills(root, scope=scope)
+        result = generate_all_skills(root, scope=scope, surface=surface)
     except PrivacyScanError as exc:
         raise click.ClickException(exc.message) from exc
     if result.generated:
@@ -319,9 +321,12 @@ def _print_agents_generate(
     *,
     scope: TargetScope = "project_shared",
     label: str | None = None,
+    surface: str = "cli_context_sync",
 ) -> None:
     try:
-        result = generate_all_agents(root, strict=strict, on_drop=on_drop, scope=scope, label=label)
+        result = generate_all_agents(
+            root, strict=strict, on_drop=on_drop, scope=scope, label=label, surface=surface
+        )
     except StrictDropError as exc:
         click.secho(f"  [strict] {exc}", fg="red")
         raise click.Abort()
@@ -428,10 +433,11 @@ def _print_commands_generate(
     *,
     scope: TargetScope = "project_shared",
     label: str | None = None,
+    surface: str = "cli_context_sync",
 ) -> None:
     try:
         result = generate_all_commands(
-            root, strict=strict, on_drop=on_drop, scope=scope, label=label
+            root, strict=strict, on_drop=on_drop, scope=scope, label=label, surface=surface
         )
     except CommandStrictDropError as exc:
         click.secho(f"  [strict] {exc}", fg="red")
@@ -1198,6 +1204,16 @@ def diff_cmd(include: tuple[str, ...], scope_flag: str | None) -> None:
     is_flag=True,
     help="Skip confirmation prompts before writing settings files outside this project.",
 )
+@click.option(
+    "--all-projects",
+    "all_projects",
+    is_flag=True,
+    help=(
+        "Sync every eligible discovered project (enrolled + on disk), not just "
+        "the current one. project_shared tier only; ineligible projects are "
+        "reported and skipped. One project's failure does not abort the batch."
+    ),
+)
 @_SCOPE_OPTION
 @_LABEL_OPTION
 def sync_cmd(
@@ -1205,12 +1221,76 @@ def sync_cmd(
     strict: bool,
     on_drop: str,
     yes: bool,
+    all_projects: bool,
     scope_flag: str | None,
     label: str | None,
 ) -> None:
     """Sync context.md to all detected agent files."""
     inc = _parse_include(include)
+
+    if all_projects:
+        # ADR-0025: the batch is project_shared-only — `user` would fan the
+        # SAME host files out once per project and `project_local` has no
+        # runtime fan-out (ADR-0011 §3), mirroring the web sync-all gates.
+        if scope_flag not in (None, "project_shared"):
+            raise click.UsageError(
+                "--all-projects syncs the project_shared tier only; drop "
+                "--scope or pass --scope project_shared (sync other tiers "
+                "per project, without --all-projects)."
+            )
+        _warn_label_ineligible_kinds(label, inc)
+        _run_sync_all_projects(inc=inc, strict=strict, on_drop=on_drop, yes=yes, label=label)
+        return
+
     root = _find_project_root()
+    if _run_sync_legs(
+        root,
+        inc=inc,
+        strict=strict,
+        on_drop=on_drop,
+        yes=yes,
+        scope_flag=scope_flag,
+        label=label,
+    ):
+        click.secho("Synced.", fg="green")
+
+
+def _run_sync_legs(
+    root: Path,
+    *,
+    inc: set[str],
+    strict: bool,
+    on_drop: str,
+    yes: bool,
+    scope_flag: str | None,
+    label: str | None,
+    batch: bool = False,
+    surface: str = "cli_context_sync",
+) -> bool:
+    """Run one project's sync legs (project memory + included artifact kinds).
+
+    Returns False only on the single-project missing-``context.md`` early
+    refusal (no legs ran — the caller must not print ``Synced.``, the
+    historical behavior Codex impl review caught a regression on); True
+    on every path that ran the legs.
+
+    The extracted body of ``mm context sync`` — the single-project path
+    calls it once with ``batch=False`` and keeps its historical behavior
+    byte-identical. ``--all-projects`` (ADR-0025) calls it per project
+    with ``batch=True``, which changes exactly two things:
+
+    - a missing ``context.md`` is a yellow note (a registered project
+      without project memory is not a batch failure; the single-project
+      red "run init first" guidance stays single-only), and
+    - ``_warn_label_ineligible_kinds`` is suppressed — the batch
+      orchestrator prints it once, not once per project.
+
+    The batch caller passes ``scope_flag="project_shared"`` explicitly:
+    the settings leg resolves its scope via ``_resolve_cli_scope``, which
+    otherwise consults ``cfg.hooks.target_scope`` — a config-pinned
+    ``user`` value would fan the same host files out once per project
+    (the ADR-0025 tier pin; covered by the batch settings-scope test).
+    """
     ctx_path = _context_path(root)
 
     if ctx_path.exists():
@@ -1247,9 +1327,9 @@ def sync_cmd(
                 click.echo(
                     "No agent files detected. Use 'mm context generate --agent all' to create them."
                 )
-    elif not inc:
+    elif not inc and not batch:
         click.secho(f"{CONTEXT_FILENAME} not found. Run 'mm context init' first.", fg="red")
-        return
+        return False
     else:
         click.secho(f"  ({CONTEXT_FILENAME} missing — skipping project memory)", fg="yellow")
 
@@ -1259,22 +1339,23 @@ def sync_cmd(
     # which leaks ``cfg.hooks.target_scope`` into the artifact axis —
     # ADR-0011 PR-E1 Codex review trip-wire).
     artifact_scope = _resolve_artifact_cli_scope(scope_flag)
-    _warn_label_ineligible_kinds(label, inc)
+    if not batch:
+        _warn_label_ineligible_kinds(label, inc)
 
     if "skills" in inc:
         click.echo("")
-        _print_skills_generate(root, scope=artifact_scope)
+        _print_skills_generate(root, scope=artifact_scope, surface=surface)
 
     if "agents" in inc:
         click.echo("")
         _print_agents_generate(
-            root, strict=strict, on_drop=on_drop, scope=artifact_scope, label=label
+            root, strict=strict, on_drop=on_drop, scope=artifact_scope, label=label, surface=surface
         )
 
     if "commands" in inc:
         click.echo("")
         _print_commands_generate(
-            root, strict=strict, on_drop=on_drop, scope=artifact_scope, label=label
+            root, strict=strict, on_drop=on_drop, scope=artifact_scope, label=label, surface=surface
         )
 
     if "settings" in inc:
@@ -1289,7 +1370,102 @@ def sync_cmd(
         else:
             click.secho("  Skipped settings sync (declined).", fg="yellow")
 
-    click.secho("Synced.", fg="green")
+    return True
+
+
+#: CLI remediation per ``sync_skip_reason`` code (the code derivation is
+#: shared with the web batch route — ``context.projects.sync_skip_reason``).
+_CLI_SYNC_SKIP_REASONS: dict[str, str] = {
+    "missing_root": "missing — root no longer exists; re-register or `mm context projects remove`",
+    "sync_paused": "paused — `mm context projects resume <scope_id>` to include it",
+    "sync_not_enrolled": "not enrolled — `mm context projects add <path>` to include it",
+    "stale_project": "stale — no .memtomem/ store; run `mm context init` there first",
+}
+
+
+def _run_sync_all_projects(
+    *,
+    inc: set[str],
+    strict: bool,
+    on_drop: str,
+    yes: bool,
+    label: str | None,
+) -> None:
+    """Orchestrate ``mm context sync --all-projects`` (ADR-0025, #1279).
+
+    Cloned from the ``_run_update_all`` flow: discover → classify
+    (eligibility/health — NOT a dirty-diff preview) → preview table →
+    confirm → serial execute with per-project failure isolation →
+    summary, exit 1 if any project failed. Zero eligible projects exits
+    0 informationally (cron safety, the update-all precedent).
+
+    Discovery anchors at ``_find_project_root()`` — not raw ``Path.cwd()``
+    like ``mm context projects list`` — so running from a project
+    SUBDIRECTORY treats that project as the cwd scope, matching both
+    single-sync semantics (which walks up) and the web lifespan anchor.
+    """
+    cfg = _projects_gateway_cfg()
+    scopes = _projects_discover(cfg, cwd=_find_project_root())
+    rows: list[tuple[ProjectScope, str | None]] = [(s, sync_skip_reason(s)) for s in scopes]
+    runnable = [s for s, code in rows if code is None]
+
+    click.echo(f"{len(rows)} project scope(s) discovered:")
+    for s, code in rows:
+        if code is None:
+            click.secho(f"  sync  {s.scope_id}  {s.label}  ({s.root})", fg="green")
+        else:
+            click.secho(
+                f"  skip  {s.scope_id}  {s.label}  ({s.root})  [{_CLI_SYNC_SKIP_REASONS[code]}]",
+                fg="yellow",
+            )
+
+    if not runnable:
+        click.echo("No projects are eligible for sync; nothing to do.")
+        return
+
+    if not yes:
+        click.confirm(f"\nSync {len(runnable)} project(s)?", abort=True)
+
+    successes = 0
+    failures = 0
+    for s in runnable:
+        assert s.root is not None  # sync_skip_reason() filtered missing roots
+        click.secho(f"\n→ {s.label} ({s.root})", fg="cyan")
+        try:
+            _run_sync_legs(
+                s.root,
+                inc=inc,
+                strict=strict,
+                on_drop=on_drop,
+                yes=yes,
+                # Explicit tier pin — see _run_sync_legs docstring (ADR-0025).
+                scope_flag="project_shared",
+                label=label,
+                batch=True,
+                surface="cli_context_sync_all_projects",
+            )
+        except click.exceptions.Abort:
+            # Strict-drop legs raise Abort after printing their [strict]
+            # diagnostic; in a batch that fails the project, not the run.
+            click.secho(f"  ✗ {s.root}: aborted (strict-drop)", fg="red")
+            failures += 1
+        except click.ClickException as exc:
+            # Privacy Gate A and engine refusals — this project's row fails,
+            # the batch continues (a secret in one project must not block
+            # clean siblings; the _run_update_all precedent).
+            click.secho(f"  ✗ {s.root}: {exc.message}", fg="red")
+            failures += 1
+        except OSError as exc:
+            click.secho(f"  ✗ {s.root}: {exc}", fg="red")
+            failures += 1
+        else:
+            successes += 1
+
+    click.echo(
+        f"\nSummary: {successes} synced, {failures} failed, {len(rows) - len(runnable)} skipped."
+    )
+    if failures:
+        raise click.exceptions.Exit(1)
 
 
 # ── Version snapshots + label pointers (ADR-0022) ────────────────────
@@ -4164,10 +4340,16 @@ def _projects_store(cfg: ContextGatewayConfig) -> KnownProjectsStore:
     return KnownProjectsStore(Path(cfg.known_projects_path).expanduser())
 
 
-def _projects_discover(cfg: ContextGatewayConfig) -> list[ProjectScope]:
-    """Discover with the exact flags the web GET /api/context/projects uses."""
+def _projects_discover(cfg: ContextGatewayConfig, cwd: Path | None = None) -> list[ProjectScope]:
+    """Discover with the exact flags the web GET /api/context/projects uses.
+
+    ``cwd`` overrides the server-cwd anchor: the ``--all-projects`` batch
+    passes ``_find_project_root()`` so a run from a project subdirectory
+    anchors at the project root (the web lifespan does the same); the
+    ``mm context projects`` subcommands keep the raw-cwd default.
+    """
     return discover_project_scopes(
-        Path.cwd(),
+        Path.cwd() if cwd is None else cwd,
         Path(cfg.known_projects_path).expanduser(),
         experimental_claude_projects_scan=cfg.experimental_claude_projects_scan,
         auto_display_configured_projects=cfg.auto_display_configured_projects,

--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -41,6 +41,7 @@ __all__ = [
     "discover_project_scopes",
     "annotate_project_health",
     "resolve_project_selector",
+    "sync_skip_reason",
 ]
 
 
@@ -883,6 +884,40 @@ def has_runtime_marker(root: Path) -> bool:
     checkout.
     """
     return any((root / m).is_dir() for m in _MARKER_DIRS)
+
+
+# ── Batch-sync eligibility (ADR-0025) ────────────────────────────────────
+
+
+def sync_skip_reason(scope: ProjectScope) -> str | None:
+    """Why *scope* is excluded from a batch sync run, or ``None`` if eligible.
+
+    One derivation shared by ``mm context sync --all-projects`` and the web
+    ``POST /api/context/sync-all-projects`` loop so the two surfaces cannot
+    drift on WHICH scopes execute; each surface owns its remediation
+    message. The paused / not-enrolled split mirrors the web
+    ``resolve_writable_scope_root`` eligibility 409.
+
+    Codes, in evaluation order:
+
+    - ``missing_root`` — the root is gone; checked first because physical
+      absence trumps enrollment state (a paused project whose tree was
+      also deleted reports the physical problem).
+    - ``sync_paused`` / ``sync_not_enrolled`` — ``sync_eligible`` is False:
+      an enrolled known-project whose ``enabled`` flag is off, or a
+      discovery-only scope never enrolled.
+    - ``stale_project`` — root exists but has no ``.memtomem/`` store.
+      Batch-only gate: bulk-syncing a tree the user never initialized
+      would at best no-op every phase and at worst seed bookkeeping; the
+      per-type single routes stay ungated on stale.
+    """
+    if scope.root is None or scope.missing:
+        return "missing_root"
+    if not scope.sync_eligible:
+        return "sync_paused" if "known-projects" in scope.sources else "sync_not_enrolled"
+    if scope.stale:
+        return "stale_project"
+    return None
 
 
 # ── CLI / web project selector ───────────────────────────────────────────

--- a/packages/memtomem/src/memtomem/web/routes/context_sync_all.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_sync_all.py
@@ -51,6 +51,31 @@ ADR-0024 resolves that deferral and records the contracts:
   on ``project_shared`` every settings generator targets inside the
   project root, so the in-band host-write gate cannot fire here
   (ADR-0024 §Alternatives records both).
+
+Second mutator: ``POST /api/context/sync-all-projects`` (ADR-0025,
+#1279) — the cross-project batch. It loops the SAME five-phase run over
+every discovered project scope, producing a per-project × per-phase
+report. Contracts on top of the single-project route's:
+
+- **Batch reports, never refuses.** Where the single route 409s on an
+  ineligible explicit selector, the batch emits a ``skipped`` project
+  entry with a ``reason_code`` (``sync_paused`` / ``sync_not_enrolled``
+  / ``missing_root`` / ``stale_project``) and proceeds. ``stale_project``
+  (root exists, no ``.memtomem/``) is batch-only: bulk-syncing a tree the
+  user never initialized would at best no-op every phase and at worst
+  seed bookkeeping; the per-type single routes stay ungated on stale.
+- **Per-project lock window.** The ``_gateway_lock`` +
+  ``asyncio.timeout(300)`` window wraps ONE project's five phases and is
+  released between projects — project stores are independent, so
+  cross-project interleaving by other mutators is harmless, while a
+  batch-wide window would starve them for N×5 phases. A project-level
+  timeout / unexpected error converts to a ``failed`` project entry
+  (completed phases kept — their writes are real; ``summary`` present
+  iff the phase loop completed) and the batch proceeds. There is
+  deliberately NO batch-level timeout: it would discard completed
+  projects' reports mid-flight.
+- **Tier policy unchanged** — ``project_shared`` only, same two 400s.
+- Version snapshots carry ``surface="web_context_sync_all_projects"``.
 """
 
 from __future__ import annotations
@@ -60,15 +85,16 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from memtomem.config import TargetScope
+from memtomem.context.projects import ProjectScope, sync_skip_reason
 from memtomem.web.routes._locks import _gateway_lock
 from memtomem.web.routes.context_agents import _sync_agents_core
 from memtomem.web.routes.context_commands import _sync_commands_core
 from memtomem.web.routes.context_gateway import _classify_exception, _redact_message
 from memtomem.web.routes.context_mcp_servers import _sync_mcp_servers_core
-from memtomem.web.routes.context_projects import resolve_writable_scope_root
+from memtomem.web.routes.context_projects import _discover_for, resolve_writable_scope_root
 from memtomem.web.routes.context_skills import _sync_skills_core
 from memtomem.web.routes.context_transfer import _error
 from memtomem.web.routes.settings_sync import _sync_settings_core
@@ -92,6 +118,10 @@ _SYNC_ALL_PHASES: tuple[str, ...] = (
 #: ``surface`` parameter — version snapshots name the actual orchestrator
 #: instead of impersonating the standalone per-type routes.
 _SYNC_ALL_SURFACE = "web_context_sync_all"
+
+#: Same role for the cross-project batch (ADR-0025): snapshots taken
+#: during a batch run name the batch, not the single-project orchestrator.
+_SYNC_ALL_PROJECTS_SURFACE = "web_context_sync_all_projects"
 
 #: One outer window = five sequential phases × the standalone routes' 60s
 #: budget. The engine-internal cross-process lock budgets
@@ -147,6 +177,8 @@ async def _run_phase(
     phase_type: str,
     project_root: Path,
     target_scope: TargetScope,
+    *,
+    surface: str = _SYNC_ALL_SURFACE,
 ) -> dict[str, Any]:
     """Run one per-type core and shape its phase entry; never raises HTTP.
 
@@ -155,17 +187,16 @@ async def _run_phase(
     error (``OSError`` mid fan-out, …) fails only ITS phase — a bare
     propagate would 500 the whole request and discard the completed
     phases' report. Classification + redaction reuse the overview error
-    taxonomy.
+    taxonomy. ``surface`` flows to the version-snapshot audit trail —
+    the cross-project batch passes its own identity.
     """
     try:
         if phase_type == "skills":
-            native = await _sync_skills_core(project_root, target_scope, surface=_SYNC_ALL_SURFACE)
+            native = await _sync_skills_core(project_root, target_scope, surface=surface)
         elif phase_type == "commands":
-            native = await _sync_commands_core(
-                project_root, target_scope, surface=_SYNC_ALL_SURFACE
-            )
+            native = await _sync_commands_core(project_root, target_scope, surface=surface)
         elif phase_type == "agents":
-            native = await _sync_agents_core(project_root, target_scope, surface=_SYNC_ALL_SURFACE)
+            native = await _sync_agents_core(project_root, target_scope, surface=surface)
         elif phase_type == "mcp-servers":
             native = await _sync_mcp_servers_core(project_root)
         else:  # settings
@@ -226,6 +257,31 @@ def _summarize(phases: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _reject_ineligible_tier(target_scope: TargetScope) -> None:
+    """Shared tier gate for both sync-all routes (ADR-0024 §4 / ADR-0025).
+
+    One source for the two 400 literals — the per-route tests pin them by
+    full equality, and the batch deliberately refuses the same tiers for
+    the same reasons (a user-tier batch would also multiply the per-type
+    host-write confirmation bypass by N projects).
+    """
+    if target_scope == "project_local":
+        raise _error(
+            400,
+            "validation",
+            "Sync all is supported on the project_shared tier; project_local "
+            "is a draft tier with no runtime fan-out (ADR-0011 §3).",
+        )
+    if target_scope == "user":
+        raise _error(
+            400,
+            "validation",
+            "Sync all is a project-tier action (#1263); sync skills, commands, "
+            "agents, and settings individually on the user tier (mcp-servers "
+            "sync is project_shared-only).",
+        )
+
+
 @router.post("/context/sync-all")
 async def sync_all_context(
     project_root: Path = Depends(resolve_writable_scope_root),
@@ -249,21 +305,7 @@ async def sync_all_context(
     all on the ADR-0023 §10 envelope except the resolver's pre-existing
     409 shape (B-1 #1284 retrofits it).
     """
-    if target_scope == "project_local":
-        raise _error(
-            400,
-            "validation",
-            "Sync all is supported on the project_shared tier; project_local "
-            "is a draft tier with no runtime fan-out (ADR-0011 §3).",
-        )
-    if target_scope == "user":
-        raise _error(
-            400,
-            "validation",
-            "Sync all is a project-tier action (#1263); sync skills, commands, "
-            "agents, and settings individually on the user tier (mcp-servers "
-            "sync is project_shared-only).",
-        )
+    _reject_ineligible_tier(target_scope)
     phases: list[dict[str, Any]] = []
     try:
         async with asyncio.timeout(_SYNC_ALL_TIMEOUT_S):
@@ -279,3 +321,179 @@ async def sync_all_context(
             "runtime files; re-run to converge.",
         )
     return {"phases": phases, "summary": _summarize(phases)}
+
+
+# ── Cross-project batch (ADR-0025, #1279) ────────────────────────────────
+
+
+#: Web remediation prose per ``sync_skip_reason`` code. The CODE derivation
+#: is shared with the CLI (``context.projects.sync_skip_reason``) so the
+#: surfaces cannot drift on which scopes execute; the messages are
+#: surface-appropriate (portal here, ``mm`` verbs on the CLI).
+_SKIP_MESSAGES: dict[str, str] = {
+    "missing_root": (
+        "project root no longer exists on disk; re-register it or remove "
+        "the entry from the Projects portal."
+    ),
+    "sync_paused": (
+        "sync enrollment is paused for this project; resume it from the "
+        "Projects portal to include it in batch sync."
+    ),
+    "sync_not_enrolled": (
+        "discovery-only project (never enrolled); register it from the "
+        "Projects portal to include it in batch sync."
+    ),
+    "stale_project": (
+        "project has no .memtomem/ store (never initialized); run "
+        "`mm context init` there before syncing."
+    ),
+}
+
+
+def _project_skip(scope: ProjectScope) -> tuple[str, str] | None:
+    """``(reason_code, message)`` when *scope* must be skipped, else None."""
+    code = sync_skip_reason(scope)
+    if code is None:
+        return None
+    return code, _SKIP_MESSAGES[code]
+
+
+def _summarize_projects(entries: list[dict[str, Any]]) -> dict[str, Any]:
+    """Batch-level roll-up over the per-project entries.
+
+    ``status``: ``failed`` (every EXECUTED project failed) / ``ok`` (no
+    executed project failed or partial — an all-skipped batch is ``ok``
+    with ``executed: 0`` visible: skipping paused projects is the designed
+    outcome, and unattended callers need the no-op run to read as success)
+    / ``partial`` otherwise. Totals aggregate the embedded phase lists —
+    counts, not classifications (#1262); a failed project's completed
+    phases still count (their writes are real).
+    """
+    counts = {"ok": 0, "partial": 0, "failed": 0, "skipped": 0}
+    generated_total = 0
+    skipped_rows_total = 0
+    for entry in entries:
+        counts[entry["status"]] += 1
+        for phase in entry.get("phases", ()):
+            generated_total += len(phase.get("generated", ()))
+            skipped_rows_total += len(phase.get("skipped", ()))
+    executed = len(entries) - counts["skipped"]
+    if executed and counts["failed"] == executed:
+        status = "failed"
+    elif counts["failed"] or counts["partial"]:
+        status = "partial"
+    else:
+        status = "ok"
+    return {
+        "status": status,
+        "projects_total": len(entries),
+        "executed": executed,
+        **counts,
+        "generated_total": generated_total,
+        "skipped_rows_total": skipped_rows_total,
+    }
+
+
+@router.post("/context/sync-all-projects")
+async def sync_all_projects_context(
+    request: Request,
+    target_scope: TargetScope = Query(
+        "project_shared",
+        description=(
+            "Canonical-residency tier to fan out in every project. Only "
+            "project_shared is supported — same gates as /context/sync-all."
+        ),
+    ),
+) -> dict:
+    """Run the five-phase sync for every eligible discovered project.
+
+    Returns HTTP 200 with ``{projects: [...], summary: {...}}`` whenever
+    the loop ran; non-2xx only for the pre-run tier gate (400) and CSRF
+    (403). Per-project entries embed the single-project report verbatim
+    (``phases`` + ``summary``) under the project identity; ineligible
+    scopes become ``skipped`` entries (batch reports, never refuses —
+    the single route's eligibility 409 has no batch analogue). One
+    project's failure — engine error, lock timeout — converts to a
+    ``failed`` entry and the loop proceeds (``error`` envelope attached,
+    completed ``phases`` kept, ``summary`` present iff the phase loop
+    completed). Lock + timeout window is PER PROJECT — see the module
+    docstring.
+    """
+    _reject_ineligible_tier(target_scope)
+    entries: list[dict[str, Any]] = []
+    for scope in _discover_for(request):
+        base: dict[str, Any] = {
+            "project_scope_id": scope.scope_id,
+            "label": scope.label,
+            "root": str(scope.root) if scope.root is not None else None,
+        }
+        skip = _project_skip(scope)
+        if skip is not None:
+            reason_code, message = skip
+            entries.append(
+                {**base, "status": "skipped", "reason_code": reason_code, "message": message}
+            )
+            continue
+        assert scope.root is not None  # _project_skip returned a missing_root row otherwise
+        phases: list[dict[str, Any]] = []
+        try:
+            async with asyncio.timeout(_SYNC_ALL_TIMEOUT_S):
+                async with _gateway_lock:
+                    for phase_type in _SYNC_ALL_PHASES:
+                        phases.append(
+                            await _run_phase(
+                                phase_type,
+                                scope.root,
+                                target_scope,
+                                surface=_SYNC_ALL_PROJECTS_SURFACE,
+                            )
+                        )
+        except TimeoutError:
+            entries.append(
+                {
+                    **base,
+                    "status": "failed",
+                    "phases": phases,
+                    "error": {
+                        "error_kind": "busy",
+                        "http_status": 503,
+                        "message": (
+                            "sync timed out for this project — another sync may "
+                            "be in progress. Phases that completed before the "
+                            "timeout have already written their runtime files; "
+                            "re-run to converge."
+                        ),
+                    },
+                }
+            )
+            continue
+        except Exception as exc:  # defensive — _run_phase contains engine errors
+            logger.error(
+                "sync-all-projects %s failed outside the phase runner: %s",
+                scope.scope_id,
+                exc,
+                exc_info=True,
+            )
+            entries.append(
+                {
+                    **base,
+                    "status": "failed",
+                    "phases": phases,
+                    "error": {
+                        "error_kind": _classify_exception(exc),
+                        "message": _redact_message(str(exc)),
+                        "http_status": 500,
+                    },
+                }
+            )
+            continue
+        project_summary = _summarize(phases)
+        entries.append(
+            {
+                **base,
+                "status": project_summary["status"],
+                "phases": phases,
+                "summary": project_summary,
+            }
+        )
+    return {"projects": entries, "summary": _summarize_projects(entries)}

--- a/packages/memtomem/tests/test_cli_context_sync_all_projects.py
+++ b/packages/memtomem/tests/test_cli_context_sync_all_projects.py
@@ -1,0 +1,381 @@
+"""CLI tests for ``mm context sync --all-projects`` (A-9 #1279, ADR-0025).
+
+Single-project ``mm context sync`` behavior is pinned by the existing
+suites (``test_context_sync_scope.py``, ``test_context_sync_empty_guard.py``,
+…) — the ``_run_sync_legs`` extraction keeps that path byte-identical and
+those suites are the parity pin. This file covers what the batch adds:
+
+- preview table → confirm → serial execute → summary, ``--yes`` and the
+  decline path, exit 1 on any failed project;
+- skip rows (paused / missing / stale) with reasons, and the zero-eligible
+  no-op exit 0 (cron safety);
+- per-project failure isolation (privacy Gate A) — sibling still syncs;
+- the project_shared tier pin: usage errors for other ``--scope`` values,
+  and the settings leg ignoring a config-pinned ``hooks.target_scope =
+  "user"`` (positive: project settings written; negative: HOME untouched —
+  asserting only HOME would false-pass a no-op leg, Codex design-gate fold);
+- the ``_find_project_root()`` discovery anchor: a run from a project
+  SUBDIRECTORY targets the project root, never the subdir (Codex fold).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli.context_cmd import context as context_group
+from memtomem.config import ContextGatewayConfig
+
+from .helpers import set_home
+
+_SKILL_BODY = "# Demo skill\n\nDo the demo thing.\n"
+
+_AGENT_BODY = """---
+name: reviewer
+description: Code review agent
+tools: [Read, Grep]
+---
+You are a code review agent.
+"""
+
+_SECRET_AGENT_BODY = """---
+name: leaky
+description: leaks a credential
+---
+key=AKIA1234567890ABCDEF
+"""
+
+_HOOK_RULE = {
+    "matcher": "",
+    "hooks": [{"type": "command", "command": "echo ok"}],
+}
+
+
+# ── Setup helpers ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Sandbox HOME and scrub the env override that outranks config.json."""
+    home = tmp_path / "home"
+    home.mkdir()
+    set_home(monkeypatch, home)
+    monkeypatch.delenv("MEMTOMEM_HOOKS__TARGET_SCOPE", raising=False)
+    return home
+
+
+@pytest.fixture
+def known_projects_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the CLI's ``ContextGatewayConfig()`` at a per-test registry.
+
+    A real config instance (not a bare fake) because ``_projects_discover``
+    also reads the two scan flags.
+    """
+    kp = tmp_path / "kp.json"
+    monkeypatch.setattr(
+        "memtomem.cli.context_cmd.ContextGatewayConfig",
+        lambda: ContextGatewayConfig(
+            known_projects_path=kp,
+            experimental_claude_projects_scan=False,
+        ),
+    )
+    return kp
+
+
+def _seed_known_projects(path: Path, entries: list[tuple[Path, bool]]) -> None:
+    doc = {
+        "version": 1,
+        "projects": [
+            {"root": str(p), "added_at": "2026-01-01T00:00:00Z", "label": None, "enabled": en}
+            for p, en in entries
+        ],
+    }
+    path.write_text(json.dumps(doc), encoding="utf-8")
+
+
+def _project(
+    tmp_path: Path,
+    name: str,
+    *,
+    store: bool = True,
+    skill: bool = False,
+    agent_body: str | None = None,
+    settings: bool = False,
+) -> Path:
+    root = tmp_path / name
+    root.mkdir()
+    (root / ".claude").mkdir()
+    if store:
+        (root / ".memtomem").mkdir()
+    if skill:
+        skill_dir = root / ".memtomem" / "skills" / "demo-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(_SKILL_BODY, encoding="utf-8")
+    if agent_body is not None:
+        agents = root / ".memtomem" / "agents"
+        agents.mkdir(parents=True, exist_ok=True)
+        name_line = [ln for ln in agent_body.splitlines() if ln.startswith("name:")][0]
+        (agents / f"{name_line.split(':', 1)[1].strip()}.md").write_text(
+            agent_body, encoding="utf-8"
+        )
+    if settings:
+        (root / ".memtomem" / "settings.json").write_text(
+            json.dumps({"hooks": {"PostToolUse": [_HOOK_RULE]}}),
+            encoding="utf-8",
+        )
+    return root
+
+
+def _runtime_skill(root: Path) -> Path:
+    return root / ".claude" / "skills" / "demo-skill" / "SKILL.md"
+
+
+# ── Flow: preview / confirm / execute / summary ──────────────────────────
+
+
+def test_decline_at_confirm_writes_nothing(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    a = _project(tmp_path, "proj-a", skill=True)
+    b = _project(tmp_path, "proj-b", skill=True)
+    _seed_known_projects(known_projects_path, [(a, True), (b, True)])
+    monkeypatch.chdir(a)
+
+    result = CliRunner().invoke(
+        context_group, ["sync", "--all-projects", "--include", "skills"], input="n\n"
+    )
+    assert result.exit_code != 0
+    assert "2 project scope(s) discovered:" in result.output
+    assert "Sync 2 project(s)?" in result.output
+    assert not _runtime_skill(a).exists()
+    assert not _runtime_skill(b).exists()
+
+
+def test_yes_executes_every_eligible_project(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    a = _project(tmp_path, "proj-a", skill=True)
+    b = _project(tmp_path, "proj-b", skill=True)
+    _seed_known_projects(known_projects_path, [(a, True), (b, True)])
+    monkeypatch.chdir(a)  # cwd row coalesces with a's registry entry
+
+    result = CliRunner().invoke(
+        context_group, ["sync", "--all-projects", "--include", "skills", "--yes"]
+    )
+    assert result.exit_code == 0, result.output
+    assert _runtime_skill(a).read_text(encoding="utf-8") == _SKILL_BODY
+    assert _runtime_skill(b).read_text(encoding="utf-8") == _SKILL_BODY
+    # The batch memory-leg note (a registered project without context.md
+    # is not a failure) and the update-all-style summary.
+    assert "missing — skipping project memory" in result.output.replace("context.md ", "")
+    assert "Summary: 2 synced, 0 failed, 0 skipped." in result.output
+
+
+def test_subdirectory_run_anchors_at_project_root(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex design-gate fold: discovery anchors at ``_find_project_root()``
+    — from a subdir the PARENT project is the cwd scope; nothing is ever
+    created under the subdir (raw ``Path.cwd()`` would make the subdir a
+    stale scope and skip the project entirely)."""
+    a = _project(tmp_path, "proj-a", skill=True)
+    (a / "pyproject.toml").write_text('[project]\nname = "a"\nversion = "0"\n', encoding="utf-8")
+    subdir = a / "src" / "pkg"
+    subdir.mkdir(parents=True)
+    _seed_known_projects(known_projects_path, [])
+    monkeypatch.chdir(subdir)
+
+    result = CliRunner().invoke(
+        context_group, ["sync", "--all-projects", "--include", "skills", "--yes"]
+    )
+    assert result.exit_code == 0, result.output
+    assert f"({a})" in result.output  # the preview row names the project root
+    assert "Summary: 1 synced, 0 failed, 0 skipped." in result.output
+    assert _runtime_skill(a).exists()
+    assert not (subdir / ".claude").exists()
+    assert not (subdir / ".memtomem").exists()
+
+
+def test_skip_rows_paused_missing_stale(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    a = _project(tmp_path, "proj-a", skill=True)
+    paused = _project(tmp_path, "paused", skill=True)
+    gone = _project(tmp_path, "gone")
+    stale = _project(tmp_path, "stale", store=False)
+    _seed_known_projects(known_projects_path, [(paused, False), (gone, True), (stale, True)])
+    shutil.rmtree(gone)
+    monkeypatch.chdir(a)
+
+    result = CliRunner().invoke(
+        context_group, ["sync", "--all-projects", "--include", "skills", "--yes"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "paused — `mm context projects resume" in result.output
+    assert "missing — root no longer exists" in result.output
+    assert "stale — no .memtomem/ store" in result.output
+    assert "Summary: 1 synced, 0 failed, 3 skipped." in result.output
+    assert _runtime_skill(a).exists()
+    assert not _runtime_skill(paused).exists()
+
+
+def test_zero_eligible_projects_is_noop_success(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cron safety (the ``_run_update_all`` precedent): an empty registry
+    plus a stale cwd exits 0 with an info line, no prompt."""
+    neutral = _project(tmp_path, "neutral", store=False)
+    _seed_known_projects(known_projects_path, [])
+    monkeypatch.chdir(neutral)
+
+    result = CliRunner().invoke(context_group, ["sync", "--all-projects"])
+    assert result.exit_code == 0, result.output
+    assert "No projects are eligible for sync; nothing to do." in result.output
+    assert "Sync " not in result.output  # never reached the confirm prompt
+
+
+# ── Failure isolation ────────────────────────────────────────────────────
+
+
+def test_privacy_block_fails_project_but_not_batch(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    a = _project(tmp_path, "proj-a", agent_body=_AGENT_BODY)
+    leaky = _project(tmp_path, "leaky", agent_body=_SECRET_AGENT_BODY)
+    _seed_known_projects(known_projects_path, [(leaky, True)])
+    monkeypatch.chdir(a)
+
+    result = CliRunner().invoke(
+        context_group, ["sync", "--all-projects", "--include", "agents", "--yes"]
+    )
+    assert result.exit_code == 1, result.output
+    assert (a / ".claude" / "agents" / "reviewer.md").exists()
+    assert f"✗ {leaky}" in result.output
+    assert "Summary: 1 synced, 1 failed, 0 skipped." in result.output
+    # The blocked secret never reaches the runtime tree or the output.
+    assert not (leaky / ".claude" / "agents" / "leaky.md").exists()
+    assert "AKIA1234567890ABCDEF" not in result.output
+
+
+# ── Tier pin (ADR-0025 §4) ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("tier", ["user", "project_local"])
+def test_scope_other_than_project_shared_is_usage_error(
+    tier: str,
+    tmp_path: Path,
+    fake_home: Path,
+    known_projects_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    a = _project(tmp_path, "proj-a")
+    _seed_known_projects(known_projects_path, [])
+    monkeypatch.chdir(a)
+
+    result = CliRunner().invoke(context_group, ["sync", "--all-projects", "--scope", tier])
+    assert result.exit_code == 2, result.output
+    assert "--all-projects syncs the project_shared tier only" in result.output
+
+
+def test_explicit_project_shared_scope_is_accepted(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    a = _project(tmp_path, "proj-a", skill=True)
+    _seed_known_projects(known_projects_path, [])
+    monkeypatch.chdir(a)
+
+    result = CliRunner().invoke(
+        context_group,
+        ["sync", "--all-projects", "--scope", "project_shared", "--include", "skills", "--yes"],
+    )
+    assert result.exit_code == 0, result.output
+    assert _runtime_skill(a).exists()
+
+
+def _arm_user_scope_config(fake_home: Path) -> None:
+    """Pin ``hooks.target_scope = user`` in the (sandboxed) config.json."""
+    cfg_dir = fake_home / ".memtomem"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.json").write_text(
+        json.dumps({"hooks": {"target_scope": "user"}}), encoding="utf-8"
+    )
+
+
+def test_settings_leg_pinned_to_project_shared_despite_user_config(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ADR-0025 §4 + Codex design-gate fold: with ``hooks.target_scope =
+    "user"`` pinned in config, the batch settings leg must still write the
+    PROJECT settings files (positive — a HOME-only assertion would
+    false-pass a no-op leg) and must not touch the host ``~/.claude``
+    (negative — the N×-host-write hazard)."""
+    _arm_user_scope_config(fake_home)
+    a = _project(tmp_path, "proj-a", settings=True)
+    b = _project(tmp_path, "proj-b", settings=True)
+    _seed_known_projects(known_projects_path, [(b, True)])
+    monkeypatch.chdir(a)
+
+    result = CliRunner().invoke(
+        context_group, ["sync", "--all-projects", "--include", "settings", "--yes"]
+    )
+    assert result.exit_code == 0, result.output
+    assert (a / ".claude" / "settings.json").is_file()
+    assert (b / ".claude" / "settings.json").is_file()
+    assert not (fake_home / ".claude" / "settings.json").exists()
+    assert "Summary: 2 synced, 0 failed, 0 skipped." in result.output
+
+
+def test_user_config_control_single_sync_does_write_home(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Control for the pin test above: the SAME config arms a real hazard —
+    a plain single-project sync resolves the user tier from config and
+    writes the host file (with ``--yes``). Proves the batch assertion is
+    not vacuous."""
+    _arm_user_scope_config(fake_home)
+    a = _project(tmp_path, "proj-a", settings=True)
+    _seed_known_projects(known_projects_path, [])
+    monkeypatch.chdir(a)
+
+    result = CliRunner().invoke(context_group, ["sync", "--include", "settings", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert (fake_home / ".claude" / "settings.json").is_file()
+
+
+# ── Single-project extraction parity ─────────────────────────────────────
+
+
+def test_single_sync_missing_context_prints_no_false_success(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex impl-review regression: plain ``mm context sync`` in a project
+    with no ``context.md`` and no ``--include`` refuses with the init hint
+    and must NOT also print ``Synced.`` — the extracted ``_run_sync_legs``
+    early-return has to keep suppressing the caller's success line."""
+    a = _project(tmp_path, "proj-a")  # .memtomem exists, no context.md
+    _seed_known_projects(known_projects_path, [])
+    monkeypatch.chdir(a)
+
+    result = CliRunner().invoke(context_group, ["sync"])
+    assert result.exit_code == 0, result.output
+    assert "not found. Run 'mm context init' first." in result.output
+    assert "Synced." not in result.output
+
+
+# ── Option validation ────────────────────────────────────────────────────
+
+
+def test_unknown_include_rejected_before_discovery(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    a = _project(tmp_path, "proj-a")
+    _seed_known_projects(known_projects_path, [])
+    monkeypatch.chdir(a)
+
+    result = CliRunner().invoke(context_group, ["sync", "--all-projects", "--include", "bogus"])
+    assert result.exit_code == 2, result.output
+    assert "Unknown --include value 'bogus'" in result.output

--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -25,6 +25,7 @@ from memtomem.context.projects import (
     compute_scope_id,
     discover_project_scopes,
     has_runtime_marker,
+    sync_skip_reason,
 )
 
 
@@ -1361,3 +1362,57 @@ def test_selector_nonexistent_path_raises(tmp_path: Path) -> None:
     scopes = _discover(tmp_path, cwd)
     with pytest.raises(UnknownProjectSelectorError, match="existing directory"):
         resolve_project_selector(str(tmp_path / "nope"), scopes)
+
+
+# ── sync_skip_reason (ADR-0025) ──────────────────────────────────────────
+
+
+def _scope_for_skip(
+    *,
+    root: Path | None,
+    sources: tuple[str, ...] = ("known-projects",),
+    missing: bool = False,
+    stale: bool = False,
+    enabled: bool = True,
+    sync_eligible: bool = False,
+) -> ProjectScope:
+    return ProjectScope(
+        scope_id="p-000000000000",
+        label="x",
+        root=root,
+        tier="project",
+        sources=sources,
+        missing=missing,
+        stale=stale,
+        enabled=enabled,
+        sync_eligible=sync_eligible,
+    )
+
+
+def test_sync_skip_reason_eligible_is_none(tmp_path: Path) -> None:
+    scope = _scope_for_skip(root=tmp_path, sync_eligible=True)
+    assert sync_skip_reason(scope) is None
+
+
+def test_sync_skip_reason_codes(tmp_path: Path) -> None:
+    assert sync_skip_reason(_scope_for_skip(root=tmp_path, missing=True)) == "missing_root"
+    assert sync_skip_reason(_scope_for_skip(root=None)) == "missing_root"
+    assert (
+        sync_skip_reason(_scope_for_skip(root=tmp_path, sources=("known-projects",), enabled=False))
+        == "sync_paused"
+    )
+    assert (
+        sync_skip_reason(_scope_for_skip(root=tmp_path, sources=("claude-projects",)))
+        == "sync_not_enrolled"
+    )
+    assert (
+        sync_skip_reason(_scope_for_skip(root=tmp_path, stale=True, sync_eligible=True))
+        == "stale_project"
+    )
+
+
+def test_sync_skip_reason_missing_trumps_paused(tmp_path: Path) -> None:
+    """A paused project whose root is also gone reports the physical
+    problem — eligibility is moot for a tree that no longer exists."""
+    scope = _scope_for_skip(root=tmp_path, missing=True, enabled=False)
+    assert sync_skip_reason(scope) == "missing_root"

--- a/packages/memtomem/tests/test_web_invariants_registry.py
+++ b/packages/memtomem/tests/test_web_invariants_registry.py
@@ -83,6 +83,7 @@ _CSRF_PROTECTED: frozenset[str] = frozenset(
         "context_skills.sync_skills",
         "context_skills.update_skill",
         "context_sync_all.sync_all_context",
+        "context_sync_all.sync_all_projects_context",
         "context_transfer.transfer_context_artifact",
         "context_versions.create_artifact_version",
         "context_versions.delete_artifact_label",
@@ -192,6 +193,8 @@ _REDACTION_EXEMPT: dict[str, str] = {
     "context_skills.sync_skills": "filesystem-driven sync",
     "context_sync_all.sync_all_context": "filesystem-driven sync (per-type "
     "cores under one lock); no content payload",
+    "context_sync_all.sync_all_projects_context": "filesystem-driven sync "
+    "(same cores, one lock window per project); no content payload",
     "context_transfer.transfer_context_artifact": (
         "no content payload — moves/copies existing canonical bytes between "
         "stores; project_shared landings run Gate A in-engine on the staged tree"

--- a/packages/memtomem/tests/test_web_routes_context_sync_all_projects.py
+++ b/packages/memtomem/tests/test_web_routes_context_sync_all_projects.py
@@ -1,0 +1,511 @@
+"""HTTP-layer tests for ``POST /api/context/sync-all-projects`` (A-9 #1279, ADR-0025).
+
+The single-project sync-all route is pinned by
+``test_web_routes_context_sync_all.py``; this file covers what the
+cross-project batch adds:
+
+- per-project entries embedding the single-project report verbatim, and
+  batch ≡ single effect parity per executed project;
+- skip semantics: paused / missing / stale scopes become reported
+  ``skipped`` rows with reason codes (batch reports, never refuses);
+- the all-skipped batch summary edge (``ok`` with ``executed: 0`` — a
+  ``failed == executed``-first roll-up would mark 0/0 failed);
+- per-project failure isolation (privacy block, per-project timeout) and
+  the per-project — NOT batch-wide — ``_gateway_lock`` window;
+- tier gates and the host-isolation acceptance criterion (user-tier
+  fan-out must never fire);
+- ``surface`` pass-through to the cores (kwarg pin — a monkeypatched
+  engine test that ignores kwargs would false-pass the attribution).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from memtomem.config import ContextGatewayConfig, Mem2MemConfig
+from memtomem.web.app import create_app
+from memtomem.web.routes.context_sync_all import _SYNC_ALL_PHASES, _summarize_projects
+
+from .helpers import set_home
+
+_SKILL_BODY = b"# Demo skill\n\nDo the demo thing.\n"
+
+_CMD_BODY = b"""---
+description: Review code
+allowed-tools: [Read, Grep]
+---
+Review the provided file.
+"""
+
+_AGENT_BODY = b"""---
+name: reviewer
+description: Code review agent
+tools: [Read, Grep]
+---
+You are a code review agent.
+"""
+
+_SECRET_AGENT_BODY = b"""---
+name: leaky
+description: leaks a credential
+---
+key=AKIA1234567890ABCDEF
+"""
+
+_HOOK_RULE = {
+    "matcher": "",
+    "hooks": [{"type": "command", "command": "echo ok"}],
+}
+
+
+# ── Fixtures (mirror test_web_routes_context_sync_all.py) ────────────────
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    set_home(monkeypatch, home)
+    return home
+
+
+@pytest.fixture
+def cwd_root(tmp_path: Path, fake_home: Path) -> Path:
+    """Return the cwd project root with markers + store (HOME sandboxed)."""
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    (cwd / ".claude").mkdir()
+    (cwd / ".memtomem").mkdir()
+    return cwd
+
+
+@pytest.fixture
+def known_projects_path(tmp_path: Path) -> Path:
+    return tmp_path / "kp.json"
+
+
+@pytest.fixture
+def app(cwd_root: Path, known_projects_path: Path):
+    application = create_app(lifespan=None, mode="dev")
+    application.state.project_root = cwd_root
+    application.state.storage = AsyncMock()
+    config = Mem2MemConfig()
+    config.context_gateway = ContextGatewayConfig(
+        known_projects_path=known_projects_path,
+        experimental_claude_projects_scan=False,
+    )
+    application.state.config = config
+    application.state.search_pipeline = None
+    application.state.index_engine = None
+    application.state.embedder = None
+    application.state.dedup_scanner = None
+    application.state.last_reload_error = None
+    return application
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _seed_artifacts(root: Path) -> None:
+    """One canonical of every type (LF bytes — sync-style on every platform)."""
+    skill = root / ".memtomem" / "skills" / "demo-skill"
+    skill.mkdir(parents=True, exist_ok=True)
+    (skill / "SKILL.md").write_bytes(_SKILL_BODY)
+
+    commands = root / ".memtomem" / "commands"
+    commands.mkdir(parents=True, exist_ok=True)
+    (commands / "demo-cmd.md").write_bytes(_CMD_BODY)
+
+    agents = root / ".memtomem" / "agents"
+    agents.mkdir(parents=True, exist_ok=True)
+    (agents / "reviewer.md").write_bytes(_AGENT_BODY)
+
+    mcp = root / ".memtomem" / "mcp-servers"
+    mcp.mkdir(parents=True, exist_ok=True)
+    (mcp / "demo-srv.json").write_text(
+        json.dumps({"command": "uvx", "args": ["demo-server"]}, indent=2),
+        encoding="utf-8",
+    )
+
+    (root / ".memtomem" / "settings.json").write_text(
+        json.dumps({"hooks": {"PostToolUse": [_HOOK_RULE]}}),
+        encoding="utf-8",
+    )
+
+
+def _runtime_tree(root: Path) -> dict[str, bytes]:
+    """Map of root-relative POSIX path → bytes for every runtime output."""
+    tree: dict[str, bytes] = {}
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root).as_posix()
+        if rel.startswith(".memtomem/"):
+            continue
+        tree[rel] = path.read_bytes()
+    return tree
+
+
+async def _register(client, root: Path, *, enabled: bool | None = None) -> str:
+    resp = await client.post("/api/context/known-projects", json={"root": str(root)})
+    assert resp.status_code == 200, resp.text
+    scope_id = resp.json()["project_scope_id"]
+    if enabled is not None:
+        resp = await client.patch(
+            f"/api/context/known-projects/{scope_id}", json={"enabled": enabled}
+        )
+        assert resp.status_code == 200, resp.text
+    return scope_id
+
+
+def _other_project(tmp_path: Path, name: str) -> Path:
+    other = tmp_path / name
+    other.mkdir()
+    (other / ".claude").mkdir()
+    (other / ".memtomem").mkdir()
+    return other
+
+
+def _entry(data: dict, root: Path) -> dict:
+    matches = [p for p in data["projects"] if p["root"] == str(root)]
+    assert len(matches) == 1, data["projects"]
+    return matches[0]
+
+
+def _home_snapshot(home: Path) -> dict[str, bytes]:
+    return {p.relative_to(home).as_posix(): p.read_bytes() for p in home.rglob("*") if p.is_file()}
+
+
+# ── Report shape + effect parity ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_multi_project_report_and_parity_with_single_route(
+    client, cwd_root: Path, fake_home: Path, tmp_path: Path
+) -> None:
+    """Executed entries embed the single-project report verbatim (phase
+    order pinned), identically-seeded projects produce identical runtime
+    trees, and the batch's writes match the single sync-all route's on a
+    third identically-seeded project. The fake HOME stays byte-identical
+    — the acceptance criterion that user-tier fan-out never fires."""
+    project_a = _other_project(tmp_path, "proj-a")
+    _seed_artifacts(cwd_root)
+    _seed_artifacts(project_a)
+    await _register(client, project_a)
+    home_before = _home_snapshot(fake_home)
+
+    resp = await client.post("/api/context/sync-all-projects")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    assert [e["root"] for e in data["projects"]] == [str(cwd_root), str(project_a)]
+    for root in (cwd_root, project_a):
+        entry = _entry(data, root)
+        assert entry["status"] == "ok"
+        assert entry["project_scope_id"].startswith("p-")
+        assert [p["type"] for p in entry["phases"]] == list(_SYNC_ALL_PHASES)
+        assert all(p["status"] == "ok" for p in entry["phases"])
+        assert entry["summary"]["status"] == "ok"
+        assert entry["summary"]["ok"] == len(_SYNC_ALL_PHASES)
+
+    tree_cwd = _runtime_tree(cwd_root)
+    tree_a = _runtime_tree(project_a)
+    assert tree_cwd and tree_cwd == tree_a
+    assert any(rel.startswith(".claude/skills/") for rel in tree_a)
+    assert ".mcp.json" in tree_a
+    assert ".claude/settings.json" in tree_a
+
+    summary = data["summary"]
+    assert summary["status"] == "ok"
+    assert summary["projects_total"] == 2
+    assert summary["executed"] == 2
+    assert summary["ok"] == 2
+    assert summary["skipped"] == 0
+    assert summary["generated_total"] > 0
+
+    # Effect parity with the single-project route: a third identical
+    # project synced via /context/sync-all lands the same runtime tree.
+    project_b = _other_project(tmp_path, "proj-b")
+    _seed_artifacts(project_b)
+    scope_b = await _register(client, project_b)
+    single = await client.post("/api/context/sync-all", params={"project_scope_id": scope_b})
+    assert single.status_code == 200, single.text
+    assert _runtime_tree(project_b) == tree_a
+
+    # User-tier fan-out never fired: HOME is byte-identical.
+    assert _home_snapshot(fake_home) == home_before
+
+
+# ── Skip semantics ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_paused_project_skipped_with_reason_sibling_executes(
+    client, cwd_root: Path, tmp_path: Path
+) -> None:
+    """A paused project is a reported skip row — the single route's
+    eligibility 409 has no batch analogue — and does not stop siblings."""
+    paused = _other_project(tmp_path, "paused")
+    _seed_artifacts(paused)
+    await _register(client, paused, enabled=False)
+    _seed_artifacts(cwd_root)
+
+    resp = await client.post("/api/context/sync-all-projects")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    entry = _entry(data, paused)
+    assert entry["status"] == "skipped"
+    assert entry["reason_code"] == "sync_paused"
+    assert "paused" in entry["message"]
+    assert "phases" not in entry
+    assert _runtime_tree(paused) == {}
+
+    assert _entry(data, cwd_root)["status"] == "ok"
+    assert data["summary"]["status"] == "ok"
+    assert data["summary"]["executed"] == 1
+    assert data["summary"]["skipped"] == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_and_stale_projects_skipped(client, cwd_root: Path, tmp_path: Path) -> None:
+    import shutil
+
+    gone = _other_project(tmp_path, "gone")
+    await _register(client, gone)
+    shutil.rmtree(gone)
+
+    stale = tmp_path / "stale"
+    stale.mkdir()
+    (stale / ".claude").mkdir()  # runtime marker but no .memtomem store
+    await _register(client, stale)
+
+    _seed_artifacts(cwd_root)
+    resp = await client.post("/api/context/sync-all-projects")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    assert _entry(data, gone)["reason_code"] == "missing_root"
+    stale_entry = _entry(data, stale)
+    assert stale_entry["reason_code"] == "stale_project"
+    assert "mm context init" in stale_entry["message"]
+    # The batch-only stale gate really skipped: nothing was written there.
+    assert _runtime_tree(stale) == {}
+    assert data["summary"]["executed"] == 1
+    assert data["summary"]["skipped"] == 2
+
+
+@pytest.mark.asyncio
+async def test_all_skipped_batch_is_ok_with_executed_zero(
+    client, cwd_root: Path, tmp_path: Path
+) -> None:
+    """Codex design-gate fold: an all-skipped batch reads ``ok`` with
+    ``executed: 0`` visible — skipping paused projects is the designed
+    outcome, and a ``failed == executed``-first roll-up would mark 0/0
+    as failed."""
+    (cwd_root / ".memtomem").rmdir()  # cwd becomes stale (empty store dir)
+    paused = _other_project(tmp_path, "paused")
+    _seed_artifacts(paused)
+    await _register(client, paused, enabled=False)
+
+    resp = await client.post("/api/context/sync-all-projects")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    assert {e["status"] for e in data["projects"]} == {"skipped"}
+    assert _entry(data, cwd_root)["reason_code"] == "stale_project"
+    assert _entry(data, paused)["reason_code"] == "sync_paused"
+    summary = data["summary"]
+    assert summary["status"] == "ok"
+    assert summary["executed"] == 0
+    assert summary["skipped"] == 2
+    assert summary["projects_total"] == 2
+    assert summary["generated_total"] == 0
+
+
+# ── Failure isolation ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_privacy_block_fails_one_project_sibling_still_runs(
+    client, cwd_root: Path, tmp_path: Path
+) -> None:
+    """Gate A in project A fails A's agents phase (entry ``partial``);
+    the sibling still executes fully and the batch reads ``partial``.
+    The blocked secret never round-trips into the batch report."""
+    leaky = _other_project(tmp_path, "leaky")
+    _seed_artifacts(leaky)
+    (leaky / ".memtomem" / "agents" / "leaky.md").write_bytes(_SECRET_AGENT_BODY)
+    await _register(client, leaky)
+    _seed_artifacts(cwd_root)
+
+    resp = await client.post("/api/context/sync-all-projects")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    entry = _entry(data, leaky)
+    assert entry["status"] == "partial"
+    agents_phase = [p for p in entry["phases"] if p["type"] == "agents"][0]
+    assert agents_phase["status"] == "failed"
+    assert agents_phase["error"]["reason_code"] == "privacy_blocked"
+    assert "AKIA1234567890ABCDEF" not in resp.text
+    # Later phases of the SAME project still ran (ADR-0024 §1, per phase).
+    assert (leaky / ".mcp.json").is_file()
+
+    assert _entry(data, cwd_root)["status"] == "ok"
+    assert data["summary"]["status"] == "partial"
+    assert data["summary"]["partial"] == 1
+    assert data["summary"]["ok"] == 1
+
+
+@pytest.mark.asyncio
+async def test_project_timeout_fails_row_and_batch_proceeds(
+    client, cwd_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A per-project timeout converts to a failed entry (busy envelope,
+    completed phases kept — here none, skills hangs first) and the NEXT
+    project still executes: there is no batch-level timeout."""
+    from memtomem.context import skills as skills_module
+    from memtomem.web.routes import context_skills, context_sync_all
+
+    slow = _other_project(tmp_path, "slow")
+    _seed_artifacts(slow)
+    await _register(client, slow)
+    _seed_artifacts(cwd_root)
+
+    monkeypatch.setattr(context_sync_all, "_SYNC_ALL_TIMEOUT_S", 0.2)
+    real_generate = skills_module.generate_all_skills
+
+    def conditional_slow(project_root, *args, **kwargs):
+        if project_root == cwd_root:
+            time.sleep(0.6)
+        return real_generate(project_root, *args, **kwargs)
+
+    monkeypatch.setattr(context_skills, "generate_all_skills", conditional_slow)
+
+    resp = await client.post("/api/context/sync-all-projects")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    timed_out = _entry(data, cwd_root)
+    assert timed_out["status"] == "failed"
+    assert timed_out["error"]["error_kind"] == "busy"
+    assert timed_out["error"]["http_status"] == 503
+    assert timed_out["phases"] == []  # skills hung — nothing completed
+    assert "summary" not in timed_out  # summary present iff the loop completed
+
+    survivor = _entry(data, slow)
+    assert survivor["status"] == "ok"
+    assert _runtime_tree(slow) != {}
+
+    assert data["summary"]["status"] == "partial"
+    assert data["summary"]["failed"] == 1
+    assert data["summary"]["ok"] == 1
+
+
+# ── Lock model + gates ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_lock_window_is_per_project(
+    client, cwd_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ADR-0025 §3: one ``_gateway_lock`` acquisition PER EXECUTED project
+    (released between projects), not one batch-wide window and not one per
+    phase."""
+    from memtomem.web.routes import _locks
+
+    project_a = _other_project(tmp_path, "proj-a")
+    _seed_artifacts(project_a)
+    await _register(client, project_a)
+    _seed_artifacts(cwd_root)
+
+    acquisitions = 0
+    real_aenter = _locks._LoopLocalLock.__aenter__
+
+    async def counting_aenter(self):
+        nonlocal acquisitions
+        if self is _locks._gateway_lock:
+            acquisitions += 1
+        return await real_aenter(self)
+
+    monkeypatch.setattr(_locks._LoopLocalLock, "__aenter__", counting_aenter)
+
+    resp = await client.post("/api/context/sync-all-projects")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["summary"]["executed"] == 2
+    assert acquisitions == 2
+
+
+@pytest.mark.asyncio
+async def test_tier_gates_match_single_route(client) -> None:
+    for tier, fragment in (("project_local", "project_shared"), ("user", "project-tier")):
+        resp = await client.post("/api/context/sync-all-projects", params={"target_scope": tier})
+        assert resp.status_code == 400, resp.text
+        detail = resp.json()["detail"]
+        assert detail["error_kind"] == "validation"
+        assert fragment in detail["message"]
+
+
+@pytest.mark.asyncio
+async def test_surface_kwarg_reaches_cores(
+    client, cwd_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The batch passes its own audit surface to the artifact cores; the
+    single route keeps the A-8 default (kwarg pin — an engine monkeypatch
+    that drops kwargs would false-pass the attribution)."""
+    from memtomem.web.routes import context_sync_all
+
+    _seed_artifacts(cwd_root)
+    surfaces: list[str | None] = []
+
+    async def capture_skills_core(project_root, target_scope, *, surface=None):
+        surfaces.append(surface)
+        return {"generated": [], "dropped": [], "skipped": [], "canonical_root": ""}
+
+    monkeypatch.setattr(context_sync_all, "_sync_skills_core", capture_skills_core)
+
+    resp = await client.post("/api/context/sync-all-projects")
+    assert resp.status_code == 200, resp.text
+    resp = await client.post("/api/context/sync-all")
+    assert resp.status_code == 200, resp.text
+    assert surfaces == ["web_context_sync_all_projects", "web_context_sync_all"]
+
+
+# ── Unit pins for the batch roll-up ──────────────────────────────────────
+
+
+def test_summarize_projects_ladder() -> None:
+    ok = {"status": "ok", "phases": [{"generated": ["a"], "skipped": []}]}
+    partial = {"status": "partial", "phases": [{"generated": [], "skipped": [{"r": 1}]}]}
+    failed = {"status": "failed", "phases": []}
+    skipped = {"status": "skipped"}
+
+    all_skipped = _summarize_projects([skipped, skipped])
+    assert all_skipped["status"] == "ok"
+    assert all_skipped["executed"] == 0
+    assert all_skipped["skipped"] == 2
+
+    assert _summarize_projects([ok, skipped])["status"] == "ok"
+    assert _summarize_projects([ok, partial])["status"] == "partial"
+    assert _summarize_projects([ok, failed])["status"] == "partial"
+    assert _summarize_projects([failed, failed, skipped])["status"] == "failed"
+
+    totals = _summarize_projects([ok, partial, failed, skipped])
+    assert totals["projects_total"] == 4
+    assert totals["executed"] == 3
+    assert totals["generated_total"] == 1
+    assert totals["skipped_rows_total"] == 1

--- a/packages/memtomem/tests/test_web_routes_context_sync_all_projects.py
+++ b/packages/memtomem/tests/test_web_routes_context_sync_all_projects.py
@@ -21,7 +21,6 @@ cross-project batch adds:
 from __future__ import annotations
 
 import json
-import time
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -376,25 +375,33 @@ async def test_project_timeout_fails_row_and_batch_proceeds(
     client, cwd_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A per-project timeout converts to a failed entry (busy envelope,
-    completed phases kept — here none, skills hangs first) and the NEXT
-    project still executes: there is no batch-level timeout."""
-    from memtomem.context import skills as skills_module
-    from memtomem.web.routes import context_skills, context_sync_all
+    completed phases kept — here none, the first phase hangs) and the NEXT
+    project still executes: there is no batch-level timeout.
+
+    Stubbed at the ``_run_phase`` seam — the loop/timeout/error-shaping
+    semantics under test live in the route, and the real-engine-under-
+    timeout combination is already pinned by the A-8 suite. The first
+    windows CI run proved the real-engine variant platform-flaky: the
+    SURVIVOR'S five real phases also blew the shrunk 0.2s budget on the
+    slower runner.
+    """
+    import asyncio
+
+    from memtomem.web.routes import context_sync_all
 
     slow = _other_project(tmp_path, "slow")
     _seed_artifacts(slow)
     await _register(client, slow)
     _seed_artifacts(cwd_root)
 
-    monkeypatch.setattr(context_sync_all, "_SYNC_ALL_TIMEOUT_S", 0.2)
-    real_generate = skills_module.generate_all_skills
+    monkeypatch.setattr(context_sync_all, "_SYNC_ALL_TIMEOUT_S", 0.15)
 
-    def conditional_slow(project_root, *args, **kwargs):
+    async def conditional_phase(phase_type, project_root, target_scope, *, surface=None):
         if project_root == cwd_root:
-            time.sleep(0.6)
-        return real_generate(project_root, *args, **kwargs)
+            await asyncio.sleep(5)  # > the shrunk per-project budget
+        return {"type": phase_type, "status": "ok", "generated": [], "skipped": []}
 
-    monkeypatch.setattr(context_skills, "generate_all_skills", conditional_slow)
+    monkeypatch.setattr(context_sync_all, "_run_phase", conditional_phase)
 
     resp = await client.post("/api/context/sync-all-projects")
     assert resp.status_code == 200, resp.text
@@ -404,12 +411,12 @@ async def test_project_timeout_fails_row_and_batch_proceeds(
     assert timed_out["status"] == "failed"
     assert timed_out["error"]["error_kind"] == "busy"
     assert timed_out["error"]["http_status"] == 503
-    assert timed_out["phases"] == []  # skills hung — nothing completed
+    assert timed_out["phases"] == []  # the first phase hung — nothing completed
     assert "summary" not in timed_out  # summary present iff the loop completed
 
     survivor = _entry(data, slow)
     assert survivor["status"] == "ok"
-    assert _runtime_tree(slow) != {}
+    assert [p["type"] for p in survivor["phases"]] == list(_SYNC_ALL_PHASES)
 
     assert data["summary"]["status"] == "partial"
     assert data["summary"]["failed"] == 1


### PR DESCRIPTION
Closes #1279 (campaign #1270 item A-9). **ADR-0025 rides this PR**, narrowly superseding ADR-0021's "mutations remain single active-project per invocation" clause — for sync orchestration only, with an in-place rider on the clause. ADR-0023 §3 explicitly delegated this supersession here.

## What

Keeping N registered projects' runtime files fresh after canonical edits required running sync once per project by hand. This adds the batch surfaces:

- **CLI** — `mm context sync --all-projects`: serial loop over the discovered project scopes, cloned from the `_run_update_all` flow (discover → eligibility/health classify → preview table → confirm/`--yes` → serial execute → summary, exit 1 if any project failed; zero eligible projects exits 0 informationally for cron safety). Include semantics unchanged — the flag multiplies what single sync already does per project.
- **Web** — `POST /api/context/sync-all-projects`: loops the A-8 five-phase run (ADR-0024) per project, returning `{projects: [...], summary: {...}}` where executed entries embed the single-project report verbatim and ineligible scopes become `skipped` entries with reason codes.

## Key decisions (ADR-0025)

- **Batch reports, never refuses.** Paused / never-enrolled / missing / stale scopes are reported skip rows (`sync_paused` / `sync_not_enrolled` / `missing_root` / `stale_project`) — the single route's eligibility 409 has no batch analogue. The code derivation is shared (`context.projects.sync_skip_reason`) so CLI and web cannot drift on which scopes execute; each surface owns its remediation prose. `stale_project` is a batch-only gate (bulk must not seed `.memtomem/` into never-initialized trees; single routes stay ungated).
- **Per-project isolation; per-project lock window.** One `_gateway_lock` + `asyncio.timeout(300)` window per project, released between projects (a batch-wide window would starve other mutators and protects no cross-project invariant). A project-level timeout/error converts to a failed entry — completed phases kept, `summary` present iff the phase loop completed — and the batch proceeds. Deliberately no batch-level timeout (it would discard completed projects' reports).
- **project_shared only.** Web reuses the A-8 tier-400 literals via the extracted `_reject_ineligible_tier` (full-equality pins stay byte-identical); CLI usage-errors other `--scope` values and pins the settings leg's `scope_flag` so a config-pinned `hooks.target_scope="user"` cannot fan the same host files out once per project.
- **Batch summary roll-up**: `failed` = every executed project failed; an all-skipped batch is `ok` with `executed: 0` visible (skipping paused projects is the designed outcome).
- **Audit attribution**: version snapshots carry `web_context_sync_all_projects` / `cli_context_sync_all_projects` (`_run_phase` and the CLI `_print_*_generate` helpers gained a pass-through `surface` kwarg; defaults preserve the existing single-surface attribution).
- CLI batch discovery anchors at `find_project_root()` (not raw cwd) so a run from a project subdirectory targets the project root — matching single-sync semantics and the web lifespan anchor.

## Surfaces touched

- `web/routes/context_sync_all.py` — new route + `_project_skip` / `_summarize_projects`; `_run_phase` surface kwarg; shared tier gate.
- `cli/context_cmd.py` — `--all-projects` flag; `_run_sync_legs` extraction (single-project path byte-identical; the existing sync suites are the parity pin); `_run_sync_all_projects`; `_projects_discover` optional cwd anchor.
- `context/projects.py` — `sync_skip_reason` (shared eligibility derivation).
- `docs/adr/0025-cross-project-sync-orchestration.md` (new), ADR-0021 rider, `docs/guides/reference.md` one-line cookbook entry.
- Invariants registry: `context_sync_all.sync_all_projects_context` classified in `_CSRF_PROTECTED` + `_REDACTION_EXEMPT`.

No static/JS changes (front-end switchover is a B-track follow-up); no MCP changes (ADR-0021 §5 scope-out unchanged).

## Tests

- `test_web_routes_context_sync_all_projects.py` (10): report shape + batch≡single effect parity + HOME isolation, paused/missing/stale skip rows, the all-skipped `ok`/`executed: 0` edge, privacy-block failure isolation, per-project timeout isolation, per-project lock-window count, tier 400s, `surface` kwarg pin, `_summarize_projects` ladder.
- `test_cli_context_sync_all_projects.py` (12): decline/`--yes` flow, subdirectory anchor (no subdir writes), skip rows, zero-eligible no-op, privacy failure isolation with exit 1, `--scope` usage errors, settings-leg tier pin with positive+negative assertions plus a control test proving the armed config really writes HOME on single sync, include validation.
- `sync_skip_reason` unit pins (4 codes + eligible + missing-trumps-paused) in `test_context_projects.py`.

All three Codex design-gate folds (subdir anchor pin, settings-pin positive+negative pair, all-skipped summary edge) are covered. HOME-isolated throughout (acceptance criterion: user-tier fan-out must not touch real host dirs).

## Review rounds

- Codex design gate: NEEDS-FIX → three test-matrix folds (above) → converged.
- Codex impl review: NEEDS-FIX → one Major, reproduced: the `_run_sync_legs` extraction made plain `mm context sync` print `Synced.` after the missing-`context.md` refusal (false success). Fixed by returning a completed/refused bool from the legs (suggested shape, folded verbatim); regression test added and mutation-validated (fails on pre-fix code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
