### PR TITLE
fix(tests): isolate HOME in test_mcp_config_rollback (#1249)

### DIFF
--- a/packages/memtomem/tests/test_session_tracing.py
+++ b/packages/memtomem/tests/test_session_tracing.py
@@ -723,7 +723,13 @@ class TestConfigSaveValidationAndRollback:
         assert app_mock.state.config.session_trace.langfuse_enabled is False
 
     @pytest.mark.anyio
-    async def test_mcp_config_rollback(self, monkeypatch):
+    async def test_mcp_config_rollback(self, monkeypatch, tmp_path):
+        # Isolate HOME: on a persist failure the MCP rollback rebuilds a fresh
+        # config via load_config_d + load_config_overrides, both of which read
+        # ~/.memtomem (config.d/ and config.json). Without isolation a developer
+        # whose real config.json sets session_trace.langfuse_enabled=true leaks
+        # into the rollback baseline and this assertion flips to True (#1249).
+        set_home(monkeypatch, tmp_path)
         app_mock = MagicMock()
         app_mock.config = Mem2MemConfig()
         app_mock.config.session_trace.enabled = True


### PR DESCRIPTION
## What

`test_mcp_config_rollback` fails on any contributor machine whose real
`~/.memtomem/config.json` sets `session_trace.langfuse_enabled: true`. Fixes #1249.

## Why it failed

The MCP `mem_config` persist-failure rollback (`status_config.py`) rebuilds a
fresh config from disk:

```python
fresh = Mem2MemConfig()
load_config_d(fresh, quiet=True)
load_config_overrides(fresh)   # reads ~/.memtomem/config.json
```

The test never isolated HOME, so the developer's real `config.json` leaked
`langfuse_enabled=true` into the rollback baseline and the final
`assert ... is False` flipped to True. CI never sees it (clean HOME); it only
bites contributors who actually use session tracing.

## Fix

Apply the existing `set_home` helper so the rollback reads an empty user config.
Both `_override_path()` and `_config_d_path()` resolve via `.expanduser()`, so
`set_home` (HOME + USERPROFILE) covers `config.json` and `config.d/` on POSIX
and Windows alike.

The test stays meaningful: with isolation the reloaded baseline is the default
`langfuse_enabled=False`, so a broken rollback — which would leave the runtime
mutation's True in place — still fails the assertion.

## Scope

Only `test_mcp_config_rollback` needed this. The other tests the issue named are
already isolated: `test_web_api_patch_rollback` mocks `_build_fresh_config`, and
`test_save_config_validation_rejection` / `test_cli_config_set_validation_error`
use the `override_path` fixture; `test_langfuse_validator_keys_missing` does no
config read. (The issue's "4 tests fail" was an overcount — only this one
reproduces.)

## Test

- Reproduced the failure on a machine with `langfuse_enabled: true` in the real config.
- After the fix: the test passes; full `test_session_tracing.py` is 31 passed; `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
