### PR TITLE
feat(context): cross-project drift status — status --all-projects + GET /api/context/status-all (#1280)

### DIFF
--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -1208,6 +1208,8 @@ mm context init --include=agents --scope user --force-unsafe-import   # bypass G
 mm context generate --agent all        # generate all agent files
 mm context generate --include=agents --label production # generate files using the 'production' labeled snapshot (agents/commands only)
 mm context diff                        # check sync status
+mm context status                      # installed wiki assets + their drift state (read-only)
+mm context status --all-projects       # aggregated drift across enrolled on-disk projects (read-only; same data as GET /api/context/status-all)
 mm context sync                        # sync context.md → agent files (project_shared default)
 mm context sync --scope user           # fan out from ~/.memtomem/... → ~/.{claude,gemini,codex}/...
 mm context sync --include=skills --scope project_local   # NO_FANOUT skip (no runtime per ADR §3)

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -75,7 +75,15 @@ from memtomem.context.projects import (
     sync_skip_reason,
 )
 from memtomem.context.lockfile import LockfileError
-from memtomem.context.status import classify_status, load_with_recovery, scan_user_artifacts
+from memtomem.context.status import (
+    DRIFT_STATES,
+    ProjectStatus,
+    classify_status,
+    collect_project_status,
+    iter_kind_drift_counts,
+    load_with_recovery,
+    scan_user_artifacts,
+)
 from memtomem.context.generator import (
     GENERATORS,
     extract_sections_from_agent_file,
@@ -2045,7 +2053,17 @@ _PROJECT_LOCAL_ANNOTATION = "(draft, no fan-out)"
         "Canonical artifact tier to show. project_local rows are drafts with no runtime fan-out."
     ),
 )
-def status_cmd(scope_flag: TargetScope) -> None:
+@click.option(
+    "--all-projects",
+    "all_projects",
+    is_flag=True,
+    help=(
+        "Aggregate drift across every eligible discovered project (enrolled "
+        "+ on disk), not just the current one. Read-only; project_shared "
+        "tier only; ineligible projects are reported and skipped."
+    ),
+)
+def status_cmd(scope_flag: TargetScope, all_projects: bool) -> None:
     """Show installed wiki assets and their drift state.
 
     Read-only. Walks ``<project>/.memtomem/lock.json`` and classifies
@@ -2053,7 +2071,25 @@ def status_cmd(scope_flag: TargetScope) -> None:
     normal runs (cron-friendly chaining via ``mm context status && mm
     context update --all``); only a corrupt / version-mismatched
     lockfile produces a non-zero exit.
+
+    ``--all-projects`` (#1280) renders the cross-project aggregate
+    instead: per-project drift rows + runtime diff counts, grouped under
+    project headers. Same exit contract per project — drift alone still
+    exits 0; a corrupt lockfile or a failed collection exits 1.
     """
+    if all_projects:
+        # #1280: the aggregate is project_shared-only, mirroring the sync
+        # batch gate — `user` is one global store (not per-project) and
+        # `project_local` has no runtime fan-out to drift (ADR-0011 §3).
+        if scope_flag != "project_shared":
+            raise click.UsageError(
+                "--all-projects reports the project_shared tier only; drop "
+                "--scope or pass --scope project_shared (inspect other "
+                "tiers per project, without --all-projects)."
+            )
+        _run_status_all_projects()
+        return
+
     root = _find_project_root()
 
     # Diagnostic lockfile read — surfaces a version mismatch as an
@@ -2169,6 +2205,118 @@ def status_cmd(scope_flag: TargetScope) -> None:
 
     if lockfile_error is not None:
         raise click.exceptions.Exit(1)
+
+
+def _run_status_all_projects() -> None:
+    """Orchestrate ``mm context status --all-projects`` (#1280).
+
+    Read-only sibling of ``_run_sync_all_projects``: discover (anchored at
+    ``_find_project_root()`` so a subdirectory run targets its project) →
+    eligibility classify → per-project render. No preview/confirm step —
+    there is nothing to confirm on a read. Eligibility reuses the SAME
+    ``sync_skip_reason`` derivation: pause is documented as "exclude from
+    --all batches / web Sync", and the point of the aggregate is to predict
+    exactly what ``mm context sync --all-projects`` would operate on.
+
+    Per-project failure isolation: one project's crash prints a red row and
+    the batch continues. Exit mirrors the single-project contract — drift
+    alone exits 0 (the cron chain ``status && sync`` stays viable); exit 1
+    iff any project had a corrupt/version-mismatched lockfile or its
+    collection crashed. Zero-eligible exits 0 informationally (the batch
+    precedent).
+    """
+    cfg = _projects_gateway_cfg()
+    scopes = _projects_discover(cfg, cwd=_find_project_root())
+    wiki = WikiStore.at_default()
+
+    click.echo(f"{len(scopes)} project scope(s) discovered:")
+    drifted = clean = errors = skipped = 0
+    for s in scopes:
+        code = sync_skip_reason(s)
+        if code is not None:
+            skipped += 1
+            click.secho(
+                f"\nskip  {s.scope_id}  {s.label}  ({s.root})  [{_CLI_SYNC_SKIP_REASONS[code]}]",
+                fg="yellow",
+            )
+            continue
+        assert s.root is not None  # sync_skip_reason() filtered missing roots
+        click.secho(f"\n→ {s.label}  ({s.scope_id}, {s.root})", fg="cyan")
+        try:
+            status = collect_project_status(s.root, wiki=wiki, target_scope="project_shared")
+        except Exception as exc:  # defensive — read-only batch: one project's
+            # surprise (unreadable tree, a git failure shape the engine doesn't
+            # degrade internally) must not hide its siblings.
+            click.secho(f"  ✗ status collection failed: {exc}", fg="red")
+            errors += 1
+            continue
+        if _render_project_status(status):
+            errors += 1
+        elif status.drift:
+            drifted += 1
+        else:
+            clean += 1
+
+    click.echo(
+        f"\nSummary: {drifted} with drift, {clean} clean, {errors} error(s), {skipped} skipped."
+    )
+    if errors:
+        raise click.exceptions.Exit(1)
+
+
+def _render_project_status(status: ProjectStatus) -> bool:
+    """Render one project's aggregate block; True when it counts as an error.
+
+    Detail rows render ONLY for :data:`DRIFT_STATES` — the aggregate answers
+    "which projects drifted", so clean/untracked inventory stays in the
+    header counts and the full row list remains the single-project verb's
+    job. The ``runtime drift:`` line enumerates the SAME
+    ``iter_kind_drift_counts`` stream the shared ``drift`` flag is computed
+    from, so the rendered table and the summary classification cannot
+    disagree.
+    """
+    if status.lockfile_error is not None:
+        click.secho(f"  ✗ lock.json: {status.lockfile_error}", fg="red")
+
+    installed = sum(1 for r in status.rows if r.state not in ("local-draft", "untracked"))
+    untracked = status.state_counts["untracked"]
+    extra = f" (+ {untracked} untracked)" if untracked else ""
+    state_parts = [
+        f"{status.state_counts[k]} {k}"
+        for k in ("ok", "behind", "dirty", "missing", "stale-pin")
+        if status.state_counts[k]
+    ]
+    states = ": " + ", ".join(state_parts) if state_parts else ""
+    wiki_note = (
+        f"wiki HEAD {status.wiki_head[:12]}"
+        if status.wiki_head is not None
+        # classify_status already degraded per-row reasons (absent vs
+        # present-but-unusable); the header only needs the "can't check
+        # pins" caveat — single-status wording.
+        else "wiki unavailable; pin reachability not checked"
+    )
+    click.echo(f"  {installed} asset(s) installed{extra}{states} — {wiki_note}")
+
+    for row in status.rows:
+        if row.state not in DRIFT_STATES:
+            continue
+        glyph, color = _STATUS_GLYPH[row.state]
+        line = f"  {glyph}  {row.asset_type}/{row.name}"
+        if row.reason:
+            line += f"  ({row.reason})"
+        click.secho(line, fg=color)
+
+    runtime_bits = [
+        f"{kind.replace('_', '-')} {count} {key.replace('_', ' ')}"
+        for kind, key, count in iter_kind_drift_counts(status.diff_counts)
+    ]
+    for kind, exc in status.diff_errors.items():
+        runtime_bits.append(f"{kind.replace('_', '-')} diff failed ({exc})")
+    if runtime_bits:
+        click.secho("  runtime drift: " + "; ".join(runtime_bits), fg="yellow")
+    else:
+        click.echo("  runtime: in sync")
+    return status.lockfile_error is not None
 
 
 # ── install --all (PR-D C3) ─────────────────────────────────────────────

--- a/packages/memtomem/src/memtomem/context/status.py
+++ b/packages/memtomem/src/memtomem/context/status.py
@@ -32,10 +32,10 @@ without a usable wiki to compare against.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, get_args
 
 from memtomem.config import TargetScope
 from memtomem.context._names import is_internal_artifact_dir
@@ -48,14 +48,27 @@ from memtomem.context.skills import SKILL_MANIFEST
 from memtomem.wiki.store import WikiNotFoundError, WikiStore
 
 __all__ = [
+    "DRIFT_STATES",
+    "ProjectStatus",
     "StatusRow",
     "StatusState",
     "classify_status",
+    "collect_project_status",
+    "iter_kind_drift_counts",
     "scan_user_artifacts",
+    "summarize_diff_statuses",
+    "summarize_diff_with_canonical",
+    "summarize_settings_statuses",
 ]
 
 
 StatusState = Literal["ok", "behind", "dirty", "missing", "stale-pin", "local-draft", "untracked"]
+
+#: States that mean "this install needs attention" for the cross-project
+#: aggregate (#1280). ``ok`` is clean; ``untracked`` and ``local-draft`` are
+#: informational tiers (served / draft inventory with no wiki pin to drift
+#: from), so a project carrying only those still reads as clean.
+DRIFT_STATES: frozenset[str] = frozenset({"behind", "dirty", "missing", "stale-pin"})
 
 _LOCAL_DRAFT_MANIFEST: dict[str, str] = {
     "agents": AGENT_DIR_FILENAME,
@@ -409,6 +422,270 @@ def load_with_recovery(project_root: Path | str) -> tuple[dict, str | None]:
         return doc, None
     except LockfileError as exc:
         return lockfile.load(strict=False), str(exc)
+
+
+# ── Cross-project aggregation (#1280) ───────────────────────────────────
+#
+# One derivation consumed by BOTH batch surfaces — ``mm context status
+# --all-projects`` and web ``GET /api/context/status-all`` — so the CLI
+# table and the web payload cannot drift on classification vocabulary
+# (the #1280 acceptance criterion). The web overview route imports the
+# ``summarize_*`` helpers too, so the per-kind count keys here are the
+# SAME keys ``GET /api/context/overview`` has always emitted.
+
+
+def summarize_diff_statuses(triples: Sequence[tuple[str, str, str]]) -> dict:
+    """Summarise ``(runtime, name, status)`` triples into per-status counts.
+
+    Key vocabulary: ``total`` (distinct names) plus one count key per engine
+    status with spaces snake_cased — ``in sync`` → ``in_sync``, ``out of
+    sync`` → ``out_of_sync``, ``missing target`` → ``missing_target``,
+    ``missing canonical`` → ``missing_canonical``, ``parse error`` →
+    ``parse_error``, ``invalid name`` → ``invalid_name``. Moved verbatim
+    from the web overview's ``_count_statuses`` (#1280) so the CLI batch
+    and every web aggregate share one keying rule.
+    """
+    names: set[str] = set()
+    counts: dict[str, int] = {}
+    for _runtime, name, status in triples:
+        names.add(name)
+        key = status.replace(" ", "_")
+        counts[key] = counts.get(key, 0) + 1
+    return {"total": len(names), **counts}
+
+
+def summarize_diff_with_canonical(
+    triples: Sequence[tuple[str, str, str]],
+    canonical_names: set[str],
+) -> dict:
+    """Summarise runtime diffs plus canonical-only draft rows.
+
+    ``project_local`` agents / skills / commands have no runtime fan-out, so
+    their diff list can be empty even when canonical drafts exist. Count the
+    canonical names explicitly so aggregate totals match list views. Moved
+    verbatim from the web overview's ``_count_context_statuses`` (#1280).
+    """
+    result = summarize_diff_statuses(triples)
+    runtime_names = {name for _runtime, name, _status in triples}
+    canonical_only = canonical_names - runtime_names
+    if canonical_only:
+        result["total"] = len(runtime_names | canonical_names)
+        result["local_draft"] = len(canonical_only)
+    return result
+
+
+def summarize_settings_statuses(statuses: Sequence[str]) -> dict[str, int | str]:
+    """Roll ``diff_settings`` per-generator statuses into the overview shape.
+
+    Extracted verbatim from the web overview's inline settings block (#1280).
+    ``total`` counts only **applicable** generators (``skipped`` items are
+    N/A — an uninstalled runtime must not read as actionable work). The four
+    non-skipped categories are all represented so ``in_sync + out_of_sync +
+    missing_target + error == total`` holds — consumers can render
+    per-status segments without entries silently dropping on the floor.
+    ``status`` is the roll-up: ``in_sync`` (everything in sync or skipped),
+    ``error`` (any per-file failure), else ``out_of_sync``. ``error`` is a
+    COUNT here, parallel to its siblings — distinct from the bool ``error``
+    flag web error envelopes carry; the two shapes live on disjoint paths.
+    """
+    total_applicable = sum(1 for s in statuses if s != "skipped")
+    in_sync = sum(1 for s in statuses if s == "in sync")
+    out_of_sync = sum(1 for s in statuses if s == "out of sync")
+    missing_target = sum(1 for s in statuses if s == "missing target")
+    error_count = sum(1 for s in statuses if s == "error")
+    if all(s in ("in sync", "skipped") for s in statuses):
+        status = "in_sync"
+    elif any(s == "error" for s in statuses):
+        status = "error"
+    else:
+        status = "out_of_sync"
+    return {
+        "total": total_applicable,
+        "in_sync": in_sync,
+        "out_of_sync": out_of_sync,
+        "missing_target": missing_target,
+        "error": error_count,
+        "status": status,
+    }
+
+
+#: Per-kind count keys that do NOT signal drift. Anything else positive —
+#: ``out_of_sync``, ``missing_target``, ``missing_canonical``,
+#: ``parse_error``, ``invalid_name``, and any FUTURE engine status — reads
+#: as drift, so a new status defaults to loud rather than silently clean
+#: (Codex design-gate fold on #1280).
+_CLEAN_DIFF_KEYS: frozenset[str] = frozenset({"total", "in_sync", "local_draft"})
+#: The settings summary's clean keys (``status`` is the roll-up string, not
+#: a count; ``skipped`` generators are excluded from ``total`` upstream).
+_CLEAN_SETTINGS_KEYS: frozenset[str] = frozenset({"total", "in_sync", "status"})
+
+
+def iter_kind_drift_counts(
+    diff_counts: dict[str, dict[str, int | str]],
+) -> Iterator[tuple[str, str, int]]:
+    """Yield ``(kind, status_key, count)`` for every drift-signaling count.
+
+    THE drift enumeration both batch surfaces derive from — the CLI renders
+    its ``runtime drift:`` line from these triples and ``ProjectStatus.drift``
+    is ``any()`` over the same stream, so what the table shows and what the
+    roll-up says cannot disagree. Iteration order follows ``diff_counts``
+    insertion order (skills → commands → agents → mcp_servers → settings as
+    built by :func:`collect_project_status`), keys within a kind in summary
+    insertion order — deterministic output for tests and humans alike.
+    """
+    for kind, counts in diff_counts.items():
+        clean = _CLEAN_SETTINGS_KEYS if kind == "settings" else _CLEAN_DIFF_KEYS
+        for key, value in counts.items():
+            if key not in clean and isinstance(value, int) and value > 0:
+                yield kind, key, value
+
+
+@dataclass(frozen=True)
+class ProjectStatus:
+    """One project's full drift aggregate (#1280).
+
+    ``rows`` / ``state_counts`` cover the wiki-install axis
+    (:func:`classify_status`, filtered to the requested tier;
+    ``state_counts`` always carries all seven :data:`StatusState` keys and
+    conserves ``sum(values) == len(rows)``). ``diff_counts`` covers the
+    canonical→runtime axis: skills / commands / agents / mcp_servers via
+    :func:`summarize_diff_with_canonical` plus settings via
+    :func:`summarize_settings_statuses`. A kind whose diff scan RAISED is
+    absent from ``diff_counts`` and present in ``diff_errors`` with the raw
+    exception — redaction/classification is a surface concern (the web
+    formats an error envelope, the CLI prints the message).
+
+    ``drift`` is the shared roll-up predicate: any row state in
+    :data:`DRIFT_STATES`, any diff error, or any per-kind count outside the
+    kind's clean key set. ``lockfile_error`` does NOT imply drift — surfaces
+    report it as an error condition instead.
+    """
+
+    wiki_head: str | None
+    lockfile_error: str | None
+    rows: list[StatusRow]
+    state_counts: dict[str, int]
+    diff_counts: dict[str, dict[str, int | str]]
+    diff_errors: dict[str, BaseException]
+    drift: bool
+
+
+def collect_project_status(
+    project_root: Path | str,
+    *,
+    wiki: WikiStore | None = None,
+    target_scope: TargetScope = "project_shared",
+) -> ProjectStatus:
+    """Aggregate one project's wiki-install states + runtime diff counts.
+
+    The per-project unit both #1280 batch surfaces call once per eligible
+    discovered scope. *wiki* should be the caller's single
+    ``WikiStore.at_default()`` instance reused across the batch (the wiki
+    is global); each call still probes ``current_commit`` itself via
+    :func:`classify_status`, so ``wiki_head`` is honest per classification.
+    Wiki-unreachable degrades exactly like single-project status — rows
+    render with ``stale-pin`` reasons and ``wiki_head`` is ``None``.
+
+    *target_scope* pins the row tier filter AND the diff/settings scope.
+    Batch surfaces pass ``project_shared`` (the only tier the batch verbs
+    accept): lockfile-tracked rows plus ``untracked`` canonicals stay,
+    ``project_local`` draft rows drop, and the settings leg cannot inherit
+    a config-pinned ``hooks.target_scope = "user"`` (the A-9 precedent —
+    a host-tier scope must not leak into a batch over N projects).
+
+    Per-kind diff failures are contained (recorded in ``diff_errors``);
+    only :func:`classify_status` / lockfile reads raising would escape,
+    and those already degrade internally — callers still isolate per
+    project defensively.
+    """
+    from memtomem.context.agents import canonical_agent_name, diff_agents, list_canonical_agents
+    from memtomem.context.commands import (
+        canonical_command_name,
+        diff_commands,
+        list_canonical_commands,
+    )
+    from memtomem.context.mcp_servers import diff_mcp_servers, list_canonical_mcp_servers
+    from memtomem.context.settings import diff_settings
+    from memtomem.context.skills import diff_skills, list_canonical_skills
+
+    root = Path(project_root).expanduser()
+    _doc, lockfile_error = load_with_recovery(root)
+    wiki_head, all_rows = classify_status(root, wiki=wiki)
+    rows = [row for row in all_rows if row.tier == target_scope]
+
+    state_counts: dict[str, int] = {state: 0 for state in get_args(StatusState)}
+    for row in rows:
+        state_counts[row.state] += 1
+
+    diff_counts: dict[str, dict[str, int | str]] = {}
+    diff_errors: dict[str, BaseException] = {}
+
+    try:
+        diff_counts["skills"] = summarize_diff_with_canonical(
+            diff_skills(root, scope=target_scope),
+            {p.name for p in list_canonical_skills(root, scope=target_scope)},
+        )
+    except Exception as exc:
+        diff_errors["skills"] = exc
+
+    try:
+        # Layout-aware name extraction — under directory layout the manifest
+        # is ``<name>/command.md``, so ``p.stem`` would collapse every draft
+        # to one phantom "command" row (the overview's #624 lesson).
+        diff_counts["commands"] = summarize_diff_with_canonical(
+            diff_commands(root, scope=target_scope),
+            {
+                canonical_command_name(p, layout)
+                for p, layout in list_canonical_commands(root, scope=target_scope)
+            },
+        )
+    except Exception as exc:
+        diff_errors["commands"] = exc
+
+    try:
+        diff_counts["agents"] = summarize_diff_with_canonical(
+            diff_agents(root, scope=target_scope),
+            {
+                canonical_agent_name(p, layout)
+                for p, layout in list_canonical_agents(root, scope=target_scope)
+            },
+        )
+    except Exception as exc:
+        diff_errors["agents"] = exc
+
+    try:
+        if target_scope == "project_shared":
+            diff_counts["mcp_servers"] = summarize_diff_with_canonical(
+                diff_mcp_servers(root),
+                {p.stem for p in list_canonical_mcp_servers(root)},
+            )
+        else:
+            # Single-tier by design — mirror the overview's placeholder.
+            diff_counts["mcp_servers"] = {"total": 0, "local_draft": 0}
+    except Exception as exc:
+        diff_errors["mcp_servers"] = exc
+
+    try:
+        diff_counts["settings"] = summarize_settings_statuses(
+            [r.status for r in diff_settings(root, scope=target_scope).values()]
+        )
+    except Exception as exc:
+        diff_errors["settings"] = exc
+
+    drift = (
+        any(row.state in DRIFT_STATES for row in rows)
+        or bool(diff_errors)
+        or any(True for _ in iter_kind_drift_counts(diff_counts))
+    )
+    return ProjectStatus(
+        wiki_head=wiki_head,
+        lockfile_error=lockfile_error,
+        rows=rows,
+        state_counts=state_counts,
+        diff_counts=diff_counts,
+        diff_errors=diff_errors,
+        drift=drift,
+    )
 
 
 def _tolerant_iter_entries(

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -482,11 +482,15 @@ def _status_all_entry(
     so they pass through ``sanitize_diff_reason`` — the established
     display-sanitize boundary; ``lockfile_error`` gets the same treatment.
     Failed diff kinds become ``_error_payload`` envelopes under their kind
-    key, exactly like the single-project overview.
+    key, exactly like the single-project overview — INCLUDING the shape
+    split: settings uses the status-based envelope, the four artifact
+    kinds use the count-based one (Codex impl-review fold — one shape for
+    all five would hand clients two incompatible settings error
+    envelopes across the two routes).
     """
     diff_counts: dict[str, Any] = dict(status.diff_counts)
     for kind, exc in status.diff_errors.items():
-        diff_counts[kind] = _error_payload(exc, shape="total")
+        diff_counts[kind] = _error_payload(exc, shape="status" if kind == "settings" else "total")
     if status.lockfile_error:
         entry_status = "error"
     elif status.drift:

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -2,19 +2,29 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from memtomem.privacy import scan as _privacy_scan
 from memtomem.config import TargetScope
 from memtomem.context import override as _override
 from memtomem.context._names import GENERATOR_VENDOR
-from memtomem.web.routes.context_projects import resolve_scope_root
+from memtomem.context.projects import sync_skip_reason
+from memtomem.context.status import (
+    ProjectStatus,
+    collect_project_status,
+    summarize_diff_with_canonical,
+    summarize_settings_statuses,
+)
+from memtomem.wiki.store import WikiStore
+from memtomem.web.routes.context_projects import _discover_for, resolve_scope_root
 
 try:
     import tomllib
@@ -35,34 +45,10 @@ _ERROR_MESSAGE_LIMIT = 200
 _SECRET_REDACTED_MARKER = "<redacted: secret-shape>"
 
 
-def _count_statuses(triples: list[tuple[str, str, str]]) -> dict:
-    """Summarise ``(runtime, name, status)`` triples into per-status counts."""
-    names: set[str] = set()
-    counts: dict[str, int] = {}
-    for _runtime, name, status in triples:
-        names.add(name)
-        key = status.replace(" ", "_")
-        counts[key] = counts.get(key, 0) + 1
-    return {"total": len(names), **counts}
-
-
-def _count_context_statuses(
-    triples: list[tuple[str, str, str]],
-    canonical_names: set[str],
-) -> dict:
-    """Summarise runtime diffs plus canonical-only draft rows.
-
-    ``project_local`` agents / skills / commands have no runtime fan-out, so
-    their diff list can be empty even when canonical drafts exist. Count the
-    canonical names explicitly so overview totals match list views.
-    """
-    result = _count_statuses(triples)
-    runtime_names = {name for _runtime, name, _status in triples}
-    canonical_only = canonical_names - runtime_names
-    if canonical_only:
-        result["total"] = len(runtime_names | canonical_names)
-        result["local_draft"] = len(canonical_only)
-    return result
+# The count derivations (``summarize_diff_statuses`` /
+# ``summarize_diff_with_canonical`` / ``summarize_settings_statuses``) live
+# in ``memtomem.context.status`` since #1280 so the CLI batch verb and every
+# web aggregate share one keying rule.
 
 
 def _classify_exception(exc: BaseException) -> str:
@@ -353,7 +339,7 @@ async def context_overview(
     result: dict[str, dict[str, int | bool | str]] = {}
 
     try:
-        result["skills"] = _count_context_statuses(
+        result["skills"] = summarize_diff_with_canonical(
             diff_skills(project_root, scope=target_scope),
             {p.name for p in list_canonical_skills(project_root, scope=target_scope)},
         )
@@ -362,7 +348,7 @@ async def context_overview(
         result["skills"] = _error_payload(exc, shape="total")
 
     try:
-        result["commands"] = _count_context_statuses(
+        result["commands"] = summarize_diff_with_canonical(
             diff_commands(project_root, scope=target_scope),
             {
                 canonical_command_name(p, layout)
@@ -374,7 +360,7 @@ async def context_overview(
         result["commands"] = _error_payload(exc, shape="total")
 
     try:
-        result["agents"] = _count_context_statuses(
+        result["agents"] = summarize_diff_with_canonical(
             diff_agents(project_root, scope=target_scope),
             {
                 canonical_agent_name(p, layout)
@@ -387,7 +373,7 @@ async def context_overview(
 
     try:
         if target_scope == "project_shared":
-            result["mcp_servers"] = _count_context_statuses(
+            result["mcp_servers"] = summarize_diff_with_canonical(
                 diff_mcp_servers(project_root),
                 {p.stem for p in list_canonical_mcp_servers(project_root)},
             )
@@ -399,48 +385,15 @@ async def context_overview(
 
     try:
         settings_diff = diff_settings(project_root, scope=target_scope)
-        statuses = [r.status for r in settings_diff.values()]
-        # `total` counts only **applicable** generators (runtime installed +
-        # canonical source present). `skipped` items are N/A — including them
-        # would make the dashboard read "1/2 synced" even when the second slot
-        # is "no Codex installed", which misleads the user about actionable work.
-        total_applicable = sum(1 for s in statuses if s != "skipped")
-        # diff_settings emits 5 status values (settings.py:386-404):
-        # `in sync`, `out of sync`, `missing target`, `error`, `skipped`.
-        # All four non-skipped categories must be represented as count
-        # fields so `in_sync + out_of_sync + missing_target + error ==
-        # total_applicable` holds — that contract lets future consumers
-        # render per-status segments without the count silently dropping
-        # entries on the floor. `missing target` is the common first-use
-        # state (existing is None — settings.py:403-404), parallel to
-        # how skills/commands/agents already emit `missing_target`.
-        in_sync = sum(1 for s in statuses if s == "in sync")
-        out_of_sync = sum(1 for s in statuses if s == "out of sync")
-        missing_target = sum(1 for s in statuses if s == "missing target")
-        error_count = sum(1 for s in statuses if s == "error")
-        if all(s in ("in sync", "skipped") for s in statuses):
-            status = "in_sync"
-        elif any(s == "error" for s in statuses):
-            # In-band error: per-file failure already classified by diff_settings.
-            # No error_kind here — adding one would conflate distinct per-file causes.
-            status = "error"
-        else:
-            status = "out_of_sync"
-        # `error` is a count here (parallel to `out_of_sync` / `in_sync` /
-        # `missing_target`), NOT the bool flag `_error_payload(shape="total")`
-        # emits when the whole call raises. The two shapes are on disjoint
-        # code paths. The frontend uses truthiness on `d.error` (any
-        # positive int OR the bool `true` reaches the danger render at
+        # In-band `error` is a COUNT (per-file failures already classified by
+        # diff_settings — no error_kind, which would conflate distinct per-file
+        # causes), NOT the bool flag `_error_payload(shape="status")` emits
+        # when the whole call raises. The two shapes are on disjoint code
+        # paths. The frontend uses truthiness on `d.error` (any positive int
+        # OR the bool `true` reaches the danger render at
         # context-gateway.js:136-145), so `error: 0` correctly skips the
         # danger branch and `error: >=1` reaches it — both shapes work.
-        result["settings"] = {
-            "total": total_applicable,
-            "in_sync": in_sync,
-            "out_of_sync": out_of_sync,
-            "missing_target": missing_target,
-            "error": error_count,
-            "status": status,
-        }
+        result["settings"] = summarize_settings_statuses([r.status for r in settings_diff.values()])
     except Exception as exc:
         logger.exception("diff_settings failed")
         result["settings"] = _error_payload(exc, shape="status")
@@ -487,3 +440,192 @@ async def context_runtimes(
         logger.exception("probe_all_runtimes failed")
         runtimes = []
     return {"project_root": str(project_root), "runtimes": runtimes}
+
+
+# ── GET /context/status-all — cross-project drift aggregation (#1280) ────
+
+#: Remediation prose per ``sync_skip_reason`` code. The CODE derivation is
+#: shared with the batch-sync surfaces (``context.projects.sync_skip_reason``)
+#: so batch views cannot drift on WHICH scopes are reported; the prose is
+#: surface-local (read-context wording — these rows explain why a project is
+#: absent from a status report, not why a write was withheld).
+_STATUS_ALL_SKIP_MESSAGES: dict[str, str] = {
+    "missing_root": (
+        "project root no longer exists on disk; re-register it or remove "
+        "the entry from the Projects portal."
+    ),
+    "sync_paused": (
+        "sync enrollment is paused for this project; resume it from the "
+        "Projects portal to include it in batch views."
+    ),
+    "sync_not_enrolled": (
+        "discovery-only project (never enrolled); register it from the "
+        "Projects portal to include it in batch views."
+    ),
+    "stale_project": (
+        "project has no .memtomem/ store (never initialized); run "
+        "`mm context init` there before it can be reported."
+    ),
+}
+
+
+def _status_all_entry(
+    base: dict[str, Any], status: ProjectStatus, project_root: Path
+) -> dict[str, Any]:
+    """Serialize one executed project's ``ProjectStatus`` for the wire.
+
+    Entry ``status`` vocabulary: ``error`` (corrupt / version-mismatched
+    lockfile — the aggregate is kept but cannot be trusted as complete, the
+    single-status CLI's exit-1 condition), else ``drift``/``ok`` from the
+    shared predicate. Row ``reason`` strings can embed wiki paths and raw
+    exception text (this is the first surface serializing ``StatusRow``),
+    so they pass through ``sanitize_diff_reason`` — the established
+    display-sanitize boundary; ``lockfile_error`` gets the same treatment.
+    Failed diff kinds become ``_error_payload`` envelopes under their kind
+    key, exactly like the single-project overview.
+    """
+    diff_counts: dict[str, Any] = dict(status.diff_counts)
+    for kind, exc in status.diff_errors.items():
+        diff_counts[kind] = _error_payload(exc, shape="total")
+    if status.lockfile_error:
+        entry_status = "error"
+    elif status.drift:
+        entry_status = "drift"
+    else:
+        entry_status = "ok"
+    return {
+        **base,
+        "status": entry_status,
+        "wiki_head": status.wiki_head,
+        "lockfile_error": (
+            sanitize_diff_reason(status.lockfile_error, project_root)
+            if status.lockfile_error
+            else None
+        ),
+        "state_counts": status.state_counts,
+        "diff_counts": diff_counts,
+        "rows": [
+            {
+                "asset_type": row.asset_type,
+                "name": row.name,
+                "pin_commit": row.pin_commit,
+                "installed_at": row.installed_at,
+                "state": row.state,
+                "dirty_file_count": row.dirty_file_count,
+                "reason": sanitize_diff_reason(row.reason, project_root),
+                "tier": row.tier,
+            }
+            for row in status.rows
+        ],
+    }
+
+
+@router.get("/context/status-all")
+async def context_status_all(
+    request: Request,
+    target_scope: TargetScope = Query(
+        "project_shared",
+        description=(
+            "Canonical-residency tier to aggregate in every project. Only "
+            "project_shared is supported: the user tier is one global store "
+            "(meaningless per project) and project_local has no fan-out to "
+            "drift — mirror of the batch-sync tier gate."
+        ),
+    ),
+) -> dict:
+    """Aggregate per-project drift status across every discovered project.
+
+    The read half of ADR-0025's batch story (#1280): one call answers
+    "which of my projects have drifted" instead of N ``/context/overview``
+    fetches. Read-only — per-root filesystem/git reads, NO gateway lock,
+    and each project's collection runs off the event loop. Returns 200
+    whenever the loop ran; non-2xx only for the tier gate (400).
+
+    Per-project entries: ``skipped`` (shared ``sync_skip_reason`` codes +
+    surface-local prose), ``error`` (corrupt lockfile, or the collector
+    raised — A-9's failed-entry envelope shape), else ``ok``/``drift`` via
+    the shared ``ProjectStatus.drift`` predicate. ``summary`` is counts
+    only — deliberately NO roll-up status string: A-9's ``ok|partial|
+    failed`` describe mutation success, while fleet health here is just
+    ``drifted + errors == 0``, derivable; a third vocabulary would invite
+    drift.
+    """
+    if target_scope != "project_shared":
+        # ADR-0023 §10 object envelope, constructed inline: importing the
+        # shared ``_error`` helper from context_transfer would be a circular
+        # import (context_transfer already imports this module's classifier);
+        # B-1 #1284 owns consolidating the envelope constructors.
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error_kind": "validation",
+                "message": (
+                    "status-all aggregates the project_shared tier only: the "
+                    "user tier is one global store (not per-project) and "
+                    "project_local has no runtime fan-out to drift (ADR-0011 "
+                    "§3); use the single-project routes for those views."
+                ),
+            },
+        )
+    wiki = WikiStore.at_default()
+    entries: list[dict[str, Any]] = []
+    counts = {"drifted": 0, "clean": 0, "errors": 0, "skipped": 0}
+    for scope in _discover_for(request):
+        base: dict[str, Any] = {
+            "project_scope_id": scope.scope_id,
+            "label": scope.label,
+            "root": str(scope.root) if scope.root is not None else None,
+        }
+        code = sync_skip_reason(scope)
+        if code is not None:
+            counts["skipped"] += 1
+            entries.append(
+                {
+                    **base,
+                    "status": "skipped",
+                    "reason_code": code,
+                    "message": _STATUS_ALL_SKIP_MESSAGES[code],
+                }
+            )
+            continue
+        assert scope.root is not None  # sync_skip_reason returned missing_root otherwise
+        try:
+            status = await asyncio.to_thread(
+                collect_project_status,
+                scope.root,
+                wiki=wiki,
+                target_scope=target_scope,
+            )
+        except Exception as exc:  # defensive — collect contains per-kind failures
+            logger.error(
+                "status-all %s failed outside the collector: %s",
+                scope.scope_id,
+                exc,
+                exc_info=True,
+            )
+            counts["errors"] += 1
+            entries.append(
+                {
+                    **base,
+                    "status": "error",
+                    "error": {
+                        "error_kind": _classify_exception(exc),
+                        "message": _redact_message(str(exc)),
+                        "http_status": 500,
+                    },
+                }
+            )
+            continue
+        entry = _status_all_entry(base, status, scope.root)
+        key = {"error": "errors", "drift": "drifted", "ok": "clean"}[entry["status"]]
+        counts[key] += 1
+        entries.append(entry)
+    return {
+        "target_scope": target_scope,
+        "projects": entries,
+        "summary": {
+            "projects_total": len(entries),
+            "executed": len(entries) - counts["skipped"],
+            **counts,
+        },
+    }

--- a/packages/memtomem/tests/test_cli_status_all_projects.py
+++ b/packages/memtomem/tests/test_cli_status_all_projects.py
@@ -1,0 +1,303 @@
+"""CLI tests for ``mm context status --all-projects`` (A-10 #1280).
+
+Single-project ``mm context status`` behavior is pinned by
+``test_context_status.py`` / ``test_cli_status.py``; the shared
+``collect_project_status`` derivation has its own unit pins there too.
+This file covers what the batch verb adds:
+
+- grouped per-project render: drift-only detail rows, runtime drift line,
+  per-project summary classification, batch summary counts;
+- skip rows (paused / missing / stale) via the shared ``sync_skip_reason``
+  derivation, and the zero-eligible informational exit 0;
+- the project_shared tier gate (usage error for other ``--scope`` values);
+- the ``_find_project_root()`` discovery anchor from a subdirectory
+  (the A-9 Codex fold, mirrored);
+- exit semantics: drift alone exits 0 (cron chain ``status && sync``),
+  corrupt lockfile exits 1, and a crashed collection exits 1 with the
+  sibling still reported (per-project isolation — Codex design-gate fold);
+- wiki-absent degradation (the #1280 acceptance criterion).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli.context_cmd import context as context_group
+from memtomem.config import ContextGatewayConfig
+from memtomem.context.status import collect_project_status
+from memtomem.wiki.store import WikiStore
+
+from .helpers import set_home
+
+_AGENT_BODY = """---
+name: reviewer
+description: Code review agent
+tools: [Read, Grep]
+---
+You are a code review agent.
+"""
+
+
+# ── Fixtures (mirror test_cli_context_sync_all_projects.py) ─────────────
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Sandbox HOME + the wiki env override so runs are machine-hermetic."""
+    home = tmp_path / "home"
+    home.mkdir()
+    set_home(monkeypatch, home)
+    monkeypatch.delenv("MEMTOMEM_WIKI_PATH", raising=False)
+    return home
+
+
+@pytest.fixture
+def known_projects_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    kp = tmp_path / "kp.json"
+    monkeypatch.setattr(
+        "memtomem.cli.context_cmd.ContextGatewayConfig",
+        lambda: ContextGatewayConfig(
+            known_projects_path=kp,
+            experimental_claude_projects_scan=False,
+        ),
+    )
+    return kp
+
+
+def _seed_known_projects(path: Path, entries: list[tuple[Path, bool]]) -> None:
+    doc = {
+        "version": 1,
+        "projects": [
+            {"root": str(p), "added_at": "2026-01-01T00:00:00Z", "label": None, "enabled": en}
+            for p, en in entries
+        ],
+    }
+    path.write_text(json.dumps(doc), encoding="utf-8")
+
+
+def _project(
+    tmp_path: Path,
+    name: str,
+    *,
+    store: bool = True,
+    agent: bool = False,
+) -> Path:
+    root = tmp_path / name
+    root.mkdir()
+    (root / ".claude").mkdir()
+    if store:
+        (root / ".memtomem").mkdir()
+    if agent:
+        agents = root / ".memtomem" / "agents"
+        agents.mkdir(parents=True)
+        (agents / "reviewer.md").write_text(_AGENT_BODY, encoding="utf-8")
+    return root
+
+
+# ── Grouped render + summary ─────────────────────────────────────────────
+
+
+def test_aggregate_groups_drift_and_clean(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One drifted + one clean project: grouped blocks, runtime drift line
+    from the shared enumeration, batch summary counts — and exit 0 (drift
+    alone must keep the cron chain ``status && sync`` viable)."""
+    a = _project(tmp_path, "proj-a", agent=True)  # canonical never synced → drift
+    b = _project(tmp_path, "proj-b")  # empty store → clean
+    _seed_known_projects(known_projects_path, [(a, True), (b, True)])
+    monkeypatch.chdir(a)
+
+    result = CliRunner().invoke(context_group, ["status", "--all-projects"])
+
+    assert result.exit_code == 0, result.output
+    assert "2 project scope(s) discovered:" in result.output
+    assert f"{a}" in result.output and f"{b}" in result.output
+    # The drifted project's runtime line uses the engine status vocabulary
+    # (snake keys un-snaked for display) and names the kind.
+    assert "runtime drift:" in result.output
+    assert "missing target" in result.output
+    # The clean project renders the in-sync line.
+    assert "runtime: in sync" in result.output
+    assert "Summary: 1 with drift, 1 clean, 0 error(s), 0 skipped." in result.output
+
+
+def test_untracked_counts_in_header_not_rows(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Untracked canonicals are header inventory (+ N untracked), never
+    detail rows — detail rows are reserved for DRIFT_STATES."""
+    a = _project(tmp_path, "proj-a", agent=True)
+    _seed_known_projects(known_projects_path, [(a, True)])
+    monkeypatch.chdir(a)
+
+    result = CliRunner().invoke(context_group, ["status", "--all-projects"])
+
+    assert result.exit_code == 0, result.output
+    assert "(+ 1 untracked)" in result.output
+    assert "agents/reviewer" not in result.output  # no detail row for untracked
+
+
+def test_scope_gate_usage_error(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    a = _project(tmp_path, "proj-a")
+    _seed_known_projects(known_projects_path, [(a, True)])
+    monkeypatch.chdir(a)
+
+    result = CliRunner().invoke(context_group, ["status", "--all-projects", "--scope", "user"])
+
+    assert result.exit_code != 0
+    assert "project_shared tier only" in result.output
+
+
+def test_skip_rows_paused_missing_stale(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ineligible scopes are reported skip rows — the shared
+    ``sync_skip_reason`` codes with the CLI remediation prose — and never
+    classified (no crash on a missing root: the #1280 acceptance
+    criterion)."""
+    a = _project(tmp_path, "proj-a")
+    paused = _project(tmp_path, "paused")
+    gone = _project(tmp_path, "gone")
+    stale = _project(tmp_path, "stale", store=False)
+    _seed_known_projects(
+        known_projects_path,
+        [(a, True), (paused, False), (gone, True), (stale, True)],
+    )
+    shutil.rmtree(gone)
+    monkeypatch.chdir(a)
+
+    result = CliRunner().invoke(context_group, ["status", "--all-projects"])
+
+    assert result.exit_code == 0, result.output
+    assert "paused — `mm context projects resume" in result.output
+    assert "missing — root no longer exists" in result.output
+    assert "stale — no .memtomem/ store" in result.output
+    assert "Summary: 0 with drift, 1 clean, 0 error(s), 3 skipped." in result.output
+
+
+def test_subdirectory_run_anchors_at_project_root(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Discovery anchors at ``_find_project_root()`` — from a subdir the
+    PARENT project is the cwd scope (raw ``Path.cwd()`` would make the
+    subdir a stale scope and report the project as skipped)."""
+    a = _project(tmp_path, "proj-a")
+    (a / "pyproject.toml").write_text('[project]\nname = "a"\nversion = "0"\n', encoding="utf-8")
+    subdir = a / "src" / "pkg"
+    subdir.mkdir(parents=True)
+    _seed_known_projects(known_projects_path, [])
+    monkeypatch.chdir(subdir)
+
+    result = CliRunner().invoke(context_group, ["status", "--all-projects"])
+
+    assert result.exit_code == 0, result.output
+    assert f"{a}" in result.output
+    assert "stale — no .memtomem/ store" not in result.output
+    assert "Summary: 0 with drift, 1 clean, 0 error(s), 0 skipped." in result.output
+
+
+# ── Error isolation + exit semantics ─────────────────────────────────────
+
+
+def test_corrupt_lockfile_exits_one_sibling_reported(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    a = _project(tmp_path, "proj-a")
+    (a / ".memtomem" / "lock.json").write_text("{not json", encoding="utf-8")
+    b = _project(tmp_path, "proj-b")
+    _seed_known_projects(known_projects_path, [(a, True), (b, True)])
+    monkeypatch.chdir(a)
+
+    result = CliRunner().invoke(context_group, ["status", "--all-projects"])
+
+    assert result.exit_code == 1, result.output
+    assert "lock.json" in result.output
+    assert f"{b}" in result.output  # sibling still rendered
+    assert "Summary: 0 with drift, 1 clean, 1 error(s), 0 skipped." in result.output
+
+
+def test_collector_crash_isolated_and_exits_one(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex design-gate fold: a real collection crash (not a lockfile
+    error) prints a red row, the sibling still renders, exit 1. The
+    monkeypatched collector pins the pass-through kwargs — a wrapper that
+    swallowed ``wiki``/``target_scope`` would false-pass the batch tier
+    pin."""
+    a = _project(tmp_path, "proj-a")
+    b = _project(tmp_path, "proj-b")
+    _seed_known_projects(known_projects_path, [(a, True), (b, True)])
+    monkeypatch.chdir(a)
+
+    seen_kwargs: list[dict] = []
+
+    def _exploding(root, **kwargs):
+        seen_kwargs.append(kwargs)
+        if root == a:
+            raise OSError("boom: unreadable tree")
+        return collect_project_status(root, **kwargs)
+
+    monkeypatch.setattr("memtomem.cli.context_cmd.collect_project_status", _exploding)
+
+    result = CliRunner().invoke(context_group, ["status", "--all-projects"])
+
+    assert result.exit_code == 1, result.output
+    assert "status collection failed: boom: unreadable tree" in result.output
+    assert "Summary: 0 with drift, 1 clean, 1 error(s), 0 skipped." in result.output
+    assert len(seen_kwargs) == 2
+    for kwargs in seen_kwargs:
+        assert kwargs["target_scope"] == "project_shared"
+        assert isinstance(kwargs["wiki"], WikiStore)
+
+
+def test_zero_eligible_informational_exit_zero(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All-skipped batch exits 0 (cron safety, the batch precedent). The
+    cwd anchor must NOT be inside any project for this to be reachable."""
+    paused = _project(tmp_path, "paused")
+    _seed_known_projects(known_projects_path, [(paused, False)])
+    neutral = tmp_path / "neutral"
+    neutral.mkdir()
+    monkeypatch.chdir(neutral)
+
+    result = CliRunner().invoke(context_group, ["status", "--all-projects"])
+
+    assert result.exit_code == 0, result.output
+    assert "Summary: 0 with drift, 0 clean, 0 error(s)," in result.output
+
+
+def test_wiki_absent_degradation_note(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1280 acceptance: wiki-unreachable degrades per single-project
+    semantics — a clean installed entry renders as a stale-pin detail row
+    under the project block, header notes the unchecked pins, exit 0."""
+    a = _project(tmp_path, "proj-a")
+    dest = a / ".memtomem" / "skills" / "pinned"
+    dest.mkdir(parents=True)
+    (dest / "SKILL.md").write_bytes(b"# s\n")
+    from memtomem.context._atomic import installed_at_from_dest
+    from memtomem.context.lockfile import Lockfile
+
+    Lockfile.at(a).upsert_entry(
+        "skills", "pinned", wiki_commit="0" * 40, installed_at=installed_at_from_dest(dest)
+    )
+    _seed_known_projects(known_projects_path, [(a, True)])
+    monkeypatch.chdir(a)
+
+    result = CliRunner().invoke(context_group, ["status", "--all-projects"])
+
+    assert result.exit_code == 0, result.output
+    assert "wiki unavailable; pin reachability not checked" in result.output
+    assert "skills/pinned" in result.output
+    assert "(wiki not present)" in result.output
+    assert "Summary: 1 with drift, 0 clean, 0 error(s), 0 skipped." in result.output

--- a/packages/memtomem/tests/test_context_status.py
+++ b/packages/memtomem/tests/test_context_status.py
@@ -18,6 +18,7 @@ import shutil
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import get_args
 
 import pytest
 from click.testing import CliRunner
@@ -26,7 +27,17 @@ from memtomem.cli.context_cmd import context as context_group
 from memtomem.context._atomic import atomic_write_bytes, installed_at_from_dest
 from memtomem.context.lockfile import Lockfile
 from memtomem.context.migrate import migrate_scope
-from memtomem.context.status import StatusRow, classify_status, scan_user_artifacts
+from memtomem.context.status import (
+    DRIFT_STATES,
+    StatusRow,
+    StatusState,
+    classify_status,
+    collect_project_status,
+    iter_kind_drift_counts,
+    scan_user_artifacts,
+    summarize_diff_statuses,
+    summarize_settings_statuses,
+)
 from memtomem.wiki.store import WikiStore
 
 from .helpers import set_home
@@ -1030,3 +1041,256 @@ def test_cli_status_degraded_wiki_exits_zero(wiki_root: Path, tmp_path: Path, mo
     assert "present but unusable" in result.output
     assert "wiki not present" not in result.output
     assert "stale-pin" in result.output
+
+
+# ── collect_project_status — the cross-project aggregate unit (#1280) ────
+#
+# The derivation both `mm context status --all-projects` and web
+# `GET /api/context/status-all` consume. Vocabulary pins are FULL equality
+# (a substring match would have passed with parse_error/invalid_name
+# missing — the Codex design-gate catch these sections exist for).
+
+
+def test_summarize_diff_statuses_full_vocabulary() -> None:
+    """One count key per engine status, spaces snake_cased — full == pin."""
+    triples = [
+        ("claude", "a", "in sync"),
+        ("claude", "b", "out of sync"),
+        ("claude", "c", "missing target"),
+        ("claude", "d", "missing canonical"),
+        ("claude", "e", "parse error"),
+        ("claude", "f", "invalid name"),
+        ("gemini", "b", "out of sync"),
+    ]
+    assert summarize_diff_statuses(triples) == {
+        "total": 6,
+        "in_sync": 1,
+        "out_of_sync": 2,
+        "missing_target": 1,
+        "missing_canonical": 1,
+        "parse_error": 1,
+        "invalid_name": 1,
+    }
+
+
+def test_summarize_settings_statuses_full_shape() -> None:
+    """Settings roll-up: skipped excluded from total, error count + status."""
+    assert summarize_settings_statuses(["in sync", "skipped"]) == {
+        "total": 1,
+        "in_sync": 1,
+        "out_of_sync": 0,
+        "missing_target": 0,
+        "error": 0,
+        "status": "in_sync",
+    }
+    assert summarize_settings_statuses(["error", "out of sync", "missing target"]) == {
+        "total": 3,
+        "in_sync": 0,
+        "out_of_sync": 1,
+        "missing_target": 1,
+        "error": 1,
+        "status": "error",
+    }
+
+
+def test_iter_kind_drift_counts_classification() -> None:
+    """Drift enumeration: clean keys silent, EVERYTHING else loud.
+
+    ``parse_error`` / ``invalid_name`` (the Codex design-gate catch) and an
+    unknown future status key must all surface; ``total``/``in_sync``/
+    ``local_draft`` and the settings ``status`` string must not.
+    """
+    diff_counts = {
+        "skills": {"total": 3, "in_sync": 2, "local_draft": 1, "out_of_sync": 1},
+        "commands": {"total": 2, "parse_error": 1, "invalid_name": 1, "future_status": 1},
+        "agents": {"total": 1, "in_sync": 1},
+        "mcp_servers": {"total": 1, "missing_target": 1, "missing_canonical": 1},
+        "settings": {
+            "total": 2,
+            "in_sync": 1,
+            "out_of_sync": 0,
+            "missing_target": 0,
+            "error": 1,
+            "status": "error",
+        },
+    }
+    assert list(iter_kind_drift_counts(diff_counts)) == [
+        ("skills", "out_of_sync", 1),
+        ("commands", "parse_error", 1),
+        ("commands", "invalid_name", 1),
+        ("commands", "future_status", 1),
+        ("mcp_servers", "missing_target", 1),
+        ("mcp_servers", "missing_canonical", 1),
+        ("settings", "error", 1),
+    ]
+
+
+def _collect_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Sandbox HOME + wiki env so collect tests are hermetic per machine."""
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    set_home(monkeypatch, home)
+    monkeypatch.delenv("MEMTOMEM_WIKI_PATH", raising=False)
+    return home
+
+
+def test_collect_state_counts_conservation_and_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All seven StatusState keys always present; sum == len(rows); a
+    DRIFT_STATES row alone flips the shared drift flag."""
+    _collect_home(tmp_path, monkeypatch)
+    project = tmp_path / "proj"
+    (project / ".memtomem").mkdir(parents=True)
+    Lockfile.at(project).upsert_entry(
+        "agents", "ghost", wiki_commit="0" * 40, installed_at="2026-01-01T00:00:00Z"
+    )
+
+    status = collect_project_status(project)
+
+    assert set(status.state_counts) == set(get_args(StatusState))
+    assert sum(status.state_counts.values()) == len(status.rows) == 1
+    assert status.state_counts["missing"] == 1
+    assert status.rows[0].state == "missing"  # dest gone — no wiki needed
+    assert "missing" in DRIFT_STATES and status.drift is True
+    assert status.lockfile_error is None
+
+
+def test_collect_clean_empty_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty store + no runtimes: zero rows, all-clean counts, drift False."""
+    _collect_home(tmp_path, monkeypatch)
+    project = tmp_path / "proj"
+    (project / ".memtomem").mkdir(parents=True)
+
+    status = collect_project_status(project)
+
+    assert status.rows == []
+    assert status.drift is False
+    assert status.diff_errors == {}
+    assert set(status.diff_counts) == {"skills", "commands", "agents", "mcp_servers", "settings"}
+    assert list(iter_kind_drift_counts(status.diff_counts)) == []
+
+
+def test_collect_runtime_drift_alone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A never-synced canonical drifts on the runtime axis with zero wiki rows
+    (missing target — the canonical exists, the runtime file doesn't)."""
+    _collect_home(tmp_path, monkeypatch)
+    project = tmp_path / "proj"
+    (project / ".claude").mkdir(parents=True)  # claude generators applicable
+    agents = project / ".memtomem" / "agents"
+    agents.mkdir(parents=True)
+    (agents / "reviewer.md").write_text(
+        "---\nname: reviewer\ndescription: r\n---\nbody\n", encoding="utf-8"
+    )
+
+    status = collect_project_status(project)
+
+    assert status.state_counts["untracked"] == 1  # canonical, no lockfile entry
+    assert all(status.state_counts[s] == 0 for s in DRIFT_STATES)
+    assert status.diff_counts["agents"].get("missing_target", 0) >= 1
+    assert status.drift is True
+
+
+def test_collect_parse_error_canonical_drifts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex design-gate fold: an unparseable canonical emits ``parse error``
+    rows — outside the clean key set, so the project must read as drifted."""
+    _collect_home(tmp_path, monkeypatch)
+    project = tmp_path / "proj"
+    agents = project / ".memtomem" / "agents"
+    agents.mkdir(parents=True)
+    (agents / "broken.md").write_text("no frontmatter at all\n", encoding="utf-8")
+
+    status = collect_project_status(project)
+
+    assert status.diff_counts["agents"].get("parse_error", 0) >= 1
+    assert status.drift is True
+
+
+def test_collect_invalid_name_runtime_drifts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex design-gate fold: an invalid-name runtime file emits ``invalid
+    name`` rows — also drift."""
+    _collect_home(tmp_path, monkeypatch)
+    project = tmp_path / "proj"
+    (project / ".memtomem").mkdir(parents=True)
+    claude_agents = project / ".claude" / "agents"
+    claude_agents.mkdir(parents=True)
+    (claude_agents / "-bad.md").write_text(
+        "---\nname: -bad\ndescription: x\n---\nbody\n", encoding="utf-8"
+    )
+
+    status = collect_project_status(project)
+
+    assert status.diff_counts["agents"].get("invalid_name", 0) >= 1
+    assert status.drift is True
+
+
+def test_collect_wiki_absent_degrades_to_stale_pin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1280 acceptance: wiki-unreachable degrades exactly like the single
+    verb — clean installs become stale-pin rows, wiki_head None, no crash."""
+    _collect_home(tmp_path, monkeypatch)
+    project = tmp_path / "proj"
+    project.mkdir()
+    _setup_installed_at_pin(project, "skills", "foo", {"SKILL.md": b"x\n"}, "0" * 40)
+
+    status = collect_project_status(project)
+
+    assert status.wiki_head is None
+    assert status.state_counts["stale-pin"] == 1
+    assert status.rows[0].reason == "wiki not present"
+    assert status.drift is True
+
+
+def test_collect_lockfile_error_keeps_partial_aggregate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A corrupt lockfile is reported, NOT raised, and does not by itself
+    flip drift — surfaces classify the entry as an error separately. The
+    rest of the aggregate keeps working: an untracked canonical still
+    renders its row (its runtime fan-out gap is then genuine drift —
+    ``diff_skills`` emits ``missing target`` per runtime regardless of
+    lockfile health)."""
+    _collect_home(tmp_path, monkeypatch)
+    project = tmp_path / "proj"
+    (project / ".memtomem").mkdir(parents=True)
+    (project / ".memtomem" / "lock.json").write_text("{not json", encoding="utf-8")
+
+    status = collect_project_status(project)
+
+    assert status.lockfile_error is not None
+    assert status.rows == []
+    assert status.drift is False  # lockfile_error alone is NOT drift
+
+    skills = project / ".memtomem" / "skills" / "draft-skill"
+    skills.mkdir(parents=True)
+    (skills / "SKILL.md").write_text("# s\n", encoding="utf-8")
+
+    status = collect_project_status(project)
+
+    assert status.lockfile_error is not None
+    assert [r.state for r in status.rows] == ["untracked"]  # partial aggregate
+    assert status.diff_counts["skills"].get("missing_target", 0) >= 1
+    assert status.drift is True
+
+
+def test_collect_target_scope_filters_draft_tiers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """project_shared pin: local drafts drop from rows, so the local-draft
+    state count is structurally zero under the batch tier."""
+    _collect_home(tmp_path, monkeypatch)
+    project = tmp_path / "proj"
+    draft = project / ".memtomem" / "agents.local" / "wip"
+    draft.mkdir(parents=True)
+    (draft / "agent.md").write_text("---\nname: wip\ndescription: d\n---\nbody\n", encoding="utf-8")
+
+    status = collect_project_status(project, target_scope="project_shared")
+
+    assert status.rows == []
+    assert status.state_counts["local-draft"] == 0
+    assert status.drift is False

--- a/packages/memtomem/tests/test_web_routes_context_status_all.py
+++ b/packages/memtomem/tests/test_web_routes_context_status_all.py
@@ -291,6 +291,34 @@ async def test_collector_crash_error_entry_sibling_intact(
 
 
 @pytest.mark.asyncio
+async def test_settings_diff_error_uses_status_shape_envelope(
+    client, cwd_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex impl-review fold: a raising ``diff_settings`` must serialize
+    with the OVERVIEW's settings envelope (status-based: ``status: error``
+    + ``error_kind``/``error_message``), not the artifact kinds'
+    count-based ``{"total": 0, "error": true}`` shape — one client must
+    not meet two incompatible settings error envelopes across the two
+    routes. The contained error still reads as drift."""
+
+    def _boom(project_root, *, scope):
+        raise RuntimeError("settings diff exploded")
+
+    monkeypatch.setattr("memtomem.context.settings.diff_settings", _boom)
+
+    resp = await client.get("/api/context/status-all")
+    assert resp.status_code == 200, resp.text
+    entry = _entry(resp.json(), cwd_root)
+
+    settings_envelope = entry["diff_counts"]["settings"]
+    assert settings_envelope["status"] == "error"
+    assert settings_envelope["error_kind"] == "internal"
+    assert "settings diff exploded" in settings_envelope["error_message"]
+    assert "total" not in settings_envelope  # the count-shape marker must NOT leak in
+    assert entry["status"] == "drift"  # contained per-kind error == drift, not entry error
+
+
+@pytest.mark.asyncio
 async def test_lockfile_error_entry_keeps_partial_aggregate(
     client, cwd_root: Path, tmp_path: Path
 ) -> None:

--- a/packages/memtomem/tests/test_web_routes_context_status_all.py
+++ b/packages/memtomem/tests/test_web_routes_context_status_all.py
@@ -1,0 +1,390 @@
+"""Web tests for ``GET /api/context/status-all`` (A-10 #1280).
+
+The shared ``collect_project_status`` derivation is unit-pinned in
+``test_context_status.py``; this file covers the route's own contracts:
+
+- per-project entry shapes (``ok``/``drift``/``skipped``/``error``) and the
+  counts-only batch summary;
+- skip entries via the shared ``sync_skip_reason`` codes (full-literal pin);
+- the project_shared tier gate (400 validation envelope);
+- per-project crash isolation with pass-through kwarg pins (Codex fold);
+- corrupt lockfile ⇒ entry ``error`` with the partial aggregate retained
+  (Codex design-gate fold) and the sanitized ``lockfile_error`` string;
+- wiki-absent degradation (the #1280 acceptance criterion);
+- CLI ↔ web summary parity on one fixture tree (the shared-vocabulary
+  acceptance criterion pinned end to end).
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from click.testing import CliRunner
+from httpx import ASGITransport, AsyncClient
+
+from memtomem.cli.context_cmd import context as context_group
+from memtomem.config import ContextGatewayConfig, Mem2MemConfig
+from memtomem.context._atomic import installed_at_from_dest
+from memtomem.context.lockfile import Lockfile
+from memtomem.context.status import collect_project_status
+from memtomem.web.app import create_app
+from memtomem.wiki.store import WikiStore
+
+from .helpers import set_home
+
+_AGENT_BODY = b"""---
+name: reviewer
+description: Code review agent
+tools: [Read, Grep]
+---
+You are a code review agent.
+"""
+
+_SKIP_CODES = {"missing_root", "sync_paused", "sync_not_enrolled", "stale_project"}
+
+
+# ── Fixtures (mirror test_web_routes_context_sync_all_projects.py) ───────
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    set_home(monkeypatch, home)
+    monkeypatch.delenv("MEMTOMEM_WIKI_PATH", raising=False)
+    return home
+
+
+@pytest.fixture
+def cwd_root(tmp_path: Path, fake_home: Path) -> Path:
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    (cwd / ".claude").mkdir()
+    (cwd / ".memtomem").mkdir()
+    return cwd
+
+
+@pytest.fixture
+def known_projects_path(tmp_path: Path) -> Path:
+    return tmp_path / "kp.json"
+
+
+@pytest.fixture
+def app(cwd_root: Path, known_projects_path: Path):
+    application = create_app(lifespan=None, mode="dev")
+    application.state.project_root = cwd_root
+    application.state.storage = AsyncMock()
+    config = Mem2MemConfig()
+    config.context_gateway = ContextGatewayConfig(
+        known_projects_path=known_projects_path,
+        experimental_claude_projects_scan=False,
+    )
+    application.state.config = config
+    application.state.search_pipeline = None
+    application.state.index_engine = None
+    application.state.embedder = None
+    application.state.dedup_scanner = None
+    application.state.last_reload_error = None
+    return application
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _seed_agent(root: Path) -> None:
+    agents = root / ".memtomem" / "agents"
+    agents.mkdir(parents=True, exist_ok=True)
+    (agents / "reviewer.md").write_bytes(_AGENT_BODY)
+
+
+def _seed_missing_install(root: Path) -> None:
+    """Lockfile entry whose dest is gone — a wiki-axis ``missing`` row that
+    needs no wiki repo at all."""
+    Lockfile.at(root).upsert_entry(
+        "agents", "ghost", wiki_commit="0" * 40, installed_at="2026-01-01T00:00:00Z"
+    )
+
+
+async def _register(client, root: Path, *, enabled: bool | None = None) -> str:
+    resp = await client.post("/api/context/known-projects", json={"root": str(root)})
+    assert resp.status_code == 200, resp.text
+    scope_id = resp.json()["project_scope_id"]
+    if enabled is not None:
+        resp = await client.patch(
+            f"/api/context/known-projects/{scope_id}", json={"enabled": enabled}
+        )
+        assert resp.status_code == 200, resp.text
+    return scope_id
+
+
+def _other_project(tmp_path: Path, name: str) -> Path:
+    other = tmp_path / name
+    other.mkdir()
+    (other / ".claude").mkdir()
+    (other / ".memtomem").mkdir()
+    return other
+
+
+def _entry(data: dict, root: Path) -> dict:
+    matches = [p for p in data["projects"] if p["root"] == str(root)]
+    assert len(matches) == 1, data["projects"]
+    return matches[0]
+
+
+# ── Entry shapes + summary ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_aggregate_two_projects_shape(client, cwd_root: Path, tmp_path: Path) -> None:
+    """Drifted + clean entries carry the full aggregate shape; the summary
+    is counts-only (deliberately no roll-up status string — fleet health is
+    ``drifted + errors == 0``, derivable)."""
+    _seed_agent(cwd_root)  # never synced → runtime drift
+    _seed_missing_install(cwd_root)  # wiki-axis missing row
+    clean = _other_project(tmp_path, "proj-clean")
+    await _register(client, clean)
+
+    resp = await client.get("/api/context/status-all")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    assert data["target_scope"] == "project_shared"
+    drifted = _entry(data, cwd_root)
+    assert drifted["status"] == "drift"
+    assert drifted["project_scope_id"].startswith("p-")
+    assert drifted["lockfile_error"] is None
+    assert set(drifted["state_counts"]) == {
+        "ok",
+        "behind",
+        "dirty",
+        "missing",
+        "stale-pin",
+        "local-draft",
+        "untracked",
+    }
+    assert drifted["state_counts"]["missing"] == 1
+    assert drifted["state_counts"]["untracked"] == 1
+    assert set(drifted["diff_counts"]) == {
+        "skills",
+        "commands",
+        "agents",
+        "mcp_servers",
+        "settings",
+    }
+    assert drifted["diff_counts"]["agents"].get("missing_target", 0) >= 1
+    ghost_rows = [r for r in drifted["rows"] if r["name"] == "ghost"]
+    assert ghost_rows == [
+        {
+            "asset_type": "agents",
+            "name": "ghost",
+            "pin_commit": "0" * 40,
+            "installed_at": "2026-01-01T00:00:00Z",
+            "state": "missing",
+            "dirty_file_count": 0,
+            "reason": "dest missing",
+            "tier": "project_shared",
+        }
+    ]
+
+    clean_entry = _entry(data, clean)
+    assert clean_entry["status"] == "ok"
+    assert clean_entry["rows"] == []
+
+    assert data["summary"] == {
+        "projects_total": 2,
+        "executed": 2,
+        "drifted": 1,
+        "clean": 1,
+        "errors": 0,
+        "skipped": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_skip_entries_shared_reason_codes(client, cwd_root: Path, tmp_path: Path) -> None:
+    """Ineligible scopes become skip entries — reason codes are the shared
+    ``sync_skip_reason`` literals, full-set pinned; no crash on a missing
+    or stale root (the #1280 acceptance criterion)."""
+    paused = _other_project(tmp_path, "paused")
+    await _register(client, paused, enabled=False)
+    gone = _other_project(tmp_path, "gone")
+    await _register(client, gone)
+    shutil.rmtree(gone)
+    stale = tmp_path / "stale"
+    stale.mkdir()
+    (stale / ".claude").mkdir()  # markers but no .memtomem store
+    await _register(client, stale)
+
+    resp = await client.get("/api/context/status-all")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    by_code = {e["reason_code"]: e for e in data["projects"] if e["status"] == "skipped"}
+    assert set(by_code) == {"sync_paused", "missing_root", "stale_project"}
+    assert set(by_code) < _SKIP_CODES
+    for entry in by_code.values():
+        assert entry["message"]
+        assert "rows" not in entry
+    assert data["summary"]["skipped"] == 3
+    assert data["summary"]["executed"] == 1  # the cwd scope
+
+
+@pytest.mark.asyncio
+async def test_tier_gate_400_validation_envelope(client) -> None:
+    for tier in ("user", "project_local"):
+        resp = await client.get("/api/context/status-all", params={"target_scope": tier})
+        assert resp.status_code == 400, resp.text
+        detail = resp.json()["detail"]
+        assert detail["error_kind"] == "validation"
+        assert "project_shared tier only" in detail["message"]
+
+
+# ── Error isolation ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_collector_crash_error_entry_sibling_intact(
+    client, cwd_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One project's crash becomes an ``error`` entry (A-9 failed-entry
+    envelope shape) and the loop proceeds. The monkeypatched collector pins
+    the pass-through kwargs (wiki instance + the batch tier) — a wrapper
+    that dropped them would false-pass."""
+    sibling = _other_project(tmp_path, "proj-b")
+    await _register(client, sibling)
+    seen_kwargs: list[dict] = []
+
+    def _exploding(root, **kwargs):
+        seen_kwargs.append(kwargs)
+        if root == cwd_root:
+            raise PermissionError("boom: unreadable tree")
+        return collect_project_status(root, **kwargs)
+
+    monkeypatch.setattr("memtomem.web.routes.context_gateway.collect_project_status", _exploding)
+
+    resp = await client.get("/api/context/status-all")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    failed = _entry(data, cwd_root)
+    assert failed["status"] == "error"
+    assert failed["error"]["error_kind"] == "permission"
+    assert "boom" in failed["error"]["message"]
+    assert failed["error"]["http_status"] == 500
+    assert _entry(data, sibling)["status"] == "ok"
+    assert data["summary"]["errors"] == 1
+    assert data["summary"]["clean"] == 1
+    assert len(seen_kwargs) == 2
+    for kwargs in seen_kwargs:
+        assert kwargs["target_scope"] == "project_shared"
+        assert isinstance(kwargs["wiki"], WikiStore)
+
+
+@pytest.mark.asyncio
+async def test_lockfile_error_entry_keeps_partial_aggregate(
+    client, cwd_root: Path, tmp_path: Path
+) -> None:
+    """Codex design-gate fold: a corrupt lockfile makes the entry ``error``
+    while the partial aggregate (state_counts / diff_counts / rows) is
+    retained, the summary counts it, and the sanitized error string never
+    leaks the absolute project root."""
+    (cwd_root / ".memtomem" / "lock.json").write_text("{not json", encoding="utf-8")
+    skills = cwd_root / ".memtomem" / "skills" / "draft-skill"
+    skills.mkdir(parents=True)
+    (skills / "SKILL.md").write_text("# s\n", encoding="utf-8")
+
+    resp = await client.get("/api/context/status-all")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    entry = _entry(data, cwd_root)
+    assert entry["status"] == "error"
+    assert entry["lockfile_error"]
+    assert str(cwd_root) not in entry["lockfile_error"]
+    assert entry["state_counts"]["untracked"] == 1  # partial aggregate retained
+    assert [r["state"] for r in entry["rows"]] == ["untracked"]
+    assert data["summary"]["errors"] == 1
+    assert data["summary"]["executed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_wiki_absent_degrades_to_stale_pin_rows(client, cwd_root: Path) -> None:
+    """#1280 acceptance: with no wiki repo the clean install renders as a
+    stale-pin row (reason pinned), wiki_head is null, and the project reads
+    as drifted — exactly the single-project degradation."""
+    dest = cwd_root / ".memtomem" / "skills" / "pinned"
+    dest.mkdir(parents=True)
+    (dest / "SKILL.md").write_bytes(b"# s\n")
+    Lockfile.at(cwd_root).upsert_entry(
+        "skills", "pinned", wiki_commit="0" * 40, installed_at=installed_at_from_dest(dest)
+    )
+
+    resp = await client.get("/api/context/status-all")
+    assert resp.status_code == 200, resp.text
+    entry = _entry(resp.json(), cwd_root)
+
+    assert entry["status"] == "drift"
+    assert entry["wiki_head"] is None
+    assert entry["state_counts"]["stale-pin"] == 1
+    row = [r for r in entry["rows"] if r["name"] == "pinned"][0]
+    assert row["state"] == "stale-pin"
+    assert row["reason"] == "wiki not present"
+
+
+# ── CLI ↔ web parity ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cli_web_summary_parity(
+    client,
+    cwd_root: Path,
+    tmp_path: Path,
+    known_projects_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shared-vocabulary acceptance criterion, end to end: one fixture
+    tree drives both surfaces and the per-project classification counts
+    must agree exactly (web summary == CLI summary line)."""
+    _seed_agent(cwd_root)  # drift
+    clean = _other_project(tmp_path, "proj-clean")
+    await _register(client, clean)
+    paused = _other_project(tmp_path, "paused")
+    await _register(client, paused, enabled=False)
+
+    resp = await client.get("/api/context/status-all")
+    assert resp.status_code == 200, resp.text
+    summary = resp.json()["summary"]
+    assert summary == {
+        "projects_total": 3,
+        "executed": 2,
+        "drifted": 1,
+        "clean": 1,
+        "errors": 0,
+        "skipped": 1,
+    }
+
+    monkeypatch.setattr(
+        "memtomem.cli.context_cmd.ContextGatewayConfig",
+        lambda: ContextGatewayConfig(
+            known_projects_path=known_projects_path,
+            experimental_claude_projects_scan=False,
+        ),
+    )
+    monkeypatch.chdir(cwd_root)
+    result = CliRunner().invoke(context_group, ["status", "--all-projects"])
+
+    assert result.exit_code == 0, result.output
+    assert (
+        f"Summary: {summary['drifted']} with drift, {summary['clean']} clean, "
+        f"{summary['errors']} error(s), {summary['skipped']} skipped." in result.output
+    )


### PR DESCRIPTION
Closes #1280. Part of the context-gateway completion campaign (#1270, item A-10).

## Problem

`mm context status` walks one project's lockfile; the portal shows per-project
tiles but there is no aggregated "which of my projects have drifted" view.
Checking 10 projects means 10 invocations (#1280).

## What this adds

**CLI** — `mm context status --all-projects`: discovery anchored at
`_find_project_root()` (the A-9 subdir-anchor fold), per-project grouped
blocks (header counts + drift-only detail rows + a `runtime drift:` line),
skip rows for ineligible scopes, batch summary. Drift alone still exits 0
(the cron chain `status && sync` stays viable); exit 1 iff a project's
lockfile is corrupt or its collection crashed (per-project isolation —
sibling projects still render).

**Web** — `GET /api/context/status-all`: read-only, NO gateway lock,
per-root collection via `asyncio.to_thread`. Per-project entries:
`ok|drift|skipped|error`; skip entries carry the shared `sync_skip_reason`
codes + surface-local prose; crash entries carry the A-9 failed-entry error
envelope; corrupt-lockfile entries are `error` with the partial aggregate
retained. `summary` is counts only (`projects_total/executed/drifted/clean/
errors/skipped`) — deliberately no roll-up status string: A-9's
`ok|partial|failed` describe mutation success, while fleet health here is
`drifted + errors == 0`, derivable.

**Shared derivation** (`context/status.py`) — the #1280 acceptance criterion
"CLI table and web payload share the classification vocabulary" is enforced
structurally, not by convention:

- `collect_project_status(root, *, wiki, target_scope)` → `ProjectStatus`:
  classify_status rows filtered to the tier + 7-key `state_counts`
  (count-conserving) + per-kind `diff_counts` + raw `diff_errors` + the
  shared `drift` flag. Both surfaces call it; redaction stays a web concern.
- `summarize_diff_statuses` / `summarize_diff_with_canonical` MOVED here
  from the web overview's private `_count_statuses` / `_count_context_statuses`
  (overview now imports them — byte-identical behavior, its suites are the
  parity pin), so the per-kind count keys are one keying rule everywhere.
- `summarize_settings_statuses` extracted from the overview's inline
  settings block, same shape (`total/in_sync/out_of_sync/missing_target/
  error/status`).
- Drift predicate (Codex design-gate fold): any `DRIFT_STATES` row
  (`behind/dirty/missing/stale-pin`), any diff error, or any positive
  per-kind count OUTSIDE the closed clean set (`total/in_sync/local_draft`;
  settings adds `status`) — so `parse_error`, `invalid_name`, and any FUTURE
  engine status read as drift (loud, never silently clean).
  `iter_kind_drift_counts` is the single enumeration: the CLI renders its
  `runtime drift:` line from the same stream the flag is computed from.

**Eligibility** reuses `context.projects.sync_skip_reason` verbatim (the
ADR-0025 shared derivation): pause is documented as "exclude from --all
batches / web Sync", and the aggregate predicting exactly what
`sync --all-projects` would execute is the point. Missing/stale roots are
reported skip rows, never crashes (acceptance criterion). Both surfaces pin
the batch to `project_shared` (CLI UsageError / web 400 validation envelope,
mirroring the sync-all tier gates: the user tier is one global store, and a
config-pinned `hooks.target_scope=user` must not leak into a batch).

Wiki-unreachable degrades exactly like the single verb (acceptance
criterion): clean installs render as `stale-pin` rows, `wiki_head` null,
header notes pins unchecked. One `WikiStore.at_default()` instance is
reused across the batch (the wiki is global).

## Notes

- No new ADR: ADR-0025 superseded ADR-0021's mutation clause for sync
  orchestration; reads were never single-project-gated (the portal already
  reads cross-project). The route rides ADR-0025's read half conceptually.
- The 400 envelope is constructed inline in `context_gateway.py` —
  importing the shared `_error` helper from `context_transfer` would be a
  circular import (context_transfer already imports this module's
  classifier). B-1 #1284 owns consolidating envelope constructors.
- First web serialization of `StatusRow`: row `reason` strings and
  `lockfile_error` pass through `sanitize_diff_reason` (root-strip + HOME
  collapse + secret-shape replace + truncate).
- Non-goals (B-track dashboard concerns): per-project `last_synced_at` /
  `runtime_coverage` (opt-in on existing routes), CLI JSON output, caching.

## Tests

- `test_context_status.py`: full-literal vocabulary pins incl.
  `parse_error`/`invalid_name` (Codex fold), drift truth table, 7-key
  count conservation, wiki-absent degradation, corrupt-lockfile partial
  aggregate (lockfile_error alone is NOT drift), tier filtering.
- `test_cli_status_all_projects.py` (new): grouped render, skip rows,
  zero-eligible exit 0, scope gate, subdir anchor, corrupt-lockfile exit 1
  with sibling reported, collector-crash isolation with pass-through kwarg
  pins (Codex fold), wiki-absent note.
- `test_web_routes_context_status_all.py` (new): entry/summary shape pins,
  shared skip-code set, 400 tier gate envelope, crash isolation + kwarg
  pins, lockfile-error entry with partial aggregate + sanitized message
  (Codex fold), wiki-absent degradation, and an end-to-end CLI↔web summary
  parity test on one fixture tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
