### PR TITLE
feat(web): Add Project duplicate-add transparency (created flag + toast branch) (#1292)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -4990,17 +4990,17 @@ def projects_add_cmd(path: Path, label: str | None) -> None:
     cfg = _projects_gateway_cfg()
     store = _projects_store(cfg)
     try:
-        already = any(
-            compute_scope_id(e.root) == compute_scope_id(path) for e in store.load(strict=True)
-        )
-        entry = store.add(path, label=label)
+        # ``add_with_status`` decides created-vs-existing INSIDE the store's write
+        # lock, replacing a racy load-then-add check across two separate lock
+        # windows (the web route shares this same atomic path — #1292).
+        entry, created = store.add_with_status(path, label=label)
     except KnownProjectsCorruptError as exc:
         raise click.ClickException(str(exc)) from exc
     scope_id = compute_scope_id(entry.root)
-    if already:
-        click.echo(f"Already registered: {scope_id} ({entry.root})")
-    else:
+    if created:
         click.secho(f"Registered: {scope_id} ({entry.root})", fg="green")
+    else:
+        click.echo(f"Already registered: {scope_id} ({entry.root})")
 
 
 @projects_group.command("remove")

--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -275,13 +275,34 @@ class KnownProjectsStore:
 
         Raises :class:`KnownProjectsCorruptError` instead of re-baselining
         the list to ``[new_entry]`` when the file exists but is corrupt.
+
+        Thin wrapper over :meth:`add_with_status` for callers that don't need to
+        know whether the entry was freshly created.
+        """
+        entry, _created = self.add_with_status(root, label=label)
+        return entry
+
+    def add_with_status(
+        self, root: Path, label: str | None = None
+    ) -> tuple[_KnownProjectEntry, bool]:
+        """Like :meth:`add`, but also report whether the entry was freshly created.
+
+        Returns ``(entry, created)``: ``created`` is ``False`` when *root* was
+        already registered (the existing entry is returned unchanged) and ``True``
+        when a new entry was appended. The flag is decided INSIDE the same
+        exclusive lock as the write, so it cannot disagree with the persisted state
+        under a concurrent add of the same root — unlike a load-then-add check
+        spread across two separate lock windows.
+
+        Raises :class:`KnownProjectsCorruptError` instead of re-baselining
+        the list to ``[new_entry]`` when the file exists but is corrupt.
         """
         normalized = Path(root).expanduser()
         with _file_lock(_lock_path_for(self._path)):
             entries = self.load(strict=True)
             for existing in entries:
                 if _normalize_for_scope_id(existing.root) == _normalize_for_scope_id(normalized):
-                    return existing
+                    return existing, False
             new_entry = _KnownProjectEntry(
                 root=normalized,
                 added_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -289,7 +310,7 @@ class KnownProjectsStore:
                 enabled=True,
             )
             self._write(entries + [new_entry])
-            return new_entry
+            return new_entry, True
 
     def remove_by_scope_id(self, scope_id: str) -> bool:
         """Drop the entry whose computed scope_id matches. Returns True if removed.

--- a/packages/memtomem/src/memtomem/web/routes/context_projects.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_projects.py
@@ -455,7 +455,7 @@ async def add_known_project(body: AddProjectRequest, request: Request) -> dict:
     # a blank project name.
     label = (body.label or "").strip() or None
     try:
-        entry = store.add(candidate, label=label)
+        entry, created = store.add_with_status(candidate, label=label)
     except KnownProjectsCorruptError as exc:
         # Server-side state file is corrupt — 500, not 4xx: the request was
         # valid, the store refused the write to avoid wiping registrations.
@@ -467,6 +467,11 @@ async def add_known_project(body: AddProjectRequest, request: Request) -> dict:
         "scope_id": project_scope_id,
         "root": str(entry.root),
         "label": entry.label,
+        # ``created`` is False when this root was already registered — the POST is
+        # idempotent and returns the existing entry. The Add Project UI branches
+        # its toast on this so a no-op re-add reads as "already tracked" rather
+        # than a fresh "added" success (#1292).
+        "created": created,
     }
     if not has_runtime_marker(entry.root):
         # ``warning_code`` follows the PR1 (#549) machine-readable pattern so

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -6015,7 +6015,16 @@ document.querySelectorAll('.ctx-add-project-btn').forEach(btn => {
         const warningKey = data.warning_code
           ? `settings.ctx.add_project_warning_${data.warning_code}`
           : null;
-        if (warningKey) {
+        if (data.created === false) {
+          // ``created === false`` means the POST was a no-op: this root was
+          // already tracked (the route is idempotent — #1292). Surface that as
+          // an info toast BEFORE the warning branches — the no_runtime_marker
+          // warning was already shown on the original add, so re-warning on a
+          // no-op re-add is noise; the signal the user needs is "nothing
+          // changed". ``=== false`` (not falsy) so an older server that omits
+          // ``created`` keeps the prior success/warning behavior.
+          showToast(t('settings.ctx.add_project_already_tracked'), 'info');
+        } else if (warningKey) {
           const localized = t(warningKey);
           // ``t()`` returns the key itself when no translation exists; in
           // that case fall back to the server prose rather than showing the

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1539,7 +1539,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=19"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=81"></script>
+  <script src="/context-gateway.js?v=82"></script>
   <script src="/context-portal.js?v=6"></script>
   <script src="/path-picker.js?v=4"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -616,6 +616,7 @@
   "settings.ctx.add_project": "Add Project",
   "settings.ctx.add_project_prompt": "Absolute path to a project root (e.g. /Users/me/Edu/inflearn):",
   "settings.ctx.add_project_success": "Project added",
+  "settings.ctx.add_project_already_tracked": "Project already tracked",
   "settings.ctx.add_project_warning_no_runtime_marker": "No .claude/.gemini/.agents/.kimi/.memtomem directory found under this root.",
   "settings.ctx.portal_title": "Projects",
   "settings.ctx.portal_desc": "Browse, switch, rename, and unregister the projects memtomem tracks. Health shows which roots are missing or not yet initialized.",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -616,6 +616,7 @@
   "settings.ctx.add_project": "프로젝트 추가",
   "settings.ctx.add_project_prompt": "프로젝트 루트 절대 경로 (예: /Users/me/Edu/inflearn):",
   "settings.ctx.add_project_success": "프로젝트가 추가되었습니다",
+  "settings.ctx.add_project_already_tracked": "이미 추적 중인 프로젝트입니다",
   "settings.ctx.add_project_warning_no_runtime_marker": "이 루트 아래에 .claude/.gemini/.agents/.kimi/.memtomem 디렉터리를 찾지 못했습니다.",
   "settings.ctx.portal_title": "프로젝트",
   "settings.ctx.portal_desc": "memtomem이 추적하는 프로젝트를 조회·전환·이름 변경·등록 해제합니다. 상태 표시로 루트가 없거나 아직 초기화되지 않은 프로젝트를 알 수 있습니다.",

--- a/packages/memtomem/tests-js/path-picker-purpose.test.mjs
+++ b/packages/memtomem/tests-js/path-picker-purpose.test.mjs
@@ -198,4 +198,67 @@ describe('Context Gateway Add Project picker', () => {
       'settings.ctx.add_project_warning_future_unknown_code',
     );
   });
+
+  it('shows the success toast on a fresh add (created:true)', async () => {
+    const { window, toast } = await captureOnSelectToast({
+      scripts: ['i18n.js', 'app.js', 'path-picker.js', 'context-gateway.js'],
+      response: {
+        scope_id: 'scope-new',
+        root: '/tmp/project-new',
+        label: 'project-new',
+        created: true,
+      },
+    });
+    expect(toast.textContent).toBe(window.I18N.t('settings.ctx.add_project_success'));
+    // ``captureOnSelectToast`` returns the ``.toast-msg`` span; the type class
+    // lives on its parent ``.toast`` div (``toast toast-<type>``).
+    expect(toast.parentElement.classList.contains('toast-success')).toBe(true);
+  });
+
+  it('shows the "already tracked" info toast on a duplicate add (created:false)', async () => {
+    // #1292: the route is idempotent — re-adding a tracked root returns the
+    // existing entry with ``created: false``. A no-op re-add must read as info,
+    // not a fresh "added" success.
+    const { window, toast } = await captureOnSelectToast({
+      scripts: ['i18n.js', 'app.js', 'path-picker.js', 'context-gateway.js'],
+      response: {
+        scope_id: 'scope-dup',
+        root: '/tmp/project-dup',
+        label: 'project-dup',
+        created: false,
+      },
+    });
+    expect(toast.textContent).toBe(
+      window.I18N.t('settings.ctx.add_project_already_tracked'),
+    );
+    expect(toast.parentElement.classList.contains('toast-info')).toBe(true);
+    expect(toast.textContent).not.toBe(window.I18N.t('settings.ctx.add_project_success'));
+  });
+
+  it('prefers the "already tracked" info toast over the no_runtime_marker warning', async () => {
+    // #1292 precedence pin (Codex design-gate Major): a duplicate add of a
+    // marker-less root carries BOTH ``created: false`` AND ``warning_code``.
+    // The no-op signal wins — the marker warning was already surfaced on the
+    // original add, so re-warning on a no-op re-add would be noise.
+    const { window, toast } = await captureOnSelectToast({
+      scripts: ['i18n.js', 'app.js', 'path-picker.js', 'context-gateway.js'],
+      response: {
+        scope_id: 'scope-dup-nomarker',
+        root: '/tmp/project-dup-nomarker',
+        label: 'project-dup-nomarker',
+        created: false,
+        warning_code: 'no_runtime_marker',
+        warning: 'No .claude/.gemini/.agents/.kimi/.memtomem directory found under this root.',
+      },
+    });
+    expect(toast.textContent).toBe(
+      window.I18N.t('settings.ctx.add_project_already_tracked'),
+    );
+    expect(toast.parentElement.classList.contains('toast-info')).toBe(true);
+    // The warning branch must NOT win.
+    expect(toast.parentElement.classList.contains('toast-warning')).toBe(false);
+    expect(toast.textContent).not.toBe(
+      window.I18N.t('settings.ctx.add_project_warning_no_runtime_marker'),
+    );
+  });
 });

--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -101,6 +101,22 @@ def test_store_add_is_idempotent(tmp_path: Path) -> None:
     assert len(store.load()) == 1
 
 
+def test_store_add_with_status_reports_created(tmp_path: Path) -> None:
+    """``add_with_status`` returns created=True on the first add and False on an
+    idempotent re-add — the signal the Add Project UI / CLI branch their
+    "added" vs "already tracked" feedback on (#1292)."""
+    project = tmp_path / "alpha"
+    project.mkdir()
+    store = KnownProjectsStore(tmp_path / "kp.json")
+    entry, created = store.add_with_status(project)
+    assert created is True
+    again, created_again = store.add_with_status(project)
+    assert created_again is False
+    # The no-op re-add returns the same entry and keeps the store deduped.
+    assert again.root == entry.root
+    assert len(store.load()) == 1
+
+
 def test_store_remove_by_scope_id(tmp_path: Path) -> None:
     project = tmp_path / "alpha"
     project.mkdir()

--- a/packages/memtomem/tests/test_web_routes_context_projects.py
+++ b/packages/memtomem/tests/test_web_routes_context_projects.py
@@ -683,6 +683,10 @@ async def test_post_idempotent(client, tmp_path: Path) -> None:
     r2 = await client.post("/api/context/known-projects", json={"root": str(proj)})
     assert r1.status_code == 200 and r2.status_code == 200
     assert r1.json()["scope_id"] == r2.json()["scope_id"]
+    # ``created`` distinguishes the fresh add from the idempotent re-add (#1292)
+    # so the Add Project UI can branch "added" vs "already tracked".
+    assert r1.json()["created"] is True
+    assert r2.json()["created"] is False
     listing = await client.get("/api/context/projects")
     # cwd + the registered one — exactly two.
     assert len(listing.json()["scopes"]) == 2


### PR DESCRIPTION
## Problem

`POST /api/context/known-projects` is idempotent: re-adding an already-tracked root returns `200` with the existing entry. The Add Project UI fired the generic **"Project added"** success toast either way, so a no-op re-add was indistinguishable from a fresh registration — the roster doesn't change and the user is left unsure whether anything happened.

(The issue says `POST /api/context/projects`; the real route is `POST /api/context/known-projects` / `add_known_project`.)

## Changes

- **Store** — add `KnownProjectsStore.add_with_status() -> (entry, created)` that decides created-vs-existing **inside the existing write lock**; `add()` now delegates to it (signature/return unchanged → back-compat).
- **Route** — surface `created: bool` on the `200` response (additive; warning fields unchanged).
- **JS Add Project button** — branch the toast: `created === false` shows an **info "Project already tracked"** toast, taking precedence over the `no_runtime_marker` warning. Rationale: the marker warning was already surfaced on the original add, so re-warning on a no-op re-add is noise — the fresh signal the user needs is "nothing changed". `=== false` (not falsy) means an older server that omits `created` keeps the prior success/warning behavior.
- **i18n** — `settings.ctx.add_project_already_tracked` in `en` + `ko`.
- **Cache-bust** — `context-gateway.js` `v81 → v82`.

## Incidental hardening (disclosed)

The CLI `mm context projects add` hand-rolled the same created detection with a **racy load-then-add check across two separate lock windows** (a TOCTOU). Folded it onto `add_with_status` — output strings (`Registered:` / `Already registered:`) unchanged, corrupt-file behavior unchanged — so CLI + web share one atomic created-detection path and the race is gone.

## Out of scope (deliberate)

The issue's optional item — *"replace the `window.prompt` fallback path with an inline error + retry"* — is left for a focused follow-up. That fallback only fires when `path-picker.js` fails to load (vendor cache miss), and an inline-error+retry UI is not the trivial change the issue gated it on. `_ctxPortalEnroll` (the Portal "enroll" action) keeps its own toast: it only ever hits not-yet-registered roots, so `created` is always `true` there.

## Tests

- **Store** — `test_store_add_with_status_reports_created`: `created=True` on first add, `False` on idempotent re-add (entry preserved, store stays deduped).
- **Route** — `test_post_idempotent` extended to pin `created` both ways (`True` then `False`).
- **vitest** (`path-picker-purpose.test.mjs`) — pins all three toast branches: success (`created:true` → `toast-success`), info (`created:false` → `toast-info`), and the **precedence** case where `created:false` **and** `warning_code` are both present → the info toast wins. New JS pins mutation-validated.

## Verification

- `ruff check` + `ruff format --check` (src + tests) — clean.
- `pytest -m "not ollama"` over store / route / CLI / i18n / invariants-registry — green.
- Full `vitest` suite — 239 passed.
- Reviewed by Codex (design-gate + impl-review).

Closes the last open item of #1271 (B-9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
