### PR TITLE
a11y(web): sr-only text for the 13 hand-rolled spinner renders (#1316)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1104,6 +1104,13 @@ function panelLoading(container) {
     '<div class="loading-panel"><div class="spinner-panel"></div>'
     + `<span class="sr-only">${escapeHtml(t('common.loading'))}</span></div>`;
 }
+// sr-only "Loading…" text alternative for hand-rolled spinner markup that can't
+// route through panelLoading() — bespoke .empty-state or bare .spinner-panel
+// renders that keep their own wrapper for layout. Mirrors the span panelLoading()
+// injects so every spinner has a screen-reader voice instead of silence (#1316).
+function srLoading() {
+  return `<span class="sr-only">${escapeHtml(t('common.loading'))}</span>`;
+}
 
 // ── A5: Empty State ──
 // Owns its `.empty-state` wrapper — callers must NOT add their own.
@@ -5794,7 +5801,7 @@ async function loadUploadUsage() {
 async function loadTags() {
   const emptyEl = qs('tags-empty');
   const listEl  = qs('tags-list');
-  emptyEl.innerHTML = '<div class="spinner-panel"></div>';
+  emptyEl.innerHTML = `<div class="spinner-panel"></div>${srLoading()}`;
   show(emptyEl);
   hide(listEl);
   hide(qs('tags-stats'));
@@ -7209,7 +7216,7 @@ async function openSourcePreview(sourcePath, highlightStart, highlightEnd) {
   title.textContent = basename(sourcePath);
   title.title = sourcePath;
   info.textContent = 'Loading…';
-  body.innerHTML = '<div class="loading-panel"><div class="spinner-panel"></div></div>';
+  panelLoading(body);
   openSourcePreviewModal();
 
   try {
@@ -7467,7 +7474,7 @@ qs('d-source-btn').addEventListener('click', async () => {
   if (!sourceFile) return;
 
   const list = qs('source-chunks-list');
-  list.innerHTML = '<div class="loading-panel"><div class="spinner-panel"></div></div>';
+  panelLoading(list);
   // Hide related panel to avoid stacking
   hide(qs('related-panel'));
   show(panel);

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -5352,7 +5352,7 @@ async function _ctxFetchFieldMap(type, name) {
 async function _ctxLoadDiff(type, name, detailEl) {
   const pane = detailEl.querySelector(`#ctx-pane-${type}-diff`);
   if (!pane) return;
-  pane.innerHTML = '<div class="empty-state"><div class="spinner-panel"></div></div>';
+  pane.innerHTML = `<div class="empty-state"><div class="spinner-panel"></div>${srLoading()}</div>`;
   try {
     // Diff is required, field map is optional + parallel-fetched. ``Promise.all``
     // would fail the whole pane on a /rendered hiccup; the explicit

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1530,16 +1530,16 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=128"></script>
+  <script src="/app.js?v=129"></script>
   <script src="/chunk-progress.js?v=1"></script>
-  <script src="/settings-config.js?v=10"></script>
+  <script src="/settings-config.js?v=11"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>
-  <script src="/settings-maintenance.js?v=4"></script>
-  <script src="/settings-namespaces.js?v=9"></script>
-  <script src="/settings-harness.js?v=2"></script>
-  <script src="/settings-hooks-watchdog.js?v=19"></script>
+  <script src="/settings-maintenance.js?v=5"></script>
+  <script src="/settings-namespaces.js?v=10"></script>
+  <script src="/settings-harness.js?v=3"></script>
+  <script src="/settings-hooks-watchdog.js?v=20"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=82"></script>
+  <script src="/context-gateway.js?v=83"></script>
   <script src="/context-portal.js?v=6"></script>
   <script src="/path-picker.js?v=4"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/settings-config.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-config.js
@@ -352,7 +352,7 @@ function _syncConfigToUI() {
 async function loadConfig() {
   const loadingEl = qs('config-loading');
   const contentEl = qs('config-content');
-  loadingEl.innerHTML = '<div class="spinner-panel"></div>';
+  loadingEl.innerHTML = `<div class="spinner-panel"></div>${srLoading()}`;
   show(loadingEl); hide(contentEl);
 
   try {

--- a/packages/memtomem/src/memtomem/web/static/settings-harness.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-harness.js
@@ -68,7 +68,7 @@ function toggleHelp() {
 
 async function loadHarnessSessions() {
   const list = qs('sessions-list');
-  list.innerHTML = '<div class="empty-state"><div class="spinner-panel"></div></div>';
+  list.innerHTML = `<div class="empty-state"><div class="spinner-panel"></div>${srLoading()}</div>`;
   try {
     const data = await api('GET', '/api/sessions?limit=50');
     if (!data.sessions.length) {
@@ -104,7 +104,7 @@ async function showSessionEvents(sessionId) {
   const list = qs('session-events-list');
   qs('session-events-title').textContent = `Events: ${sessionId.slice(0, 8)}...`;
   show(panel);
-  list.innerHTML = '<div class="spinner-panel"></div>';
+  list.innerHTML = `<div class="spinner-panel"></div>${srLoading()}`;
   try {
     const data = await api('GET', `/api/sessions/${sessionId}/events`);
     _sessionEventsCache = data.events;
@@ -166,7 +166,7 @@ qs('sessions-refresh-btn')?.addEventListener('click', loadHarnessSessions);
 
 async function loadHarnessScratch() {
   const list = qs('scratch-list');
-  list.innerHTML = '<div class="empty-state"><div class="spinner-panel"></div></div>';
+  list.innerHTML = `<div class="empty-state"><div class="spinner-panel"></div>${srLoading()}</div>`;
   try {
     const data = await api('GET', '/api/scratch');
     if (!data.entries.length) {
@@ -245,7 +245,7 @@ qs('scratch-refresh-btn')?.addEventListener('click', loadHarnessScratch);
 
 async function loadHarnessProcedures() {
   const list = qs('procedures-list');
-  list.innerHTML = '<div class="empty-state"><div class="spinner-panel"></div></div>';
+  list.innerHTML = `<div class="empty-state"><div class="spinner-panel"></div>${srLoading()}</div>`;
   try {
     const data = await api('GET', '/api/procedures');
     if (!data.procedures.length) {
@@ -274,7 +274,7 @@ qs('procedures-refresh-btn')?.addEventListener('click', loadHarnessProcedures);
 
 async function loadHarnessHealth() {
   const report = qs('health-report');
-  report.innerHTML = '<div class="empty-state"><div class="spinner-panel"></div></div>';
+  report.innerHTML = `<div class="empty-state"><div class="spinner-panel"></div>${srLoading()}</div>`;
   try {
     const d = await api('GET', '/api/eval');
     report.innerHTML = `

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -953,7 +953,7 @@ async function loadWatchdogStatus() {
   const report = qs('health-watchdog-report');
   const bar = qs('health-watchdog-status-bar');
   bar.style.display = 'none';
-  report.innerHTML = '<div class="empty-state"><div class="spinner-panel"></div></div>';
+  report.innerHTML = `<div class="empty-state"><div class="spinner-panel"></div>${srLoading()}</div>`;
   try {
     const d = await api('GET', '/api/watchdog/status');
     if (!d.enabled) {

--- a/packages/memtomem/src/memtomem/web/static/settings-maintenance.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-maintenance.js
@@ -50,7 +50,7 @@ async function runDedupScan() {
   hide(qs('dedup-list'));
   hide(qs('dedup-msg'));
   show(empty);
-  empty.innerHTML = '<div class="spinner-panel"></div>';
+  empty.innerHTML = `<div class="spinner-panel"></div>${srLoading()}`;
 
   // Abort any previous request and set a timeout aligned with the server.
   if (STATE.dedupAbortCtrl) STATE.dedupAbortCtrl.abort();

--- a/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
@@ -215,7 +215,7 @@ async function loadNamespacesTab() {
   // gated to dev mode in `_buildNsCard` because their backend routes stay
   // on admin_router until chunk-id stability lands (ADR-0005 follow-up).
   const list = qs('ns-list');
-  list.innerHTML = '<div class="loading-panel"><div class="spinner-panel"></div></div>';
+  panelLoading(list);
 
   try {
     const data = await api('GET', '/api/namespaces');

--- a/packages/memtomem/tests-js/ctx-a11y.test.mjs
+++ b/packages/memtomem/tests-js/ctx-a11y.test.mjs
@@ -88,6 +88,21 @@ describe('panelLoading — sr-only text alternative (#1285)', () => {
   });
 });
 
+describe('srLoading — sr-only text for hand-rolled spinners (#1316)', () => {
+  it('returns an sr-only span carrying common.loading, beside the bespoke spinner', async () => {
+    const { window } = await bootApp({ scripts: ['i18n.js', 'app.js'] });
+    await window.I18N.init();
+    const div = window.document.createElement('div');
+    // Mirror a bespoke .empty-state spinner render that can't use panelLoading().
+    div.innerHTML = `<div class="empty-state"><div class="spinner-panel"></div>${window.srLoading()}</div>`;
+    const sr = div.querySelector('.sr-only');
+    expect(sr).toBeTruthy();
+    expect(sr.textContent).toBe(window.t('common.loading'));
+    expect(sr.hasAttribute('aria-live')).toBe(false); // parent may already be live
+    expect(div.querySelector('.spinner-panel')).toBeTruthy(); // spinner kept
+  });
+});
+
 describe('showConfirm — cancelText driven every call, no leak (#1285)', () => {
   let window;
 

--- a/packages/memtomem/tests/web/test_spinner_a11y.py
+++ b/packages/memtomem/tests/web/test_spinner_a11y.py
@@ -1,0 +1,62 @@
+"""Static a11y pin: every spinner render carries a screen-reader text
+alternative (#1316).
+
+The decorative ``.spinner-panel`` is silent to screen readers on its own.
+The shared ``panelLoading()`` helper and the ``srLoading()`` helper (for
+bespoke wrappers that keep their own layout) both inject an ``sr-only``
+``common.loading`` span; the one ``home.state.loading`` spinner uses an
+``aria-label`` instead. This guard fails if a new hand-rolled spinner render
+lands without any of those, regressing the #1316 sweep — and it failed on
+every one of the 13 sites that #1316 fixed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_STATIC_DIR = Path(__file__).resolve().parents[2] / "src" / "memtomem" / "web" / "static"
+
+# A real spinner render is markup: ``class="…spinner-panel…"``. Prose/comments
+# that merely mention ``.spinner-panel`` (CSS-selector style, no ``class="``)
+# are deliberately NOT matched.
+_SPINNER_MARKUP = re.compile(r'class="[^"]*\bspinner-panel\b[^"]*"')
+# Any of these on the same line — or the immediately following line, so the
+# two-line ``panelLoading()`` author site counts — gives the spinner a voice.
+_TEXT_ALT = re.compile(r"sr-only|aria-label|srLoading\(")
+
+
+def _js_files() -> list[Path]:
+    return sorted(_STATIC_DIR.glob("*.js"))
+
+
+def test_static_js_present() -> None:
+    assert _js_files(), f"no static JS under {_STATIC_DIR} — path drift?"
+
+
+def test_some_spinner_markup_exists() -> None:
+    """Guard against the assertion vacuously passing if the markup is renamed."""
+    blob = "\n".join(f.read_text(encoding="utf-8") for f in _js_files())
+    assert _SPINNER_MARKUP.search(blob), (
+        "no spinner-panel markup found at all — did the class get renamed? "
+        "Update this guard's pattern alongside the markup."
+    )
+
+
+@pytest.mark.parametrize("js", _js_files(), ids=lambda p: p.name)
+def test_every_spinner_render_has_sr_text_alternative(js: Path) -> None:
+    lines = js.read_text(encoding="utf-8").splitlines()
+    offenders: list[str] = []
+    for i, line in enumerate(lines):
+        if not _SPINNER_MARKUP.search(line):
+            continue
+        window = line + "\n" + (lines[i + 1] if i + 1 < len(lines) else "")
+        if not _TEXT_ALT.search(window):
+            offenders.append(f"{js.name}:{i + 1}: {line.strip()}")
+    assert not offenders, (
+        "spinner render(s) without an sr-only / aria-label / srLoading() text "
+        "alternative (#1316) — route the markup through panelLoading() or append "
+        "srLoading():\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
## What

#1315 (B-2 of #1271) gave the shared `panelLoading()` spinner an `sr-only`
"Loading…" text alternative, but ~13 other sites hand-roll the spinner markup
**without** calling the helper, so they stayed silent for screen readers. This
closes that gap. Fixes #1316.

## Changes

- **Route same-shape renders through `panelLoading()`** where the markup already
  matched (`<div class="loading-panel"><div class="spinner-panel">`): `app.js` ×2,
  `settings-namespaces.js`.
- **Add an `srLoading()` helper** (next to `panelLoading()` in `app.js`) that
  returns the exact `<span class="sr-only">${t('common.loading')}</span>`
  `panelLoading()` injects, and append it at the bespoke sites that keep their own
  wrapper for layout (bare `.spinner-panel` and `.empty-state` spinners):
  `settings-harness.js` ×5, `settings-maintenance.js`, `settings-config.js`,
  `settings-hooks-watchdog.js`, the `context-gateway.js` diff pane, and the
  `app.js` empty-state spinner.

No new i18n keys — `common.loading` (en.json:984 + ko) and the `.sr-only` utility
already shipped with #1315. Cache-bust `?v=` bumped for the 7 touched JS files.

## Tests (triple web-static gate)

- **`tests/web/test_spinner_a11y.py`** — a static structural guard asserting every
  `class="…spinner-panel…"` render in the static JS carries an
  `sr-only` / `aria-label` / `srLoading()` text alternative on the same or the next
  line (so the two-line `panelLoading()` author site counts, and the one
  `home.state.loading` `aria-label` spinner is allowed). It fails on all 13 pre-fix
  sites and is **mutation-validated** (reverting one site to a bare spinner re-reds
  it), so a future silent spinner is caught regardless of which file it lands in.
- **`ctx-a11y.test.mjs`** — a vitest pinning `srLoading()`'s output beside a bespoke
  `.empty-state` spinner.
- Verified green: structural guard (15 passed), `test_i18n.py` (67), full vitest
  suite (240), `test_context_gateway_overview.py` + `_a11y.py` (41); `ruff` clean.

Follow-up to #1315; part of the #1271 a11y track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
