### PR TITLE
docs(web): state the Context Gateway diff-payload contract (#1256)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -537,6 +537,13 @@ async def update_agent(
 
 
 def _safe_rel(p: Path, project_root: Path) -> str:
+    """Project-relative path as a POSIX string for API payloads.
+
+    ``.as_posix()`` (not ``str``) so canonical/runtime paths come back
+    ``/``-separated on every platform — the Web UI and diff payloads pin POSIX
+    separators (#1256). Falls back to the absolute POSIX path for user-tier
+    locations outside ``project_root``.
+    """
     try:
         return p.relative_to(project_root).as_posix()
     except ValueError:

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -100,6 +100,13 @@ def _reject_project_local_write(target_scope: TargetScope, action: str) -> None:
 
 
 def _safe_rel(p: Path, project_root: Path) -> str:
+    """Project-relative path as a POSIX string for API payloads.
+
+    ``.as_posix()`` (not ``str``) so canonical/runtime paths come back
+    ``/``-separated on every platform — the Web UI and diff payloads pin POSIX
+    separators (#1256). Falls back to the absolute POSIX path for user-tier
+    locations outside ``project_root``.
+    """
     try:
         return p.relative_to(project_root).as_posix()
     except ValueError:

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -1,4 +1,18 @@
-"""Tests for Context Gateway web routes (overview + skills + commands + agents)."""
+"""Tests for Context Gateway web routes (overview + skills + commands + agents).
+
+Diff-payload contract pinned by ``TestDiffCommand`` / ``TestDiffAgent`` (#1256):
+
+- **Paths** are normalized to POSIX separators on every platform. The route
+  helpers ``_safe_rel`` in ``context_commands`` / ``context_agents`` return
+  ``.as_posix()`` so the Web UI receives stable ``/``-separated paths; the diff
+  tests assert literal POSIX strings (e.g. ``.claude/commands/ghost.md``) rather
+  than ``str(Path(...))``, which would be backslash-joined on Windows.
+- **Content** is LF, not platform-native. Canonical generators and sync write
+  LF bytes, so fixtures here use ``_write_text_lf`` (raw bytes) instead of
+  ``Path.write_text`` (text mode translates ``\\n`` -> ``\\r\\n`` on Windows).
+  The original Windows CRLF breakage was that fixture artifact, not the route
+  re-normalizing newlines.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

#1256 (Windows CI: Context Gateway diff tests fail on CRLF + path-separator) was
functionally fixed by #1264 (bfa272b6) — the 4 `TestDiffCommand` / `TestDiffAgent`
tests are green and `windows-latest` is clean on recent `main` runs. The only
remaining done-when item was *"the chosen contract is stated in the diff payload
code or test module docstring."* This PR states it; it is **docs-only, no behavior
change**.

- `_safe_rel` in `context_agents.py` / `context_commands.py`: a docstring saying
  payload paths are POSIX-normalized via `.as_posix()` (not `str`), so the Web UI
  receives stable `/`-separated paths on every platform.
- `test_web_routes_context.py` module docstring: the diff tests pin **POSIX
  paths** and **LF content**, and the earlier Windows CRLF failure was a *fixture
  artifact* (text-mode writes translate `\n` → `\r\n` on Windows), now handled by
  `_write_text_lf` — the route does not re-normalize newlines.

Closes #1256.

## Verification

- `uv run pytest packages/memtomem/tests/test_web_routes_context.py -q` → 121 passed
- `uv run ruff check` + `ruff format --check` on the 3 touched files → clean

## Out of scope (separate finding)

While auditing the same bug shape tree-wide, `_safe_rel` in **`context_skills.py`**
and **`context_mcp_servers.py`** still return `str(...)` (platform-native), not
`.as_posix()` — so their `canonical_path` / `path` payloads would carry backslashes
on Windows, the exact issue #1256 fixed for agents/commands. Those routes are not
exercised by #1256's diff tests, so this is a *latent* same-shape bug. Deliberately
left for a separate PR (one focused change per PR); not documented here to avoid
claiming a contract the code doesn't yet honor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
