### PR TITLE
fix(web): git-protect project_local landings in the transfer route (#1310)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_transfer.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_transfer.py
@@ -272,6 +272,44 @@ def _serialize(result: TransferResult | McpServerCopyResult) -> dict[str, Any]:
     }
 
 
+async def _ensure_dest_local_gitignored(dst_root: Path) -> str:
+    """Append the ``project_local`` ``.gitignore`` marker at the transfer
+    DESTINATION after a successful ``project_local`` apply.
+
+    Web parity for the CLI dispatch (``_ensure_local_tier_gitignored``,
+    cross-project aware since #1274) and the MCP action (#1283): without
+    this the web transfer route was the one surface that could leave a
+    ``project_local`` canonical un-git-protected at the destination
+    (#1310). Reuses the same idempotent helper, so the marker block and
+    the ``.git``-required precondition stay byte-identical across surfaces.
+
+    Returns the helper's status code (``appended`` / ``already_present`` /
+    ``no_git_repo_pyproject_only`` / ``no_project_signal``) for the
+    response, and logs the non-write skips at WARNING so a dropped marker
+    is never silent (mirrors the warnings the CLI/MCP surfaces emit).
+    """
+    from memtomem.cli.context_cmd import _append_gitignore_marker
+
+    wrote, msg = await asyncio.to_thread(_append_gitignore_marker, dst_root)
+    if wrote:
+        logger.info("transfer: appended project_local .gitignore marker at %s", dst_root)
+    elif msg == "no_git_repo_pyproject_only":
+        logger.warning(
+            "transfer: project_local landing at %s resolved via pyproject.toml but "
+            ".git is missing — .gitignore marker not written; the local tier is not "
+            "git-protected (run `git init` at the destination first).",
+            dst_root,
+        )
+    elif msg == "no_project_signal":
+        logger.warning(
+            "transfer: project_local landing at %s has neither .git nor pyproject.toml "
+            "— .gitignore marker not written; the local tier is not git-protected.",
+            dst_root,
+        )
+    # ``already_present`` is the quiet, idempotent case (marker already on disk).
+    return msg
+
+
 @router.post("/context/{kind}/{name}/transfer")
 async def transfer_context_artifact(
     kind: str,
@@ -494,4 +532,10 @@ async def transfer_context_artifact(
             host_targets=host_targets,
             plan=_serialize(result),
         )
-    return {"status": "plan" if dry_run else "ok", **_serialize(result)}
+    payload: dict[str, Any] = {"status": "plan" if dry_run else "ok", **_serialize(result)}
+    if apply_ and body.to_target_scope == "project_local":
+        # ADR-0011 project_local gitignore contract at the DESTINATION —
+        # parity with the CLI dispatch (#1274) and the MCP action (#1283);
+        # the web route was the one transfer surface that skipped it (#1310).
+        payload["gitignore_marker"] = await _ensure_dest_local_gitignored(dst_root)
+    return payload

--- a/packages/memtomem/tests/test_web_routes_context_transfer.py
+++ b/packages/memtomem/tests/test_web_routes_context_transfer.py
@@ -180,6 +180,75 @@ async def test_cross_project_copy_keeps_source(client, cwd_root: Path, tmp_path:
     assert (_shared_agents(other) / "foo" / "agent.md").is_file()
 
 
+# ── #1310: project_local landing git-protects the DESTINATION ────────────
+
+
+@pytest.mark.asyncio
+async def test_cross_project_local_transfer_appends_dest_gitignore(
+    client, cwd_root: Path, tmp_path: Path
+) -> None:
+    """A web transfer landing on project_local git-protects the DESTINATION
+    (CLI/MCP parity, #1310): the dest .gitignore gets the marker, the SOURCE
+    project is never git-touched, and the response reports ``appended``."""
+    from memtomem.cli.context_cmd import _GITIGNORE_MARKER
+
+    src_manifest = _write_agent(_shared_agents(cwd_root), "foo")
+    other = _other_project(tmp_path)
+    (other / ".git").mkdir()  # marker is only meaningful in a git working tree
+    scope_b = await _register(client, other)
+
+    resp = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={
+            "mode": "copy",
+            "to_target_scope": "project_local",
+            "to_project_scope_id": scope_b,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["to_scope"] == "project_local"
+    assert data["gitignore_marker"] == "appended"
+
+    # Canonical landed on the destination's local tier.
+    assert (_local_agents(other) / "foo" / "agent.md").is_file()
+    # Destination .gitignore now carries the marker block.
+    dst_gi = (other / ".gitignore").read_text(encoding="utf-8")
+    assert _GITIGNORE_MARKER in dst_gi
+    assert ".memtomem/*.local/" in dst_gi
+    # The SOURCE project is never git-touched by a destination landing.
+    assert not (cwd_root / ".gitignore").exists()
+    assert src_manifest.read_text(encoding="utf-8") == _AGENT_BODY  # copy kept source
+
+
+@pytest.mark.asyncio
+async def test_project_local_transfer_without_git_surfaces_skip(
+    client, cwd_root: Path, tmp_path: Path
+) -> None:
+    """When the project_local destination has a store but no git signal, the
+    marker write is skipped (meaningful only in a git tree) and the skip is
+    SURFACED in the response instead of silently dropped (#1310)."""
+    _write_agent(_shared_agents(cwd_root), "foo")
+    other = _other_project(tmp_path)  # .memtomem + .claude, no .git / pyproject
+    scope_b = await _register(client, other)
+
+    resp = await client.post(
+        "/api/context/agents/foo/transfer",
+        json={
+            "mode": "copy",
+            "to_target_scope": "project_local",
+            "to_project_scope_id": scope_b,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["gitignore_marker"] == "no_project_signal"
+    # No .gitignore conjured in a non-git directory.
+    assert not (other / ".gitignore").exists()
+
+
 @pytest.mark.asyncio
 async def test_copy_rename_surfaces_provenance_reason_code(
     client, cwd_root: Path, tmp_path: Path


### PR DESCRIPTION
## What

`POST /api/context/{kind}/{name}/transfer` was the one transfer surface that did
not append the `project_local` `.gitignore` marker (`.memtomem/*.local/`,
`.memtomem/.staging/`) at the destination after a `project_local` landing.
Fixes #1310.

## Why it matters

The CLI dispatch (`_ensure_local_tier_gitignored`, cross-project aware since
#1274) and the MCP action (#1283) both append the marker. The web route did not —
so a web-driven transfer could leave a `project_local` canonical
**un-git-protected** at the destination, even though the local draft tier is
meant to be gitignored. (Disclosed in ADR-0023 §13 and the #1309 PR body.)

## Fix

After a successful `project_local` apply, append the marker via the same
idempotent `_append_gitignore_marker` helper the CLI/MCP use, so the marker block
and the `.git`-required precondition stay byte-identical across all three
surfaces. The helper's status code is returned on the response as
`gitignore_marker` (`appended` / `already_present` / `no_git_repo_pyproject_only`
/ `no_project_signal`), and the non-write skips are logged at WARNING so a
dropped marker is never silent — mirroring the user-facing warnings the CLI/MCP
emit. Gated on `apply_ and to_target_scope == "project_local"`, so dry-run plans
and `needs_confirmation` round-trips never touch disk.

## Tests

- `test_cross_project_local_transfer_appends_dest_gitignore`: cross-project web
  transfer to `project_local` writes the marker at the **destination** `.gitignore`,
  never touches the source project, and reports `gitignore_marker == "appended"`.
- `test_project_local_transfer_without_git_surfaces_skip`: a destination with a
  store but no git signal surfaces `no_project_signal` in the response and conjures
  no `.gitignore`.
- Mutation-validated: bypassing the real append fails both pins.
- Full `test_web_routes_context_transfer.py` = 33 passed; `ruff` clean; `mypy` clean.

## Not in scope

A web-UI warning toast for the skip states (the `gitignore_marker` field is now on
the response for a UI consumer to surface). The data-protection bug — the missing
marker write — is the fix here; the toast is a small optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
