### PR TITLE
feat(context): cross-project per-hook copy for settings hooks (#1281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+- **Cross-project per-hook copy for settings hooks (ADR-0023 §11).** New
+  `mm context settings-copy --event … --matcher … --to-project <scope_id|path>`
+  and `POST /api/context/settings/hooks/copy` copy ONE canonical-matched hook
+  entry into another project. The copy is durable by construction — it writes
+  the destination's canonical `.memtomem/settings.json` (so the destination's
+  own syncs maintain the rule) and the destination-tier Claude settings file
+  (ownership-stamped, live immediately); other runtimes pick the entry up on
+  the destination's next settings sync (the exact command is printed).
+  Idempotent re-runs are no-ops, same-matcher conflicts are skipped with the
+  colliding entry named, and the privacy scan (Gate A) runs for every
+  destination tier with no force valve. Companion fix: settings sync now
+  re-reads the canonical under the per-target lock, so a concurrently
+  in-flight sync can no longer prune a rule another gateway writer just
+  landed (#1281).
+
 ## [0.2.4] — 2026-06-04
 
 Patch release on top of 0.2.3: a multi-project **Context Portal**,

--- a/docs/adr/0023-cross-project-artifact-transfer.md
+++ b/docs/adr/0023-cross-project-artifact-transfer.md
@@ -48,7 +48,7 @@ to its native error shape (the established `PrivacyScanError` pattern).
 | agents | yes (PR-E4, now via engine) | yes | yes | yes | yes |
 | commands | yes (PR-E4, now via engine) | yes | yes | yes | yes |
 | skills | yes (dir tree) | yes | yes | yes | yes |
-| settings hooks | `settings-migrate` path, NOT this engine | — | A-11 #1281 (per-hook copy, separate mechanism) | A-11 #1281 | — |
+| settings hooks | `settings-migrate` path, NOT this engine | — | no (copy-only v1, #1281 scope) | yes — `settings-copy` per-hook (A-11 #1281, separate mechanism: §11) | — |
 | mcp-servers | n/a (single-tier by design, ADR-0016 §3 note) | — | A-12 #1282 (separate mechanism) | A-12 #1282 | — |
 | memory | ADR-0012 (cross-DB migration, deferred) | — | — | — | — |
 
@@ -337,6 +337,48 @@ no-commit claim. The response serializes `TransferResult` verbatim
 (absolute paths; `src_project_scope_id` / `dst_project_scope_id`
 computed for project tiers so the UI can offer one-click follow-up
 sync; the §9 provenance triple on the wire for client matching).
+
+### 11. Settings hooks: the A-11 per-hook copy mechanism (#1281)
+
+Settings hooks are not `{kind}/{name}` artifacts, so their
+cross-project copy is a **separate engine**
+(`context/settings_copy.py`; CLI `mm context settings-copy`, web
+`POST /api/context/settings/hooks/copy` in `settings_sync.py`) that
+inherits this ADR's surface contracts (§10's error envelope,
+disclose-then-confirm, destination eligibility, engine-offload shape)
+with four mechanism-specific decisions A-12/A-13 should inherit where
+applicable:
+
+- **Dual write, canonical first (durability).** A stamped rule absent
+  from the destination's canonical `.memtomem/settings.json` is
+  garbage-collected by that project's next settings sync (ADR-0019
+  owned-rule GC), so a tier-only copy would self-destruct. The copy
+  writes the destination canonical (entry verbatim — the durable
+  definition) and then the destination-tier Claude settings file
+  (ADR-0019-stamped — live immediately); other runtimes ride the
+  printed `cd <dst> && mm context sync --include=settings --scope
+  <tier>` follow-up. Companion fix: `generate_all_settings` re-reads
+  the canonical **under** the per-target lock so an in-flight sync
+  holding a stale canonical cannot prune the freshly stamped rule;
+  every no-write early exit stays pre-lock (host sidecars are never
+  touched before consent).
+- **Gate A always, `scope="project_shared"` hardcoded.** The
+  destination canonical is git-tracked for every destination tier
+  (the `promote_target_rule` precedent), so the fragment scan runs
+  unconditionally, before the consent round-trip, with no force valve.
+- **Pending-write-keyed gates.** `confirm_project_shared` is required
+  whenever a git-tracked write is pending (the canonical leg always
+  qualifies; `project_local` tier alone therefore still gates — unlike
+  artifact transfers); `allow_host_writes` when the user-tier file
+  would be written. No-op re-runs (`already_at_target` both legs)
+  never prompt. Destination eligibility is evaluated as a project-tier
+  destination for every tier — the canonical leg is a project write,
+  so a paused destination refuses even user-tier copies.
+- **Cross-leg conflict rule.** A canonical conflict skips both legs
+  (a tier-only write would be replaced by the destination's own sync —
+  the silent-evaporation failure); a tier conflict still writes the
+  canonical leg and reports the half-apply. Conflicts never duplicate
+  a matcher and the report names the colliding entry.
 
 ## Backward compatibility
 

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -294,6 +294,32 @@ When the source or target lives outside the project root (e.g.
 `--from=user`, which resolves to `~/.claude/settings.json`), `--apply`
 prompts for confirmation; pass `--yes` to skip the prompt in scripts.
 
+`settings-migrate` moves entries between tiers of ONE project. To propagate
+a single hook to ANOTHER project ("I want this guard hook in project B
+too"), use the cross-project sibling:
+
+```bash
+mm context settings-copy --event PostToolUse --matcher "Edit|Write" \
+    --to-project ~/work/project-b                                     # dry-run
+mm context settings-copy --event PostToolUse --matcher "Edit|Write" \
+    --to-project ~/work/project-b --apply --confirm-project-shared    # mutate
+```
+
+`--to-project` takes a `p-<sha12>` scope_id from `mm context projects list`
+or a filesystem path. The copy writes the destination's canonical
+`.memtomem/settings.json` (so the destination's own syncs keep the rule
+alive) plus the destination-tier Claude settings file (`--to <tier>`,
+defaulting to the resolved `hooks.target_scope`); Codex/Gemini/Kimi pick
+the entry up on the destination's next
+`mm context sync --include=settings` — the exact command is printed.
+Because the destination canonical is git-tracked, `--apply` requires
+`--confirm-project-shared` whenever something would actually be written,
+and the privacy scan runs for every destination tier with no force valve.
+Re-runs are idempotent no-ops; a same-matcher rule with different content
+at the destination is skipped with the colliding entry named (never
+duplicated). When several entries share `(event, matcher)`, disambiguate
+with `--hook-command <substring>`.
+
 ---
 
 ## Tool Usage Guidelines (Add to CLAUDE.md)

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -3974,14 +3974,13 @@ def settings_copy_cmd(
         raise click.ClickException(str(exc)) from exc
 
     # Pending writes drive the gates (the #1263 contract: no-op requests
-    # never prompt). A canonical conflict blocks BOTH legs in the engine,
-    # so a pending tier write requires a non-conflicted canonical.
-    will_write_canonical = plan.canonical_state == "missing"
-    will_write_target = plan.canonical_state != "conflict" and plan.target_state == "missing"
-    git_tracked_write = will_write_canonical or (
-        will_write_target and dst_scope == "project_shared"
+    # never prompt). The plan properties encode the cross-leg rule (a
+    # canonical conflict blocks both legs) so the web route's envelopes
+    # and these prompts cannot drift on what counts as pending.
+    git_tracked_write = plan.pending_canonical_write or (
+        plan.pending_target_write and dst_scope == "project_shared"
     )
-    host_write = will_write_target and dst_scope == "user"
+    host_write = plan.pending_target_write and dst_scope == "user"
 
     if json_out:
         payload = _hook_copy_payload(

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -105,6 +105,12 @@ from memtomem.context.settings_doctor import (
     detect_duplicate_tiers,
     format_warning,
 )
+from memtomem.context.settings_copy import (
+    HookCopyPlan,
+    HookCopyResult,
+    apply_hook_copy,
+    plan_hook_copy,
+)
 from memtomem.context.settings_migrate import (
     apply_migration,
     format_plan_summary,
@@ -3740,6 +3746,334 @@ def settings_migrate_cmd(
         # discovered at apply time; the user must resolve manually before
         # re-running migrate. Match `mm context migrate`'s exit-1 on any
         # partial failure.
+        raise click.exceptions.Exit(1)
+
+
+# ── settings-copy (#1281, campaign #1270 A-11) ──────────────────────
+
+
+def _leg_glyph_note(state: str, reason: str, *, already_note: str, add_note: str) -> tuple:
+    """(glyph, color, note) for one settings-copy plan leg."""
+    if state == "conflict":
+        return ("✗", "red", f"skip (conflict: {reason})")
+    if state == "exact":
+        return ("·", "cyan", already_note)
+    return ("→", "green", add_note)
+
+
+def _print_hook_copy_plan(plan: HookCopyPlan) -> None:
+    """Render the settings-copy dry-run / pre-apply preview."""
+    click.echo(f"Plan: copy hook [{plan.label}]  {plan.signature.command_shape}")
+    click.echo(f"  from {plan.src_canonical_path}")
+    click.echo(f"  to   {plan.dst_project_root} ({plan.dst_scope} tier)")
+    for leg, path, state, reason, add_note in (
+        (
+            "canonical",
+            plan.dst_canonical_path,
+            plan.canonical_state,
+            plan.canonical_reason,
+            "add entry (durable definition)",
+        ),
+        (
+            "tier     ",
+            plan.dst_target_path,
+            plan.target_state,
+            plan.target_reason,
+            "add stamped rule (live immediately)",
+        ),
+    ):
+        glyph, color, note = _leg_glyph_note(
+            state, reason, already_note="already present", add_note=add_note
+        )
+        click.secho(f"  {glyph}  {leg} {path}  ({note})", fg=color)
+
+
+def _hook_copy_payload(plan: HookCopyPlan, status: str) -> dict[str, Any]:
+    """Base ``--json`` payload for one settings-copy plan."""
+    return {
+        "status": status,
+        "applied": False,
+        "event": plan.signature.event,
+        "matcher": plan.signature.matcher,
+        "command_preview": plan.signature.command_shape,
+        "src_project": str(plan.src_project_root),
+        "dst_project": str(plan.dst_project_root),
+        "dst_scope": plan.dst_scope,
+        "src_canonical": str(plan.src_canonical_path),
+        "dst_canonical": str(plan.dst_canonical_path),
+        "dst_target": str(plan.dst_target_path),
+        "canonical": {"state": plan.canonical_state, "reason": plan.canonical_reason},
+        "target": {"state": plan.target_state, "reason": plan.target_reason},
+    }
+
+
+def _print_hook_copy_result(result: HookCopyResult) -> None:
+    """Human-readable apply outcome for one settings-copy."""
+    plan = result.plan
+    if result.canonical_written:
+        click.secho(f"  ✓ wrote canonical entry to {plan.dst_canonical_path}", fg="green")
+    elif result.canonical_already:
+        click.echo(f"  · canonical already carries [{plan.label}] — no change")
+    if result.target_written:
+        click.secho(f"  ✓ wrote stamped rule to {plan.dst_target_path}", fg="green")
+    elif result.target_already:
+        click.echo(f"  · {plan.dst_scope} tier already carries [{plan.label}] — no change")
+    for warning in result.warnings:
+        click.secho(f"  ⚠ {warning}", fg="yellow", err=True)
+    if result.canonical_written or result.target_written:
+        click.echo(
+            f"\nNext: run `{result.sync_command}` to fan the entry out to the "
+            f"destination's other runtimes (Codex/Gemini/Kimi)."
+        )
+
+
+@context.command("settings-copy")
+@click.option("--event", required=True, help="Hook event name (e.g. PostToolUse).")
+@click.option(
+    "--matcher",
+    default="",
+    help="Hook matcher under the event; omit for matcher-less events (e.g. SessionStart).",
+)
+@click.option(
+    "--hook-command",
+    "hook_command",
+    default=None,
+    metavar="SUBSTRING",
+    help=(
+        "Disambiguator when several entries share (event, matcher): "
+        "substring matched against the normalized command."
+    ),
+)
+@click.option(
+    "--to-project",
+    "to_project",
+    required=True,
+    metavar="SCOPE_ID|PATH",
+    help=(
+        "Destination project — a p-<sha12> scope_id from `mm context projects "
+        "list`, or a filesystem path (typing a path is consent to target an "
+        "unregistered project)."
+    ),
+)
+@click.option(
+    "--to",
+    "to_scope",
+    type=click.Choice(list(get_args(TargetScope))),
+    default=None,
+    help=(
+        "Destination Claude settings tier for the immediate fan-out. "
+        "Omitted: the resolved hooks.target_scope (the tier sync writes)."
+    ),
+)
+@click.option(
+    "--apply",
+    "apply_",
+    is_flag=True,
+    default=False,
+    help="Execute the copy (default is a dry-run preview).",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation and host-write prompts. Requires --apply.",
+)
+@click.option(
+    "--confirm-project-shared",
+    "confirm_project_shared",
+    is_flag=True,
+    default=False,
+    help=(
+        "Required (in addition to --apply) when the copy writes the "
+        "destination's git-tracked files — the canonical "
+        ".memtomem/settings.json always is one. --yes alone does not "
+        "satisfy this opt-in (mirrors `mm context copy`)."
+    ),
+)
+@click.option(
+    "--json",
+    "json_out",
+    is_flag=True,
+    default=False,
+    help="Emit a structured JSON result instead of human-readable output.",
+)
+def settings_copy_cmd(
+    event: str,
+    matcher: str,
+    hook_command: str | None,
+    to_project: str,
+    to_scope: str | None,
+    apply_: bool,
+    yes: bool,
+    confirm_project_shared: bool,
+    json_out: bool,
+) -> None:
+    """Copy one canonical-matched hook entry into another project.
+
+    Cross-project sibling of ``settings-migrate`` (which moves entries
+    between tiers of ONE project). The copy is durable by construction:
+    it writes the destination's canonical ``.memtomem/settings.json``
+    (so the destination's own syncs maintain the rule) AND the
+    destination-tier Claude settings file (ADR-0019-stamped, live
+    immediately). Other runtimes (Codex/Gemini/Kimi) pick the entry up
+    on the destination's next ``mm context sync --include=settings`` —
+    the exact command is printed.
+
+    Copy-only in v1; the source project is never modified. Identity is
+    the canonical hook signature; ``already at target`` re-runs are
+    no-ops and a conflicting same-matcher rule at the destination is
+    skipped with a report naming the colliding entry (never duplicated).
+    A privacy scan (Gate A) always runs — the destination canonical is
+    git-tracked for every tier; there is no force valve.
+
+    Exit codes: ``0`` clean (or dry-run), ``1`` declined confirmation,
+    conflicts, or apply-time drift.
+    """
+    if yes and not apply_:
+        raise click.UsageError("--yes is only valid with --apply")
+
+    src_root = _find_project_root()
+
+    cfg = _projects_gateway_cfg()
+    try:
+        dst_root, dst_scope_rec = resolve_project_selector(to_project, _projects_discover(cfg))
+    except UnknownProjectSelectorError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if dst_scope_rec is not None and not dst_scope_rec.enabled:
+        # Same refusal as `mm context copy` — a paused destination would
+        # hold a canonical entry that never fans out there.
+        raise click.ClickException(
+            f"destination project {dst_scope_rec.scope_id} ({dst_root}) is "
+            f"paused — sync enrollment is disabled, so the copied hook would "
+            f"not fan out there. Run `mm context projects resume "
+            f"{dst_scope_rec.scope_id}` first, or pick another destination."
+        )
+    # Unconditional (unlike artifact transfer's user-tier exemption): the
+    # canonical leg lands in the destination PROJECT for every tier.
+    if not (dst_root / ".memtomem").is_dir():
+        raise click.ClickException(
+            f"destination project has no .memtomem/ store: {dst_root}\n"
+            f"  Initialize it first: cd {dst_root} && mm context init"
+        )
+
+    dst_scope = to_scope if to_scope is not None else _resolve_cli_scope(None)
+
+    try:
+        plan = plan_hook_copy(
+            src_root,
+            event=event,
+            matcher=matcher,
+            hook_command=hook_command,
+            dst_project_root=dst_root,
+            dst_scope=dst_scope,
+        )
+    except ValueError as exc:
+        # HookNotFoundError / AmbiguousHookSelectorError / same-project /
+        # unknown tier — all ValueError subclasses with CLI-ready messages.
+        raise click.ClickException(str(exc)) from exc
+
+    # Pending writes drive the gates (the #1263 contract: no-op requests
+    # never prompt). A canonical conflict blocks BOTH legs in the engine,
+    # so a pending tier write requires a non-conflicted canonical.
+    will_write_canonical = plan.canonical_state == "missing"
+    will_write_target = plan.canonical_state != "conflict" and plan.target_state == "missing"
+    git_tracked_write = will_write_canonical or (
+        will_write_target and dst_scope == "project_shared"
+    )
+    host_write = will_write_target and dst_scope == "user"
+
+    if json_out:
+        payload = _hook_copy_payload(
+            plan,
+            "noop" if plan.is_noop else ("conflicts" if plan.has_conflict else "ok"),
+        )
+    else:
+        _print_hook_copy_plan(plan)
+
+    if not apply_:
+        if json_out:
+            click.echo(json.dumps(payload, indent=2))
+        else:
+            confirm_note = " --confirm-project-shared" if git_tracked_write else ""
+            click.echo(f"\nRun with --apply{confirm_note} to execute.")
+        return
+
+    if plan.is_noop:
+        # Nothing to write — never prompt for a no-op (#1263 contract).
+        if json_out:
+            payload["applied"] = True
+            click.echo(json.dumps(payload, indent=2))
+        else:
+            click.echo("  (nothing to do — the entry is already at the destination)")
+        return
+
+    # Gate B — pending write into the destination's git-tracked files
+    # (the canonical is one for EVERY tier; the project_shared tier file
+    # adds a second). Wording parity with `mm context copy`.
+    if git_tracked_write and not confirm_project_shared:
+        if yes:
+            raise click.ClickException(
+                "copying into the destination's git-tracked files (canonical "
+                ".memtomem/settings.json) requires --confirm-project-shared. "
+                "--yes alone is not sufficient: project-shared writes require "
+                "explicit opt-in."
+            )
+        if json_out:
+            payload["status"] = "needs_confirmation"
+            payload["hint"] = "Re-run with --confirm-project-shared after confirming."
+            click.echo(json.dumps(payload, indent=2))
+            raise click.exceptions.Exit(1)
+        if not click.confirm(
+            f"\nThis will copy the hook into {plan.dst_project_root}'s "
+            f"git-tracked canonical settings (.memtomem/settings.json)"
+            + (" and its project_shared tier file" if dst_scope == "project_shared" else "")
+            + ". Continue?",
+            default=False,
+        ):
+            raise click.Abort()
+
+    # Host-write prompt — the user tier file lives outside any project
+    # root (mirrors settings-migrate; satisfied by --yes).
+    if host_write and not yes:
+        if json_out:
+            payload["status"] = "needs_confirmation"
+            payload["host_writes"] = [str(plan.dst_target_path)]
+            payload["hint"] = "Re-run with --yes after confirming."
+            click.echo(json.dumps(payload, indent=2))
+            raise click.exceptions.Exit(1)
+        click.secho(
+            "settings-copy will modify the following file outside the destination project:",
+            fg="yellow",
+        )
+        click.echo(f"  {plan.dst_target_path}  (user tier)")
+        if not click.confirm("Continue?", default=False):
+            click.echo("Aborted.")
+            raise click.exceptions.Exit(1)
+
+    try:
+        result = apply_hook_copy(plan, surface="cli_context_settings_copy")
+    except PrivacyScanError as exc:
+        raise click.ClickException(exc.message) from exc
+
+    if json_out:
+        payload["applied"] = True
+        payload["canonical"]["written"] = result.canonical_written
+        payload["canonical"]["already"] = result.canonical_already
+        payload["target"]["written"] = result.target_written
+        payload["target"]["already"] = result.target_already
+        payload["needs_sync"] = result.needs_sync
+        payload["sync_command"] = result.sync_command
+        if result.warnings:
+            payload["warnings"] = result.warnings
+            payload["status"] = "conflicts"
+        click.echo(json.dumps(payload, indent=2))
+    else:
+        _print_hook_copy_result(result)
+
+    if result.warnings:
+        # Conflicts or apply-time drift left unresolved — match the
+        # settings-migrate exit-1 contract.
         raise click.exceptions.Exit(1)
 
 

--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -1207,7 +1207,7 @@ def generate_all_settings(
             )
             continue
 
-        # Steps 1-4 run under a per-target cross-process lock so a separate
+        # Steps 0-4 run under a per-target cross-process lock so a separate
         # process (a CLI ``mm context sync`` / the MCP server) or the Web UI
         # cannot land a write between the mtime recheck (Step 3) and the atomic
         # rename inside ``_write_json`` (Step 4) and silently drop a concurrent
@@ -1225,6 +1225,36 @@ def generate_all_settings(
             # non-blocking attempt: acquire iff instantly free, else abort.
             lock_timeout = max(0.0, lock_deadline - time.monotonic())
             with _file_lock(_lock_path_for(target_path), timeout=lock_timeout):
+                # Step 0: re-read the canonical under the target lock (#1281).
+                # The pre-lock read above only decides the no-write early
+                # exits (skipped / error / needs_confirmation) WITHOUT
+                # touching this target's sidecar lock — a no-canonical or
+                # unconfirmed-host-write invocation must never create or
+                # contend on a host lock file. The merge, however, must
+                # derive its contributions from a read that happens-after
+                # the lock acquire: ``settings-copy`` (cross-project per-hook
+                # copy) writes the canonical strictly before the tier file
+                # while holding both sidecar locks, so without this re-read
+                # a sync that captured a stale canonical and then waited on
+                # this lock would prune the freshly stamped, owned tier rule
+                # as "no longer emitted". Same-literal statuses keep every
+                # stable state's result shape unchanged.
+                if not canonical_path.exists():
+                    results[name] = SettingsSyncResult(
+                        status="skipped",
+                        reason="no canonical source (.memtomem/settings.json)",
+                    )
+                    continue
+                raw_locked = _safe_load_json(canonical_path)
+                if raw_locked is _MALFORMED:
+                    results[name] = SettingsSyncResult(
+                        status="error",
+                        reason=f"{canonical_path} is not valid JSON (or not a JSON object). "
+                        f"Fix the file manually.",
+                    )
+                    continue
+                contributions = raw_locked  # type: ignore[assignment]
+
                 # Step 1: read existing + capture mtime (ns)
                 existing_raw, existing_mtime_ns = _read_settings_target(name, target_path)
                 if existing_raw is _MALFORMED:

--- a/packages/memtomem/src/memtomem/context/settings_copy.py
+++ b/packages/memtomem/src/memtomem/context/settings_copy.py
@@ -1,0 +1,666 @@
+"""Cross-project per-hook copy for settings hooks (#1281, campaign #1270 A-11).
+
+:mod:`memtomem.context.settings_migrate` moves canonical-matched hook
+entries between tiers of ONE project; this module copies ONE
+canonical-matched inner hook entry from a source project into another
+project. It is deliberately a separate mechanism from the artifact
+transfer engine (ADR-0023 support matrix: settings hooks are not
+``{kind}/{name}`` artifacts).
+
+Durability contract (the load-bearing design decision): a stamped
+(memtomem-owned) rule that is NOT in the destination project's canonical
+``.memtomem/settings.json`` is garbage-collected by that project's next
+settings sync (``_merge_hooks_record`` drops owned rules with no matching
+contribution — ADR-0019). A tier-only copy would therefore self-destruct.
+The copy writes TWO files at the destination, canonical first:
+
+1. ``<dst>/.memtomem/settings.json`` — the inner entry verbatim from the
+   source canonical (canonical is the pre-stamp domain; sync stamps at
+   fan-out). This makes the destination's syncs own and maintain the rule.
+2. the destination-tier Claude settings file
+   (``resolve_scope_path(dst_root, dst_scope)``) — the stamped rule
+   (ADR-0019 marker), so the hook is live immediately without a sync run.
+
+Canonical-first ordering is self-healing: a crash between the writes
+leaves the canonical in place; a re-run classifies it ``exact`` and
+completes the tier leg. Codex/Gemini/Kimi runtime fan-out is NOT
+generated — the result carries ``needs_sync`` plus the exact follow-up
+sync command (the destination project's sync materializes the entry for
+every other runtime). The companion fix that makes the tier leg sound —
+``generate_all_settings`` re-reading the canonical under the per-target
+lock — rides the same change set; without it a sync holding a stale
+canonical could prune the freshly stamped rule.
+
+Gate A runs unconditionally with ``scope="project_shared"`` hardcoded:
+``.memtomem/settings.json`` is git-tracked regardless of the destination
+tier, so every copy lands content in the destination repo's history (the
+``promote_target_rule`` precedent — keying the scan on the tier would
+skip-warn exactly the private-tier cases the gate exists for). The scan
+covers the canonical fragment; the stamped tier rule differs only by the
+constant ``statusMessage`` marker prefix, so one scan covers both legs.
+
+Classification reuses the settings-migrate semantics per leg —
+``already_*`` is a no-op, a conflict never duplicates a matcher — with
+one cross-leg rule: a CANONICAL conflict skips both legs (writing only
+the tier rule would set up the destination's own sync to replace it with
+the conflicting canonical version, silently evaporating the copy), while
+a TIER conflict still writes the canonical leg (the definition is
+durable; the destination's next sync surfaces the tier conflict through
+the established ownership-merge warnings).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shlex
+import time
+from contextlib import ExitStack
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from memtomem.context._atomic import _file_lock, _lock_path_for
+from memtomem.context.privacy_scan import raise_or_collect, scan_text_content
+from memtomem.context.settings import (
+    CANONICAL_SETTINGS_FILE,
+    _MALFORMED,
+    _SETTINGS_LOCK_BUDGET_S,
+    _read_with_mtime,
+    _rule_content_equal,
+)
+from memtomem.context.settings import (
+    resolve_scope_path as _resolve_tier_path,
+)
+from memtomem.context.settings_doctor import (
+    ALL_SCOPES,
+    HookSignature,
+    _normalize_command,
+    _normalize_matcher,
+)
+from memtomem.context.settings_migrate import (
+    _safe_load_json_dict,
+    _signature_for_inner,
+    _stamp_rule_for_target,
+    _write_json,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "AmbiguousHookSelectorError",
+    "HookCopyPlan",
+    "HookCopyResult",
+    "HookNotFoundError",
+    "LegState",
+    "apply_hook_copy",
+    "format_copy_summary",
+    "plan_hook_copy",
+]
+
+
+class HookNotFoundError(ValueError):
+    """The selector matched no canonical inner hook entry at the source."""
+
+
+class AmbiguousHookSelectorError(ValueError):
+    """The selector matched more than one canonical inner hook entry."""
+
+
+#: Per-leg classification. ``missing`` → the leg will be written;
+#: ``exact`` → functionally equal entry already present (no-op);
+#: ``conflict`` → a different entry holds the ``(event, matcher)`` slot.
+LegState = Literal["missing", "exact", "conflict"]
+
+
+@dataclass(frozen=True)
+class HookCopyPlan:
+    """One source hook entry and how it would land at the destination.
+
+    Leg states are computed lock-free at plan time for preview;
+    :func:`apply_hook_copy` re-reads and re-classifies both destination
+    files under their sidecar locks before writing (the settings-migrate
+    TOCTOU discipline), so a separated dry-run → apply workflow stays
+    sound. ``canonical_inner`` is the source canonical's inner entry
+    verbatim — the copied content is frozen at plan time (the
+    settings-migrate ``rule_to_write_at_target`` precedent).
+    """
+
+    src_project_root: Path
+    dst_project_root: Path
+    dst_scope: str
+    src_canonical_path: Path
+    dst_canonical_path: Path
+    dst_target_path: Path
+    signature: HookSignature
+    canonical_inner: dict
+    rule_for_canonical: dict
+    rule_for_target: dict
+    canonical_state: LegState
+    canonical_reason: str
+    target_state: LegState
+    target_reason: str
+
+    @property
+    def label(self) -> str:
+        """Human ``event:matcher`` label (event alone for empty matchers)."""
+        sig = self.signature
+        return f"{sig.event}:{sig.matcher}" if sig.matcher else sig.event
+
+    @property
+    def is_noop(self) -> bool:
+        """Both legs already carry the entry — nothing to write."""
+        return self.canonical_state == "exact" and self.target_state == "exact"
+
+    @property
+    def has_conflict(self) -> bool:
+        return self.canonical_state == "conflict" or self.target_state == "conflict"
+
+
+@dataclass
+class HookCopyResult:
+    """Outcome of one apply step."""
+
+    plan: HookCopyPlan
+    canonical_written: bool = False
+    target_written: bool = False
+    canonical_already: bool = False
+    target_already: bool = False
+    warnings: list[str] = field(default_factory=list)
+    needs_sync: bool = True
+    sync_command: str = ""
+
+
+def _sync_followup_command(dst_root: Path, dst_scope: str) -> str:
+    """Exact follow-up sync command for the non-Claude runtime fan-out.
+
+    Always ``cd``-prefixed — settings contributions are project-anchored
+    even for the user tier (unlike artifact user-tier sync), and a
+    single-project cross-cwd sync selector does not exist (A-9 shipped
+    only ``--all-projects``). ``--scope`` is pinned because the bare
+    command resolves the tier from ``hooks.target_scope`` and would sync
+    a different file for a non-default destination tier.
+    """
+    return (
+        f"cd {shlex.quote(str(dst_root))} && mm context sync --include=settings --scope {dst_scope}"
+    )
+
+
+# ── Selection (source side) ─────────────────────────────────────────
+
+
+def _iter_canonical_candidates(
+    canonical_hooks: dict,
+    event: str,
+    matcher_norm: str,
+) -> list[tuple[HookSignature, dict]]:
+    """Unique-signature inner entries under ``(event, matcher)`` in source order."""
+    out: list[tuple[HookSignature, dict]] = []
+    seen: set[HookSignature] = set()
+    rules = canonical_hooks.get(event, [])
+    if not isinstance(rules, list):
+        return out
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if _normalize_matcher(rule.get("matcher", "")) != matcher_norm:
+            continue
+        inner_list = rule.get("hooks", [])
+        if not isinstance(inner_list, list):
+            continue
+        for inner in inner_list:
+            sig = _signature_for_inner(event, rule.get("matcher", ""), inner)
+            if sig is None or sig in seen:
+                continue
+            seen.add(sig)
+            out.append((sig, inner))
+    return out
+
+
+def _available_labels(canonical_hooks: dict) -> list[str]:
+    """All ``event:matcher`` labels carrying at least one signed inner entry."""
+    labels: list[str] = []
+    seen: set[tuple[str, str]] = set()
+    if not isinstance(canonical_hooks, dict):
+        return labels
+    for event, rules in canonical_hooks.items():
+        if not isinstance(event, str) or not isinstance(rules, list):
+            continue
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            matcher = _normalize_matcher(rule.get("matcher", ""))
+            inner_list = rule.get("hooks", [])
+            if not isinstance(inner_list, list):
+                continue
+            if not any(
+                _signature_for_inner(event, matcher, inner) is not None for inner in inner_list
+            ):
+                continue
+            key = (event, matcher)
+            if key in seen:
+                continue
+            seen.add(key)
+            labels.append(f"{event}:{matcher}" if matcher else event)
+    return labels
+
+
+# ── Classification (destination side) ───────────────────────────────
+
+
+def _rule_inner_commands(rules: list[dict]) -> list[str]:
+    """Normalized command previews of every inner entry in *rules*."""
+    out: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        for inner in rule.get("hooks", []):
+            if not isinstance(inner, dict):
+                continue
+            command = _normalize_command(inner.get("command", ""))
+            if command:
+                out.append(command)
+    return out
+
+
+def _classify_leg(
+    doc: dict,
+    sig: HookSignature,
+    canonical_inner: dict,
+    *,
+    leg: str,
+) -> tuple[LegState, str]:
+    """Classify how one destination document relates to the copied entry.
+
+    Same three-state semantics as ``settings_migrate._classify_target``
+    (ownership-marker fields ignored via ``_rule_content_equal``), but the
+    conflict reason NAMES the colliding entry — the issue's acceptance
+    criterion — instead of the migrate-specific remediation prose.
+    """
+    hooks = doc.get("hooks", {})
+    if not isinstance(hooks, dict):
+        # Structurally unusable hooks value — surfaced by the caller as a
+        # malformed-leg refusal before classification is attempted.
+        return ("conflict", f"{leg} 'hooks' is not a record keyed by event name")
+    rules = hooks.get(sig.event, [])
+    if not isinstance(rules, list):
+        return ("conflict", f"{leg} 'hooks.{sig.event}' is not a list of rules")
+    same_matcher = [
+        rule
+        for rule in rules
+        if isinstance(rule, dict) and _normalize_matcher(rule.get("matcher", "")) == sig.matcher
+    ]
+    if not same_matcher:
+        return ("missing", "")
+    for rule in same_matcher:
+        for inner in rule.get("hooks", []):
+            if isinstance(inner, dict) and _rule_content_equal(
+                {"matcher": sig.matcher, "hooks": [inner]},
+                {"matcher": sig.matcher, "hooks": [canonical_inner]},
+            ):
+                return ("exact", "")
+    label = f"{sig.event}:{sig.matcher}" if sig.matcher else sig.event
+    colliding = _rule_inner_commands(same_matcher)
+    preview = "; ".join(repr(c) for c in colliding[:3]) if colliding else "no command entries"
+    return (
+        "conflict",
+        (
+            f"{leg} already has a rule under '{label}' whose inner hooks "
+            f"differ from the copied entry (existing: {preview}). Resolve "
+            f"manually, then re-run the copy — a same-matcher duplicate "
+            f"would fire twice."
+        ),
+    )
+
+
+def _append_rule(doc: dict, event: str, rule: dict) -> dict:
+    """Return a copy of *doc* with *rule* appended under ``hooks[event]``.
+
+    Callers guarantee (via :func:`_classify_leg`) that ``hooks`` is a
+    record and ``hooks[event]`` is absent or a list — a malformed shape
+    classifies as a conflict-grade refusal and never reaches the append,
+    so this helper never coerces (the ``MalformedSettingsError`` lesson:
+    coercing destroys the user's hook configuration).
+    """
+    out = dict(doc)
+    hooks = dict(out.get("hooks", {})) if isinstance(out.get("hooks"), dict) else {}
+    existing = hooks.get(event, [])
+    rules = list(existing) if isinstance(existing, list) else []
+    rules.append(rule)
+    hooks[event] = rules
+    out["hooks"] = hooks
+    return out
+
+
+# ── Gate A ──────────────────────────────────────────────────────────
+
+
+def _gate_a_scan(plan: HookCopyPlan, surface: str) -> None:
+    """Scan the exact canonical fragment the copy would write (always).
+
+    ``scope="project_shared"`` is hardcoded — the destination canonical
+    ``.memtomem/settings.json`` is git-tracked regardless of the
+    destination tier (``promote_target_rule`` precedent). Raises
+    :class:`memtomem.context.privacy_scan.PrivacyBlockedError` on a hit;
+    surfaces translate (CLI → ClickException, web → HTTP 422 string).
+    """
+    fragment = json.dumps(
+        {plan.signature.event: [plan.rule_for_canonical]},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    scan = scan_text_content(
+        fragment,
+        source_path=plan.src_canonical_path,
+        surface=surface,
+        scope="project_shared",
+        project_root=plan.dst_project_root,
+    )
+    if scan.decision in ("blocked", "blocked_project_shared"):
+        raise_or_collect(
+            scan,
+            scope="project_shared",
+            kind="hook rule",
+            artifact_name=plan.label,
+            remediation_hint=(
+                f"Remove the secret from the hook rule in "
+                f"{plan.src_canonical_path}, then re-run the copy. There is "
+                f"no force valve: the destination canonical "
+                f"({plan.dst_canonical_path}) is git-tracked for every "
+                f"destination tier."
+            ),
+        )
+
+
+# ── Planning ────────────────────────────────────────────────────────
+
+
+def plan_hook_copy(
+    src_project_root: Path,
+    *,
+    event: str,
+    matcher: str,
+    dst_project_root: Path,
+    dst_scope: str,
+    hook_command: str | None = None,
+) -> HookCopyPlan:
+    """Resolve the selector at the source and classify the destination legs.
+
+    Read-only. Raises:
+
+    * :class:`HookNotFoundError` — source canonical missing/has no
+      signed entry under ``(event, matcher)`` (message lists the
+      available labels), or the ``hook_command`` filter eliminated every
+      candidate (message lists the commands under the matcher).
+    * :class:`AmbiguousHookSelectorError` — more than one signed entry
+      under ``(event, matcher)`` and no/too-loose ``hook_command``
+      (message lists the candidate command previews).
+    * :class:`ValueError` — unknown ``dst_scope``, or source and
+      destination resolve to the same project (settings-migrate's
+      territory).
+    """
+    if dst_scope not in ALL_SCOPES:
+        raise ValueError(f"unknown destination tier: {dst_scope!r} (use one of {ALL_SCOPES})")
+
+    src_root = src_project_root.expanduser().resolve()
+    dst_root = dst_project_root.expanduser().resolve()
+    if src_root == dst_root:
+        raise ValueError(
+            "source and destination are the same project; cross-tier moves "
+            "within one project are `mm context settings-migrate`'s job, and "
+            "fan-out is `mm context sync --include=settings`'s."
+        )
+
+    src_canonical_path = src_root / CANONICAL_SETTINGS_FILE
+    canonical = _safe_load_json_dict(src_canonical_path)
+    if canonical is None:
+        raise HookNotFoundError(
+            f"source project has no readable canonical settings "
+            f"({src_canonical_path}); nothing to copy from."
+        )
+    canonical_hooks = canonical.get("hooks", {})
+    if not isinstance(canonical_hooks, dict):
+        canonical_hooks = {}
+
+    matcher_norm = _normalize_matcher(matcher)
+    candidates = _iter_canonical_candidates(canonical_hooks, event, matcher_norm)
+    if not candidates:
+        labels = _available_labels(canonical_hooks)
+        listing = "; available: " + ", ".join(labels) if labels else "; the canonical has no hooks"
+        label = f"{event}:{matcher_norm}" if matcher_norm else event
+        raise HookNotFoundError(
+            f"no canonical-matched hook entry under '{label}' in {src_canonical_path}{listing}."
+        )
+    if hook_command is not None:
+        narrowed = [(s, i) for s, i in candidates if hook_command in s.command_shape]
+        if not narrowed:
+            previews = ", ".join(repr(s.command_shape) for s, _ in candidates)
+            raise HookNotFoundError(
+                f"--hook-command {hook_command!r} matches none of the entries "
+                f"under '{event}:{matcher_norm}' (candidates: {previews})."
+            )
+        candidates = narrowed
+    if len(candidates) > 1:
+        previews = ", ".join(repr(s.command_shape) for s, _ in candidates)
+        raise AmbiguousHookSelectorError(
+            f"{len(candidates)} entries match '{event}:{matcher_norm}'; "
+            f"disambiguate with --hook-command <substring> (candidates: {previews})."
+        )
+    sig, canonical_inner = candidates[0]
+
+    rule_for_canonical = {"matcher": sig.matcher, "hooks": [canonical_inner]}
+    rule_for_target = _stamp_rule_for_target(sig.event, rule_for_canonical)
+
+    dst_canonical_path = dst_root / CANONICAL_SETTINGS_FILE
+    dst_target_path = _resolve_tier_path(dst_root, dst_scope)
+
+    canonical_state, canonical_reason = _classify_dst_file(
+        dst_canonical_path, sig, canonical_inner, leg="destination canonical settings"
+    )
+    target_state, target_reason = _classify_dst_file(
+        dst_target_path, sig, canonical_inner, leg=f"destination {dst_scope} tier"
+    )
+
+    return HookCopyPlan(
+        src_project_root=src_root,
+        dst_project_root=dst_root,
+        dst_scope=dst_scope,
+        src_canonical_path=src_canonical_path,
+        dst_canonical_path=dst_canonical_path,
+        dst_target_path=dst_target_path,
+        signature=sig,
+        canonical_inner=canonical_inner,
+        rule_for_canonical=rule_for_canonical,
+        rule_for_target=rule_for_target,
+        canonical_state=canonical_state,
+        canonical_reason=canonical_reason,
+        target_state=target_state,
+        target_reason=target_reason,
+    )
+
+
+def _classify_dst_file(
+    path: Path,
+    sig: HookSignature,
+    canonical_inner: dict,
+    *,
+    leg: str,
+) -> tuple[LegState, str]:
+    """Lock-free plan-time classification of one destination file.
+
+    A missing file is ``missing`` (the leg creates it); an unreadable or
+    non-object file classifies as ``conflict`` so the plan surfaces the
+    refusal up front (apply re-derives and refuses the same way).
+    """
+    if not path.is_file():
+        return ("missing", "")
+    doc = _safe_load_json_dict(path)
+    if doc is None:
+        return (
+            "conflict",
+            f"{leg} ({path}) is not valid JSON (or not a JSON object); fix it manually first.",
+        )
+    return _classify_leg(doc, sig, canonical_inner, leg=leg)
+
+
+# ── Apply ───────────────────────────────────────────────────────────
+
+
+def apply_hook_copy(
+    plan: HookCopyPlan,
+    *,
+    surface: str = "cli_context_settings_copy",
+) -> HookCopyResult:
+    """Apply *plan*: Gate A, then canonical leg, then tier leg.
+
+    Both destination sidecar locks are held for the whole transaction in
+    sorted order under one shared ``_SETTINGS_LOCK_BUDGET_S`` deadline
+    (the settings-migrate pair-lock discipline; the set() dedupes a
+    degenerate same-path pair). Both files are re-read and re-classified
+    under the locks; the plan-time states are advisory only. Per-leg
+    ``st_mtime_ns`` rechecks remain the second layer against direct disk
+    edits that bypass the sidecar locks.
+
+    Cross-leg conflict rule (module docstring): canonical conflict skips
+    both legs; tier conflict still writes the canonical leg. Malformed
+    files refuse their leg loudly and are never rewritten — a malformed
+    CANONICAL also skips the tier leg (a tier-only write is the
+    self-destructing copy this module exists to prevent).
+    """
+    _gate_a_scan(plan, surface)
+
+    result = HookCopyResult(
+        plan=plan,
+        needs_sync=True,
+        sync_command=_sync_followup_command(plan.dst_project_root, plan.dst_scope),
+    )
+    retry_hint = "Re-run the copy to retry."
+
+    lock_deadline = time.monotonic() + _SETTINGS_LOCK_BUDGET_S
+
+    def _lock_timeout() -> float:
+        return max(0.0, lock_deadline - time.monotonic())
+
+    lock_paths = sorted(
+        {_lock_path_for(plan.dst_canonical_path), _lock_path_for(plan.dst_target_path)},
+        key=str,
+    )
+    try:
+        with ExitStack() as stack:
+            for lock_path in lock_paths:
+                stack.enter_context(_file_lock(lock_path, timeout=_lock_timeout()))
+
+            # ── canonical leg ────────────────────────────────────────
+            canonical_raw, canonical_mtime_ns = _read_with_mtime(plan.dst_canonical_path)
+            if canonical_raw is _MALFORMED:
+                result.warnings.append(
+                    f"{plan.dst_canonical_path} is not valid JSON (or not a "
+                    f"JSON object); refusing to rewrite it — nothing was "
+                    f"written (a tier-only copy would be pruned by the next "
+                    f"sync). Fix the file manually, then re-run the copy."
+                )
+                return result
+            canonical_doc: dict = canonical_raw if isinstance(canonical_raw, dict) else {}
+
+            state, reason = _classify_leg(
+                canonical_doc,
+                plan.signature,
+                plan.canonical_inner,
+                leg="destination canonical settings",
+            )
+            if state == "conflict":
+                result.warnings.append(reason)
+                return result
+            if state == "exact":
+                result.canonical_already = True
+            else:
+                if (
+                    plan.dst_canonical_path.is_file()
+                    and plan.dst_canonical_path.stat().st_mtime_ns != canonical_mtime_ns
+                ):
+                    result.warnings.append(
+                        f"{plan.dst_canonical_path} was modified by another "
+                        f"process during apply; nothing was written. {retry_hint}"
+                    )
+                    return result
+                _write_json(
+                    plan.dst_canonical_path,
+                    _append_rule(canonical_doc, plan.signature.event, plan.rule_for_canonical),
+                )
+                result.canonical_written = True
+
+            # ── tier leg ─────────────────────────────────────────────
+            target_raw, target_mtime_ns = _read_with_mtime(plan.dst_target_path)
+            if target_raw is _MALFORMED:
+                result.warnings.append(
+                    f"{plan.dst_target_path} is not valid JSON (or not a JSON "
+                    f"object); the canonical entry was written but the "
+                    f"{plan.dst_scope} tier was not. Fix the file manually, "
+                    f"then re-run the copy or `{result.sync_command}`."
+                )
+                return result
+            target_doc: dict = target_raw if isinstance(target_raw, dict) else {}
+
+            state, reason = _classify_leg(
+                target_doc,
+                plan.signature,
+                plan.canonical_inner,
+                leg=f"destination {plan.dst_scope} tier",
+            )
+            if state == "conflict":
+                result.warnings.append(reason)
+                if result.canonical_written:
+                    result.warnings.append(
+                        "the canonical entry WAS written — the definition is "
+                        "durable; resolve the tier conflict and re-run the "
+                        "copy, or let the destination's next settings sync "
+                        "surface it through the ownership-merge warnings."
+                    )
+                return result
+            if state == "exact":
+                result.target_already = True
+                return result
+            if (
+                plan.dst_target_path.is_file()
+                and plan.dst_target_path.stat().st_mtime_ns != target_mtime_ns
+            ):
+                result.warnings.append(
+                    f"{plan.dst_target_path} was modified by another process "
+                    f"during apply; the canonical entry was written but the "
+                    f"{plan.dst_scope} tier was not. {retry_hint}"
+                )
+                return result
+            _write_json(
+                plan.dst_target_path,
+                _append_rule(target_doc, plan.signature.event, plan.rule_for_target),
+            )
+            result.target_written = True
+    except TimeoutError:
+        result.warnings.append(
+            f"another process held a settings lock past the "
+            f"{_SETTINGS_LOCK_BUDGET_S:g}s acquisition budget "
+            f"({plan.dst_canonical_path} / {plan.dst_target_path}); nothing "
+            f"was written. {retry_hint}"
+        )
+
+    return result
+
+
+# ── Reporting ───────────────────────────────────────────────────────
+
+
+def format_copy_summary(result: HookCopyResult) -> str:
+    """One-line summary for the CLI footer."""
+    parts: list[str] = []
+    if result.canonical_written:
+        parts.append("canonical entry added")
+    elif result.canonical_already:
+        parts.append("already in canonical")
+    if result.target_written:
+        parts.append(f"{result.plan.dst_scope} tier rule added")
+    elif result.target_already:
+        parts.append(f"already at {result.plan.dst_scope} tier")
+    if result.warnings:
+        parts.append(f"{len(result.warnings)} warning(s)")
+    return ", ".join(parts) if parts else "nothing to do"

--- a/packages/memtomem/src/memtomem/context/settings_copy.py
+++ b/packages/memtomem/src/memtomem/context/settings_copy.py
@@ -95,6 +95,7 @@ __all__ = [
     "LegState",
     "apply_hook_copy",
     "format_copy_summary",
+    "gate_a_scan",
     "plan_hook_copy",
 ]
 
@@ -155,6 +156,24 @@ class HookCopyPlan:
     @property
     def has_conflict(self) -> bool:
         return self.canonical_state == "conflict" or self.target_state == "conflict"
+
+    @property
+    def pending_canonical_write(self) -> bool:
+        """The canonical leg would write — drives the git-tracked-write gate."""
+        return self.canonical_state == "missing"
+
+    @property
+    def pending_target_write(self) -> bool:
+        """The tier leg would write.
+
+        A canonical conflict blocks BOTH legs in :func:`apply_hook_copy`,
+        so a pending tier write requires a non-conflicted canonical.
+        Surfaces key their consent gates on these two properties (the
+        no-op-never-prompts contract): the CLI's ``--confirm-project-shared``
+        / host-write prompt and the web route's ``confirm_project_shared``
+        / ``allow_host_writes`` envelopes must agree on what is pending.
+        """
+        return self.canonical_state != "conflict" and self.target_state == "missing"
 
 
 @dataclass
@@ -335,7 +354,7 @@ def _append_rule(doc: dict, event: str, rule: dict) -> dict:
 # ── Gate A ──────────────────────────────────────────────────────────
 
 
-def _gate_a_scan(plan: HookCopyPlan, surface: str) -> None:
+def gate_a_scan(plan: HookCopyPlan, surface: str) -> None:
     """Scan the exact canonical fragment the copy would write (always).
 
     ``scope="project_shared"`` is hardcoded — the destination canonical
@@ -528,7 +547,7 @@ def apply_hook_copy(
     CANONICAL also skips the tier leg (a tier-only write is the
     self-destructing copy this module exists to prevent).
     """
-    _gate_a_scan(plan, surface)
+    gate_a_scan(plan, surface)
 
     result = HookCopyResult(
         plan=plan,

--- a/packages/memtomem/src/memtomem/web/routes/context_transfer.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_transfer.py
@@ -136,7 +136,7 @@ def _resolve_source(
 
 def _resolve_destination(
     request: Request,
-    body: TransferRequest,
+    to_project_scope_id: str | None,
     src_root: Path,
     src_scope: ProjectScope | None,
 ) -> tuple[Path, ProjectScope | None]:
@@ -146,21 +146,23 @@ def _resolve_destination(
     same-project transfer): the destination inherits the SOURCE's scope
     record so the eligibility gate below sees a paused source project
     even when the destination is only implicit. Message literals for
-    the 404s mirror ``_resolve_selected_scope`` verbatim.
+    the 404s mirror ``_resolve_selected_scope`` verbatim. Shared with the
+    settings hook copy route (``settings_sync.copy_hook_to_project``),
+    which passes its own body's selector.
     """
-    if body.to_project_scope_id is None:
+    if to_project_scope_id is None:
         return src_root, src_scope
     for scope in _discover_for(request):
-        if scope.scope_id != body.to_project_scope_id:
+        if scope.scope_id != to_project_scope_id:
             continue
         if scope.root is None or scope.missing:
             raise _error(
                 404,
                 "missing",
-                f"scope {body.to_project_scope_id!r} is registered but its root is missing",
+                f"scope {to_project_scope_id!r} is registered but its root is missing",
             )
         return scope.root, scope
-    raise _error(404, "missing", f"unknown project_scope_id: {body.to_project_scope_id!r}")
+    raise _error(404, "missing", f"unknown project_scope_id: {to_project_scope_id!r}")
 
 
 def _reject_ineligible_destination(scope: ProjectScope | None, to_scope: TargetScope) -> None:
@@ -316,7 +318,9 @@ async def transfer_context_artifact(
         )
 
     src_root, src_scope = _resolve_source(request, project_scope_id, scope_id)
-    dst_root, dst_scope = _resolve_destination(request, body, src_root, src_scope)
+    dst_root, dst_scope = _resolve_destination(
+        request, body.to_project_scope_id, src_root, src_scope
+    )
     _reject_ineligible_destination(dst_scope, body.to_target_scope)
 
     if (

--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -9,12 +9,17 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from memtomem.config import TargetScope
-from memtomem.context.privacy_scan import format_scan_block_message, scan_text_content
+from memtomem.context.privacy_scan import (
+    PrivacyBlockedError,
+    format_scan_block_message,
+    scan_text_content,
+)
+from memtomem.context.projects import compute_scope_id
 from memtomem.context.settings import (
     CANONICAL_SETTINGS_FILE,
     resolve_scope_path,
@@ -25,14 +30,29 @@ from memtomem.context.settings import (
     _write_json,
     generate_all_settings,
 )
+from memtomem.context.settings_copy import (
+    AmbiguousHookSelectorError,
+    HookCopyPlan,
+    HookCopyResult,
+    HookNotFoundError,
+    apply_hook_copy,
+    gate_a_scan,
+    plan_hook_copy,
+)
 from memtomem.context.settings_doctor import (
     DuplicateTier,
     detect_duplicate_tiers,
 )
+from memtomem.web.routes._confirm import needs_confirmation_envelope
 from memtomem.web.routes._locks import _gateway_lock
 from memtomem.web.routes.context_projects import (
     resolve_scope_root,
     resolve_writable_scope_root,
+)
+from memtomem.web.routes.context_transfer import (
+    _error,
+    _reject_ineligible_destination,
+    _resolve_destination,
 )
 
 logger = logging.getLogger(__name__)
@@ -959,3 +979,197 @@ async def promote_target_rule(
                 )
     except TimeoutError:
         raise HTTPException(503, "Promote timed out — another sync may be in progress")
+
+
+# ── cross-project per-hook copy (#1281, campaign #1270 A-11) ─────────
+
+
+class HookCopyRequest(BaseModel):
+    """Body for ``POST /context/settings/hooks/copy``.
+
+    ``to_project_scope_id`` is REQUIRED — the web surface restricts
+    destinations to the registered discovery set (the A-5 contract; the
+    typed-path consent valve is CLI-only), and a same-project copy is the
+    settings-migrate/sync routes' job, refused by the engine.
+    """
+
+    event: str
+    matcher: str = ""
+    hook_command: str | None = None
+    to_project_scope_id: str
+    to_target_scope: TargetScope = "project_shared"
+    confirm_project_shared: bool = False
+    allow_host_writes: bool = False
+
+
+def _serialize_hook_copy_plan(plan: HookCopyPlan) -> dict[str, Any]:
+    """Wire shape for the plan half (nested under ``plan`` in envelopes).
+
+    ``dst_project_scope_id`` mirrors the transfer route's field the UI
+    uses for one-click follow-up sync.
+    """
+    return {
+        "event": plan.signature.event,
+        "matcher": plan.signature.matcher,
+        "command_preview": plan.signature.command_shape,
+        "src_project_root": str(plan.src_project_root),
+        "dst_project_root": str(plan.dst_project_root),
+        "dst_project_scope_id": compute_scope_id(plan.dst_project_root),
+        "dst_scope": plan.dst_scope,
+        "dst_canonical": str(plan.dst_canonical_path),
+        "dst_target": str(plan.dst_target_path),
+        "canonical": {"state": plan.canonical_state, "reason": plan.canonical_reason},
+        "target": {"state": plan.target_state, "reason": plan.target_reason},
+    }
+
+
+def _serialize_hook_copy_result(result: HookCopyResult) -> dict[str, Any]:
+    payload = _serialize_hook_copy_plan(result.plan)
+    payload["canonical"] = {
+        **payload["canonical"],
+        "written": result.canonical_written,
+        "already": result.canonical_already,
+    }
+    payload["target"] = {
+        **payload["target"],
+        "written": result.target_written,
+        "already": result.target_already,
+    }
+    payload["warnings"] = list(result.warnings)
+    payload["needs_sync"] = result.needs_sync
+    payload["sync_command"] = result.sync_command
+    return payload
+
+
+@router.post("/context/settings/hooks/copy")
+async def copy_hook_to_project(
+    body: HookCopyRequest,
+    request: Request,
+    project_root: Path = Depends(resolve_scope_root),
+    dry_run: bool = Query(
+        False,
+        description=(
+            "Preview the copy without touching disk: returns the plan "
+            "(status='plan') regardless of confirmation flags."
+        ),
+    ),
+) -> dict:
+    """Copy one canonical-matched hook entry into another project.
+
+    Web face of :func:`memtomem.context.settings_copy.apply_hook_copy`
+    (the CLI sibling is ``mm context settings-copy``). Source = the
+    ``?project_scope_id=`` project's canonical settings (server cwd when
+    omitted); destination = ``body.to_project_scope_id`` (registered
+    projects only) at ``body.to_target_scope``.
+
+    Contracts:
+
+    - **Error envelope** — object details (ADR-0023 §10 vocabulary);
+      the privacy block stays the issue-pinned 422 STRING detail.
+    - **Gate A before consent** (``promote_target_rule`` precedent): a
+      doomed copy never completes a ``needs_confirmation`` round-trip.
+      The scan always runs — the destination canonical is git-tracked
+      for every tier.
+    - **Pending-write-keyed gates** (the #1263 no-op-never-prompts
+      contract), sequential round-trips when both apply:
+      ``confirm_project_shared`` whenever a git-tracked write is pending
+      (the canonical leg always is one), then ``allow_host_writes`` with
+      ``host_targets`` when the user-tier file would be written.
+    - **Status vocabulary** matches the CLI ``--json``: ``plan`` /
+      ``needs_confirmation`` / ``noop`` / ``ok`` / ``conflicts`` (any
+      apply warning — conflict skips, drift aborts — is ``conflicts``;
+      per-leg detail rides the ``canonical`` / ``target`` objects).
+    """
+    dst_root, dst_scope_rec = _resolve_destination(
+        request, body.to_project_scope_id, project_root, None
+    )
+    # The canonical leg writes the destination PROJECT for every tier, so
+    # eligibility is evaluated as a project-tier destination — the
+    # helper's user-tier exemption covers artifact host writes, which
+    # have no project-side leg (N/A here).
+    _reject_ineligible_destination(dst_scope_rec, "project_shared")
+    if not (dst_root / ".memtomem").is_dir():
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error_kind": "conflict",
+                "reason_code": "no_memtomem_store",
+                "message": (
+                    f"destination project has no .memtomem/ store: {dst_root}. "
+                    f"Initialize it first: cd {dst_root} && mm context init"
+                ),
+                "project_scope_id": body.to_project_scope_id,
+            },
+        )
+
+    try:
+        plan = plan_hook_copy(
+            project_root,
+            event=body.event,
+            matcher=body.matcher,
+            hook_command=body.hook_command,
+            dst_project_root=dst_root,
+            dst_scope=body.to_target_scope,
+        )
+    except HookNotFoundError as exc:
+        raise _error(404, "missing", str(exc)) from exc
+    except (AmbiguousHookSelectorError, ValueError) as exc:
+        raise _error(400, "validation", str(exc)) from exc
+
+    if dry_run:
+        return {"status": "plan", **_serialize_hook_copy_plan(plan)}
+
+    # Gate A before the consent round-trip — and before the no-op check:
+    # an already-at-target re-POST of secret-bearing content still 422s,
+    # matching the promote route's scan-first ordering.
+    try:
+        gate_a_scan(plan, "web_context_settings_hook_copy")
+    except PrivacyBlockedError as exc:
+        raise HTTPException(422, exc.message) from exc
+
+    git_tracked_write = plan.pending_canonical_write or (
+        plan.pending_target_write and body.to_target_scope == "project_shared"
+    )
+    if git_tracked_write and not body.confirm_project_shared:
+        tier_note = (
+            " and its project_shared settings tier"
+            if body.to_target_scope == "project_shared"
+            else ""
+        )
+        return needs_confirmation_envelope(
+            f"This will copy the hook into the destination project's "
+            f"git-tracked files (the canonical .memtomem/settings.json"
+            f"{tier_note}). Re-POST with confirm_project_shared=true after "
+            f"confirming with the user.",
+            confirm="confirm_project_shared",
+            plan=_serialize_hook_copy_plan(plan),
+        )
+    if plan.pending_target_write and body.to_target_scope == "user" and not body.allow_host_writes:
+        return needs_confirmation_envelope(
+            "The destination tier is the user tier — a host path outside "
+            "any project root. Re-POST with allow_host_writes=true after "
+            "confirming with the user.",
+            confirm="allow_host_writes",
+            host_targets=[str(plan.dst_target_path)],
+            plan=_serialize_hook_copy_plan(plan),
+        )
+
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                # Worker thread: the engine takes cross-process sidecar
+                # locks (canonical + tier pair) with its own 30s budget
+                # (< 60s), so a cross-process holder cannot leave an
+                # un-cancellable worker writing after the 503.
+                result = await asyncio.to_thread(
+                    apply_hook_copy, plan, surface="web_context_settings_hook_copy"
+                )
+    except TimeoutError:
+        raise _error(
+            503, "busy", "Copy timed out — another sync or settings write may be in progress"
+        )
+    except PrivacyBlockedError as exc:
+        raise HTTPException(422, exc.message) from exc
+
+    status = "noop" if plan.is_noop else ("conflicts" if result.warnings else "ok")
+    return {"status": status, **_serialize_hook_copy_result(result)}

--- a/packages/memtomem/tests/test_cli_settings_copy.py
+++ b/packages/memtomem/tests/test_cli_settings_copy.py
@@ -1,0 +1,345 @@
+"""CLI tests for ``mm context settings-copy`` (#1281, A-11).
+
+Engine semantics are covered in ``test_settings_copy.py``; this file pins
+the surface: option gates, Gate B / host-write confirmation flows, the
+``--json`` schema, destination-project resolution, and exit codes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli.context_cmd import context
+from memtomem.context.projects import KnownProjectsStore, compute_scope_id
+from memtomem.context.settings import CANONICAL_SETTINGS_FILE
+
+SECRET = "api_key=AKIA1234567890ABCDEF"
+
+
+def _inner(command: str = "mm session start") -> dict:
+    return {"type": "command", "command": command, "timeout": 5000}
+
+
+def _seed_canonical(root: Path, command: str = "mm session start") -> None:
+    path = root / CANONICAL_SETTINGS_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {"hooks": {"PostToolUse": [{"matcher": "Edit|Write", "hooks": [_inner(command)]}]}},
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def cli_projects(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    """Two project roots + isolated HOME, cwd at project A (source)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude").mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    proj_a = tmp_path / "proj-a"
+    proj_b = tmp_path / "proj-b"
+    for proj in (proj_a, proj_b):
+        (proj / ".git").mkdir(parents=True)
+        (proj / ".memtomem").mkdir()
+    _seed_canonical(proj_a)
+
+    kp = tmp_path / "known_projects.json"
+
+    class _FakeCfg:
+        known_projects_path = kp
+        experimental_claude_projects_scan = False
+        auto_display_configured_projects = True
+
+    monkeypatch.setattr("memtomem.cli.context_cmd.ContextGatewayConfig", lambda: _FakeCfg())
+    monkeypatch.chdir(proj_a)
+    return {"a": proj_a.resolve(), "b": proj_b.resolve(), "home": home.resolve(), "kp": kp}
+
+
+def _invoke(args: list[str], **kwargs):
+    return CliRunner().invoke(context, args, **kwargs)
+
+
+def _copy_args(dst: Path, *extra: str) -> list[str]:
+    return [
+        "settings-copy",
+        "--event",
+        "PostToolUse",
+        "--matcher",
+        "Edit|Write",
+        "--to-project",
+        str(dst),
+        *extra,
+    ]
+
+
+# ── dry-run / gates ──────────────────────────────────────────────────
+
+
+def test_dry_run_default_writes_nothing(cli_projects) -> None:
+    result = _invoke(_copy_args(cli_projects["b"], "--to", "project_local"))
+    assert result.exit_code == 0, result.output
+    assert "Plan: copy hook [PostToolUse:Edit|Write]" in result.output
+    assert "Run with --apply --confirm-project-shared to execute." in result.output
+    assert not (cli_projects["b"] / CANONICAL_SETTINGS_FILE).exists()
+    assert not (cli_projects["b"] / ".claude").exists()
+
+
+def test_yes_requires_apply(cli_projects) -> None:
+    result = _invoke(_copy_args(cli_projects["b"], "--yes"))
+    assert result.exit_code != 0
+    assert "--yes is only valid with --apply" in result.output
+
+
+def test_apply_with_yes_alone_refuses_gate_b(cli_projects) -> None:
+    result = _invoke(_copy_args(cli_projects["b"], "--to", "project_local", "--apply", "--yes"))
+    assert result.exit_code != 0
+    assert "--confirm-project-shared" in result.output
+    assert "--yes alone is not sufficient" in result.output
+    assert not (cli_projects["b"] / CANONICAL_SETTINGS_FILE).exists()
+
+
+def test_apply_interactive_decline_aborts(cli_projects) -> None:
+    result = _invoke(_copy_args(cli_projects["b"], "--to", "project_local", "--apply"), input="n\n")
+    assert result.exit_code != 0
+    assert not (cli_projects["b"] / CANONICAL_SETTINGS_FILE).exists()
+
+
+def test_apply_happy_path_project_local(cli_projects) -> None:
+    result = _invoke(
+        _copy_args(
+            cli_projects["b"], "--to", "project_local", "--apply", "--confirm-project-shared"
+        )
+    )
+    assert result.exit_code == 0, result.output
+    assert "wrote canonical entry" in result.output
+    assert "wrote stamped rule" in result.output
+    assert "mm context sync --include=settings --scope project_local" in result.output
+
+    canonical = json.loads(
+        (cli_projects["b"] / CANONICAL_SETTINGS_FILE).read_text(encoding="utf-8")
+    )
+    assert canonical["hooks"]["PostToolUse"][0]["hooks"][0]["command"] == "mm session start"
+    tier = json.loads(
+        (cli_projects["b"] / ".claude" / "settings.local.json").read_text(encoding="utf-8")
+    )
+    assert tier["hooks"]["PostToolUse"][0]["hooks"][0]["statusMessage"].startswith("memtomem · ")
+
+
+def test_idempotent_rerun_needs_no_confirmation(cli_projects) -> None:
+    first = _invoke(
+        _copy_args(
+            cli_projects["b"], "--to", "project_local", "--apply", "--confirm-project-shared"
+        )
+    )
+    assert first.exit_code == 0, first.output
+    # Second run is a no-op: no gate flags, no prompt, exit 0.
+    second = _invoke(_copy_args(cli_projects["b"], "--to", "project_local", "--apply"))
+    assert second.exit_code == 0, second.output
+    assert "nothing to do" in second.output
+
+
+def test_user_tier_host_write_needs_yes(cli_projects) -> None:
+    declined = _invoke(
+        _copy_args(cli_projects["b"], "--to", "user", "--apply", "--confirm-project-shared"),
+        input="n\n",  # Gate B satisfied by the flag; decline the host-write prompt
+    )
+    assert declined.exit_code != 0
+    assert "outside the destination project" in declined.output
+    assert not (cli_projects["home"] / ".claude" / "settings.json").exists()
+
+    accepted = _invoke(
+        _copy_args(
+            cli_projects["b"],
+            "--to",
+            "user",
+            "--apply",
+            "--confirm-project-shared",
+            "--yes",
+        )
+    )
+    assert accepted.exit_code == 0, accepted.output
+    assert (cli_projects["home"] / ".claude" / "settings.json").is_file()
+
+
+def test_conflict_skips_and_exits_1_without_prompting(cli_projects) -> None:
+    """A canonical conflict blocks both legs — no pending write, so no
+    confirmation prompt; the report names the colliding entry."""
+    dst_canonical = cli_projects["b"] / CANONICAL_SETTINGS_FILE
+    dst_canonical.parent.mkdir(parents=True, exist_ok=True)
+    dst_canonical.write_text(
+        json.dumps(
+            {"hooks": {"PostToolUse": [{"matcher": "Edit|Write", "hooks": [_inner("rival")]}]}}
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    before = dst_canonical.read_bytes()
+    result = _invoke(_copy_args(cli_projects["b"], "--to", "project_local", "--apply"))
+    assert result.exit_code == 1
+    assert "'rival'" in result.output
+    assert dst_canonical.read_bytes() == before
+
+
+# ── destination resolution ───────────────────────────────────────────
+
+
+def test_paused_registered_destination_refuses_with_resume_hint(cli_projects) -> None:
+    store = KnownProjectsStore(cli_projects["kp"])
+    store.add(cli_projects["b"])
+    sid = compute_scope_id(cli_projects["b"])
+    store.set_enabled_by_scope_id(sid, False)
+    result = _invoke(_copy_args(cli_projects["b"], "--to", "project_local", "--apply"))
+    assert result.exit_code != 0
+    assert "paused" in result.output
+    assert f"mm context projects resume {sid}" in result.output
+
+
+def test_scope_id_selector_resolves(cli_projects) -> None:
+    KnownProjectsStore(cli_projects["kp"]).add(cli_projects["b"])
+    sid = compute_scope_id(cli_projects["b"])
+    result = _invoke(
+        [
+            "settings-copy",
+            "--event",
+            "PostToolUse",
+            "--matcher",
+            "Edit|Write",
+            "--to-project",
+            sid,
+            "--to",
+            "project_local",
+            "--apply",
+            "--confirm-project-shared",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    assert (cli_projects["b"] / CANONICAL_SETTINGS_FILE).is_file()
+
+
+def test_destination_without_store_gets_init_hint(cli_projects, tmp_path) -> None:
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    result = _invoke(_copy_args(bare, "--to", "project_local", "--apply"))
+    assert result.exit_code != 0
+    assert "no .memtomem/ store" in result.output
+    assert "mm context init" in result.output
+
+
+def test_unknown_selector_listed(cli_projects) -> None:
+    result = _invoke(
+        [
+            "settings-copy",
+            "--event",
+            "SessionStart",
+            "--to-project",
+            str(cli_projects["b"]),
+            "--to",
+            "project_local",
+        ]
+    )
+    assert result.exit_code != 0
+    assert "available: PostToolUse:Edit|Write" in result.output
+
+
+def test_same_project_destination_points_at_settings_migrate(cli_projects) -> None:
+    result = _invoke(_copy_args(cli_projects["a"], "--to", "project_local"))
+    assert result.exit_code != 0
+    assert "settings-migrate" in result.output
+
+
+# ── Gate A via the CLI ───────────────────────────────────────────────
+
+
+def test_gate_a_block_surfaces_and_writes_nothing(cli_projects) -> None:
+    _seed_canonical(cli_projects["a"], command=f"echo {SECRET}")
+    result = _invoke(
+        _copy_args(
+            cli_projects["b"], "--to", "project_local", "--apply", "--confirm-project-shared"
+        )
+    )
+    assert result.exit_code != 0
+    assert "git history is forever" in result.output
+    # The plan preview echoes the user's own local command (the
+    # settings-migrate/doctor display convention); the BLOCK MESSAGE must
+    # not echo the matched bytes (privacy contract).
+    error_tail = result.output.split("Error:", 1)[1]
+    assert SECRET not in error_tail
+    assert not (cli_projects["b"] / CANONICAL_SETTINGS_FILE).exists()
+
+
+# ── --json schema ────────────────────────────────────────────────────
+
+
+def test_json_dry_run_schema(cli_projects) -> None:
+    result = _invoke(_copy_args(cli_projects["b"], "--to", "project_local", "--json"))
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "ok"
+    assert payload["applied"] is False
+    assert payload["event"] == "PostToolUse"
+    assert payload["matcher"] == "Edit|Write"
+    assert payload["command_preview"] == "mm session start"
+    assert payload["dst_scope"] == "project_local"
+    assert payload["canonical"] == {"state": "missing", "reason": ""}
+    assert payload["target"] == {"state": "missing", "reason": ""}
+
+
+def test_json_gate_b_needs_confirmation_exit_1(cli_projects) -> None:
+    result = _invoke(_copy_args(cli_projects["b"], "--to", "project_local", "--apply", "--json"))
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["status"] == "needs_confirmation"
+    assert "confirm-project-shared" in payload["hint"]
+
+
+def test_json_user_tier_host_writes_listed(cli_projects) -> None:
+    result = _invoke(
+        _copy_args(
+            cli_projects["b"],
+            "--to",
+            "user",
+            "--apply",
+            "--confirm-project-shared",
+            "--json",
+        )
+    )
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["status"] == "needs_confirmation"
+    assert payload["host_writes"] == [str(cli_projects["home"] / ".claude" / "settings.json")]
+
+
+def test_json_apply_reports_written_legs(cli_projects) -> None:
+    result = _invoke(
+        _copy_args(
+            cli_projects["b"],
+            "--to",
+            "project_local",
+            "--apply",
+            "--confirm-project-shared",
+            "--json",
+        )
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["applied"] is True
+    assert payload["canonical"]["written"] is True
+    assert payload["target"]["written"] is True
+    assert payload["sync_command"].endswith("--scope project_local")
+
+    rerun = _invoke(_copy_args(cli_projects["b"], "--to", "project_local", "--apply", "--json"))
+    assert rerun.exit_code == 0
+    rerun_payload = json.loads(rerun.output)
+    assert rerun_payload["status"] == "noop"
+    assert rerun_payload["canonical"]["state"] == "exact"
+    assert rerun_payload["target"]["state"] == "exact"

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -1450,9 +1450,7 @@ class TestGenerateCanonicalReadUnderLock:
     def _setup(self, tmp_path, command: str = "echo old"):
         project = tmp_path / "proj"
         project.mkdir()
-        _make_canonical_settings(
-            project, {"hooks": {"PostToolUse": [_rule("Edit", command)]}}
-        )
+        _make_canonical_settings(project, {"hooks": {"PostToolUse": [_rule("Edit", command)]}})
         return project
 
     def test_merge_uses_canonical_state_after_lock_acquire(self, claude_home, tmp_path):
@@ -1488,9 +1486,7 @@ class TestGenerateCanonicalReadUnderLock:
         assert results["claude_settings"].status == "ok"
         written = json.loads(target.read_text(encoding="utf-8"))
         commands = [
-            inner["command"]
-            for rule in written["hooks"]["PostToolUse"]
-            for inner in rule["hooks"]
+            inner["command"] for rule in written["hooks"]["PostToolUse"] for inner in rule["hooks"]
         ]
         assert "echo new" in commands
         assert "echo old" not in commands

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -1435,6 +1435,153 @@ class TestGenerateAllSettingsHostWriteGate:
         assert results["claude_settings"].status == "needs_confirmation"
 
 
+class TestGenerateCanonicalReadUnderLock:
+    """#1281 prerequisite — merge contributions derive from a canonical read
+    that happens-after the per-target lock acquire.
+
+    ``settings-copy`` (cross-project per-hook copy) writes the canonical
+    strictly before the tier file while holding both sidecar locks; a sync
+    that captured a stale canonical and then waited on the tier lock would
+    prune the freshly stamped owned rule as "no longer emitted". The fix
+    re-reads the canonical inside the lock — while every no-write early exit
+    (skipped / error / needs_confirmation) stays pre-lock so it never creates
+    or contends on a target sidecar lock (host paths in particular)."""
+
+    def _setup(self, tmp_path, command: str = "echo old"):
+        project = tmp_path / "proj"
+        project.mkdir()
+        _make_canonical_settings(
+            project, {"hooks": {"PostToolUse": [_rule("Edit", command)]}}
+        )
+        return project
+
+    def test_merge_uses_canonical_state_after_lock_acquire(self, claude_home, tmp_path):
+        """A canonical write landing before the lock acquire is merged.
+
+        The lock wrapper rewrites the canonical at acquire time — the exact
+        interleaving of a settings-copy committing between this sync's
+        pre-lock read and its lock acquisition. Pre-fix, the stale pre-lock
+        contributions ("echo old") were merged and the fresh entry was lost.
+        """
+        from memtomem.context import settings as settings_mod
+        from memtomem.context._atomic import _lock_path_for
+
+        project = self._setup(tmp_path)
+        canonical = project / CANONICAL_SETTINGS_FILE
+        target = project / ".claude" / "settings.json"
+        real_lock = settings_mod._file_lock
+
+        @contextlib.contextmanager
+        def mutating_lock(lock_path, *, timeout=None):
+            if lock_path == _lock_path_for(target):
+                canonical.write_text(
+                    json.dumps({"hooks": {"PostToolUse": [_rule("Edit", "echo new")]}}) + "\n",
+                    encoding="utf-8",
+                )
+            with real_lock(lock_path, timeout=timeout):
+                yield
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(settings_mod, "_file_lock", mutating_lock)
+            results = generate_all_settings(project, scope="project_shared")
+
+        assert results["claude_settings"].status == "ok"
+        written = json.loads(target.read_text(encoding="utf-8"))
+        commands = [
+            inner["command"]
+            for rule in written["hooks"]["PostToolUse"]
+            for inner in rule["hooks"]
+        ]
+        assert "echo new" in commands
+        assert "echo old" not in commands
+
+    def test_canonical_vanishing_under_lock_reports_skipped(self, claude_home, tmp_path):
+        """In-lock re-read maps a vanished canonical to the same ``skipped``
+        literal the stable no-canonical path reports; the target is never
+        written."""
+        from memtomem.context import settings as settings_mod
+        from memtomem.context._atomic import _lock_path_for
+
+        project = self._setup(tmp_path)
+        canonical = project / CANONICAL_SETTINGS_FILE
+        target = project / ".claude" / "settings.json"
+        real_lock = settings_mod._file_lock
+
+        @contextlib.contextmanager
+        def deleting_lock(lock_path, *, timeout=None):
+            if lock_path == _lock_path_for(target):
+                canonical.unlink()
+            with real_lock(lock_path, timeout=timeout):
+                yield
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(settings_mod, "_file_lock", deleting_lock)
+            results = generate_all_settings(project, scope="project_shared")
+
+        assert results["claude_settings"].status == "skipped"
+        assert not target.exists()
+
+    def test_no_canonical_user_scope_touches_no_host_sidecar(self, claude_home, tmp_path):
+        """No-canonical short-circuits BEFORE any lock: nothing may appear
+        under the host ``~/.claude/`` — not even a sidecar lock file."""
+        from memtomem.context._atomic import _lock_path_for
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        results = generate_all_settings(project, scope="user")
+        assert results["claude_settings"].status == "skipped"
+        target = claude_home / ".claude" / "settings.json"
+        assert not _lock_path_for(target).exists()
+        assert list((claude_home / ".claude").iterdir()) == []
+
+    def test_unconfirmed_host_write_touches_no_host_sidecar(self, claude_home, tmp_path):
+        """The host-write gate fires BEFORE the lock — an unconfirmed
+        user-scope invocation must not create the host sidecar lock."""
+        from memtomem.context._atomic import _lock_path_for
+
+        project = self._setup(tmp_path)
+        results = generate_all_settings(project, scope="user")
+        assert results["claude_settings"].status == "needs_confirmation"
+        target = claude_home / ".claude" / "settings.json"
+        assert not _lock_path_for(target).exists()
+        assert list((claude_home / ".claude").iterdir()) == []
+
+    def test_malformed_canonical_errors_without_lock_touch(self, claude_home, tmp_path):
+        """Malformed canonical stays a pre-lock ``error`` — no sidecar."""
+        from memtomem.context._atomic import _lock_path_for
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        _make_canonical_settings(project, "{not json")
+        results = generate_all_settings(project, scope="user")
+        assert results["claude_settings"].status == "error"
+        target = claude_home / ".claude" / "settings.json"
+        assert not _lock_path_for(target).exists()
+
+    def test_contended_lock_only_aborts_write_eligible_path(self, claude_home, tmp_path):
+        """Lock contention may only surface as ``aborted`` on a path that was
+        actually going to write — a no-canonical invocation never reaches the
+        lock, so it must stay ``skipped`` even when every acquire times out."""
+        from memtomem.context import settings as settings_mod
+
+        @contextlib.contextmanager
+        def always_timeout(lock_path, *, timeout=None):
+            raise TimeoutError
+            yield  # pragma: no cover
+
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        eligible = self._setup(tmp_path)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(settings_mod, "_file_lock", always_timeout)
+            skipped = generate_all_settings(empty, scope="project_shared")
+            aborted = generate_all_settings(eligible, scope="project_shared")
+
+        assert skipped["claude_settings"].status == "skipped"
+        assert aborted["claude_settings"].status == "aborted"
+
+
 # ── ADR-0010 §3 hooks.target_scope plumbing (issue #870) ────────────────────
 
 

--- a/packages/memtomem/tests/test_settings_copy.py
+++ b/packages/memtomem/tests/test_settings_copy.py
@@ -1,0 +1,446 @@
+"""Tests for settings_copy — cross-project per-hook copy (#1281, A-11).
+
+Engine half: ``plan_hook_copy`` / ``apply_hook_copy``. The CLI and web
+surfaces have their own files (``test_cli_settings_copy.py``,
+``test_web_settings_copy.py``).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from memtomem.context.privacy_scan import PrivacyBlockedError
+from memtomem.context.settings import CANONICAL_SETTINGS_FILE, generate_all_settings
+from memtomem.context.settings_copy import (
+    AmbiguousHookSelectorError,
+    HookNotFoundError,
+    apply_hook_copy,
+    format_copy_summary,
+    plan_hook_copy,
+)
+
+from .helpers import set_home
+
+# AKIA fixture per feedback_force_unsafe_redaction_valve_only.md — a generic
+# placeholder would pass the real scanner and false-negative every assert.
+SECRET = "api_key=AKIA1234567890ABCDEF"
+
+
+def _inner(command: str = "mm session start", *, timeout: int = 5000) -> dict:
+    return {"type": "command", "command": command, "timeout": timeout}
+
+
+def _rule(matcher: str = "Edit|Write", *, inners: list[dict] | None = None) -> dict:
+    return {"matcher": matcher, "hooks": list(inners) if inners is not None else [_inner()]}
+
+
+def _write_doc(path, doc: dict | str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(doc, str):
+        path.write_text(doc, encoding="utf-8")
+    else:
+        path.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+
+
+def _read_doc(path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude").mkdir()
+    set_home(monkeypatch, home)
+    return home
+
+
+@pytest.fixture
+def src_project(tmp_path):
+    root = tmp_path / "src-proj"
+    root.mkdir()
+    _write_doc(
+        root / CANONICAL_SETTINGS_FILE,
+        {"hooks": {"PostToolUse": [_rule("Edit|Write", inners=[_inner("mm session start")])]}},
+    )
+    return root
+
+
+@pytest.fixture
+def dst_project(tmp_path):
+    root = tmp_path / "dst-proj"
+    (root / ".memtomem").mkdir(parents=True)
+    return root
+
+
+def _plan(src, dst, *, scope: str = "project_shared", **kwargs):
+    return plan_hook_copy(
+        src,
+        event=kwargs.pop("event", "PostToolUse"),
+        matcher=kwargs.pop("matcher", "Edit|Write"),
+        dst_project_root=dst,
+        dst_scope=scope,
+        **kwargs,
+    )
+
+
+# ── Planning / selection ────────────────────────────────────────────
+
+
+class TestPlanSelection:
+    def test_plan_resolves_single_candidate(self, src_project, dst_project):
+        plan = _plan(src_project, dst_project)
+        assert plan.signature.event == "PostToolUse"
+        assert plan.signature.matcher == "Edit|Write"
+        assert plan.canonical_inner == _inner("mm session start")
+        assert plan.canonical_state == "missing"
+        assert plan.target_state == "missing"
+        assert plan.label == "PostToolUse:Edit|Write"
+
+    def test_target_rule_is_stamped_canonical_rule_is_not(self, src_project, dst_project):
+        plan = _plan(src_project, dst_project)
+        assert "statusMessage" not in plan.rule_for_canonical["hooks"][0]
+        assert plan.rule_for_target["hooks"][0]["statusMessage"].startswith("memtomem · ")
+
+    def test_no_match_lists_available_labels(self, src_project, dst_project):
+        with pytest.raises(HookNotFoundError, match=r"available: PostToolUse:Edit\|Write"):
+            _plan(src_project, dst_project, event="SessionStart", matcher="")
+
+    def test_missing_source_canonical_raises(self, tmp_path, dst_project):
+        bare = tmp_path / "bare"
+        bare.mkdir()
+        with pytest.raises(HookNotFoundError, match="no readable canonical settings"):
+            _plan(bare, dst_project)
+
+    def test_ambiguous_selector_lists_candidates(self, src_project, dst_project):
+        _write_doc(
+            src_project / CANONICAL_SETTINGS_FILE,
+            {
+                "hooks": {
+                    "PostToolUse": [
+                        _rule("Edit|Write", inners=[_inner("mm session start"), _inner("mm idx")])
+                    ]
+                }
+            },
+        )
+        with pytest.raises(AmbiguousHookSelectorError, match="mm session start.*mm idx"):
+            _plan(src_project, dst_project)
+
+    def test_hook_command_disambiguates(self, src_project, dst_project):
+        _write_doc(
+            src_project / CANONICAL_SETTINGS_FILE,
+            {
+                "hooks": {
+                    "PostToolUse": [
+                        _rule("Edit|Write", inners=[_inner("mm session start"), _inner("mm idx")])
+                    ]
+                }
+            },
+        )
+        plan = _plan(src_project, dst_project, hook_command="idx")
+        assert plan.canonical_inner["command"] == "mm idx"
+
+    def test_hook_command_eliminating_all_lists_candidates(self, src_project, dst_project):
+        with pytest.raises(HookNotFoundError, match="matches none.*mm session start"):
+            _plan(src_project, dst_project, hook_command="nope")
+
+    def test_matcher_is_normalized_for_matching(self, src_project, dst_project):
+        plan = _plan(src_project, dst_project, matcher="  Edit|Write  ")
+        assert plan.signature.matcher == "Edit|Write"
+
+    def test_same_project_refused(self, src_project):
+        with pytest.raises(ValueError, match="settings-migrate"):
+            _plan(src_project, src_project)
+
+    def test_unknown_dst_scope_refused(self, src_project, dst_project):
+        with pytest.raises(ValueError, match="unknown destination tier"):
+            _plan(src_project, dst_project, scope="prod")
+
+    def test_plan_classifies_existing_states(self, src_project, dst_project):
+        # exact at canonical, conflict at tier
+        _write_doc(
+            dst_project / CANONICAL_SETTINGS_FILE,
+            {"hooks": {"PostToolUse": [_rule("Edit|Write", inners=[_inner("mm session start")])]}},
+        )
+        _write_doc(
+            dst_project / ".claude" / "settings.json",
+            {"hooks": {"PostToolUse": [_rule("Edit|Write", inners=[_inner("rival cmd")])]}},
+        )
+        plan = _plan(src_project, dst_project)
+        assert plan.canonical_state == "exact"
+        assert plan.target_state == "conflict"
+        assert "'rival cmd'" in plan.target_reason
+        assert plan.has_conflict
+
+
+# ── Apply ───────────────────────────────────────────────────────────
+
+
+class TestApplyFresh:
+    def test_writes_canonical_verbatim_and_tier_stamped(self, src_project, dst_project):
+        result = apply_hook_copy(_plan(src_project, dst_project))
+        assert result.canonical_written and result.target_written
+        assert not result.warnings
+
+        canonical = _read_doc(dst_project / CANONICAL_SETTINGS_FILE)
+        [c_rule] = canonical["hooks"]["PostToolUse"]
+        assert c_rule == _rule("Edit|Write", inners=[_inner("mm session start")])
+
+        tier = _read_doc(dst_project / ".claude" / "settings.json")
+        [t_rule] = tier["hooks"]["PostToolUse"]
+        [t_inner] = t_rule["hooks"]
+        assert t_inner["command"] == "mm session start"
+        assert t_inner["statusMessage"] == "memtomem · PostToolUse"
+
+    def test_missing_dst_canonical_file_is_created(self, src_project, tmp_path):
+        dst = tmp_path / "dst-empty"
+        dst.mkdir()
+        result = apply_hook_copy(_plan(src_project, dst))
+        assert result.canonical_written
+        assert (dst / CANONICAL_SETTINGS_FILE).is_file()
+
+    def test_preserves_unrelated_dst_content(self, src_project, dst_project):
+        _write_doc(
+            dst_project / CANONICAL_SETTINGS_FILE,
+            {"hooks": {"SessionStart": [_rule("", inners=[_inner("dst own")])]}},
+        )
+        _write_doc(
+            dst_project / ".claude" / "settings.json",
+            {"permissions": {"allow": ["Bash"]}, "hooks": {}},
+        )
+        result = apply_hook_copy(_plan(src_project, dst_project))
+        assert result.canonical_written and result.target_written
+        canonical = _read_doc(dst_project / CANONICAL_SETTINGS_FILE)
+        assert "SessionStart" in canonical["hooks"]
+        tier = _read_doc(dst_project / ".claude" / "settings.json")
+        assert tier["permissions"] == {"allow": ["Bash"]}
+
+    def test_user_tier_destination_home_isolated(self, src_project, dst_project, fake_home):
+        result = apply_hook_copy(_plan(src_project, dst_project, scope="user"))
+        assert result.canonical_written and result.target_written
+        tier = _read_doc(fake_home / ".claude" / "settings.json")
+        [t_rule] = tier["hooks"]["PostToolUse"]
+        assert t_rule["hooks"][0]["statusMessage"].startswith("memtomem · ")
+        # canonical still lands at the destination PROJECT, not under HOME
+        assert (dst_project / CANONICAL_SETTINGS_FILE).is_file()
+
+    def test_project_local_tier_path(self, src_project, dst_project):
+        result = apply_hook_copy(_plan(src_project, dst_project, scope="project_local"))
+        assert result.target_written
+        assert (dst_project / ".claude" / "settings.local.json").is_file()
+
+    def test_sync_command_pins_cd_and_scope(self, src_project, dst_project):
+        result = apply_hook_copy(_plan(src_project, dst_project, scope="project_local"))
+        assert result.needs_sync
+        assert str(dst_project) in result.sync_command
+        assert result.sync_command.endswith(
+            "mm context sync --include=settings --scope project_local"
+        )
+
+
+class TestApplyIdempotent:
+    def test_second_run_reports_already_at_target(self, src_project, dst_project):
+        apply_hook_copy(_plan(src_project, dst_project))
+        canonical_before = (dst_project / CANONICAL_SETTINGS_FILE).read_bytes()
+        tier_before = (dst_project / ".claude" / "settings.json").read_bytes()
+
+        second = apply_hook_copy(_plan(src_project, dst_project))
+        assert not second.canonical_written and not second.target_written
+        assert second.canonical_already and second.target_already
+        assert not second.warnings
+        assert second.plan.is_noop
+        assert (dst_project / CANONICAL_SETTINGS_FILE).read_bytes() == canonical_before
+        assert (dst_project / ".claude" / "settings.json").read_bytes() == tier_before
+        assert "already" in format_copy_summary(second)
+
+    def test_copy_then_sync_at_destination_is_stable(self, src_project, dst_project, fake_home):
+        """The durability claim: the copied rule survives the destination's
+        own settings sync (owned-slot replace, no duplicate, no prune)."""
+        apply_hook_copy(_plan(src_project, dst_project))
+        results = generate_all_settings(dst_project, scope="project_shared")
+        assert results["claude_settings"].status == "ok"
+        tier = _read_doc(dst_project / ".claude" / "settings.json")
+        rules = [r for r in tier["hooks"]["PostToolUse"] if r.get("matcher", "") == "Edit|Write"]
+        assert len(rules) == 1
+        assert rules[0]["hooks"][0]["command"] == "mm session start"
+
+
+class TestApplyConflicts:
+    def test_canonical_conflict_skips_both_legs(self, src_project, dst_project):
+        _write_doc(
+            dst_project / CANONICAL_SETTINGS_FILE,
+            {"hooks": {"PostToolUse": [_rule("Edit|Write", inners=[_inner("rival cmd")])]}},
+        )
+        before = (dst_project / CANONICAL_SETTINGS_FILE).read_bytes()
+        result = apply_hook_copy(_plan(src_project, dst_project))
+        assert not result.canonical_written and not result.target_written
+        assert any("'rival cmd'" in w for w in result.warnings)
+        assert (dst_project / CANONICAL_SETTINGS_FILE).read_bytes() == before
+        assert not (dst_project / ".claude" / "settings.json").exists()
+
+    def test_tier_conflict_still_writes_canonical(self, src_project, dst_project):
+        _write_doc(
+            dst_project / ".claude" / "settings.json",
+            {"hooks": {"PostToolUse": [_rule("Edit|Write", inners=[_inner("rival cmd")])]}},
+        )
+        tier_before = (dst_project / ".claude" / "settings.json").read_bytes()
+        result = apply_hook_copy(_plan(src_project, dst_project))
+        assert result.canonical_written and not result.target_written
+        assert any("'rival cmd'" in w for w in result.warnings)
+        assert any("canonical entry WAS written" in w for w in result.warnings)
+        assert (dst_project / ".claude" / "settings.json").read_bytes() == tier_before
+        canonical = _read_doc(dst_project / CANONICAL_SETTINGS_FILE)
+        assert canonical["hooks"]["PostToolUse"] == [
+            _rule("Edit|Write", inners=[_inner("mm session start")])
+        ]
+
+    def test_different_timeout_is_a_conflict_not_exact(self, src_project, dst_project):
+        _write_doc(
+            dst_project / CANONICAL_SETTINGS_FILE,
+            {
+                "hooks": {
+                    "PostToolUse": [
+                        _rule("Edit|Write", inners=[_inner("mm session start", timeout=1)])
+                    ]
+                }
+            },
+        )
+        result = apply_hook_copy(_plan(src_project, dst_project))
+        assert not result.canonical_written
+        assert result.warnings
+
+    def test_stamped_tier_rule_classifies_exact(self, src_project, dst_project):
+        """Ownership-marker fields are ignored for equality — a previously
+        synced (stamped) destination rule is already_at_target, not a
+        conflict."""
+        _write_doc(
+            dst_project / ".claude" / "settings.json",
+            {
+                "hooks": {
+                    "PostToolUse": [
+                        _rule(
+                            "Edit|Write",
+                            inners=[
+                                {
+                                    **_inner("mm session start"),
+                                    "statusMessage": "memtomem · PostToolUse",
+                                }
+                            ],
+                        )
+                    ]
+                }
+            },
+        )
+        result = apply_hook_copy(_plan(src_project, dst_project))
+        assert result.canonical_written
+        assert result.target_already and not result.target_written
+        assert not result.warnings
+
+
+class TestApplyMalformed:
+    def test_malformed_dst_canonical_refuses_both_legs(self, src_project, dst_project):
+        _write_doc(dst_project / CANONICAL_SETTINGS_FILE, "{not json")
+        result = apply_hook_copy(_plan(src_project, dst_project))
+        assert not result.canonical_written and not result.target_written
+        assert any("not valid JSON" in w for w in result.warnings)
+        assert not (dst_project / ".claude" / "settings.json").exists()
+
+    def test_malformed_dst_tier_writes_canonical_only(self, src_project, dst_project):
+        _write_doc(dst_project / ".claude" / "settings.json", "[1, 2]")
+        result = apply_hook_copy(_plan(src_project, dst_project))
+        assert result.canonical_written and not result.target_written
+        assert any("not valid JSON" in w for w in result.warnings)
+        assert (dst_project / ".claude" / "settings.json").read_text(encoding="utf-8") == "[1, 2]"
+
+    def test_list_shaped_hooks_in_dst_canonical_refused_not_coerced(self, src_project, dst_project):
+        _write_doc(dst_project / CANONICAL_SETTINGS_FILE, {"hooks": []})
+        before = (dst_project / CANONICAL_SETTINGS_FILE).read_bytes()
+        result = apply_hook_copy(_plan(src_project, dst_project))
+        assert not result.canonical_written
+        assert any("not a record" in w for w in result.warnings)
+        assert (dst_project / CANONICAL_SETTINGS_FILE).read_bytes() == before
+
+
+class TestApplyConcurrency:
+    def test_canonical_mtime_drift_aborts_everything(self, src_project, dst_project, monkeypatch):
+        from memtomem.context import settings_copy as mod
+
+        _write_doc(dst_project / CANONICAL_SETTINGS_FILE, {"hooks": {}})
+        real = mod._read_with_mtime
+
+        def stale(path):
+            doc, mtime = real(path)
+            if path == dst_project / CANONICAL_SETTINGS_FILE:
+                return doc, mtime - 1
+            return doc, mtime
+
+        monkeypatch.setattr(mod, "_read_with_mtime", stale)
+        result = apply_hook_copy(_plan(src_project, dst_project))
+        assert not result.canonical_written and not result.target_written
+        assert any("modified by another process" in w for w in result.warnings)
+
+    def test_tier_mtime_drift_keeps_canonical_reports_partial(
+        self, src_project, dst_project, monkeypatch
+    ):
+        from memtomem.context import settings_copy as mod
+
+        _write_doc(dst_project / ".claude" / "settings.json", {"hooks": {}})
+        real = mod._read_with_mtime
+
+        def stale(path):
+            doc, mtime = real(path)
+            if path == dst_project / ".claude" / "settings.json":
+                return doc, mtime - 1
+            return doc, mtime
+
+        monkeypatch.setattr(mod, "_read_with_mtime", stale)
+        result = apply_hook_copy(_plan(src_project, dst_project))
+        assert result.canonical_written and not result.target_written
+        assert any("tier was not" in w for w in result.warnings)
+
+    def test_lock_budget_exhaustion_writes_nothing(self, src_project, dst_project, monkeypatch):
+        import contextlib
+
+        from memtomem.context import settings_copy as mod
+
+        @contextlib.contextmanager
+        def always_timeout(lock_path, *, timeout=None):
+            raise TimeoutError
+            yield  # pragma: no cover
+
+        monkeypatch.setattr(mod, "_file_lock", always_timeout)
+        result = apply_hook_copy(_plan(src_project, dst_project))
+        assert not result.canonical_written and not result.target_written
+        assert any("acquisition budget" in w for w in result.warnings)
+        assert not (dst_project / CANONICAL_SETTINGS_FILE).exists()
+
+
+class TestGateA:
+    def test_secret_bearing_hook_blocks_before_any_write(self, tmp_path, dst_project):
+        src = tmp_path / "src-secret"
+        src.mkdir()
+        _write_doc(
+            src / CANONICAL_SETTINGS_FILE,
+            {"hooks": {"PostToolUse": [_rule("Edit", inners=[_inner(f"echo {SECRET}")])]}},
+        )
+        with pytest.raises(PrivacyBlockedError) as exc_info:
+            apply_hook_copy(_plan(src, dst_project, matcher="Edit"))
+        assert "git history is forever" in str(exc_info.value)
+        assert SECRET not in str(exc_info.value)  # never echo the matched bytes
+        assert not (dst_project / CANONICAL_SETTINGS_FILE).exists()
+        assert not (dst_project / ".claude" / "settings.json").exists()
+
+    def test_gate_runs_for_private_tier_destinations_too(self, tmp_path, dst_project, fake_home):
+        """The destination canonical is git-tracked regardless of tier —
+        a user-tier destination must scan (and block) identically."""
+        src = tmp_path / "src-secret"
+        src.mkdir()
+        _write_doc(
+            src / CANONICAL_SETTINGS_FILE,
+            {"hooks": {"PostToolUse": [_rule("Edit", inners=[_inner(f"echo {SECRET}")])]}},
+        )
+        with pytest.raises(PrivacyBlockedError):
+            apply_hook_copy(_plan(src, dst_project, matcher="Edit", scope="user"))
+        assert not (fake_home / ".claude" / "settings.json").exists()

--- a/packages/memtomem/tests/test_web_invariants_registry.py
+++ b/packages/memtomem/tests/test_web_invariants_registry.py
@@ -96,6 +96,7 @@ _CSRF_PROTECTED: frozenset[str] = frozenset(
         "scratch.promote_scratch",
         "scratch.set_scratch",
         "settings_sync.apply_settings_sync",
+        "settings_sync.copy_hook_to_project",
         "settings_sync.delete_target_rule",
         "settings_sync.promote_target_rule",
         "settings_sync.resolve_conflict",
@@ -228,6 +229,11 @@ _REDACTION_EXEMPT: dict[str, str] = {
     "scratch.set_scratch": "scratch is local-only ephemeral note storage "
     "outside the LTM trust boundary; redaction not applicable",
     "settings_sync.apply_settings_sync": "structured settings merge; no free-form prose",
+    "settings_sync.copy_hook_to_project": (
+        "no free-form content payload — copies an existing canonical hook "
+        "entry between projects; the engine's Gate A fragment scan runs for "
+        "every destination tier (the canonical leg is always git-tracked)"
+    ),
     "settings_sync.delete_target_rule": "structured settings hook rule deletion; no free-form prose",
     "settings_sync.resolve_conflict": "structured settings conflict resolution; no free-form prose",
     "system.embed_text": "ephemeral compute; no persistence",

--- a/packages/memtomem/tests/test_web_routes_settings_copy.py
+++ b/packages/memtomem/tests/test_web_routes_settings_copy.py
@@ -1,0 +1,357 @@
+"""HTTP-layer tests for ``POST /api/context/settings/hooks/copy`` (#1281, A-11).
+
+Engine semantics (dual-write durability, conflicts, locking, Gate A
+internals) are pinned by ``test_settings_copy.py``; this file covers what
+the WEB surface adds:
+
+- destination resolution through project discovery (404 unknown, 409
+  ``sync_paused`` for every tier — the canonical leg is a project write,
+  409 ``no_memtomem_store``);
+- the sequential disclose-then-confirm round-trips
+  (``confirm_project_shared`` then user-tier ``allow_host_writes`` with
+  ``host_targets``), keyed on PENDING writes so no-op re-POSTs never
+  prompt;
+- Gate A before consent — the issue-pinned 422 STRING detail, for
+  private destination tiers too;
+- the object error envelope and the CLI-parity status vocabulary
+  (``plan`` / ``needs_confirmation`` / ``noop`` / ``ok`` / ``conflicts``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from memtomem.config import ContextGatewayConfig, Mem2MemConfig
+from memtomem.context.settings import CANONICAL_SETTINGS_FILE
+from memtomem.web.app import create_app
+
+from .helpers import set_home
+
+SECRET = "api_key=AKIA1234567890ABCDEF"
+
+
+def _inner(command: str = "mm session start") -> dict:
+    return {"type": "command", "command": command, "timeout": 5000}
+
+
+def _seed_canonical(root: Path, command: str = "mm session start") -> None:
+    path = root / CANONICAL_SETTINGS_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {"hooks": {"PostToolUse": [{"matcher": "Edit|Write", "hooks": [_inner(command)]}]}},
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+# ── Fixtures (the test_web_routes_context_transfer harness shape) ────
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    set_home(monkeypatch, home)
+    return home
+
+
+@pytest.fixture
+def cwd_root(tmp_path: Path, home: Path) -> Path:
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    (cwd / ".claude").mkdir()
+    (cwd / ".memtomem").mkdir()
+    _seed_canonical(cwd)
+    return cwd
+
+
+@pytest.fixture
+def known_projects_path(tmp_path: Path) -> Path:
+    return tmp_path / "kp.json"
+
+
+@pytest.fixture
+def app(cwd_root: Path, known_projects_path: Path):
+    application = create_app(lifespan=None, mode="dev")
+    application.state.project_root = cwd_root
+    application.state.storage = AsyncMock()
+    config = Mem2MemConfig()
+    config.context_gateway = ContextGatewayConfig(
+        known_projects_path=known_projects_path,
+        experimental_claude_projects_scan=False,
+    )
+    application.state.config = config
+    application.state.search_pipeline = None
+    application.state.index_engine = None
+    application.state.embedder = None
+    application.state.dedup_scanner = None
+    application.state.last_reload_error = None
+    return application
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def _register(client, root: Path, *, enabled: bool | None = None) -> str:
+    resp = await client.post("/api/context/known-projects", json={"root": str(root)})
+    assert resp.status_code == 200, resp.text
+    scope_id = resp.json()["project_scope_id"]
+    if enabled is not None:
+        resp = await client.patch(
+            f"/api/context/known-projects/{scope_id}", json={"enabled": enabled}
+        )
+        assert resp.status_code == 200, resp.text
+    return scope_id
+
+
+def _other_project(tmp_path: Path, name: str = "proj-b", *, store: bool = True) -> Path:
+    other = tmp_path / name
+    other.mkdir()
+    (other / ".claude").mkdir()
+    if store:
+        (other / ".memtomem").mkdir()
+    return other
+
+
+def _body(scope_id: str, **overrides) -> dict:
+    body = {
+        "event": "PostToolUse",
+        "matcher": "Edit|Write",
+        "to_project_scope_id": scope_id,
+        "to_target_scope": "project_local",
+    }
+    body.update(overrides)
+    return body
+
+
+COPY_URL = "/api/context/settings/hooks/copy"
+
+
+# ── destination resolution ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unknown_destination_404_envelope(client) -> None:
+    resp = await client.post(COPY_URL, json=_body("p-000000000000"))
+    assert resp.status_code == 404
+    detail = resp.json()["detail"]
+    assert detail["error_kind"] == "missing"
+    assert "unknown project_scope_id" in detail["message"]
+
+
+@pytest.mark.asyncio
+async def test_paused_destination_409_for_private_tier_too(client, tmp_path) -> None:
+    """The canonical leg writes the destination project for EVERY tier —
+    a paused destination refuses even when the tier is project_local."""
+    other = _other_project(tmp_path)
+    scope_id = await _register(client, other, enabled=False)
+    resp = await client.post(COPY_URL, json=_body(scope_id))
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["error_kind"] == "conflict"
+    assert detail["reason_code"] == "sync_paused"
+    assert not (other / CANONICAL_SETTINGS_FILE).exists()
+
+
+@pytest.mark.asyncio
+async def test_destination_without_store_409(client, tmp_path) -> None:
+    other = _other_project(tmp_path, store=False)
+    scope_id = await _register(client, other)
+    resp = await client.post(COPY_URL, json=_body(scope_id))
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["reason_code"] == "no_memtomem_store"
+    assert "mm context init" in detail["message"]
+
+
+# ── selector errors ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unmatched_selector_404_lists_labels(client, tmp_path) -> None:
+    other = _other_project(tmp_path)
+    scope_id = await _register(client, other)
+    resp = await client.post(COPY_URL, json=_body(scope_id, event="SessionStart", matcher=""))
+    assert resp.status_code == 404
+    detail = resp.json()["detail"]
+    assert detail["error_kind"] == "missing"
+    assert "available: PostToolUse:Edit|Write" in detail["message"]
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_selector_400(client, tmp_path, cwd_root) -> None:
+    (cwd_root / CANONICAL_SETTINGS_FILE).write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PostToolUse": [
+                        {
+                            "matcher": "Edit|Write",
+                            "hooks": [_inner("mm session start"), _inner("mm idx")],
+                        }
+                    ]
+                }
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    other = _other_project(tmp_path)
+    scope_id = await _register(client, other)
+    resp = await client.post(COPY_URL, json=_body(scope_id))
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert detail["error_kind"] == "validation"
+    assert "--hook-command" in detail["message"] or "hook_command" in detail["message"]
+
+
+@pytest.mark.asyncio
+async def test_same_project_destination_400(client, cwd_root) -> None:
+    scope_id = await _register(client, cwd_root)
+    resp = await client.post(COPY_URL, json=_body(scope_id))
+    assert resp.status_code == 400
+    assert "settings-migrate" in resp.json()["detail"]["message"]
+
+
+# ── dry-run / confirm round-trips / apply ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dry_run_returns_plan_writes_nothing(client, tmp_path) -> None:
+    other = _other_project(tmp_path)
+    scope_id = await _register(client, other)
+    resp = await client.post(f"{COPY_URL}?dry_run=true", json=_body(scope_id))
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["status"] == "plan"
+    assert payload["command_preview"] == "mm session start"
+    assert payload["canonical"] == {"state": "missing", "reason": ""}
+    assert payload["target"] == {"state": "missing", "reason": ""}
+    assert payload["dst_project_scope_id"] == scope_id
+    assert not (other / CANONICAL_SETTINGS_FILE).exists()
+
+
+@pytest.mark.asyncio
+async def test_confirm_round_trip_then_apply(client, tmp_path) -> None:
+    other = _other_project(tmp_path)
+    scope_id = await _register(client, other)
+
+    first = await client.post(COPY_URL, json=_body(scope_id))
+    assert first.status_code == 200, first.text
+    envelope = first.json()
+    assert envelope["status"] == "needs_confirmation"
+    assert envelope["confirm"] == "confirm_project_shared"
+    assert envelope["plan"]["dst_scope"] == "project_local"
+    assert not (other / CANONICAL_SETTINGS_FILE).exists()
+
+    second = await client.post(COPY_URL, json=_body(scope_id, confirm_project_shared=True))
+    assert second.status_code == 200, second.text
+    payload = second.json()
+    assert payload["status"] == "ok"
+    assert payload["canonical"]["written"] is True
+    assert payload["target"]["written"] is True
+    assert payload["sync_command"].endswith("--scope project_local")
+
+    canonical = json.loads((other / CANONICAL_SETTINGS_FILE).read_text(encoding="utf-8"))
+    assert canonical["hooks"]["PostToolUse"][0]["hooks"][0]["command"] == "mm session start"
+    tier = json.loads((other / ".claude" / "settings.local.json").read_text(encoding="utf-8"))
+    assert tier["hooks"]["PostToolUse"][0]["hooks"][0]["statusMessage"].startswith("memtomem · ")
+
+
+@pytest.mark.asyncio
+async def test_user_tier_stacks_both_gates(client, tmp_path, home) -> None:
+    other = _other_project(tmp_path)
+    scope_id = await _register(client, other)
+    body = _body(scope_id, to_target_scope="user")
+
+    first = await client.post(COPY_URL, json=body)
+    assert first.json()["confirm"] == "confirm_project_shared"
+
+    second = await client.post(COPY_URL, json={**body, "confirm_project_shared": True})
+    envelope = second.json()
+    assert envelope["status"] == "needs_confirmation"
+    assert envelope["confirm"] == "allow_host_writes"
+    assert envelope["host_targets"] == [str(home / ".claude" / "settings.json")]
+    assert not (home / ".claude" / "settings.json").exists()
+
+    third = await client.post(
+        COPY_URL,
+        json={**body, "confirm_project_shared": True, "allow_host_writes": True},
+    )
+    assert third.status_code == 200, third.text
+    assert third.json()["status"] == "ok"
+    assert (home / ".claude" / "settings.json").is_file()
+    # The canonical leg still lands at the destination PROJECT.
+    assert (other / CANONICAL_SETTINGS_FILE).is_file()
+
+
+@pytest.mark.asyncio
+async def test_noop_repost_never_prompts(client, tmp_path) -> None:
+    other = _other_project(tmp_path)
+    scope_id = await _register(client, other)
+    applied = await client.post(COPY_URL, json=_body(scope_id, confirm_project_shared=True))
+    assert applied.json()["status"] == "ok"
+
+    # Re-POST without ANY confirm flag: nothing pending → no envelope.
+    rerun = await client.post(COPY_URL, json=_body(scope_id))
+    assert rerun.status_code == 200, rerun.text
+    payload = rerun.json()
+    assert payload["status"] == "noop"
+    assert payload["canonical"]["already"] is True
+    assert payload["target"]["already"] is True
+
+
+@pytest.mark.asyncio
+async def test_canonical_conflict_reports_conflicts_no_prompt(client, tmp_path) -> None:
+    other = _other_project(tmp_path)
+    canonical = other / CANONICAL_SETTINGS_FILE
+    canonical.parent.mkdir(parents=True, exist_ok=True)
+    canonical.write_text(
+        json.dumps(
+            {"hooks": {"PostToolUse": [{"matcher": "Edit|Write", "hooks": [_inner("rival")]}]}}
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    before = canonical.read_bytes()
+    scope_id = await _register(client, other)
+
+    resp = await client.post(COPY_URL, json=_body(scope_id))
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["status"] == "conflicts"
+    assert any("'rival'" in w for w in payload["warnings"])
+    assert canonical.read_bytes() == before
+
+
+# ── Gate A ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_gate_a_422_string_before_consent(client, tmp_path, cwd_root) -> None:
+    """Scan-first ordering: a doomed copy 422s instead of completing a
+    needs_confirmation round-trip — and the detail is the issue-pinned
+    STRING, even for a private destination tier."""
+    _seed_canonical(cwd_root, command=f"echo {SECRET}")
+    other = _other_project(tmp_path)
+    scope_id = await _register(client, other)
+
+    resp = await client.post(COPY_URL, json=_body(scope_id))  # no confirm flags
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert isinstance(detail, str)
+    assert "git history is forever" in detail
+    assert SECRET not in detail
+    assert not (other / CANONICAL_SETTINGS_FILE).exists()


### PR DESCRIPTION
## Summary

Campaign #1270 item **A-11**: cross-project per-hook copy for settings hooks. Closes #1281.

`mm context settings-migrate` moves hook entries between tiers of ONE project; propagating a single hook to another project required hand-editing that project's settings files. This PR adds:

- **`context/settings_copy.py`** — the engine: `plan_hook_copy` resolves ONE canonical-matched inner entry (`(event, matcher)` selector, `--hook-command` substring disambiguation, `HookSignature` identity) and `apply_hook_copy` writes it at the destination **canonical-first under the sorted sidecar pair lock**, with in-lock re-classification and per-leg mtime rechecks.
- **`mm context settings-copy`** — the CLI surface on the copy verb family's conventions (`--to-project <scope_id|path>` with the A-1 selector, paused-destination refusal, init hint for store-less destinations, dry-run default, `--apply`, `--json`).
- **`POST /api/context/settings/hooks/copy`** — the web action, housed with the settings rule actions in `settings_sync.py`. The dashboard UI affordance deliberately rides B-6 #1289 (the same split A-5 used); this route is the web-action deliverable for A-11.

### Why a dual write

A stamped (memtomem-owned) rule absent from the destination's canonical `.memtomem/settings.json` is garbage-collected by that project's next settings sync (ADR-0019 owned-rule GC) — a tier-only copy would self-destruct in the most common setup. The copy therefore writes the destination canonical (the durable definition, entry verbatim) plus the destination-tier Claude settings file (ADR-0019-stamped, live immediately); Codex/Gemini/Kimi ride the printed `cd <dst> && mm context sync --include=settings --scope <tier>` follow-up. Canonical-first ordering is self-healing across crashes. Contracts pinned in **ADR-0023 §11** for A-12/A-13 to inherit.

### Prerequisite fix (first commit; scope disclosed)

`generate_all_settings` read the canonical BEFORE acquiring the per-target sidecar lock, so a sync that captured a stale canonical and then waited on the tier lock could prune the freshly stamped rule the copy had just landed (Codex design-gate finding). Fix: re-read the canonical **under** the per-target lock as the merge's authoritative contributions, while every no-write early exit (no-canonical `skipped`, malformed `error`, host-write `needs_confirmation`, no-target `skipped`) stays pre-lock — those paths never create or contend on a host sidecar lock, and lock contention (`aborted`) remains reachable only on write-eligible paths. Pin tests are mutation-validated (both race pins fail on the pre-fix code).

### Gates

- **Gate A always**: the destination canonical is git-tracked for every destination tier, so the fragment scan (the `promote_target_rule` shape, `scope="project_shared"` hardcoded) runs unconditionally, before the consent round-trip, with no force valve.
- **Pending-write-keyed confirms** (the #1263 no-op-never-prompts contract): `--confirm-project-shared` / `confirm_project_shared` whenever a git-tracked write is pending (the canonical leg always qualifies); the host-write prompt / `allow_host_writes` + `host_targets` when the user-tier file would be written; idempotent re-runs prompt for nothing. The CLI and the web route derive "pending" from the same plan properties, so the surfaces cannot drift.
- **Conflicts never duplicate a matcher**: a canonical conflict skips both legs (a tier-only write would be replaced by the destination's own sync — silent evaporation), a tier conflict still writes the canonical leg and says so; reports name the colliding entry.
- Destination eligibility is evaluated as a project-tier destination for every tier (the canonical leg is a project write), so a paused destination refuses even user-tier copies.

## Review

- Codex design gate, 2 rounds: NEEDS-FIX → folded (sync read-discipline fix, `--scope`-pinned follow-up command, route placement, the exact safe re-read ordering with its host-sidecar/status-regression consequences) → converged.
- Codex implementation review of this range: **SHIP**, no findings (independently re-ran the four suites — 175 passed).

## Tests

- 31 engine + 18 CLI + 12 web-route tests, plus 6 `generate_all_settings` ordering pins (mutation-validated) and the web invariants-registry entries (CSRF-protected, redaction-exempt with justification).
- Issue acceptance criteria: idempotent re-run reports already-at-target ✓; conflict at target skips with a report naming the colliding entry ✓; HOME-isolated tests for user-tier destinations ✓.
- Full local suite green except the known machine-env failures (`test_web_cli` ×12 and `test_session_tracing` — verified byte-identical on clean `origin/main`; tracked noise, #1249). Playwright web suite: 222 passed.
- Guide commands rehearsed end-to-end against the real CLI in an isolated HOME, including the printed follow-up sync (the copied rule survives the destination's own sync: one rule, no prune, no duplicate).

Part of #1270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
