### PR TITLE
feat(mcp): mem_context_artifact_transfer action — headless face of the transfer engine (#1283)

### DIFF
--- a/docs/adr/0023-cross-project-artifact-transfer.md
+++ b/docs/adr/0023-cross-project-artifact-transfer.md
@@ -440,6 +440,67 @@ Mechanism-specific decisions:
   canonical-wins per name), or a broken `.mcp.json` its sync will
   refuse on.
 
+### 13. MCP action surface (A-13 #1283)
+
+`mem_context_artifact_transfer` (`server/tools/context.py`) is the
+headless-agent face: one `@register("context")` action routed via
+`mem_do` (the core-9 default tool set stays frozen), wrapping the same
+engine call — `transfer_artifact` for `agents`/`commands`/`skills`,
+the §12 `copy_mcp_server` adapter for `asset_type="mcp-servers"`, with
+the §12 branch gates mirrored verbatim (copy-only, no rename, tiers
+pinned `project_shared`, cross-project only). Gate A audit attribution
+is `surface="mcp_context_artifact_transfer"` for both branches — one
+action, one attribution unit (`web_context_transfer` precedent).
+
+Params mirror the web body with MCP-family naming and text-message
+ergonomics: `asset_type`, `name`, `mode` (`move`|`copy`),
+`from_scope` (auto-detect default), `to_scope` (**source tier when
+omitted** — the CLI default, not the web's required field; at least
+one of `to_scope`/`to_project_scope_id` is required),
+`to_project_scope_id`, `as_name` (copy-rename), `apply` (dry-run
+default, the family convention the web spells `?dry_run=`), and the
+two §10 confirm flags. Source is always the server cwd's project —
+MCP tools are cwd-anchored like the CLI, so the §10
+implicit-destination eligibility subtlety (non-cwd *source* selector)
+cannot arise.
+
+**Trust boundary (the §10 web rails, agent-shaped):** destinations are
+addressable **only** as registered/discovered `scope_id`s — the
+typed-path consent valve stays CLI-only (a human typing a path is
+consent; an agent passing one is not) — and eligibility takes the
+web's stricter `sync_eligible` line: paused AND never-enrolled
+(discovery-only) destinations refuse, each naming its remediation
+(`mm context projects resume <id>` / `mm context projects add
+<root>`). Note the CLI is deliberately looser on the second case
+(selecting a scan-only scope_id is treated like typed-path consent).
+Both confirmation gates apply on `apply=True` only and return a
+`needs confirmation:` message naming the exact re-call flag
+(`confirm_project_shared=True` for `project_shared`,
+`allow_host_writes=True` for the `user` tier — the settings surfaces'
+flag, per the A-13 Codex design-gate fold); dry-run never gates,
+never writes, and its footer names the flag(s) the destination tier
+will require. `project_local` landings append the destination
+project's `.gitignore` marker and surface the non-write warning
+states (CLI/migrate parity; the web route's missing marker is a named
+follow-up gap, not a contract).
+
+**Result/errors are prefixed text**, not an envelope: the §10
+`error_kind` vocabulary degrades to the migrate tool's documented
+prefixes — `error:` (bad input, not-found, partial-commit recovery
+steps), `refused:` (state refusals: collision, eligibility, missing
+destination store), `needs confirmation:`, `privacy block:` (Gate A,
+string detail parity with every sync surface). Engine errors still
+map by TYPE (`ArtifactNotFoundError`, `TransferCollisionError`,
+`McpServerParseError`, `MigratePartialError`, `PrivacyScanError`).
+Success output mirrors the CLI renderer (`sync_command` else
+`sync_hint` follow-up). The engine call runs in a worker thread with
+`lock_timeout=30.0` (§10's budget): an MCP agent cannot Ctrl-C a
+stuck cross-process pair-lock wait, so the engine self-aborts
+(nothing acquired or committed) and the tool reports `error: transfer
+timed out…` instead of hanging the call. There is no outer
+`asyncio.timeout` — no HTTP request window to fit, and the MCP server
+is not the web server's event loop.
+
 ## Backward compatibility
 
 - `migrate_scope` keeps its exact signature, result dataclass
@@ -542,6 +603,9 @@ Mechanism-specific decisions:
   `_remove_runtime_fanout_for` — two-root split, `migrate_scope`
   wrapper, `ArtifactNotFoundError`),
   `packages/memtomem/src/memtomem/web/routes/context_transfer.py`
-  (`transfer_context_artifact`, §10) and
+  (`transfer_context_artifact`, §10),
   `packages/memtomem/src/memtomem/web/routes/_confirm.py`
-  (`needs_confirmation_envelope`).
+  (`needs_confirmation_envelope`), and
+  `packages/memtomem/src/memtomem/server/tools/context.py`
+  (`mem_context_artifact_transfer`, `_resolve_transfer_destination`,
+  `_format_transfer_result` — §13).

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -781,7 +781,7 @@ When `MEMTOMEM_SESSION_TRACE__LANGFUSE_ENABLED=true` is set, both public and sec
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MEMTOMEM_TOOL_MODE` | `core` | Which MCP tools are exposed: `core` (9 tools), `standard` (38 incl. `mem_do`), `full` (86) |
+| `MEMTOMEM_TOOL_MODE` | `core` | Which MCP tools are exposed: `core` (9 tools), `standard` (38 incl. `mem_do`), `full` (87) |
 
 In `core` mode, use `mem_do(action="...", params={...})` to access any of the 70+ non-core actions. Fewer tools means less context usage for AI agents.
 

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -381,7 +381,7 @@ mm status
 uses, so the output is identical. Useful as a sanity check between
 `mm init` and the first editor-side call.
 
-### Available MCP Tools (86)
+### Available MCP Tools (87)
 
 | Category | Tools |
 |----------|-------|
@@ -413,12 +413,12 @@ uses, so the output is identical. Useful as a sanity check between
 | **Data** | `mem_export`, `mem_import` |
 | **Config** | `mem_stats`, `mem_status`, `mem_config`\*, `mem_embedding_reset`\*, `mem_reset`\* |
 | **Evaluation** | `mem_eval` |
-| **Context** | `mem_context_detect`, `mem_context_init`, `mem_context_generate`, `mem_context_diff`, `mem_context_sync`, `mem_context_memory_migrate`, `mem_context_artifact_migrate`, `mem_context_version`, `mem_context_promote` (context tools accept `include="skills,agents,commands"` for canonical artifact workflows; `init`, `generate`, `sync`, `diff`, `version`, and `promote` accept `scope="project_shared\|user\|project_local"` — the canonical **tier** per ADR-0016 §2; `generate`/`sync` also accept `on_drop="ignore\|warn\|error"` (and the legacy alias `strict=True` ≡ `on_drop="error"`) to control how dropped sub-agent or command fields are reported, and a `label="latest\|v1\|production"` parameter to deploy from a specific version snapshot (agents/commands only); `version` manages snapshots via `action="list"\|"create"`; `promote` moves or deletes label pointers to versions; `memory_migrate` takes `from_scope`/`to_scope` instead of a single `scope` because it has two endpoints, plus `apply=True` to execute and `confirm_project_shared=True` when writing to the git-tracked tier; `artifact_migrate` migrates agents/commands/skills — flat→dir layout when `to_scope` is omitted, or a scope-tier move when it is set (`apply=True` to execute, `force=True` for dirty flat→dir, `confirm_project_shared=True` for the git-tracked tier); `mem_context_migrate` is a deprecated alias for `mem_context_memory_migrate`) |
+| **Context** | `mem_context_detect`, `mem_context_init`, `mem_context_generate`, `mem_context_diff`, `mem_context_sync`, `mem_context_memory_migrate`, `mem_context_artifact_migrate`, `mem_context_artifact_transfer`, `mem_context_version`, `mem_context_promote` (context tools accept `include="skills,agents,commands"` for canonical artifact workflows; `init`, `generate`, `sync`, `diff`, `version`, and `promote` accept `scope="project_shared\|user\|project_local"` — the canonical **tier** per ADR-0016 §2; `generate`/`sync` also accept `on_drop="ignore\|warn\|error"` (and the legacy alias `strict=True` ≡ `on_drop="error"`) to control how dropped sub-agent or command fields are reported, and a `label="latest\|v1\|production"` parameter to deploy from a specific version snapshot (agents/commands only); `version` manages snapshots via `action="list"\|"create"`; `promote` moves or deletes label pointers to versions; `memory_migrate` takes `from_scope`/`to_scope` instead of a single `scope` because it has two endpoints, plus `apply=True` to execute and `confirm_project_shared=True` when writing to the git-tracked tier; `artifact_migrate` migrates agents/commands/skills — flat→dir layout when `to_scope` is omitted, or a scope-tier move when it is set (`apply=True` to execute, `force=True` for dirty flat→dir, `confirm_project_shared=True` for the git-tracked tier); `artifact_transfer` moves or copies one canonical artifact between tiers and/or **registered projects** — `mode="move"\|"copy"`, `to_project_scope_id` from `mm context projects list`, `as_name` for a renamed copy, plus `asset_type="mcp-servers"` for cross-project MCP-server definition copies (`apply=True` to execute, `confirm_project_shared=True` for the git-tracked tier, `allow_host_writes=True` for a user-tier landing); `mem_context_migrate` is a deprecated alias for `mem_context_memory_migrate`) |
 
 
 \* Requires `MEMTOMEM_TOOL_MODE=full`. In `core` or `standard` mode, use `mm config` (CLI) or the Web UI Settings tab instead.
 
-> **Tool mode**: Set `MEMTOMEM_TOOL_MODE` to `core` (9 tools, default), `standard` (core + common packs + `mem_do`), or `full` (all 86 tools individually) to control how many tools are exposed. In `core` mode, use `mem_do(action="...", params={...})` to access any non-core action. Fewer tools = less context usage for AI agents.
+> **Tool mode**: Set `MEMTOMEM_TOOL_MODE` to `core` (9 tools, default), `standard` (core + common packs + `mem_do`), or `full` (all 87 tools individually) to control how many tools are exposed. In `core` mode, use `mem_do(action="...", params={...})` to access any non-core action. Fewer tools = less context usage for AI agents.
 
 ### STM Proxy Tools (optional, separate package)
 

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -63,7 +63,7 @@ sequenceDiagram
 
 ## MCP Tools at a Glance
 
-memtomem provides **86 MCP tools** organized into categories:
+memtomem provides **87 MCP tools** organized into categories:
 
 | Category | Tools | What they do |
 |----------|-------|-------------|
@@ -1231,6 +1231,14 @@ mm context projects pause <scope_id|path>   # exclude from --all batches / web S
 mm context projects resume <scope_id|path>  # re-include
 mm context projects remove <scope_id|path>  # unregister (project files untouched)
 
+# Cross-project / cross-tier transfer (ADR-0023; see "Moving artifacts" below)
+mm context copy agents foo --to project_local                  # tier copy inside this project (dry-run preview by default)
+mm context move agents foo --to project_shared --apply --confirm-project-shared  # tier move; git-tracked landing needs the extra flag
+mm context copy agents foo --to-project <scope_id> --apply     # copy to another registered project, keeping the source tier
+mm context copy agents foo --to-project ~/work/other --as foo2 --apply  # path destination (CLI-only consent valve) + renamed copy
+mm context copy mcp-servers pg --to-project <scope_id> --apply --confirm-project-shared  # copy one MCP server definition
+mm context move agents foo --from user --to project_local --apply       # --from disambiguates a multi-tier source
+
 # Note: cursor / codex / copilot fold ## Rules + ## Style into a single block;
 # `generate` warns on stderr when both sections are populated. context.md is
 # the source of truth — edit there, not in generated files.
@@ -1304,6 +1312,76 @@ mm web --dev                           # Web UI with opt-in maintainer pages
 
 Install the CLI: `uv tool install 'memtomem[all]'` (PyPI) or `uv run mm ...` (source).
 All commands support `-h` and `--help`.
+
+---
+
+## Moving artifacts between tiers and projects
+
+Three verbs share the transfer engine (ADR-0023). Pick by what should
+happen to the source:
+
+| | `move` | `copy` | `migrate` |
+|---|---|---|---|
+| Source afterwards | consumed; its stale runtime fan-out is cleaned (divergent files get a `.bak` snapshot first) | untouched | consumed (`--to` is the within-project move alias) |
+| Cross-project (`--to-project`) | yes | yes | no — within-project only |
+| Renamed copy (`--as`) | no | yes | no |
+| flat→dir layout adoption | no | no | yes (its original job, `--to` omitted) |
+| MCP server definitions (`mcp-servers`) | no | yes (cross-project only) | no |
+
+Shared rules, all verbs: destination collisions always refuse (no
+`--force` valve); destination runtime fan-out is **not** generated —
+the result prints the exact follow-up `mm context sync` command (or,
+for `mcp-servers`, the web-panel hint: `.mcp.json` fan-out is
+web-only); a `project_shared` landing runs the privacy scan (Gate A,
+no bypass) and requires `--confirm-project-shared` with `--apply`;
+default is always a dry-run preview.
+
+### Cross-project walkthrough
+
+```bash
+# One-time: register the destination so it has a scope_id (or pass a
+# filesystem path to --to-project — typing a path is the consent valve
+# for unregistered destinations, CLI-only).
+mm context projects add ~/work/other-proj --label "Other"
+mm context projects list                  # → p-1a2b3c4d5e6f  Other  ok
+
+# Preview, then execute. --to omitted keeps the source tier.
+mm context copy agents reviewer --to-project p-1a2b3c4d5e6f
+mm context copy agents reviewer --to-project p-1a2b3c4d5e6f --apply --confirm-project-shared
+
+# The result names the follow-up — destination fan-out is sync's job:
+cd ~/work/other-proj && mm context sync --scope project_shared
+```
+
+A paused destination refuses (`mm context projects resume <scope_id>`
+re-enables it), and a cross-project destination must already be a
+memtomem project (`mm context init` there first).
+
+### Headless agents (MCP)
+
+`mem_context_artifact_transfer` is the same engine via `mem_do` —
+core mode needs no extra tools:
+
+```python
+mem_do(action="context_artifact_transfer", params={
+    "asset_type": "agents", "name": "reviewer", "mode": "copy",
+    "to_project_scope_id": "p-1a2b3c4d5e6f",   # from `mm context projects list`
+})  # dry-run preview; the footer names the flags apply will need
+
+mem_do(action="context_artifact_transfer", params={
+    "asset_type": "agents", "name": "reviewer", "mode": "copy",
+    "to_project_scope_id": "p-1a2b3c4d5e6f",
+    "apply": True, "confirm_project_shared": True,
+})
+```
+
+The MCP surface is deliberately stricter than the CLI (ADR-0023 §13):
+destinations are registered `scope_id`s only (no path valve), paused
+**and** never-enrolled destinations refuse with the remediation
+command, and a `user`-tier landing — a host write outside any project
+root — needs `allow_host_writes=True` in addition to `apply=True`.
+Refusals come back prefixed (`error:` / `refused:` /
+`needs confirmation:` / `privacy block:`) so agents can branch.
 
 ---
 
@@ -1408,4 +1486,4 @@ See [`uninstall.md`](uninstall.md) for the five-step removal flow: detach the MC
 - [LLM Providers](llm-providers.md) — Optional LLM features (auto-tag, entity extraction, ask)
 - [MCP Client Setup](mcp-clients.md) — Editor-specific configuration
 - [memtomem-stm](https://github.com/memtomem/memtomem-stm) — Proactive surfacing, compression, caching (separate package)
-- [Full Tool Reference](../../packages/memtomem/README.md) — All 86 tools with parameters
+- [Full Tool Reference](../../packages/memtomem/README.md) — All 87 tools with parameters

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -132,6 +132,7 @@ from memtomem.server.tools.context import (
     mem_context_memory_migrate,
     mem_context_migrate,  # deprecated alias for mem_context_memory_migrate (#1147 B5-2)
     mem_context_artifact_migrate,
+    mem_context_artifact_transfer,  # ADR-0023 A-13 — cross-project/tier copy+move
     mem_context_version,  # ADR-0022 PR2 — version snapshots (list/create)
     mem_context_promote,  # ADR-0022 PR2 — label pointers (promote/delete)
 )

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -1,4 +1,4 @@
-"""Tools: context_detect, context_init, context_generate, context_sync, context_diff, context_memory_migrate, context_artifact_migrate."""
+"""Tools: context_detect, context_init, context_generate, context_sync, context_diff, context_memory_migrate, context_artifact_migrate, context_artifact_transfer."""
 
 from __future__ import annotations
 
@@ -18,8 +18,10 @@ from memtomem.server.tool_registry import register
 
 if TYPE_CHECKING:
     from memtomem.context._names import Layout
+    from memtomem.context.mcp_servers_copy import McpServerCopyResult
     from memtomem.context.migrate import MigrateRow, MigrateScopeResult
     from memtomem.context.scope_resolver import ArtifactKind
+    from memtomem.context.transfer import TransferMode, TransferResult
     from memtomem.context.versioning import VersionsManifest
 
 # Known --include values (mirrors cli.context_cmd._KNOWN_INCLUDES).
@@ -1549,6 +1551,484 @@ async def mem_context_artifact_migrate(
         return "Nothing to migrate."
 
     return await asyncio.to_thread(_run_artifact_flat_apply, project_root, rows, force=force)
+
+
+# ── Cross-project / cross-tier transfer (ADR-0023, A-13 #1283) ──────────────
+#
+# Headless-agent parity for ``mm context copy`` / ``mm context move``
+# (``cli/context_cmd.py:_transfer_dispatch``) and the web
+# ``POST /context/{kind}/{name}/transfer`` route
+# (``web/routes/context_transfer.py``). One ``@register`` action wrapping the
+# A-2 transfer engine; ``asset_type="mcp-servers"`` rides the A-12 copy
+# adapter exactly like the sibling surfaces. Destination projects are
+# restricted to the registered discovery set, matched by ``scope_id`` — the
+# typed-path consent valve is CLI-only (ADR-0023 §10: a human typing a path is
+# consent; an agent passing one is not), and eligibility takes the web's
+# stricter ``sync_eligible`` line for the same no-human-at-the-keyboard
+# reason (the CLI lets a selected scan-only scope through as consent).
+
+#: Whole-call pair-lock acquisition budget forwarded to the engine. Same
+#: budget as the web route's ``_TRANSFER_LOCK_BUDGET_S``: an MCP agent cannot
+#: Ctrl-C a stuck cross-process lock wait the way a CLI user can, so the
+#: engine self-aborts (committing nothing on the lock-wait path) instead of
+#: hanging the tool call.
+_TRANSFER_LOCK_BUDGET_S = 30.0
+
+
+def _format_transfer_result(result: TransferResult | McpServerCopyResult, *, apply_: bool) -> str:
+    """Plain-text summary for one copy/move transfer.
+
+    Mirrors the CLI's ``_print_transfer_result`` content: mode verb,
+    copy-rename note, fan-out lists, the A-4 provenance carry outcome,
+    engine ``notes``, and the engine's exact follow-up sync command
+    (``sync_command``, else the prose ``sync_hint`` for results with no
+    runnable command — mcp-servers fan-out is web-only). The dry-run
+    footer additionally names the confirmation flag(s) the destination
+    tier will require at apply time, so an agent learns the full
+    re-call shape from the preview.
+    """
+    layout_note = (
+        " (flat layout)" if result.layout == "flat" and result.kind != "mcp-servers" else ""
+    )
+    rename_note = f" as {result.dst_name}" if result.dst_name != result.name else ""
+    lines = [
+        f"Plan: {result.mode} {result.kind}/{result.name}{rename_note}{layout_note}",
+        f"  from {result.from_scope}: {result.src_path}",
+        f"  to   {result.to_scope}: {result.dst_path}",
+    ]
+    if not apply_:
+        if result.fanout_planned:
+            lines.append(
+                f"  will remove {len(result.fanout_planned)} stale runtime "
+                f"fan-out target(s) at scope='{result.from_scope}' (content "
+                f"that diverges from the canonical render is snapshotted to "
+                f"a .bak first):"
+            )
+            lines.extend(f"    - {path}" for path in result.fanout_planned)
+        if result.provenance == "carried":
+            lines.append(
+                "  will carry the wiki install provenance (lock.json entry) to the destination"
+            )
+        elif result.provenance == "not_carried":
+            lines.append(
+                f"  install provenance will not be carried — the artifact "
+                f"lands untracked: {result.provenance_reason}"
+            )
+        confirm_note = ""
+        if result.to_scope == "project_shared":
+            confirm_note = " and confirm_project_shared=True"
+        elif result.to_scope == "user":
+            confirm_note = " and allow_host_writes=True"
+        lines.append(f"\nRe-call with apply=True{confirm_note} to execute.")
+        if result.needs_sync and result.sync_command:
+            lines.append(f"After apply, run `{result.sync_command}` to refresh runtime fan-out.")
+        elif result.needs_sync and result.sync_hint:
+            lines.append(f"After apply, {result.sync_hint}")
+        return "\n".join(lines)
+
+    verb = "moved" if result.mode == "move" else "copied"
+    lines.append(
+        f"\n✓ {verb} {result.kind}/{result.name}: "
+        f"{result.from_scope} → {result.to_scope}{rename_note}"
+    )
+    if result.fanout_cleaned:
+        lines.append(
+            f"  cleaned {len(result.fanout_cleaned)} stale runtime fan-out "
+            f"target(s) at scope='{result.from_scope}':"
+        )
+        lines.extend(f"    - {path}" for path in result.fanout_cleaned)
+    if result.fanout_backed_up:
+        lines.append(
+            f"  {len(result.fanout_backed_up)} target(s) diverged from the "
+            f"canonical render — snapshotted before removal (review and "
+            f"delete manually):"
+        )
+        lines.extend(f"    - {path}" for path in result.fanout_backed_up)
+    if result.provenance == "carried":
+        lines.append("  carried the wiki install provenance (lock.json entry) to the destination")
+    elif result.provenance == "not_carried":
+        lines.append(
+            f"  install provenance not carried — the artifact lands "
+            f"untracked at the destination: {result.provenance_reason}"
+        )
+    lines.extend(f"  note: {note}" for note in result.notes)
+    if result.needs_sync and result.sync_command:
+        lines.append(
+            f"\nNext: run `{result.sync_command}` to generate runtime fan-out at the destination."
+        )
+    elif result.needs_sync and result.sync_hint:
+        lines.append(f"\nNext: {result.sync_hint}")
+    return "\n".join(lines)
+
+
+def _resolve_transfer_destination(to_project: str, src_root: Path) -> tuple[Path | None, str]:
+    """Resolve ``to_project_scope_id`` against the registered discovery set.
+
+    Returns ``(dst_root, "")`` on success or ``(None, refusal_text)`` —
+    the caller returns the refusal verbatim. Runs in a worker thread
+    (discovery walks the filesystem). Anchors discovery at the source
+    project root, the A-9 subdir-anchor convention shared with the CLI
+    ``--all-projects`` batch and the web lifespan.
+
+    Eligibility is the web route's ``sync_eligible`` rule
+    (``_reject_ineligible_destination``): both a paused and a
+    never-enrolled (discovery-only) destination refuse, each with the
+    remediation its state actually needs. The paused prose mirrors the
+    CLI dispatch verbatim (sibling trust-UX wording).
+    """
+    from memtomem.cli.context_cmd import _projects_discover, _projects_gateway_cfg
+
+    scope = next(
+        (
+            s
+            for s in _projects_discover(_projects_gateway_cfg(), cwd=src_root)
+            if s.scope_id == to_project
+        ),
+        None,
+    )
+    if scope is None:
+        return None, (
+            f"error: unknown to_project_scope_id: '{to_project}'. Destinations "
+            f"are restricted to registered projects — list them with "
+            f"`mm context projects list`."
+        )
+    if scope.root is None or scope.missing:
+        return None, (f"error: scope '{to_project}' is registered but its root is missing.")
+    if not scope.sync_eligible:
+        if "known-projects" in scope.sources:
+            return None, (
+                f"refused: destination project {scope.scope_id} ({scope.root}) is "
+                f"paused — sync enrollment is disabled, so the transferred "
+                f"artifact would not fan out there. Run `mm context projects "
+                f"resume {scope.scope_id}` first, or pick another destination."
+            )
+        return None, (
+            f"refused: destination project {scope.scope_id} ({scope.root}) is "
+            f"discovery-only (never enrolled for sync), so the transferred "
+            f"artifact would not fan out there. Enroll it first with "
+            f"`mm context projects add {scope.root}`, or pick another destination."
+        )
+    return scope.root, ""
+
+
+@mcp.tool()
+@tool_handler
+@register("context")
+async def mem_context_artifact_transfer(
+    asset_type: str = "",
+    name: str = "",
+    mode: str = "",
+    from_scope: str = "",
+    to_scope: str = "",
+    to_project_scope_id: str = "",
+    as_name: str = "",
+    apply: bool = False,
+    confirm_project_shared: bool = False,
+    allow_host_writes: bool = False,
+    ctx: CtxType = None,
+) -> str:
+    """Move or copy one canonical artifact between tiers and/or projects.
+
+    Headless parity for ``mm context copy`` / ``mm context move`` and the
+    web transfer endpoint — the same
+    :func:`memtomem.context.transfer.transfer_artifact` engine call with
+    the same gate semantics; no logic is re-implemented. The three verbs
+    in one view: **move** consumes the source and cleans its stale
+    runtime fan-out (destination fan-out is NOT generated — run the
+    follow-up sync command the result prints); **copy** never touches
+    the source and supports a renamed copy via ``as_name``;
+    ``mem_context_artifact_migrate`` stays the within-project legacy
+    verb (flat→dir layout adoption + tier moves).
+
+    ``asset_type="mcp-servers"`` copies one MCP server definition to
+    another project (A-12 adapter): copy-only, cross-project-only
+    (``to_project_scope_id`` required), no ``as_name``, tiers pinned to
+    ``project_shared``.
+
+    Destination projects are restricted to the registered discovery set
+    and matched by ``scope_id`` (``mm context projects list``) — the
+    typed-path escape hatch is CLI-only, and paused or never-enrolled
+    destinations refuse. Destination collisions always refuse (no force
+    valve). A ``project_shared`` landing runs the privacy scan (Gate A)
+    and requires ``confirm_project_shared=True`` with ``apply=True``
+    (Gate B); a ``user``-tier landing is a host write outside any
+    project root and requires ``allow_host_writes=True`` with
+    ``apply=True``.
+
+    Args:
+        asset_type: ``agents`` | ``commands`` | ``skills`` |
+            ``mcp-servers``. Required.
+        name: Source artifact name. Required.
+        mode: ``copy`` or ``move``. Required (``mcp-servers``: copy only).
+        from_scope: Source tier (``user`` / ``project_shared`` /
+            ``project_local``); auto-detected when omitted — pass it to
+            disambiguate when the same name lives in multiple tiers.
+        to_scope: Destination tier. Omitted: keeps the source tier (the
+            common cross-project case). At least one of ``to_scope`` /
+            ``to_project_scope_id`` is required.
+        to_project_scope_id: Destination project — a ``p-<sha12>``
+            scope_id from ``mm context projects list``. Omitted: the
+            current project. Cannot be combined with ``to_scope='user'``
+            (the user tier is global, not per-project).
+        as_name: Name for the copy at the destination (copy only). The
+            staged manifest's frontmatter ``name:`` is rewritten to
+            match; overrides/ and frozen versions/ snapshots travel
+            verbatim.
+        apply: Execute the transfer. Default ``False`` returns a dry-run
+            preview, matching the context-tool family.
+        confirm_project_shared: Required when the destination tier is
+            ``project_shared`` and ``apply=True``; MCP cannot prompt, so
+            a missing confirmation returns a ``needs confirmation``
+            message instead of touching disk.
+        allow_host_writes: Required when the destination tier is
+            ``user`` and ``apply=True`` — the canonical lands at a host
+            path outside any project root (``~/.memtomem``). Re-call
+            with ``allow_host_writes=True`` after surfacing the host
+            path to the user.
+
+    Refusals are prefixed (``error:`` for bad input, ``refused:`` for a
+    legitimate state that stops the transfer — fix the state and
+    re-call, ``needs confirmation:`` for a missing opt-in flag,
+    ``privacy block:`` for Gate A hits) so callers can branch on the
+    prefix.
+    """
+    from memtomem.context._names import InvalidNameError, validate_name
+    from memtomem.context.mcp_servers import McpServerParseError
+    from memtomem.context.mcp_servers_copy import copy_mcp_server
+    from memtomem.context.migrate import (
+        SCOPE_MIGRATABLE_KINDS,
+        ArtifactNotFoundError,
+        MigratePartialError,
+        _detect_source_scope,
+    )
+    from memtomem.context.privacy_scan import PrivacyScanError
+    from memtomem.context.transfer import TransferCollisionError, transfer_artifact
+
+    asset = asset_type or None
+    nm = name or None
+    frm = from_scope or None
+    to = to_scope or None
+    to_project = to_project_scope_id or None
+    new_name = as_name or None
+
+    if mode not in ("copy", "move"):
+        return "error: mode must be 'copy' or 'move'."
+    if asset is None:
+        return "error: asset_type is required (agents | commands | skills | mcp-servers)."
+    if nm is None:
+        return "error: name is required."
+
+    # ── mcp-servers branch gates (A-12) — BEFORE the generic combinators so
+    #    every refusal speaks mcp vocabulary (mirrors the CLI dispatch). ──
+    is_mcp = asset == "mcp-servers"
+    if is_mcp:
+        if mode != "copy":
+            return (
+                "error: mcp-servers support copy only: the canonical is "
+                "single-tier (project_shared), and a cross-project move would "
+                "orphan the source project's .mcp.json fan-out. Copy it, then "
+                "delete the source definition from its web panel if you meant "
+                "move."
+            )
+        if new_name is not None:
+            return (
+                "error: as_name is not supported for mcp-servers; the copy "
+                "keeps the server name (#1282 scope)."
+            )
+        for label, value in (("from_scope", frm), ("to_scope", to)):
+            if value is not None and value != "project_shared":
+                return (
+                    f"error: {label}='{value}' is not valid for mcp-servers: "
+                    f"the canonical is single-tier (project_shared) by design."
+                )
+        if to_project is None:
+            return (
+                "error: mcp-servers copy is cross-project only: pass "
+                "to_project_scope_id (within one project the canonical "
+                "already exists; there is no second tier to copy to)."
+            )
+        to = "project_shared"
+    else:
+        if asset not in SCOPE_MIGRATABLE_KINDS:
+            return (
+                f"error: unsupported asset_type='{asset}' for transfer "
+                f"(use one of {list(SCOPE_MIGRATABLE_KINDS)} or 'mcp-servers')."
+            )
+        for label, value in (("from_scope", frm), ("to_scope", to)):
+            if value is not None and value not in _KNOWN_ARTIFACT_SCOPES:
+                return (
+                    f"error: Unknown {label}='{value}'. Supported: {sorted(_KNOWN_ARTIFACT_SCOPES)}"
+                )
+
+    # ── Shared option-combination gates (mirror the CLI dispatch). ──
+    if to is None and to_project is None:
+        return (
+            f"error: nothing to do: pass to_scope and/or to_project_scope_id "
+            f"(a same-tier, same-project {mode} is a no-op)."
+        )
+    if to == "user" and to_project is not None:
+        return (
+            "error: to_project_scope_id cannot be combined with "
+            "to_scope='user': the user tier is global (~/.memtomem), not "
+            "per-project."
+        )
+    if new_name is not None and mode == "move":
+        return "error: as_name is only valid with mode='copy' (renamed copy)."
+
+    # Validate names BEFORE any path construction (A-3 Codex fold): the
+    # to_scope-default pre-probe below builds candidate paths from the raw
+    # name, and a traversal shape like ``../x`` must never reach a
+    # filesystem probe.
+    try:
+        name_kind = "MCP server" if is_mcp else f"{asset[:-1]} name"
+        validate_name(nm, kind=name_kind)
+        if new_name is not None:
+            validate_name(new_name, kind=name_kind)
+    except InvalidNameError as exc:
+        return f"error: {exc}"
+
+    src_root = await asyncio.to_thread(_find_project_root)
+
+    if to_project is not None:
+        dst_root, refusal = await asyncio.to_thread(
+            _resolve_transfer_destination, to_project, src_root
+        )
+        if dst_root is None:
+            return refusal
+    else:
+        dst_root = src_root
+
+    if is_mcp and dst_root.resolve() == src_root.resolve():
+        return (
+            "error: to_project_scope_id resolves to the source project; "
+            "mcp-servers copy is cross-project only."
+        )
+
+    if to is None:
+        # Tier default: keep the source tier. The engine re-detects under
+        # its own lock; this pre-probe only resolves the default (and
+        # shares the engine's missing/ambiguous error wording).
+        try:
+            detected, _src_path, _layout = await asyncio.to_thread(
+                _detect_source_scope,
+                cast("ArtifactKind", asset),
+                nm,
+                src_root,
+                cast("TargetScope | None", frm),
+            )
+        except click.ClickException as exc:
+            return f"error: {exc.message}"
+        to = detected
+        if to == "user" and to_project is not None:
+            return (
+                f"error: {asset}/{nm} lives at the user tier, which is global "
+                f"— pass to_scope='project_shared' or to_scope='project_local' "
+                f"to choose the tier it should land in inside the destination "
+                f"project."
+            )
+
+    # #1274 parity: a cross-project destination must already be a memtomem
+    # project — don't seed a half-initialized store into an arbitrary
+    # registered directory. Within-project transfers keep migrate's
+    # implicit-store behavior.
+    if to_project is not None and to != "user" and not (dst_root / ".memtomem").is_dir():
+        return (
+            f"refused: destination project has no .memtomem/ store: {dst_root}. "
+            f"Initialize it first: cd {dst_root} && mm context init"
+        )
+
+    # ── Tier-keyed confirmation gates (apply only — dry-run never gates and
+    #    never writes). Gate B mirrors mem_context_artifact_migrate; the
+    #    host-write gate mirrors the settings surfaces' allow_host_writes
+    #    and the web transfer route's user-tier gate. ──
+    if to == "project_shared" and apply and not confirm_project_shared:
+        verb = "copies" if mode == "copy" else "moves"
+        return (
+            f"needs confirmation: to_scope='project_shared' {verb} the "
+            f"canonical into the git-tracked tier. Re-call with "
+            f"confirm_project_shared=True to proceed."
+        )
+    if to == "user" and apply and not allow_host_writes:
+        return (
+            "needs confirmation: to_scope='user' writes the canonical to a "
+            "host path outside any project root (~/.memtomem). Re-call with "
+            "allow_host_writes=True after surfacing the host path to the user."
+        )
+
+    try:
+        result: TransferResult | McpServerCopyResult
+        if is_mcp:
+            result = await asyncio.to_thread(
+                copy_mcp_server,
+                nm,
+                src_project_root=src_root,
+                dst_project_root=dst_root,
+                apply_=apply,
+                surface="mcp_context_artifact_transfer",
+                lock_timeout=_TRANSFER_LOCK_BUDGET_S,
+            )
+        else:
+            result = await asyncio.to_thread(
+                transfer_artifact,
+                cast("ArtifactKind", asset),
+                nm,
+                src_project_root=src_root,
+                from_scope=cast("TargetScope | None", frm),
+                dst_project_root=None if to == "user" else dst_root,
+                to_scope=cast(TargetScope, to),
+                mode=cast("TransferMode", mode),
+                apply_=apply,
+                surface="mcp_context_artifact_transfer",
+                new_name=new_name,
+                lock_timeout=_TRANSFER_LOCK_BUDGET_S,
+            )
+    except TimeoutError:
+        # Engine lock budget expired — commits nothing by construction.
+        return (
+            "error: transfer timed out waiting for the artifact lock — "
+            "another sync or transfer may be in progress; nothing was "
+            "written. Retry once it finishes."
+        )
+    except ArtifactNotFoundError as exc:
+        return f"error: {exc.message}"
+    except TransferCollisionError as exc:
+        return f"refused: {exc.message}"
+    except PrivacyScanError as exc:
+        return f"privacy block: {exc.message}"
+    except MigratePartialError as exc:
+        return f"error: {exc.message}"
+    except McpServerParseError as exc:
+        return f"error: {exc}"
+    except (FileNotFoundError, InvalidNameError, ValueError) as exc:
+        return f"error: {exc}"
+    except click.ClickException as exc:
+        return f"error: {exc.message}"
+
+    out = _format_transfer_result(result, apply_=apply)
+    # project_local first-landing needs the gitignore marker at the
+    # DESTINATION project (parity with the CLI dispatch, cross-project
+    # aware). Surface the non-write states too — a caller MUST learn when
+    # .gitignore protection was skipped.
+    if apply and to == "project_local":
+        from memtomem.cli.context_cmd import _append_gitignore_marker
+
+        wrote, msg = await asyncio.to_thread(_append_gitignore_marker, dst_root)
+        if wrote:
+            out += "\n  Appended .gitignore marker (.memtomem/*.local/, .memtomem/.staging/)."
+        elif msg == "no_git_repo_pyproject_only":
+            out += (
+                "\n  warning: project root resolved via pyproject.toml but `.git` "
+                "missing — .gitignore not appended. Run `git init` first to "
+                "git-protect the local tier."
+            )
+        elif msg == "no_project_signal":
+            out += (
+                "\n  warning: no .git and no pyproject.toml in project root — "
+                ".gitignore append skipped; the project_local tier is not "
+                "git-protected."
+            )
+        # ``already_present`` is silent (marker already in place).
+    return out
 
 
 # ── Version snapshots + label pointers (ADR-0022) ───────────────────────────

--- a/packages/memtomem/tests/test_server_tools_context_artifact_transfer.py
+++ b/packages/memtomem/tests/test_server_tools_context_artifact_transfer.py
@@ -1,0 +1,707 @@
+"""Real-FS integration pins for the ``mem_context_artifact_transfer`` MCP tool
+(A-13 #1283, ADR-0023 §13).
+
+Headless parity for ``mm context copy`` / ``mm context move`` and the web
+transfer route — same engine, same gate semantics. These tests exercise the
+tool against real two-project filesystem layouts (not mocked) through the
+``.git`` + isolated-``HOME`` fixture the CLI transfer tests use
+(``test_cli_context_transfer.py``), and pin:
+
+* registry classification: registered via ``@register("context")``, routed by
+  ``mem_do``, NOT one of the frozen core-9;
+* the full validation-gate set mirrors the CLI dispatch (mcp-servers branch
+  gates first, names validated before any path probe);
+* ``apply=False`` (the default) never mutates and never gates;
+* tier-keyed confirmation gates: ``confirm_project_shared`` (Gate B) and
+  ``allow_host_writes`` (host-write gate — Codex design-gate fold);
+* destination resolution is registered-``scope_id``-only with the web's
+  ``sync_eligible`` eligibility line (paused AND discovery-only refuse);
+* Gate A audit attribution: ``surface="mcp_context_artifact_transfer"``;
+* engine kwargs pass-through (``surface`` / ``lock_timeout``) for both the
+  transfer engine and the mcp-servers copy adapter.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from memtomem.context.projects import KnownProjectsStore, ProjectScope, compute_scope_id
+from memtomem.server.tool_registry import ACTIONS
+from memtomem.server.tools.context import mem_context_artifact_transfer
+from memtomem.server.tools.meta import mem_do
+
+_SECRET_LITERAL = "AKIA1234567890ABCDEF"  # AWS-key shape — caught by the privacy scan
+
+
+@pytest.fixture()
+def projects(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    """Two initialized project roots + isolated HOME, cwd at project A.
+
+    ``ContextGatewayConfig`` is monkeypatched at the CLI module the MCP
+    destination resolver imports its discovery helpers from, so
+    ``to_project_scope_id`` resolution reads a tmp ``known_projects.json``
+    (pattern from ``test_cli_context_transfer.py``).
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    proj_a = tmp_path / "proj-a"
+    proj_b = tmp_path / "proj-b"
+    for proj in (proj_a, proj_b):
+        (proj / ".git").mkdir(parents=True)
+        (proj / ".memtomem").mkdir()
+
+    kp = tmp_path / "known_projects.json"
+
+    class _FakeCfg:
+        known_projects_path = kp
+        experimental_claude_projects_scan = False
+        auto_display_configured_projects = True
+
+    monkeypatch.setattr("memtomem.cli.context_cmd.ContextGatewayConfig", lambda: _FakeCfg())
+    monkeypatch.chdir(proj_a)
+    return {"a": proj_a.resolve(), "b": proj_b.resolve(), "home": home.resolve(), "kp": kp}
+
+
+def _register_b(projects: dict[str, Path]) -> str:
+    """Enroll project B in the known-projects store; return its scope_id."""
+    KnownProjectsStore(projects["kp"]).add(projects["b"])
+    return compute_scope_id(projects["b"])
+
+
+def _seed_agent(
+    projects: dict[str, Path],
+    scope: str,
+    name: str = "foo",
+    root_key: str = "a",
+    body: str | None = None,
+) -> Path:
+    """Write a dir-layout canonical agent; return the artifact dir."""
+    if scope == "user":
+        base = projects["home"] / ".memtomem" / "agents"
+    elif scope == "project_shared":
+        base = projects[root_key] / ".memtomem" / "agents"
+    elif scope == "project_local":
+        base = projects[root_key] / ".memtomem" / "agents.local"
+    else:
+        raise ValueError(scope)
+    artifact_dir = base / name
+    artifact_dir.mkdir(parents=True)
+    text = body if body is not None else f"---\nname: {name}\ndescription: t\n---\n\nhello\n"
+    (artifact_dir / "agent.md").write_text(text, encoding="utf-8")
+    return artifact_dir
+
+
+def _seed_mcp_server(projects: dict[str, Path], root_key: str = "a", name: str = "pg") -> Path:
+    store = projects[root_key] / ".memtomem" / "mcp-servers"
+    store.mkdir(parents=True, exist_ok=True)
+    path = store / f"{name}.json"
+    path.write_text(
+        json.dumps({"command": "npx", "args": ["-y", "srv"]}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+# ── registry classification (#1283 acceptance) ───────────────────────────
+
+
+def test_action_registered_in_context_category() -> None:
+    """Registered via @register outside the frozen core-9; mem_do dispatches
+    by the ``mem_``-stripped name."""
+    assert "context_artifact_transfer" in ACTIONS
+    assert ACTIONS["context_artifact_transfer"].category == "context"
+    # Param surface is the documented one (registry parses the Args section).
+    assert set(ACTIONS["context_artifact_transfer"].param_docs) == {
+        "asset_type",
+        "name",
+        "mode",
+        "from_scope",
+        "to_scope",
+        "to_project_scope_id",
+        "as_name",
+        "apply",
+        "confirm_project_shared",
+        "allow_host_writes",
+    }
+
+
+def test_action_not_in_core_nine() -> None:
+    from memtomem.server import _CORE_TOOLS
+
+    assert "mem_context_artifact_transfer" not in _CORE_TOOLS
+    assert len(_CORE_TOOLS) == 9  # the frozen default set stays frozen
+
+
+@pytest.mark.anyio
+async def test_mem_do_routes_the_action(projects) -> None:
+    out = await mem_do(action="context_artifact_transfer", params={"asset_type": "agents"})
+    # The action's own validation message proves the registry dispatch ran.
+    assert "mode must be 'copy' or 'move'" in out
+
+
+# ── validation gates (mirror the CLI dispatch) ───────────────────────────
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("kwargs", "needle"),
+    [
+        ({"asset_type": "agents", "name": "x"}, "mode must be 'copy' or 'move'"),
+        ({"name": "x", "mode": "copy"}, "asset_type is required"),
+        ({"asset_type": "agents", "mode": "copy"}, "name is required"),
+        (
+            {"asset_type": "memory", "name": "x", "mode": "copy", "to_scope": "user"},
+            "unsupported asset_type='memory'",
+        ),
+        (
+            {"asset_type": "agents", "name": "x", "mode": "copy", "to_scope": "bogus"},
+            "Unknown to_scope='bogus'",
+        ),
+        (
+            {"asset_type": "agents", "name": "x", "mode": "copy", "from_scope": "bogus"},
+            "Unknown from_scope='bogus'",
+        ),
+        ({"asset_type": "agents", "name": "x", "mode": "copy"}, "nothing to do"),
+        (
+            {
+                "asset_type": "agents",
+                "name": "x",
+                "mode": "copy",
+                "to_scope": "user",
+                "to_project_scope_id": "p-deadbeef0000",
+            },
+            "cannot be combined with",
+        ),
+        (
+            {
+                "asset_type": "agents",
+                "name": "x",
+                "mode": "move",
+                "to_scope": "user",
+                "as_name": "y",
+            },
+            "as_name is only valid with mode='copy'",
+        ),
+        (
+            {"asset_type": "agents", "name": "../x", "mode": "copy", "to_scope": "user"},
+            "error:",
+        ),
+        (
+            {
+                "asset_type": "agents",
+                "name": "x",
+                "mode": "copy",
+                "to_scope": "user",
+                "as_name": "../y",
+            },
+            "error:",
+        ),
+    ],
+)
+async def test_validation_gates(projects, kwargs, needle) -> None:
+    out = await mem_context_artifact_transfer(**kwargs)
+    assert needle in out
+    assert out.startswith("error:")
+
+
+# ── dry-run default + within-project transfers ───────────────────────────
+
+
+@pytest.mark.anyio
+async def test_dry_run_default_does_not_mutate(projects) -> None:
+    src = _seed_agent(projects, "user")
+    out = await mem_context_artifact_transfer(
+        asset_type="agents", name="foo", mode="copy", to_scope="project_local"
+    )
+    assert out.startswith("Plan: copy agents/foo")
+    assert "Re-call with apply=True to execute." in out
+    assert (src / "agent.md").exists()
+    assert not (projects["a"] / ".memtomem" / "agents.local" / "foo").exists()
+
+
+@pytest.mark.anyio
+async def test_copy_apply_keeps_source_and_appends_marker(projects) -> None:
+    src = _seed_agent(projects, "user")
+    out = await mem_context_artifact_transfer(
+        asset_type="agents", name="foo", mode="copy", to_scope="project_local", apply=True
+    )
+    assert "✓ copied agents/foo: user → project_local" in out
+    assert (src / "agent.md").exists()  # copy never touches the source
+    assert (projects["a"] / ".memtomem" / "agents.local" / "foo" / "agent.md").exists()
+    assert "Appended .gitignore marker" in out
+    gitignore = (projects["a"] / ".gitignore").read_text(encoding="utf-8")
+    assert ".memtomem/*.local/" in gitignore
+
+
+@pytest.mark.anyio
+async def test_move_apply_consumes_source(projects) -> None:
+    src = _seed_agent(projects, "project_local")
+    out = await mem_context_artifact_transfer(
+        asset_type="agents",
+        name="foo",
+        mode="move",
+        to_scope="user",
+        apply=True,
+        allow_host_writes=True,
+    )
+    assert "✓ moved agents/foo: project_local → user" in out
+    assert not src.exists()
+    assert (projects["home"] / ".memtomem" / "agents" / "foo" / "agent.md").exists()
+    # User-tier sync is project-independent — exact engine command, no cd.
+    assert "Next: run `mm context sync --scope user`" in out
+
+
+# ── tier-keyed confirmation gates ────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_project_shared_requires_confirmation(projects) -> None:
+    src = _seed_agent(projects, "user")
+    blocked = await mem_context_artifact_transfer(
+        asset_type="agents", name="foo", mode="move", to_scope="project_shared", apply=True
+    )
+    assert blocked.startswith("needs confirmation:")
+    assert "confirm_project_shared=True" in blocked
+    assert src.exists()  # nothing written without the opt-in
+
+    ok = await mem_context_artifact_transfer(
+        asset_type="agents",
+        name="foo",
+        mode="move",
+        to_scope="project_shared",
+        apply=True,
+        confirm_project_shared=True,
+    )
+    assert "✓ moved agents/foo" in ok
+    assert (projects["a"] / ".memtomem" / "agents" / "foo" / "agent.md").exists()
+
+
+@pytest.mark.anyio
+async def test_user_tier_requires_allow_host_writes(projects) -> None:
+    """Codex design-gate fold: a user-tier landing is a host write outside any
+    project root and must round-trip the same flag the settings surfaces use."""
+    src = _seed_agent(projects, "project_shared")
+    blocked = await mem_context_artifact_transfer(
+        asset_type="agents", name="foo", mode="copy", to_scope="user", apply=True
+    )
+    assert blocked.startswith("needs confirmation:")
+    assert "allow_host_writes=True" in blocked
+    assert not (projects["home"] / ".memtomem" / "agents" / "foo").exists()
+
+    ok = await mem_context_artifact_transfer(
+        asset_type="agents",
+        name="foo",
+        mode="copy",
+        to_scope="user",
+        apply=True,
+        allow_host_writes=True,
+    )
+    assert "✓ copied agents/foo: project_shared → user" in ok
+    assert (projects["home"] / ".memtomem" / "agents" / "foo" / "agent.md").exists()
+    assert src.exists()
+
+
+@pytest.mark.anyio
+async def test_user_tier_dry_run_is_ungated_and_names_the_flag(projects) -> None:
+    _seed_agent(projects, "project_shared")
+    out = await mem_context_artifact_transfer(
+        asset_type="agents", name="foo", mode="copy", to_scope="user"
+    )
+    assert out.startswith("Plan: copy agents/foo")
+    assert "Re-call with apply=True and allow_host_writes=True to execute." in out
+    assert not (projects["home"] / ".memtomem" / "agents" / "foo").exists()
+
+
+# ── cross-project destination resolution + eligibility ───────────────────
+
+
+@pytest.mark.anyio
+async def test_cross_project_move_round_trip(projects) -> None:
+    src = _seed_agent(projects, "project_shared", root_key="a")
+    sid = _register_b(projects)
+    out = await mem_context_artifact_transfer(
+        asset_type="agents",
+        name="foo",
+        mode="move",
+        to_scope="project_shared",
+        to_project_scope_id=sid,
+        apply=True,
+        confirm_project_shared=True,
+    )
+    assert "✓ moved agents/foo: project_shared → project_shared" in out
+    assert not src.exists()
+    assert (projects["b"] / ".memtomem" / "agents" / "foo" / "agent.md").exists()
+    # Engine's exact destination-project follow-up (cd-prefixed).
+    assert "mm context sync --scope project_shared" in out
+    assert str(projects["b"]) in out
+
+
+@pytest.mark.anyio
+async def test_omitted_to_scope_keeps_source_tier_cross_project(projects) -> None:
+    _seed_agent(projects, "project_shared", root_key="a")
+    sid = _register_b(projects)
+    out = await mem_context_artifact_transfer(
+        asset_type="agents", name="foo", mode="copy", to_project_scope_id=sid
+    )
+    assert out.startswith("Plan: copy agents/foo")
+    assert "to   project_shared" in out
+    assert str(projects["b"]) in out
+
+
+@pytest.mark.anyio
+async def test_user_source_with_to_project_demands_explicit_tier(projects) -> None:
+    _seed_agent(projects, "user")
+    sid = _register_b(projects)
+    out = await mem_context_artifact_transfer(
+        asset_type="agents", name="foo", mode="copy", to_project_scope_id=sid
+    )
+    assert out.startswith("error:")
+    assert "lives at the user tier" in out
+
+
+@pytest.mark.anyio
+async def test_unknown_scope_id_errors_with_registry_hint(projects) -> None:
+    _seed_agent(projects, "project_shared")
+    out = await mem_context_artifact_transfer(
+        asset_type="agents",
+        name="foo",
+        mode="copy",
+        to_scope="project_shared",
+        to_project_scope_id="p-deadbeef0000",
+    )
+    assert out.startswith("error: unknown to_project_scope_id")
+    assert "mm context projects list" in out
+
+
+@pytest.mark.anyio
+async def test_paused_destination_refuses_with_resume_hint(projects) -> None:
+    src = _seed_agent(projects, "project_shared")
+    sid = _register_b(projects)
+    KnownProjectsStore(projects["kp"]).set_enabled_by_scope_id(sid, False)
+    out = await mem_context_artifact_transfer(
+        asset_type="agents",
+        name="foo",
+        mode="move",
+        to_scope="project_shared",
+        to_project_scope_id=sid,
+        apply=True,
+        confirm_project_shared=True,
+    )
+    assert out.startswith("refused:")
+    assert "paused" in out
+    assert f"mm context projects resume {sid}" in out
+    assert src.exists()
+
+
+@pytest.mark.anyio
+async def test_discovery_only_destination_refuses_with_enroll_hint(
+    projects, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The web-strict eligibility line (ADR-0023 §13): a scan-discovered,
+    never-enrolled scope is selectable by scope_id but refuses — the CLI's
+    select-is-consent looseness does not extend to headless agents."""
+    _seed_agent(projects, "project_shared")
+    ghost = ProjectScope(
+        scope_id="p-cafecafe0000",
+        label="ghost",
+        root=projects["b"],
+        tier="project",
+        sources=("claude-projects",),
+        sync_eligible=False,
+    )
+    monkeypatch.setattr(
+        "memtomem.cli.context_cmd._projects_discover", lambda cfg, cwd=None: [ghost]
+    )
+    out = await mem_context_artifact_transfer(
+        asset_type="agents",
+        name="foo",
+        mode="copy",
+        to_scope="project_shared",
+        to_project_scope_id="p-cafecafe0000",
+    )
+    assert out.startswith("refused:")
+    assert "discovery-only" in out
+    assert "mm context projects add" in out
+
+
+@pytest.mark.anyio
+async def test_destination_without_store_refuses_with_init_hint(projects, tmp_path: Path) -> None:
+    _seed_agent(projects, "project_shared")
+    bare = tmp_path / "bare"
+    (bare / ".git").mkdir(parents=True)  # a project, but never `mm context init`ed
+    KnownProjectsStore(projects["kp"]).add(bare)
+    out = await mem_context_artifact_transfer(
+        asset_type="agents",
+        name="foo",
+        mode="copy",
+        to_scope="project_local",
+        to_project_scope_id=compute_scope_id(bare),
+    )
+    assert out.startswith("refused:")
+    assert "no .memtomem/ store" in out
+    assert "mm context init" in out
+
+
+@pytest.mark.anyio
+async def test_destination_collision_refuses(projects) -> None:
+    _seed_agent(projects, "project_shared", root_key="a")
+    sid = _register_b(projects)
+    _seed_agent(projects, "project_shared", root_key="b")  # dst already present
+    out = await mem_context_artifact_transfer(
+        asset_type="agents",
+        name="foo",
+        mode="copy",
+        to_scope="project_shared",
+        to_project_scope_id=sid,
+        apply=True,
+        confirm_project_shared=True,
+    )
+    assert out.startswith("refused:")
+    assert "destination already exists" in out
+
+
+@pytest.mark.anyio
+async def test_missing_source_is_clean_error(projects) -> None:
+    out = await mem_context_artifact_transfer(
+        asset_type="agents", name="ghost", mode="copy", to_scope="project_local", apply=True
+    )
+    assert out.startswith("error:")
+    assert "ghost" in out
+
+
+# ── Gate A (privacy scan) + audit attribution ────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_gate_a_blocks_project_shared_landing(projects) -> None:
+    src_dir = _seed_agent(
+        projects,
+        "project_local",
+        body=f"---\nname: foo\ndescription: t\n---\n\n{_SECRET_LITERAL}\n",
+    )
+    sid = _register_b(projects)
+    out = await mem_context_artifact_transfer(
+        asset_type="agents",
+        name="foo",
+        mode="move",
+        to_scope="project_shared",
+        to_project_scope_id=sid,
+        apply=True,
+        confirm_project_shared=True,
+    )
+    assert out.startswith("privacy block:")
+    assert (src_dir / "agent.md").is_file()  # move rolled back
+    assert not (projects["b"] / ".memtomem" / "agents" / "foo").exists()  # zero residue
+
+
+@pytest.mark.anyio
+async def test_gate_a_audit_attributes_mcp_surface(
+    projects, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1283 acceptance: MCP-driven transfers reach the privacy audit log as
+    ``mcp_context_artifact_transfer``, not a CLI/web literal. Spy at the
+    sync-side chokepoint every staging scan funnels through (#1246 pattern)."""
+    from memtomem.privacy import WriteGuardResult
+
+    surfaces: list[str] = []
+
+    def spy(content_text, *, surface, **kw):
+        surfaces.append(surface)
+        return WriteGuardResult("pass", [])
+
+    monkeypatch.setattr("memtomem.context.privacy_scan.privacy.enforce_write_guard", spy)
+
+    _seed_agent(projects, "user")
+    out = await mem_context_artifact_transfer(
+        asset_type="agents",
+        name="foo",
+        mode="copy",
+        to_scope="project_shared",
+        apply=True,
+        confirm_project_shared=True,
+    )
+    assert "✓ copied agents/foo" in out
+    assert surfaces, "Gate A never ran"
+    assert set(surfaces) == {"mcp_context_artifact_transfer"}
+
+
+# ── engine kwargs pass-through (monkeypatch pin) ─────────────────────────
+
+
+@pytest.mark.anyio
+async def test_engine_kwargs_pass_through(projects, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Campaign lesson: monkeypatched-engine tests must pin pass-through
+    kwargs, or a dropped ``surface=``/``lock_timeout=`` ships silently."""
+    from memtomem.context.transfer import TransferResult
+
+    captured: dict = {}
+
+    def fake_transfer(kind, name, **kwargs):
+        captured.update(kwargs, kind=kind, name=name)
+        return TransferResult(
+            kind=kind,
+            name=name,
+            dst_name=kwargs["new_name"] or name,
+            mode=kwargs["mode"],
+            from_scope="project_shared",
+            to_scope=kwargs["to_scope"],
+            src_project_root=kwargs["src_project_root"],
+            dst_project_root=kwargs["dst_project_root"],
+            src_path=Path("/x/src"),
+            dst_path=Path("/x/dst"),
+            layout="dir",
+            transferred=False,
+        )
+
+    monkeypatch.setattr("memtomem.context.transfer.transfer_artifact", fake_transfer)
+    out = await mem_context_artifact_transfer(
+        asset_type="agents",
+        name="foo",
+        mode="copy",
+        to_scope="project_local",
+        as_name="bar",
+    )
+    assert out.startswith("Plan: copy agents/foo as bar")
+    assert captured["surface"] == "mcp_context_artifact_transfer"
+    assert captured["lock_timeout"] == 30.0
+    assert captured["mode"] == "copy"
+    assert captured["new_name"] == "bar"
+    assert captured["apply_"] is False
+
+
+@pytest.mark.anyio
+async def test_mcp_copy_adapter_kwargs_pass_through(
+    projects, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from memtomem.context.mcp_servers_copy import McpServerCopyResult
+
+    captured: dict = {}
+
+    def fake_copy(name, **kwargs):
+        captured.update(kwargs, name=name)
+        return McpServerCopyResult(
+            kind="mcp-servers",
+            name=name,
+            dst_name=name,
+            mode="copy",
+            from_scope="project_shared",
+            to_scope="project_shared",
+            src_project_root=kwargs["src_project_root"],
+            dst_project_root=kwargs["dst_project_root"],
+            src_path=Path("/x/src.json"),
+            dst_path=Path("/x/dst.json"),
+            layout="flat",
+            transferred=False,
+        )
+
+    monkeypatch.setattr("memtomem.context.mcp_servers_copy.copy_mcp_server", fake_copy)
+    sid = _register_b(projects)
+    out = await mem_context_artifact_transfer(
+        asset_type="mcp-servers", name="pg", mode="copy", to_project_scope_id=sid
+    )
+    assert out.startswith("Plan: copy mcp-servers/pg")
+    assert captured["surface"] == "mcp_context_artifact_transfer"
+    assert captured["lock_timeout"] == 30.0
+    assert captured["apply_"] is False
+
+
+# ── mcp-servers branch (A-12 adapter) ────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_mcp_copy_round_trip(projects) -> None:
+    src = _seed_mcp_server(projects)
+    sid = _register_b(projects)
+    out = await mem_context_artifact_transfer(
+        asset_type="mcp-servers",
+        name="pg",
+        mode="copy",
+        to_project_scope_id=sid,
+        apply=True,
+        confirm_project_shared=True,
+    )
+    assert "✓ copied mcp-servers/pg: project_shared → project_shared" in out
+    dst = projects["b"] / ".memtomem" / "mcp-servers" / "pg.json"
+    assert dst.read_bytes() == src.read_bytes()
+    # Prose follow-up (web-only fan-out), not a runnable sync command — and
+    # no layout noise for the single-layout kind.
+    assert "Next: fan out at the destination from its web panel" in out
+    assert "(flat layout)" not in out
+
+
+@pytest.mark.anyio
+async def test_mcp_dry_run_names_required_flags(projects) -> None:
+    _seed_mcp_server(projects)
+    sid = _register_b(projects)
+    out = await mem_context_artifact_transfer(
+        asset_type="mcp-servers", name="pg", mode="copy", to_project_scope_id=sid
+    )
+    assert out.startswith("Plan: copy mcp-servers/pg")
+    assert "Re-call with apply=True and confirm_project_shared=True to execute." in out
+    assert "After apply, fan out at the destination from its web panel" in out
+    assert not (projects["b"] / ".memtomem" / "mcp-servers").exists()
+
+
+@pytest.mark.anyio
+async def test_mcp_gate_b_still_applies(projects) -> None:
+    _seed_mcp_server(projects)
+    sid = _register_b(projects)
+    out = await mem_context_artifact_transfer(
+        asset_type="mcp-servers", name="pg", mode="copy", to_project_scope_id=sid, apply=True
+    )
+    assert out.startswith("needs confirmation:")
+    assert not (projects["b"] / ".memtomem" / "mcp-servers").exists()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("kwargs", "needle"),
+    [
+        ({"mode": "move"}, "mcp-servers support copy only"),
+        ({"mode": "copy", "as_name": "pg2"}, "as_name is not supported for mcp-servers"),
+        (
+            {"mode": "copy", "to_scope": "project_local"},
+            "not valid for mcp-servers",
+        ),
+        (
+            {"mode": "copy", "from_scope": "user"},
+            "not valid for mcp-servers",
+        ),
+    ],
+)
+async def test_mcp_branch_gates(projects, kwargs, needle) -> None:
+    _seed_mcp_server(projects)
+    sid = _register_b(projects)
+    out = await mem_context_artifact_transfer(
+        asset_type="mcp-servers", name="pg", to_project_scope_id=sid, **kwargs
+    )
+    assert out.startswith("error:")
+    assert needle in out
+
+
+@pytest.mark.anyio
+async def test_mcp_requires_to_project(projects) -> None:
+    _seed_mcp_server(projects)
+    out = await mem_context_artifact_transfer(asset_type="mcp-servers", name="pg", mode="copy")
+    assert out.startswith("error:")
+    assert "cross-project only" in out
+
+
+@pytest.mark.anyio
+async def test_mcp_same_project_destination_rejected(projects) -> None:
+    _seed_mcp_server(projects)
+    KnownProjectsStore(projects["kp"]).add(projects["a"])
+    out = await mem_context_artifact_transfer(
+        asset_type="mcp-servers",
+        name="pg",
+        mode="copy",
+        to_project_scope_id=compute_scope_id(projects["a"]),
+    )
+    assert out.startswith("error:")
+    assert "resolves to the source project" in out


### PR DESCRIPTION
## Summary

A-13 (#1283), the last mechanism-track item of the context-gateway completion campaign (#1270): headless MCP agents can now reach the same transfer mechanism as the CLI verbs (`mm context copy|move`, #1299) and the web route (#1301) — one new `@register("context")` action, `mem_context_artifact_transfer`, routed via `mem_do`. The core-9 default tool set stays frozen.

- **Both engines exposed**: `transfer_artifact` for `agents`/`commands`/`skills`, and the A-12 `copy_mcp_server` adapter for `asset_type="mcp-servers"` with the sibling branch gates mirrored verbatim (copy-only, no rename, tiers pinned `project_shared`, cross-project only).
- **Web-shaped trust boundary** (ADR-0023 §13): destinations resolve against the registered discovery set by `scope_id` only — the typed-path consent valve stays CLI-only — and eligibility takes the web's stricter `sync_eligible` line: paused **and** never-enrolled destinations refuse, each naming its remediation command.
- **Tier-keyed confirmation gates**, apply-only: `confirm_project_shared=True` (Gate B) and `allow_host_writes=True` for user-tier landings. The host-write gate is a Codex design-gate fold: the MCP settings surfaces already use `allow_host_writes` for host writes, and transfer adds copy semantics `migrate` lacks, so the initial "equivalent ungated migrate path" rationale was incomplete. Dry-run never gates; its footer names the flag(s) apply will need.
- **Gate A audit attribution**: `surface="mcp_context_artifact_transfer"` for both branches (#1283 acceptance), pinned by a chokepoint-spy test.
- **Bounded lock wait**: the engine runs with the web route's 30s `lock_timeout` — an MCP agent cannot Ctrl-C a stuck cross-process pair-lock wait, so the engine self-aborts (committing nothing on the lock-wait path) instead of hanging the tool call.
- `mem_context_artifact_migrate` stays untouched (within-project flat→dir + tier moves).

## Docs

`reference.md` gains the move/copy/migrate decision matrix, a cross-project walkthrough, and the `mem_do` call shapes; `mcp-clients.md` Context row and tool-mode notes updated; tool counts bumped 86→87 (`standard` stays 38 — `context` is not a standard pack). ADR-0023 grows the §13 rider. **Every documented command was executed against an isolated two-project checkout before merge** (docs-as-tests); outputs matched the documented spellings exactly.

## Tests

42 new tests (`test_server_tools_context_artifact_transfer.py`): registry classification (+category, core-9 frozen), the full validation-gate matrix, dry-run-never-mutates, both confirmation gates (blocked→allowed pairs), cross-project round-trips, paused/discovery-only/no-store/collision refusals, Gate A block + audit-surface attribution, engine kwargs pass-through pins for both engines, and the mcp-servers branch gates. The surface/lock_timeout/host-gate pins were **mutation-validated** (production mutated once → 4 targeted failures → restored). Related scope green: 249 passed (MCP migrate/scope suites, meta-tool registry, CLI+engine+web transfer suites, mcp-servers copy, atomic-write AST guard).

## Review

Codex design gate: NEEDS-FIX on the host-write gate → folded (see above); all other decisions SHIP. Codex implementation review on the commit: **SHIP, zero findings**; it independently verified the 87/38 tool counts and ran the sibling transfer suites (92 passed).

## Known follow-up (disclosed, not fixed here)

The **web** transfer route does not append the `project_local` `.gitignore` marker at the destination project; the CLI and this MCP action do. Named as a gap in ADR-0023 §13 — candidate for a B-track follow-up.

Part of #1270. Closes #1283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
