### PR TITLE
feat(web): AbortController on context gateway scope/tier/section switches (#1286)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -244,6 +244,33 @@ async function _ctxErrorMessageFromResponse(resp, fallback) {
 // ``_ctxOverviewCache`` and the ``langchange`` listener below.
 let _ctxOverviewSeq = 0;
 
+// Per-surface AbortControllers (#1286). The seq guards already stop a superseded
+// response from PAINTING; these additionally abort the wasted in-flight request
+// the moment a scope/tier/section switch supersedes it, so the winning request
+// isn't queued behind stale ones on the browser's per-origin connection pool and
+// can't keep racing the cache-commit path. Seq guards stay as defense in depth —
+// abort is best-effort (a runtime without ``AbortController`` degrades to
+// seq-only). ``loadCtxList`` / ``loadCtxDetail`` key theirs by type (declared
+// next to ``_ctxListSeq`` / ``_ctxDetailSeq``); overview is a singleton and the
+// Projects portal owns its own (``_ctxProjectsAbort`` in context-portal.js).
+let _ctxOverviewAbort = null;
+
+// Abort the superseded request held in ``prev`` (no-op if absent / already
+// settled) and mint a fresh controller for the new invocation. Returns the new
+// controller, or null where ``AbortController`` is unavailable so callers fall
+// back to seq-only guarding. Pair with the surface's ``++seq`` at loader entry.
+function _ctxSwapAbort(prev) {
+  try { prev?.abort(); } catch { /* already aborted / unsupported — seq guards */ }
+  return typeof AbortController === 'function' ? new AbortController() : null;
+}
+
+// True for a fetch rejected by an ``AbortController`` (#1286). A superseded
+// request is never a real failure, so its caller must skip the error render /
+// toast / active-scope demotion and let the winning request own the surface.
+function _ctxIsAbortError(err) {
+  return !!err && (err.name === 'AbortError' || err.code === 20);
+}
+
 // Cache the last successful ``/api/context/overview`` payload so a
 // ``langchange`` toggle can re-render the inline ``t()`` card text from
 // the existing data — no fetch, no ``panelLoading`` spinner flash. The
@@ -385,6 +412,28 @@ function _ctxNormalizeActiveScope(scopes) {
   return active;
 }
 
+// The synthetic single-project fallback returned when ``/api/context/projects``
+// is unavailable (older deploy / browser test) or the fetch was aborted (#1286).
+// A safe default that never reports ``stale`` — so a fetch outage can't desync
+// the rendered shape from a real response or fire a spurious "Initialize"
+// prompt — and matches the API scope shape (``stale`` + the full four-key counts
+// dict, ADR-0021 PR2).
+function _ctxServerCwdFallback() {
+  return {
+    scopes: [{
+      scope_id: '',
+      label: t('settings.ctx.server_cwd'),
+      root: '',
+      tier: 'project',
+      sources: ['server-cwd'],
+      missing: false,
+      stale: false,
+      experimental: false,
+      counts: { skills: 0, commands: 0, agents: 0, 'mcp-servers': 0 },
+    }],
+  };
+}
+
 // Fetch ``/api/context/projects`` and classify the outcome, WITHOUT mutating
 // any module global. Returns ``{ data, warn, authoritative }``:
 //   - ``data``  always a ``{scopes: [...]}`` object — the real scopes on
@@ -440,8 +489,16 @@ async function _ctxFetchProjectsData(opts = {}) {
     // Matrix); leaving the gate means re-adding a coverage consumer is a
     // one-flag change. ``_ctxWithTargetScope`` appends ``&target_scope=``.
     const include = opts.includeCoverage ? 'counts,runtime_coverage' : 'counts';
-    const res = await fetch(_ctxWithTargetScope(`/api/context/projects?include=${include}`, { includeScope: false, targetScope: opts.targetScope }));
+    const res = await fetch(_ctxWithTargetScope(`/api/context/projects?include=${include}`, { includeScope: false, targetScope: opts.targetScope }), { signal: opts.signal });
     sawResponse = true;
+    // Superseded after the request was issued but before its body was read
+    // (#1286): skip the parse + classification entirely and return the benign
+    // class. A real browser rejects ``fetch`` on abort (handled in the catch);
+    // this covers the narrow window where the response resolves first, keeping a
+    // superseded fetch from racing the cache-commit path.
+    if (opts.signal?.aborted) {
+      return { data: _ctxServerCwdFallback(), warn: null, authoritative: false, aborted: true };
+    }
     if (!res.ok) {
       const detail = _ctxErrDetail((await res.json().catch(() => ({}))).detail, `HTTP ${res.status}`);
       if (res.status !== 404) warn = { kind: 'http', status: res.status, detail };
@@ -466,29 +523,24 @@ async function _ctxFetchProjectsData(opts = {}) {
       throw new Error(warn.detail);
     }
   } catch (_err) {
+    // An aborted fetch (superseded scope/tier/section switch — #1286) is NOT a
+    // real failure: it says nothing about the project roster. Force it into the
+    // benign, non-authoritative class (warn cleared, authoritative=false) so a
+    // late abort during the body read can't be misclassified by the parse/shape
+    // branches above as a loud failure (toast + active-scope demotion) — the
+    // same demote-the-persisted-selection hazard #1247 id 20 closed for network
+    // throws. The caller's seq guard discards this anyway; this also protects
+    // the unguarded legacy/portal commit paths.
+    if (_ctxIsAbortError(_err) || opts.signal?.aborted) {
+      return { data: _ctxServerCwdFallback(), warn: null, authoritative: false, aborted: true };
+    }
     // Browser tests and older deployments may not provide the multi-project
     // discovery endpoint. Preserve the legacy single-project behavior by
     // falling back to an implicit server-CWD scope; downstream requests omit
     // scope_id for server-CWD because it is the route default.
-    data = {
-      scopes: [{
-        scope_id: '',
-        label: t('settings.ctx.server_cwd'),
-        root: '',
-        tier: 'project',
-        sources: ['server-cwd'],
-        missing: false,
-        // Match the API scope shape: ``stale`` (ADR-0021 PR2) and the full
-        // four-key counts dict. The synthetic fallback is a safe default
-        // (never stale → no spurious "Initialize" prompt) so a fetch outage
-        // can't desync the rendered shape from a real response.
-        stale: false,
-        experimental: false,
-        counts: { skills: 0, commands: 0, agents: 0, 'mcp-servers': 0 },
-      }],
-    };
+    data = _ctxServerCwdFallback();
   }
-  return { data, warn, authoritative: sawResponse };
+  return { data, warn, authoritative: sawResponse, aborted: false };
 }
 
 // Commit a ``_ctxFetchProjectsData`` result into the shared module state. Split
@@ -497,7 +549,12 @@ async function _ctxFetchProjectsData(opts = {}) {
 // newer one's cache / active scope / toast memo. Carries the #1102
 // normalize-only-when-authoritative gate and the #1101 failure-toast de-dup.
 // Returns ``data`` for callers that render from it.
-function _ctxCommitProjects({ data, warn, authoritative }) {
+function _ctxCommitProjects({ data, warn, authoritative, aborted }) {
+  // A superseded/aborted projects fetch (#1286) carries no roster information,
+  // so it must not touch the shared cache, the active-scope normalization, or
+  // the failure-toast memo. Guarded callers already skip commit via their seq
+  // guard; this also hardens the unguarded legacy/portal commit paths.
+  if (aborted) return data;
   _ctxProjectsCache = data.scopes || [];
   // Normalize only when the outcome is *authoritative* about the roster.
   // Four cases:
@@ -675,6 +732,11 @@ function _ctxBumpActiveScopeDetailSeq() {
   for (const scopeType of Object.keys(_ctxDetailSeq)) {
     if (typeof _ctxDetailSeq[scopeType] === 'number') {
       _ctxDetailSeq[scopeType] += 1;
+      // Abort any in-flight detail fetch for the now-stale scope (#1286): it
+      // would otherwise resolve and paint into a pane the scope switch
+      // invalidated. The next mount mints a fresh controller via
+      // ``_ctxSwapAbort``; leaving the aborted one in place is harmless.
+      try { _ctxDetailAbort[scopeType]?.abort(); } catch { /* no-op */ }
     }
   }
 }
@@ -1608,6 +1670,11 @@ function _renderCtxOverview(data) {
 
 async function loadCtxOverview() {
   const seq = ++_ctxOverviewSeq;
+  // Abort the superseded overview load's in-flight fetches (#1286); the signal
+  // threads through BOTH the projects sub-fetch and the overview fetch so a
+  // scope/tier/section switch cancels the whole load, not just its render.
+  _ctxOverviewAbort = _ctxSwapAbort(_ctxOverviewAbort);
+  const signal = _ctxOverviewAbort?.signal;
   // Pin the tier once at entry. The projects fetch and the overview fetch must
   // run under the SAME tier — otherwise a tier flip between them would commit a
   // project list computed for one tier and then render overview counts for
@@ -1625,8 +1692,9 @@ async function loadCtxOverview() {
     // aggregate dashboard, so it skips the expensive ``probe_all_runtimes`` pass.
     const projectsResult = await _ctxFetchProjectsData({
       targetScope: requestedTier,
+      signal,
     });
-    if (seq !== _ctxOverviewSeq || requestedTier !== _ctxTargetScope) return;
+    if (seq !== _ctxOverviewSeq || requestedTier !== _ctxTargetScope) return false;
     _ctxCommitProjects(projectsResult);
     // Pin the resolved effective scope alongside the tier so the overview
     // request can't re-resolve against a cache a later refresh might mutate
@@ -1636,20 +1704,28 @@ async function loadCtxOverview() {
       targetScope: requestedTier,
       scopeId: pinnedScopeId,
       scopeResolved: true,
-    }));
+    }), { signal });
     if (!res.ok) throw new Error(_ctxErrDetail((await res.json().catch(() => ({}))).detail, t('settings.ctx.load_overview_failed')));
     const data = await res.json();
-    if (seq !== _ctxOverviewSeq || requestedTier !== _ctxTargetScope) return;
+    if (seq !== _ctxOverviewSeq || requestedTier !== _ctxTargetScope) return false;
     // Shape guard (sibling of the #1100 projects-fetch hardening): a bare-null
     // or non-object 200 would TypeError inside _renderCtxOverview; route it
     // through the failure path instead.
     if (data === null || typeof data !== 'object') throw new Error(t('settings.ctx.load_overview_failed'));
     _ctxOverviewCache = data;
     _renderCtxOverview(data);
+    return true;
   } catch (err) {
-    if (seq !== _ctxOverviewSeq || requestedTier !== _ctxTargetScope) return;
+    // An aborted fetch means a newer load superseded this one (#1286) — its
+    // seq guard already owns the panel; never paint an error over it. Return
+    // false so a caller (the Refresh button) doesn't report a success it didn't
+    // actually complete (Codex: aborted refresh must not toast "Refresh complete").
+    if (_ctxIsAbortError(err) || seq !== _ctxOverviewSeq || requestedTier !== _ctxTargetScope) return false;
     _ctxOverviewCache = null;
     el.innerHTML = emptyState('', t('settings.ctx.load_overview_failed'), err.message);
+    // This invocation owned the (error) render — it ran to completion as the
+    // latest, so it is NOT a supersede; the refresh affordance may settle.
+    return true;
   }
 }
 
@@ -2621,8 +2697,11 @@ document.getElementById('ctx-refresh-btn')?.addEventListener('click', async () =
   const btn = document.getElementById('ctx-refresh-btn');
   btnLoading(btn, true);
   try {
-    await loadCtxOverview();
-    showToast(t('toast.refresh_complete'));
+    // Only toast on a load that actually completed: a concurrent scope/tier
+    // switch (or a second refresh) aborts this one, which now returns false
+    // (#1286) — toasting "Refresh complete" then would be a lie while the
+    // winning request is still in flight (Codex review).
+    if (await loadCtxOverview()) showToast(t('toast.refresh_complete'));
   } finally { btnLoading(btn, false); }
 });
 
@@ -2639,6 +2718,9 @@ document.getElementById('ctx-refresh-btn')?.addEventListener('click', async () =
 // runtime-only banner) so its async writes are gated by the parent
 // ``loadCtxList`` invocation that originated them.
 let _ctxListSeq = { skills: 0, commands: 0, agents: 0, 'mcp-servers': 0 };
+// Per-type AbortControllers paired with ``_ctxListSeq`` (#1286): a re-issued
+// ``loadCtxList`` aborts the prior invocation's projects + scope-group fetches.
+let _ctxListAbort = { skills: null, commands: null, agents: null, 'mcp-servers': null };
 
 // rank 2c: artifact sections (Skills/Commands/Agents/MCP) scope to the
 // active project by default — the same ~30-project roster the Projects
@@ -2657,6 +2739,11 @@ let _ctxListShowAllScopes = false;
 // and the Edit-mode buffer-restore race (where an older fetch would
 // otherwise overwrite a textarea that the listener just rehydrated).
 let _ctxDetailSeq = { skills: 0, commands: 0, agents: 0, 'mcp-servers': 0 };
+// Per-type AbortControllers paired with ``_ctxDetailSeq`` (#1286), shared by
+// ``loadCtxDetail`` and ``_ctxLoadRuntimeOnlyDetail`` (both paint the same
+// ``detailEl``). Aborted on a superseding mount AND on a scope switch / list
+// wipe (see ``_ctxBumpActiveScopeDetailSeq`` and ``loadCtxList``).
+let _ctxDetailAbort = { skills: null, commands: null, agents: null, 'mcp-servers': null };
 
 // Module-level pending Edit-mode buffer that needs to be restored
 // after the next detail mount. Set when a langchange fires while the
@@ -3004,7 +3091,7 @@ function _ctxRenderItemsHtml(items, type, projectRoot, scannedDirs, { clickable 
   return html;
 }
 
-async function _loadScopeGroupItems(type, scope, container, seq) {
+async function _loadScopeGroupItems(type, scope, container, seq, signal) {
   panelLoading(container);
   try {
     const params = new URLSearchParams();
@@ -3018,7 +3105,7 @@ async function _loadScopeGroupItems(type, scope, container, seq) {
     // would ignore it, but gating keeps the wire honest about what's versionable.
     if (type === 'agents' || type === 'commands') params.set('include', 'versions');
     const query = params.toString();
-    const res = await fetch(`/api/context/${type}${query ? `?${query}` : ''}`);
+    const res = await fetch(`/api/context/${type}${query ? `?${query}` : ''}`, { signal });
     if (!res.ok) throw new Error(_ctxErrDetail((await res.json().catch(() => ({}))).detail, `Failed to load ${type}`));
     const data = await res.json();
     // Bail if a newer ``loadCtxList`` invocation has superseded this one
@@ -3094,8 +3181,9 @@ async function _loadScopeGroupItems(type, scope, container, seq) {
   } catch (err) {
     // Late-failing fetch from a previous invocation must not paint
     // ``emptyState`` over the fresh container the newer ``loadCtxList``
-    // rebuilt — same false-overwrite class as the success path above.
-    if (seq !== _ctxListSeq[type]) return;
+    // rebuilt — same false-overwrite class as the success path above. An abort
+    // is that same supersede (#1286), so bail before re-arming / painting.
+    if (_ctxIsAbortError(err) || seq !== _ctxListSeq[type]) return;
     // Re-arm the lazy-load flag (set optimistically by ``fetchOnce`` BEFORE
     // the fetch, to de-dup rapid toggles): without this, a failed group load
     // is permanent for the session — re-toggling the <details> routes through
@@ -3296,6 +3384,10 @@ function _ctxScopesLoadError(listEl, message, detail, retry) {
 
 async function loadCtxList(type) {
   const seq = ++_ctxListSeq[type];
+  // Abort the superseded list load's in-flight fetches (#1286) — the signal
+  // threads through the projects sub-fetch and every scope-group fetch below.
+  _ctxListAbort[type] = _ctxSwapAbort(_ctxListAbort[type]);
+  const signal = _ctxListAbort[type]?.signal;
   const listEl = qs(`ctx-${type}-list`);
   const detailEl = qs(`ctx-${type}-detail`);
   const statusEl = qs(`ctx-${type}-status`);
@@ -3309,6 +3401,10 @@ async function loadCtxList(type) {
   // detail re-mounted (save success, langchange) call ``loadCtxDetail``
   // AFTER this, taking a fresh seq.
   _ctxDetailSeq[type] += 1;
+  // Same reasoning extends to the abort (#1286): the wipe orphans any in-flight
+  // detail fetch for this type, so cancel it rather than let it resolve into the
+  // hidden pane. The next loadCtxDetail mints a fresh controller.
+  try { _ctxDetailAbort[type]?.abort(); } catch { /* no-op */ }
   if (detailEl) { detailEl.hidden = true; detailEl.innerHTML = ''; }
   if (statusEl) statusEl.innerHTML = '';
   panelLoading(listEl);
@@ -3326,7 +3422,7 @@ async function loadCtxList(type) {
     // Fetch then commit ONLY after the sequence guard, so a superseded
     // in-flight projects fetch can't clobber the shared cache / active scope
     // (#1194). The render below already gates on this same guard.
-    const result = await _ctxFetchProjectsData();
+    const result = await _ctxFetchProjectsData({ signal });
     if (seq !== _ctxListSeq[type]) return;
     const data = _ctxCommitProjects(result);
     const scopes = data.scopes || [];
@@ -3440,7 +3536,11 @@ async function loadCtxList(type) {
       const fetchOnce = () => {
         if (itemsEl.dataset.loaded === 'true') return;
         itemsEl.dataset.loaded = 'true';
-        _loadScopeGroupItems(type, scope, itemsEl, seq);
+        // ``signal`` is this load's controller (#1286): a group expanded after a
+        // supersede fires with an already-aborted signal, so its fetch rejects
+        // immediately instead of racing the fresh list (the seq guard inside
+        // catches it either way).
+        _loadScopeGroupItems(type, scope, itemsEl, seq, signal);
       };
       if (groupEl.open) fetchOnce();
       groupEl.addEventListener('toggle', () => { if (groupEl.open) fetchOnce(); });
@@ -3490,7 +3590,9 @@ async function loadCtxList(type) {
       }
     }
   } catch (err) {
-    if (seq !== _ctxListSeq[type]) return;
+    // Aborted = superseded by a newer list load (#1286); its seq guard owns the
+    // panel, so don't paint a load-error + Retry over it.
+    if (_ctxIsAbortError(err) || seq !== _ctxListSeq[type]) return;
     _ctxScopesLoadError(
       listEl, t('settings.ctx.load_failed', { type: _ctxTypeName(type) }), err.message,
       () => loadCtxList(type),
@@ -4637,6 +4739,11 @@ async function loadCtxDetail(type, name, opts = {}) {
     _ctxPendingEdit = null;
   }
   const seq = ++_ctxDetailSeq[type];
+  // Abort a superseding detail mount's in-flight fetch (#1286) — shares the
+  // per-type controller with ``_ctxLoadRuntimeOnlyDetail`` since both paint the
+  // same ``detailEl``.
+  _ctxDetailAbort[type] = _ctxSwapAbort(_ctxDetailAbort[type]);
+  const signal = _ctxDetailAbort[type]?.signal;
   const autoOpenDiff = opts.autoOpenDiff === true;
   const detailEl = qs(`ctx-${type}-detail`);
   detailEl.hidden = false;
@@ -4646,6 +4753,7 @@ async function loadCtxDetail(type, name, opts = {}) {
   try {
     const res = await fetch(
       _ctxWithTargetScope(`/api/context/${type}/${encodeURIComponent(name)}`),
+      { signal },
     );
     if (res.status === 404) {
       if (seq !== _ctxDetailSeq[type]) return;
@@ -5038,7 +5146,9 @@ async function loadCtxDetail(type, name, opts = {}) {
     }
 
   } catch (err) {
-    if (seq !== _ctxDetailSeq[type]) return;
+    // Aborted = a newer detail mount / scope switch superseded us (#1286); its
+    // seq guard owns the pane, so don't paint a load error over it.
+    if (_ctxIsAbortError(err) || seq !== _ctxDetailSeq[type]) return;
     detailEl.innerHTML = emptyState('', t('settings.ctx.load_detail_failed'), err.message);
   }
 }
@@ -5169,6 +5279,10 @@ async function _ctxLoadRuntimeOnlyDetail(type, name, detailEl, opts = {}) {
     _ctxPendingEdit = null;
   }
   const seq = ++_ctxDetailSeq[type];
+  // Shares the per-type detail controller with ``loadCtxDetail`` (#1286) — a
+  // canonical mount racing a runtime-only mount aborts the loser's fetch.
+  _ctxDetailAbort[type] = _ctxSwapAbort(_ctxDetailAbort[type]);
+  const signal = _ctxDetailAbort[type]?.signal;
   detailEl.hidden = false;
   _ctxCurrentDetail = { type, name, runtimeOnly: true };
   panelLoading(detailEl);
@@ -5176,6 +5290,7 @@ async function _ctxLoadRuntimeOnlyDetail(type, name, detailEl, opts = {}) {
   try {
     const res = await fetch(
       _ctxWithTargetScope(`/api/context/${type}/${encodeURIComponent(name)}/diff`),
+      { signal },
     );
     if (!res.ok) {
       throw new Error(_ctxErrDetail((await res.json().catch(() => ({}))).detail, `Failed to load ${name}`));
@@ -5278,7 +5393,9 @@ async function _ctxLoadRuntimeOnlyDetail(type, name, detailEl, opts = {}) {
     // it now that it's in the DOM (#943).
     _ctxRefreshWriteBlockedState();
   } catch (err) {
-    if (seq !== _ctxDetailSeq[type]) return;
+    // Aborted = a newer mount / scope switch superseded us (#1286); leave the
+    // pane to the winning mount rather than painting an error.
+    if (_ctxIsAbortError(err) || seq !== _ctxDetailSeq[type]) return;
     detailEl.innerHTML = emptyState('', t('settings.ctx.load_detail_failed'), err.message);
   }
 }

--- a/packages/memtomem/src/memtomem/web/static/context-portal.js
+++ b/packages/memtomem/src/memtomem/web/static/context-portal.js
@@ -44,6 +44,11 @@
 // guard) — counts are tier-dependent, so a tier flip during the fetch must not
 // paint stale numbers.
 let _ctxProjectsSeq = 0;
+// AbortController paired with _ctxProjectsSeq (#1286): a re-issued loadCtxProjects
+// aborts the prior invocation's projects fetch + its fan-out of per-scope
+// /runtimes fetches. _ctxSwapAbort / _ctxIsAbortError are defined in
+// context-gateway.js (loaded first) and shared via the global script scope.
+let _ctxProjectsAbort = null;
 // Post-guard snapshot of the scopes this section renders (see header). search /
 // sort / re-render / lookups all read this, never the shared cache.
 let _ctxPortalScopes = [];
@@ -375,9 +380,16 @@ function _ctxPortalIsPaused(scope) {
 
 async function loadCtxProjects() {
   const seq = ++_ctxProjectsSeq;
+  // Abort the superseded portal load's in-flight fetches (#1286): the signal
+  // threads through the projects fetch and the per-scope /runtimes fan-out, so a
+  // rapid re-entry / tier flip cancels the whole load instead of just dropping
+  // its render. _ctxSwapAbort degrades to seq-only where AbortController is
+  // unavailable (the guards below stay as defense in depth).
+  _ctxProjectsAbort = _ctxSwapAbort(_ctxProjectsAbort);
+  const signal = _ctxProjectsAbort?.signal;
   const requestedScope = _ctxTargetScope;
   const listEl = document.getElementById('ctx-projects-list');
-  if (!listEl) return;
+  if (!listEl) return false;
   panelLoading(listEl);
   
   _ctxPortalSyncFilterFromDeepLink();
@@ -388,10 +400,10 @@ async function loadCtxProjects() {
     // ``_ctxProjectsCache`` / active scope (#1194). The board already renders
     // from its own post-guard ``_ctxPortalScopes`` snapshot; this extends the
     // same discipline to the shared cache the helper used to commit pre-guard.
-    const result = await _ctxFetchProjectsData({ targetScope: requestedScope });
+    const result = await _ctxFetchProjectsData({ targetScope: requestedScope, signal });
     // Bail if a newer load started OR the tier flipped under us mid-fetch
     // (#972): counts in this payload were computed for ``requestedScope``.
-    if (seq !== _ctxProjectsSeq || requestedScope !== _ctxTargetScope) return;
+    if (seq !== _ctxProjectsSeq || requestedScope !== _ctxTargetScope) return false;
     const data = _ctxCommitProjects(result);
     const scopes = data.scopes || [];
     // Reset edit state on a fresh load and commit the validated snapshot before
@@ -409,7 +421,7 @@ async function loadCtxProjects() {
       _ctxScopesLoadError(
         listEl, t('settings.ctx.scopes_load_failed'), '', () => loadCtxProjects(),
       );
-      return;
+      return true; // this invocation owned the (load-error) render — not a supersede
     }
 
     // Now fetch runtimes for each scope in parallel to build the per-CLI traffic-lights (row UI)
@@ -419,7 +431,7 @@ async function loadCtxProjects() {
       }
       try {
         const url = _ctxWithTargetScope('/api/context/runtimes', { scopeId: scope.scope_id });
-        const res = await fetch(url);
+        const res = await fetch(url, { signal });
         if (!res.ok) throw new Error();
         const rData = await res.json();
         return { scopeId: scope.scope_id, runtimes: rData.runtimes || [] };
@@ -429,7 +441,7 @@ async function loadCtxProjects() {
     });
 
     const runtimesResults = await Promise.all(runtimePromises);
-    if (seq !== _ctxProjectsSeq || requestedScope !== _ctxTargetScope) return;
+    if (seq !== _ctxProjectsSeq || requestedScope !== _ctxTargetScope) return false;
 
     _ctxPortalRuntimesMap = {};
     for (const result of runtimesResults) {
@@ -439,14 +451,20 @@ async function loadCtxProjects() {
     _ctxPortalRenderHeadingChips();
     _ctxPortalRenderScaffold(listEl);
     _ctxPortalRenderRows();
+    return true;
   } catch (err) {
-    if (seq !== _ctxProjectsSeq) return;
+    // Aborted = a newer portal load superseded us (#1286); its seq guard owns
+    // the list, so don't paint a load-error + Retry over it. Return false so the
+    // Refresh button doesn't toast a success this superseded load never made
+    // (Codex review).
+    if (_ctxIsAbortError(err) || seq !== _ctxProjectsSeq) return false;
     // Route through the shared load-error helper so the failure is announced
     // (``role="alert"``) and retryable, matching the empty-roster path above.
     _ctxScopesLoadError(
       listEl, t('settings.ctx.portal_load_failed'), err.message || '',
       () => loadCtxProjects(),
     );
+    return true; // owned the (error) render — ran to completion as the latest
   }
 }
 
@@ -937,8 +955,11 @@ document.getElementById('ctx-projects-refresh-btn')?.addEventListener('click', a
   const btn = document.getElementById('ctx-projects-refresh-btn');
   btnLoading(btn, true);
   try {
-    await loadCtxProjects();
-    showToast(t('toast.refresh_complete'));
+    // Toast only when the load actually completed: a concurrent tier flip / a
+    // second refresh aborts this one, which now returns false (#1286) — a
+    // "Refresh complete" toast then would be false while the winning request is
+    // still in flight (Codex review).
+    if (await loadCtxProjects()) showToast(t('toast.refresh_complete'));
   } finally {
     btnLoading(btn, false);
   }

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1539,8 +1539,8 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=19"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=78"></script>
-  <script src="/context-portal.js?v=4"></script>
+  <script src="/context-gateway.js?v=80"></script>
+  <script src="/context-portal.js?v=6"></script>
   <script src="/path-picker.js?v=4"></script>
 </body>
 </html>

--- a/packages/memtomem/tests-js/ctx-abort-controller.test.mjs
+++ b/packages/memtomem/tests-js/ctx-abort-controller.test.mjs
@@ -1,0 +1,370 @@
+/* Regression guard for #1286 — per-surface ``AbortController``s on the context
+ * gateway. The ``seq`` guards (covered by ctx-projects-stale-fetch-race +
+ * ctx-project-fetch-failure) already stop a superseded response from PAINTING;
+ * this suite pins the two NEW behaviors the AbortControllers add:
+ *
+ *   1. Benign abort classification (#1286 / #1247 id 20): an ``AbortError`` —
+ *      whether the whole fetch rejects or the body read throws mid-stream — must
+ *      land in the silent, non-authoritative class (no toast, no active-scope
+ *      demotion). It must NOT be misclassified by the parse/shape branches as a
+ *      loud failure. The symmetric cell (a real ``SyntaxError`` stays loud)
+ *      proves the classifier keys on abort-ness, not "the body read threw"
+ *      (feedback_pin_invert_symmetric_assertion).
+ *
+ *   2. One in-flight request per surface: a switch storm (rapid re-entry) must
+ *      abort every superseded in-flight fetch, leaving exactly one live request
+ *      per surface (overview / projects / list / detail). The independence cell
+ *      proves the controllers are per-surface — a detail mount must not abort an
+ *      in-flight list fetch (a regression to one shared controller flips it red).
+ *
+ * The jsdom fetch mock here is signal-aware (rejects with an ``AbortError`` when
+ * its signal fires), unlike the seq-race suites whose signal-agnostic mocks let
+ * the seq guard stay the sole gate. Both are valid: in production ``fetch``
+ * rejects on abort; the seq guard is defense in depth.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+const ACTIVE_KEY = 'memtomem_ctx_active_scope_id';
+
+function scope(id, label, extra = {}) {
+  return {
+    scope_id: id, project_scope_id: id, label, root: id ? `/work/${label}` : '/srv',
+    tier: 'project', sources: id ? ['known-projects'] : ['server-cwd'],
+    missing: false, stale: false, experimental: false,
+    counts: { skills: 1, commands: 0, agents: 0, 'mcp-servers': 0 },
+    ...extra,
+  };
+}
+const CWD = scope('', 'Server CWD');
+const P_KEEP = scope('p-keep', 'Keeper');
+
+function jsonOk(body) {
+  return { ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body) };
+}
+
+// Mirror a real browser fetch abort: a DOMException named 'AbortError'
+// (``.code === 20``). Falls back to a tagged Error where DOMException is absent.
+function abortError() {
+  if (typeof DOMException === 'function') {
+    return new DOMException('The operation was aborted.', 'AbortError');
+  }
+  return Object.assign(new Error('aborted'), { name: 'AbortError', code: 20 });
+}
+
+const flush = () => new Promise((resolve) => { setTimeout(resolve, 0); });
+
+/* ----------------------------------------------------------------------------
+ * 1. Benign abort classification
+ * ------------------------------------------------------------------------- */
+
+function installProjectsFetch(window, responder) {
+  window.fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : input?.url || '';
+    if (url.startsWith('/api/context/projects')) return responder(init);
+    return jsonOk({});
+  };
+}
+
+function mountSelect(window) {
+  const wrap = window.document.createElement('label');
+  wrap.className = 'ctx-project-switcher';
+  wrap.dataset.type = 'overview';
+  const select = window.document.createElement('select');
+  select.className = 'ctx-project-select';
+  for (const s of [CWD, P_KEEP]) {
+    const opt = window.document.createElement('option');
+    opt.value = s.scope_id;
+    opt.textContent = s.label;
+    select.appendChild(opt);
+  }
+  wrap.appendChild(select);
+  window.document.body.appendChild(wrap);
+  window._ctxWireProjectControls();
+  return select;
+}
+
+// Seed the shared cache with [CWD, P_KEEP] and select p-keep as the active
+// project, so a stale/loud commit would visibly demote it to ''. Returns the
+// toast spy array.
+async function seedActiveKeep(window) {
+  const toasts = [];
+  window.showToast = (msg, level) => { toasts.push({ msg, level }); };
+  window.loadCtxOverview = async () => {}; // select-change triggers a reload; stub it
+  installProjectsFetch(window, () => jsonOk({ scopes: [CWD, P_KEEP] }));
+  await window._ctxFetchProjects();
+  const select = mountSelect(window);
+  select.value = 'p-keep';
+  select.dispatchEvent(new window.Event('change', { bubbles: true }));
+  expect(window.localStorage.getItem(ACTIVE_KEY)).toBe('p-keep');
+  return toasts;
+}
+
+describe('_ctxFetchProjectsData — aborted fetch is benign (#1286 / #1247 id 20)', () => {
+  it('an AbortError during the body read is silent + non-authoritative (no demotion)', async () => {
+    const { window } = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+    const toasts = await seedActiveKeep(window);
+
+    // 200 OK, but the body read aborts mid-stream (a supersede during
+    // res.json()). Pre-#1286 the parse try/catch tagged this ``kind: 'parse'``
+    // → loud toast, and ``authoritative`` stayed true (sawResponse) → the
+    // synthetic Server-CWD list normalized over the persisted selection.
+    installProjectsFetch(window, () => ({
+      ok: true, status: 200, json: async () => { throw abortError(); }, text: async () => '',
+    }));
+    const result = await window._ctxFetchProjectsData();
+    expect(result.warn).toBeNull();
+    expect(result.authoritative).toBe(false);
+    expect(result.aborted).toBe(true);
+
+    // Committing it is a no-op: cache, active scope, and toast memo untouched.
+    window._ctxCommitProjects(result);
+    expect(window.localStorage.getItem(ACTIVE_KEY)).toBe('p-keep');
+    expect(window._ctxProjectControls('overview')).toContain('p-keep');
+    expect(toasts).toHaveLength(0);
+  });
+
+  it('an already-aborted signal yields the benign class (fetch rejects, body never read)', async () => {
+    const { window } = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+    const toasts = await seedActiveKeep(window);
+
+    installProjectsFetch(window, (init) => {
+      if (init?.signal?.aborted) return Promise.reject(abortError());
+      return Promise.resolve(jsonOk({ scopes: [CWD] })); // would demote if committed
+    });
+    const ac = new AbortController();
+    ac.abort();
+    const result = await window._ctxFetchProjectsData({ signal: ac.signal });
+    expect(result.warn).toBeNull();
+    expect(result.authoritative).toBe(false);
+    expect(result.aborted).toBe(true);
+
+    window._ctxCommitProjects(result);
+    expect(window.localStorage.getItem(ACTIVE_KEY)).toBe('p-keep');
+    expect(toasts).toHaveLength(0);
+  });
+
+  it('SYMMETRIC: a real SyntaxError during the body read stays LOUD (parse failure)', async () => {
+    // The inverse of cell 1 — proves the classifier keys on the error being an
+    // abort, not merely on res.json() throwing. Reverting _ctxIsAbortError to a
+    // blanket "treat any body-read throw as benign" would flip this red.
+    const { window } = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+    await seedActiveKeep(window);
+    installProjectsFetch(window, () => ({
+      ok: true, status: 200, json: async () => { throw new SyntaxError('Unexpected token <'); }, text: async () => '<html>',
+    }));
+    const result = await window._ctxFetchProjectsData();
+    expect(result.warn).not.toBeNull();
+    expect(result.warn.kind).toBe('parse');
+    expect(result.aborted).toBeFalsy();
+  });
+
+  it('post-fetch short-circuit: a 200 resolving while already aborted is benign WITHOUT a body read', async () => {
+    // The window the catch cannot cover: the body buffered fully before the
+    // abort landed, so res.json() would SUCCEED — only the post-fetch
+    // signal.aborted check keeps the stale roster from committing as
+    // authoritative (the #1247 id 20 demotion hazard on the unguarded
+    // legacy/portal commit paths). Removing that check lets json() run and the
+    // [CWD]-only roster normalize over p-keep.
+    const { window } = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+    const toasts = await seedActiveKeep(window);
+    let jsonCalls = 0;
+    window.fetch = async (input) => {
+      const url = typeof input === 'string' ? input : input?.url || '';
+      if (url.startsWith('/api/context/projects')) {
+        // Resolves a 200 regardless of the (already-aborted) signal.
+        return { ok: true, status: 200, json: async () => { jsonCalls += 1; return { scopes: [CWD] }; }, text: async () => '' };
+      }
+      return jsonOk({});
+    };
+    const ac = new AbortController();
+    ac.abort();
+    const result = await window._ctxFetchProjectsData({ signal: ac.signal });
+    expect(result.aborted).toBe(true);
+    expect(result.warn).toBeNull();
+    expect(result.authoritative).toBe(false);
+    expect(jsonCalls).toBe(0); // short-circuited before the body read
+
+    window._ctxCommitProjects(result);
+    expect(window.localStorage.getItem(ACTIVE_KEY)).toBe('p-keep');
+    expect(toasts).toHaveLength(0);
+  });
+});
+
+/* ----------------------------------------------------------------------------
+ * 2. One in-flight request per surface (switch storm)
+ * ------------------------------------------------------------------------- */
+
+// Records every fetch whose URL matches ``park`` and returns a never-settling
+// promise that rejects with an AbortError when its signal fires — so a storm of
+// loader re-entries leaves exactly one un-aborted (live) request behind.
+function installStormFetch(window, park) {
+  const calls = [];
+  window.fetch = (input, init) => {
+    const url = typeof input === 'string' ? input : input?.url || '';
+    const signal = init?.signal;
+    if (park(url)) {
+      calls.push({ url, signal });
+      return new Promise((resolve, reject) => {
+        if (signal) {
+          if (signal.aborted) { reject(abortError()); return; }
+          signal.addEventListener('abort', () => reject(abortError()), { once: true });
+        }
+        // else: never settles (stays "in flight")
+      });
+    }
+    return Promise.resolve(jsonOk({})); // unrelated init paths resolve immediately
+  };
+  return calls;
+}
+
+function liveProfile(calls, prefix) {
+  const surface = calls.filter(c => c.url.split('?')[0].startsWith(prefix));
+  return {
+    total: surface.length,
+    live: surface.filter(c => c.signal && !c.signal.aborted).length,
+    // The live one must be the LAST request issued (FIFO supersede), not an
+    // arbitrary survivor — guards against a mutation that aborts the wrong
+    // controller (e.g. the fresh one instead of ``prev``).
+    lastIsLive: surface.length > 0 && !!surface[surface.length - 1].signal && !surface[surface.length - 1].signal.aborted,
+  };
+}
+
+describe('context gateway — switch storm leaves one in-flight request per surface (#1286)', () => {
+  it('overview: 4 rapid loads → 3 aborted, 1 live projects fetch', async () => {
+    const { window } = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+    const calls = installStormFetch(window, (u) => u.startsWith('/api/context/projects'));
+    for (let i = 0; i < 4; i++) window.loadCtxOverview();
+    await flush();
+    expect(liveProfile(calls, '/api/context/projects')).toEqual({ total: 4, live: 1, lastIsLive: true });
+  });
+
+  it('list: 4 rapid loads → 3 aborted, 1 live projects fetch', async () => {
+    const { window } = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+    const calls = installStormFetch(window, (u) => u.startsWith('/api/context/projects'));
+    for (let i = 0; i < 4; i++) window.loadCtxList('skills');
+    await flush();
+    expect(liveProfile(calls, '/api/context/projects')).toEqual({ total: 4, live: 1, lastIsLive: true });
+  });
+
+  it('detail: 4 rapid mounts → 3 aborted, 1 live detail fetch', async () => {
+    const { window } = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+    const calls = installStormFetch(window, (u) => u.split('?')[0] === '/api/context/skills/foo');
+    for (let i = 0; i < 4; i++) window.loadCtxDetail('skills', 'foo');
+    await flush();
+    expect(liveProfile(calls, '/api/context/skills/foo')).toEqual({ total: 4, live: 1, lastIsLive: true });
+  });
+
+  it('projects portal: 4 rapid loads → 3 aborted, 1 live projects fetch', async () => {
+    const { window } = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js', 'context-portal.js'] });
+    const calls = installStormFetch(window, (u) => u.startsWith('/api/context/projects'));
+    for (let i = 0; i < 4; i++) window.loadCtxProjects();
+    await flush();
+    expect(liveProfile(calls, '/api/context/projects')).toEqual({ total: 4, live: 1, lastIsLive: true });
+  });
+
+  it('INDEPENDENCE: a detail mount does NOT abort an in-flight list fetch (per-surface controllers)', async () => {
+    // A regression to a single shared controller would make loadCtxDetail's swap
+    // abort the list's still-in-flight projects fetch → listCall.aborted = true.
+    const { window } = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+    const calls = installStormFetch(
+      window,
+      (u) => u.startsWith('/api/context/projects') || u.split('?')[0] === '/api/context/skills/foo',
+    );
+    window.loadCtxList('skills');        // parks a projects fetch under _ctxListAbort.skills
+    window.loadCtxDetail('skills', 'foo'); // parks a detail fetch under _ctxDetailAbort.skills
+    await flush();
+    const listCall = calls.find(c => c.url.startsWith('/api/context/projects'));
+    const detailCall = calls.find(c => c.url.split('?')[0] === '/api/context/skills/foo');
+    expect(listCall).toBeTruthy();
+    expect(detailCall).toBeTruthy();
+    expect(listCall.signal.aborted).toBe(false);
+    expect(detailCall.signal.aborted).toBe(false);
+  });
+
+  it('REFRESH GATING (overview): a superseded refresh does NOT toast "complete"; a clean one does', async () => {
+    // Codex review: loadCtxOverview() returns early on abort/supersede, but the
+    // Refresh handler used to toast unconditionally — a concurrent scope/tier
+    // switch that aborts the in-flight refresh then lied "Refresh complete"
+    // while the winning request was still running. The handler now gates the
+    // toast on the loader's completion signal.
+
+    // Clean refresh → toast fires (proves the gate isn't stuck-false).
+    {
+      const { window } = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+      const toasts = [];
+      window.showToast = (msg) => { toasts.push(msg); };
+      window.fetch = async (input) => {
+        const url = typeof input === 'string' ? input : input?.url || '';
+        if (url.startsWith('/api/context/projects')) return jsonOk({ scopes: [CWD] });
+        if (url.startsWith('/api/context/overview')) return jsonOk({ total: 0, by_type: {} });
+        return jsonOk({});
+      };
+      window.document.getElementById('ctx-refresh-btn').click();
+      await flush();
+      await flush();
+      expect(toasts.length).toBe(1);
+    }
+
+    // Superseded refresh → no "complete" toast.
+    {
+      const { window } = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+      const toasts = [];
+      window.showToast = (msg) => { toasts.push(msg); };
+      installStormFetch(window, (u) => u.startsWith('/api/context/projects'));
+      window.document.getElementById('ctx-refresh-btn').click(); // invocation A (parked projects fetch)
+      window.loadCtxOverview();                                  // B aborts A
+      await flush();
+      expect(toasts).toHaveLength(0);
+    }
+  });
+
+  it('REFRESH GATING (portal): a superseded refresh does NOT toast "complete"; a clean one does', async () => {
+    // Clean refresh → toast fires.
+    {
+      const { window } = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js', 'context-portal.js'] });
+      const toasts = [];
+      window.showToast = (msg) => { toasts.push(msg); };
+      window.fetch = async (input) => {
+        const url = typeof input === 'string' ? input : input?.url || '';
+        if (url.startsWith('/api/context/projects')) return jsonOk({ scopes: [CWD, P_KEEP] });
+        if (url.startsWith('/api/context/runtimes')) return jsonOk({ runtimes: [] });
+        return jsonOk({});
+      };
+      window.document.getElementById('ctx-projects-refresh-btn').click();
+      await flush();
+      await flush();
+      expect(toasts.length).toBe(1);
+    }
+
+    // Superseded refresh → no toast.
+    {
+      const { window } = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js', 'context-portal.js'] });
+      const toasts = [];
+      window.showToast = (msg) => { toasts.push(msg); };
+      installStormFetch(window, (u) => u.startsWith('/api/context/projects'));
+      window.document.getElementById('ctx-projects-refresh-btn').click(); // A (parked)
+      window.loadCtxProjects();                                           // B aborts A
+      await flush();
+      expect(toasts).toHaveLength(0);
+    }
+  });
+
+  it('SCOPE SWITCH: changing the active scope aborts an in-flight detail fetch', async () => {
+    // Distinct from supersede-by-fresh-mount: changing the active project bumps
+    // every detail seq AND aborts every in-flight detail fetch (the pane's scope
+    // just became invalid). _ctxBumpActiveScopeDetailSeq is the seam the
+    // project-select handler and _ctxNormalizeActiveScope both route through.
+    // Deleting the abort line there survives every other test, so pin it here.
+    const { window } = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+    const calls = installStormFetch(window, (u) => u.split('?')[0] === '/api/context/skills/foo');
+    window.loadCtxDetail('skills', 'foo'); // parks a detail fetch under _ctxDetailAbort.skills
+    await flush();
+    const detailCall = calls.find(c => c.url.split('?')[0] === '/api/context/skills/foo');
+    expect(detailCall).toBeTruthy();
+    expect(detailCall.signal.aborted).toBe(false); // live before the switch
+    window._ctxBumpActiveScopeDetailSeq();          // an active-scope change fires this
+    expect(detailCall.signal.aborted).toBe(true);   // aborted by the scope switch
+  });
+});

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -1267,7 +1267,16 @@ class TestNoHardcodedStrings:
         # Threshold tracks the path count exactly (``>= 3``, not ``>= 2``): with
         # three guards a looser ``>= 2`` would let a future drop of any single
         # guard — including the #1194 commit-gating one — slip through green.
-        guards = re.findall(r"if \(seq !==\s*_ctxOverviewSeq(?:\s*\|\|[^)]*)?\)\s*return;", text)
+        # #1286 added an optional ``_ctxIsAbortError(err) || `` prefix to the
+        # catch-path guard (abort = a benign supersede) and switched the guard
+        # returns to ``return false`` (the refresh-completion signal), so the seq
+        # check is no longer the first operand nor always a bare ``return;``.
+        # Anchor on ``seq !==`` preceded by ``if (`` or ``|| `` and tolerate
+        # ``return false`` — still exactly three distinct guard sites.
+        guards = re.findall(
+            r"(?:if \(|\|\|\s*)seq !==\s*_ctxOverviewSeq(?:\s*\|\|[^)]*)?\)\s*return(?:\s+false)?;",
+            text,
+        )
         assert len(guards) >= 3, (
             f"expected sequence-guard returns in all three fetch-dependent paths "
             f"(intermediate-commit, success, catch), found {len(guards)}"
@@ -1512,7 +1521,10 @@ class TestNoHardcodedStrings:
         # The bail check appears as ``if (seq !== _ctxListSeq[type]) return;``
         # at every stale-write site. We expect ≥ 4 occurrences total
         # (loadCtxList success + catch, _loadScopeGroupItems success + catch).
-        guards = re.findall(r"if \(seq !==\s*_ctxListSeq\[type\]\)\s*return;", text)
+        # #1286 prefixed the two catch-path guards with ``_ctxIsAbortError(err) || ``
+        # (abort = a benign supersede), so the seq check is no longer always the
+        # first operand — match ``seq !==`` preceded by ``if (`` or ``|| ``.
+        guards = re.findall(r"(?:if \(|\|\|\s*)seq !==\s*_ctxListSeq\[type\]\)\s*return;", text)
         assert len(guards) >= 4, (
             f"expected ≥4 _ctxListSeq guards (loadCtxList success+catch + "
             f"_loadScopeGroupItems success+catch); found {len(guards)}"
@@ -1615,7 +1627,12 @@ class TestNoHardcodedStrings:
         # at least 3 guards in loadCtxDetail (404 fast-path + success +
         # catch) and 2 in _ctxLoadRuntimeOnlyDetail (success + catch).
         # Cumulative ≥5 guards across the file.
-        guards = re.findall(r"if \(seq !==\s*_ctxDetailSeq\[type\]\)\s*return;", text)
+        # #1286 prefixed the two catch-path guards with ``_ctxIsAbortError(err) || ``
+        # (abort = a benign supersede), so the seq check is no longer always the
+        # first operand — match ``seq !==`` preceded by ``if (`` or ``|| ``. The
+        # ``seq != null && seq !==`` guards in _ctxLoadVersions stay excluded
+        # (neither prefix matches), as before.
+        guards = re.findall(r"(?:if \(|\|\|\s*)seq !==\s*_ctxDetailSeq\[type\]\)\s*return;", text)
         assert len(guards) >= 5, (
             f"expected ≥5 _ctxDetailSeq guards across loadCtxDetail and "
             f"_ctxLoadRuntimeOnlyDetail (success + catch sites in both, "


### PR DESCRIPTION
## What

Per-surface `AbortController`s on the context gateway, so a scope / tier / section switch **aborts** the superseded in-flight fetch instead of leaving it to race the winning request on the browser's per-origin connection pool and the cache-commit path. Closes #1286 (B-3 of the #1271 web-UX umbrella).

The per-surface `seq` guards already prevented a stale response from *painting*; this layers abort-on-supersede on top, with the seq guards kept as defense in depth.

## Changes

- **Per-surface controllers**, swapped + aborted at each loader's entry (paired with its `++seq`) and threaded into every fetch the surface issues:
  - overview — `_ctxOverviewAbort`
  - list — `_ctxListAbort[type]` (+ scope-group fetches)
  - detail — `_ctxDetailAbort[type]` (shared by `loadCtxDetail` + `_ctxLoadRuntimeOnlyDetail`)
  - projects portal — `_ctxProjectsAbort` (+ per-scope `/runtimes` fan-out)

  A scope switch (`_ctxBumpActiveScopeDetailSeq`) and the `loadCtxList` detail-pane wipe also abort the detail controller. `_ctxSwapAbort` degrades to seq-only where `AbortController` is unavailable.
- **AbortError is benign** in `_ctxFetchProjectsData` (`warn=null, authoritative=false, aborted=true`) so a supersede during the body read isn't misclassified as a parse failure → toast + active-scope demotion (the #1247 id 20 hazard). `_ctxCommitProjects` no-ops on `aborted`, protecting the unguarded legacy/portal commit paths. A real parse / 5xx / network failure stays loud.
- **Refresh-completion gating**: `loadCtxOverview` / `loadCtxProjects` return `false` when superseded/aborted and `true` when they own the render; the two Refresh-button handlers only toast "Refresh complete" on `true` — an aborted refresh no longer reports a success it never finished.

## Scope note

Cross-*section* switches (e.g. overview→skills) don't abort the departed section's last in-flight fetch — each surface still keeps ≤1 in flight, and the lingering one stays seq-guarded (paints a hidden pane harmlessly). Same-surface storms, scope switches, and tier flips are fully covered.

## Tests

`tests-js/ctx-abort-controller.test.mjs` (12 cells, each mutation-validated):
- benign-abort classification — body-read `AbortError`, already-aborted signal, post-fetch short-circuit — plus a **symmetric** cell pinning that a real `SyntaxError` stays loud;
- per-surface switch storm leaves exactly one (FIFO-last) in-flight request;
- per-surface controller **independence** (a detail mount doesn't abort an in-flight list fetch);
- scope-switch detail abort;
- Refresh-button completion gating (superseded refresh emits no toast; a clean one does).

Existing race/failure suites (`ctx-projects-stale-fetch-race`, `ctx-project-fetch-failure`; #1194/#1080/#1100/#1101/#1102) stay green. Full `tests-js`: 230 passing (40 files). Playwright context-gateway + portal suites: green. Cache-bust gateway v80, portal v6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
