### PR TITLE
feat(context): CLI `mm context sync --include=mcp-servers` fan-out phase (#1311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+- **`mm context sync --include=mcp-servers` — CLI mcp-servers fan-out (#1311).**
+  `mm context sync` (and `--all-projects`) gained an opt-in mcp-servers phase:
+  `--include=mcp-servers` fans canonical `.memtomem/mcp-servers/*.json`
+  definitions into the project's `.mcp.json` via the same canonical-wins-per-name
+  merge the web Sync runs (reusing `generate_all_mcp_servers`, so CLI and web
+  stay byte-parallel). It is **opt-in** — a bare `mm context sync` never touches
+  `.mcp.json` — and **sync-only**: `mcp-servers` is rejected by
+  detect/init/generate/diff, which have no mcp-servers engine. Because
+  `.mcp.json` holds executable MCP-server config, the `--all-projects` batch
+  confirms per target before each rewrite (the count-only "Sync N projects?"
+  gate does not disclose it); a single-project run treats the explicit
+  `--include` as consent. `--scope` is a no-op note (mcp-servers is single-tier
+  project_shared). The cross-project `mm context copy mcp-servers` follow-up now
+  prints this as a runnable `cd <dst> && mm context sync --include=mcp-servers`
+  command instead of web-only prose. The MCP `sync` contract (`mem_context_sync`)
+  still rejects `include=mcp-servers` — that parity and an `all` alias remain an
+  ADR-0021 §"Open questions" §5 scope-out.
+
 - **Cross-project copy for MCP server definitions (ADR-0023 §12).**
   `mm context copy mcp-servers <name> --to-project <scope_id|path>` and the
   existing transfer route (`POST /api/context/mcp-servers/{name}/transfer`)
@@ -18,10 +36,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   canonical aborts the destination's entire mcp-servers sync phase), and
   symlinked canonicals are refused (the destination must be a regular
   git-tracked file).
-  Results carry a `sync_hint` (and disclosure notes for a same-name
-  `.mcp.json` runtime entry the destination's next sync would overwrite) —
-  there is no `mm context sync` phase for mcp-servers; fan-out stays on the
-  destination's web panel / Sync All (#1282).
+  Results carry a runnable `sync_command` (and disclosure notes for a
+  same-name `.mcp.json` runtime entry the destination's next sync would
+  overwrite) that fans the copied canonical into the destination's
+  `.mcp.json` — `cd <dst> && mm context sync --include=mcp-servers` (the CLI
+  sync phase landed in #1311, below; #1282).
 
 - **Cross-project per-hook copy for settings hooks (ADR-0023 §11).** New
   `mm context settings-copy --event … --matcher … --to-project <scope_id|path>`

--- a/docs/adr/0021-context-portal.md
+++ b/docs/adr/0021-context-portal.md
@@ -227,7 +227,10 @@ for triggered deferred decisions, not roadmap items.
 5. **MCP Sync-All parity** — an `all` alias and `mcp-servers` support in the
    MCP `sync` contract so headless agents reach full Sync-All parity with the
    web button. *Revisit if:* an agent/headless workflow needs MCP-driven
-   mcp-server sync. (v1 scope-out — not tracked.)
+   mcp-server sync. (v1 scope-out — not tracked.) *Update (#1311):* the **CLI**
+   gained `mm context sync --include=mcp-servers` (opt-in, sync-only); this
+   scope-out now covers only the **MCP** `sync` contract (`mem_context_sync`
+   still rejects `include=mcp-servers`) and the `all` alias.
 
 ## Alternatives considered
 

--- a/docs/adr/0023-cross-project-artifact-transfer.md
+++ b/docs/adr/0023-cross-project-artifact-transfer.md
@@ -426,14 +426,17 @@ Mechanism-specific decisions:
   alias the out-of-project target inode into the destination's
   git-tracked tree. Loud refusal over silently materializing the
   target.
-- **`sync_hint` prose instead of a `sync_command`.** No
-  `mm context sync` phase exists for mcp-servers — `.mcp.json` fan-out
-  is web-only (panel Sync, Sync All) — so prescribing the engine's
-  cd-prefixed sync command would be a no-op instruction.
-  `TransferResult` gained a presentation-only `sync_hint: str | None`
-  (engine results leave it `None`) so one CLI renderer and one web
-  serializer cover both result types; the adapter's result implements
-  the full `TransferResult` attribute surface by pinned test.
+- **`sync_hint` prose alongside the `sync_command`.** At A-12 no
+  `mm context sync` phase existed for mcp-servers, so the result carried
+  web-only prose; #1311 added the CLI `--include=mcp-servers` leg, so the
+  result now carries a runnable cd-prefixed `sync_command`
+  (`cd <dst> && mm context sync --include=mcp-servers --scope
+  project_shared`) like every other transfer, with `sync_hint` as its
+  prose mirror for non-CLI surfaces. `TransferResult` still has the
+  presentation-only `sync_hint: str | None` (engine results leave it
+  `None`) so one CLI renderer and one web serializer cover both result
+  types; the adapter's result implements the full `TransferResult`
+  attribute surface by pinned test.
   Destination `.mcp.json` disclosures ride `notes`, derived from the
   copy's own resolution path: a same-name runtime entry the
   destination's next sync will overwrite (the additive merge is

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -1330,9 +1330,10 @@ happen to the source:
 
 Shared rules, all verbs: destination collisions always refuse (no
 `--force` valve); destination runtime fan-out is **not** generated —
-the result prints the exact follow-up `mm context sync` command (or,
-for `mcp-servers`, the web-panel hint: `.mcp.json` fan-out is
-web-only); a `project_shared` landing runs the privacy scan (Gate A,
+the result prints the exact follow-up `mm context sync` command (for
+`mcp-servers`, `cd <dst> && mm context sync --include=mcp-servers
+--scope project_shared`, with web Sync as an equivalent option); a
+`project_shared` landing runs the privacy scan (Gate A,
 no bypass) and requires `--confirm-project-shared` with `--apply`;
 default is always a dry-run preview.
 

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -63,6 +63,12 @@ from memtomem.context.migrate import (
     migrate_scope,
 )
 from memtomem.context.transfer import TransferMode, TransferResult, transfer_artifact
+from memtomem.context.mcp_servers import (
+    PROJECT_MCP_CONFIG,
+    McpServerParseError,
+    McpServerPrivacyError,
+    generate_all_mcp_servers,
+)
 from memtomem.context.mcp_servers_copy import McpServerCopyResult, copy_mcp_server
 from memtomem.context.projects import (
     KnownProjectsCorruptError,
@@ -139,8 +145,20 @@ from memtomem.config import (
     load_config_overrides,
 )
 
-# Phase 1-3 supports skills/agents/commands; Phase D adds settings.
+# Phase 1-3 supports skills/agents/commands; Phase D adds settings. This is
+# the SHARED include contract for detect/init/generate/diff/sync (mirrored in
+# server/tools/context.py); keep the two frozensets in lockstep.
 _KNOWN_INCLUDES: frozenset[str] = frozenset({"skills", "agents", "commands", "settings"})
+
+# ``mm context sync`` accepts one extra kind the other four commands do not:
+# ``mcp-servers`` (#1311). It is opt-in (a bare ``mm context sync`` never
+# touches ``.mcp.json``) and SYNC-ONLY — the engine has a canonical→``.mcp.json``
+# fan-out (``generate_all_mcp_servers``) but no extract/init/diff, so adding it
+# to the shared ``_KNOWN_INCLUDES`` would make detect/init/generate/diff accept
+# a token they silently no-op. It is also CLI-only: MCP ``sync``-contract
+# parity (and an ``all`` alias) is a deliberate scope-out (ADR-0021 §"Open
+# questions" §5), so ``server/tools/context.py`` is intentionally NOT widened.
+_SYNC_INCLUDES: frozenset[str] = _KNOWN_INCLUDES | {"mcp-servers"}
 
 
 def _find_project_root() -> Path:
@@ -156,17 +174,24 @@ def _context_path(root: Path) -> Path:
     return root / CONTEXT_FILENAME
 
 
-def _parse_include(include_tuple: tuple[str, ...]) -> set[str]:
-    """Normalize ``--include`` values (repeatable option + comma-split within each)."""
+def _parse_include(
+    include_tuple: tuple[str, ...], *, allowed: frozenset[str] = _KNOWN_INCLUDES
+) -> set[str]:
+    """Normalize ``--include`` values (repeatable option + comma-split within each).
+
+    ``allowed`` is the per-command accepted set: detect/init/generate/diff use
+    the default ``_KNOWN_INCLUDES``; ``sync`` passes ``_SYNC_INCLUDES`` to also
+    accept ``mcp-servers`` (#1311).
+    """
     values: set[str] = set()
     for raw in include_tuple:
         for token in raw.split(","):
             token = token.strip()
             if not token:
                 continue
-            if token not in _KNOWN_INCLUDES:
+            if token not in allowed:
                 raise click.BadParameter(
-                    f"Unknown --include value '{token}'. Supported: {sorted(_KNOWN_INCLUDES)}"
+                    f"Unknown --include value '{token}'. Supported: {sorted(allowed)}"
                 )
             values.add(token)
     return values
@@ -180,6 +205,21 @@ _INCLUDE_OPTION = click.option(
     help=(
         "Additional artifact kinds to process (repeatable or comma-separated). "
         "Supported: skills, agents, commands, settings."
+    ),
+)
+
+# ``sync`` accepts one extra kind (mcp-servers, #1311); its own option carries
+# the accurate help so the other commands' --include help is not widened.
+_SYNC_INCLUDE_OPTION = click.option(
+    "--include",
+    "include",
+    multiple=True,
+    metavar="KIND",
+    help=(
+        "Additional artifact kinds to fan out (repeatable or comma-separated). "
+        "Supported: skills, agents, commands, settings, mcp-servers. "
+        "mcp-servers (opt-in) fans canonical MCP server definitions into the "
+        "project .mcp.json; it is a sync-only kind."
     ),
 )
 
@@ -701,6 +741,56 @@ def _print_settings_diff(root: Path, *, scope: str) -> None:
             click.secho(f"  error {name}: {r.reason}", fg="red")
 
 
+def _print_mcp_servers_generate(root: Path, *, surface: str = "cli_context_sync") -> None:
+    """Fan canonical MCP server definitions into the project ``.mcp.json`` (#1311).
+
+    The CLI leg of ``mm context sync --include=mcp-servers`` reuses the SAME
+    pure ``generate_all_mcp_servers`` core the web ``/context/mcp-servers/sync``
+    route calls, so the two surfaces stay byte-parallel: canonical-wins-per-name
+    merge, ``IN_SYNC`` no-op (no mtime churn when already in sync), and the
+    foreign-entry-preserving mode policy. A Gate A privacy hit or an unparseable
+    canonical aborts the whole leg (the engine refuses to write a partial
+    ``.mcp.json``), surfaced as a red ``ClickException`` like the other legs.
+    """
+    try:
+        result = generate_all_mcp_servers(root, surface=surface)
+    except McpServerPrivacyError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except McpServerParseError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if result.generated:
+        click.secho(f"  MCP servers fan-out: {len(result.generated)}", fg="green")
+        for runtime, name, path in result.generated:
+            rel = path.relative_to(root) if path.is_relative_to(root) else path
+            click.echo(f"    {runtime:15s}  {name}  {rel}")
+    for runtime, reason, _code in result.skipped:
+        # NO_CANONICAL_ROOT / IN_SYNC are informational (nothing to fan, or
+        # already in sync) — yellow, never an error.
+        click.secho(f"  skipped {runtime}: {reason}", fg="yellow")
+
+
+def _confirm_mcp_servers_fanout(root: Path, *, yes: bool) -> bool:
+    """Confirm a ``.mcp.json`` rewrite before an ``--all-projects`` mcp-servers leg.
+
+    A single-project ``mm context sync --include=mcp-servers`` treats the
+    explicit ``--include`` as consent and never prompts. ``--all-projects`` is
+    different: its only confirmation is the count-only "Sync N project(s)?"
+    gate, which does NOT disclose that EXECUTABLE MCP-server config
+    (command/args/env, foreign ``mcpServers`` entries carried verbatim) in each
+    project's ``.mcp.json`` is about to be rewritten. So in a batch we disclose
+    the per-target file and confirm before writing (#1311). ``--yes`` skips it.
+    """
+    if yes:
+        return True
+    target = root / PROJECT_MCP_CONFIG
+    verb = "rewrite" if target.exists() else "create"
+    click.secho(
+        f"  mcp-servers sync will {verb} executable MCP server config at {target}",
+        fg="yellow",
+    )
+    return click.confirm("  Continue?", default=False)
+
+
 _SCOPE_OPTION = click.option(
     "--scope",
     "scope_flag",
@@ -1199,7 +1289,7 @@ def diff_cmd(include: tuple[str, ...], scope_flag: str | None) -> None:
 
 
 @context.command("sync")
-@_INCLUDE_OPTION
+@_SYNC_INCLUDE_OPTION
 @click.option(
     "--strict",
     is_flag=True,
@@ -1241,7 +1331,9 @@ def sync_cmd(
     label: str | None,
 ) -> None:
     """Sync context.md to all detected agent files."""
-    inc = _parse_include(include)
+    # sync accepts mcp-servers on top of the shared kinds (#1311); the other
+    # context commands keep the default _KNOWN_INCLUDES set.
+    inc = _parse_include(include, allowed=_SYNC_INCLUDES)
 
     if all_projects:
         # ADR-0025: the batch is project_shared-only — `user` would fan the
@@ -1384,6 +1476,25 @@ def _run_sync_legs(
             _print_settings_generate(root, scope=scope, allow_host_writes=True)
         else:
             click.secho("  Skipped settings sync (declined).", fg="yellow")
+
+    if "mcp-servers" in inc:
+        click.echo("")
+        if artifact_scope != "project_shared":
+            # mcp-servers canonicals are single-tier project_shared (ADR-0016
+            # §3): there is no other tier to honor, so --scope is ignored — not
+            # an error, because a mixed --include can still carry a real scope
+            # for the other kinds (mirrors _warn_label_ineligible_kinds).
+            click.secho(
+                f"  note: --scope={artifact_scope} does not apply to mcp-servers "
+                "(single-tier project_shared); fanning out project_shared.",
+                fg="yellow",
+            )
+        # Single-project runs treat the explicit --include as consent; a batch
+        # (--all-projects) confirms per target first (see the helper).
+        if not batch or _confirm_mcp_servers_fanout(root, yes=yes):
+            _print_mcp_servers_generate(root, surface=surface)
+        else:
+            click.secho("  Skipped mcp-servers sync (declined).", fg="yellow")
 
     return True
 
@@ -3328,10 +3439,12 @@ def _print_transfer_result(result: TransferResult | McpServerCopyResult, *, appl
     artifact lands untracked).
 
     Also renders the mcp-servers copy result (A-12 #1282) — same field
-    surface by contract. ``sync_hint`` is the prose follow-up for
-    results with no runnable sync command (mcp fan-out is web-only);
-    ``(flat layout)`` is suppressed there because flat is the only
-    layout mcp-servers have, not a legacy variant worth flagging.
+    surface by contract. Since #1311 the mcp-servers result carries a
+    runnable ``sync_command`` (``cd <dst> && mm context sync
+    --include=mcp-servers``), so it takes the same command branch as the
+    artifact transfers; ``sync_hint`` is its prose mirror for non-CLI
+    surfaces. ``(flat layout)`` is suppressed for mcp-servers because flat
+    is the only layout they have, not a legacy variant worth flagging.
     """
     layout_note = (
         " (flat layout)" if result.layout == "flat" and result.kind != "mcp-servers" else ""
@@ -3487,8 +3600,9 @@ def copy_cmd(
 
     ASSET_TYPE ``mcp-servers`` copies one MCP server definition to
     another project (--to-project required; copy-only, no --as, tier
-    flags fixed at project_shared). The destination's .mcp.json fan-out
-    is web-only — the result prints the follow-up.
+    flags fixed at project_shared). The result prints the runnable
+    follow-up that fans the canonical into the destination's .mcp.json
+    (``cd <dst> && mm context sync --include=mcp-servers``; #1311).
     """
     _transfer_dispatch(
         "copy",

--- a/packages/memtomem/src/memtomem/context/mcp_servers.py
+++ b/packages/memtomem/src/memtomem/context/mcp_servers.py
@@ -263,7 +263,17 @@ class McpServerSyncResult:
     skipped: list[tuple[str, str, str]]
 
 
-def generate_all_mcp_servers(project_root: Path) -> McpServerSyncResult:
+def generate_all_mcp_servers(
+    project_root: Path, *, surface: str = "context_mcp_servers_sync"
+) -> McpServerSyncResult:
+    """Fan canonical MCP server definitions out into the project ``.mcp.json``.
+
+    ``surface`` names the calling fan-out surface for Gate A audit
+    attribution only (web ``/context/mcp-servers/sync``, the CLI
+    ``mm context sync --include=mcp-servers`` leg, ...); it does not
+    change the merge or write behavior. Callers pass their own surface so
+    the privacy-scan audit trail names the real entry point.
+    """
     paths = list_canonical_mcp_servers(project_root)
     if not paths:
         return McpServerSyncResult(
@@ -284,7 +294,7 @@ def generate_all_mcp_servers(project_root: Path) -> McpServerSyncResult:
             text,
             source_path=path,
             project_root=project_root,
-            surface="web_context_mcp_servers_sync",
+            surface=surface,
         )
         parsed = parse_mcp_server_text(text, name=path.stem, source=path)
         definitions[parsed.name] = parsed.definition

--- a/packages/memtomem/src/memtomem/context/mcp_servers_copy.py
+++ b/packages/memtomem/src/memtomem/context/mcp_servers_copy.py
@@ -39,12 +39,15 @@ Deliberate divergences from the artifact engine, each load-bearing:
   destination's git-tracked tree — Codex review blocker). Refusal is
   two-layered: a pre-flight check on the source, and an in-lock check
   on the staging entry for a source that turned into a link mid-copy.
-- **``sync_command`` is ``None``; ``sync_hint`` carries the follow-up.**
-  ``mm context sync`` has no mcp-servers phase (``--include`` accepts
-  skills/agents/commands/settings only) — fan-out into the destination's
-  ``.mcp.json`` is web-only (``POST /api/context/mcp-servers/sync``,
-  Sync All). Printing the engine's cd-prefixed sync command would
-  prescribe a no-op, so the result carries prose instead.
+- **``sync_command`` is the cd-prefixed CLI fan-out; ``sync_hint`` mirrors
+  it as prose.** Since #1311 ``mm context sync --include=mcp-servers`` fans
+  the canonical into the destination's ``.mcp.json`` (opt-in, sync-only), so
+  the result carries a runnable command (``cd <dst> && mm context sync
+  --include=mcp-servers --scope project_shared``) — cd-prefixed because the
+  destination is a different project (the cross-project ``--project`` selector
+  is A-9 #1279). ``sync_hint`` is the same instruction as prose for surfaces
+  that render the hint instead of the command, and names the web panel / API
+  (``POST /api/context/mcp-servers/sync``, Sync All) as equivalents.
 
 Gate A always runs (the destination tier IS project_shared; ``env``
 blocks are the expected hotspot) through the standard
@@ -66,6 +69,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import shlex
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
@@ -108,9 +112,10 @@ class McpServerCopyResult:
     rename, and ``provenance="not_applicable"`` (mcp-servers are not
     wiki-installed assets — there is no ``lock.json`` lineage to carry).
 
-    ``sync_command`` is always ``None`` (no CLI sync phase exists for
-    mcp-servers); ``sync_hint`` is the prose follow-up surfaces print
-    instead. ``notes`` carries the destination ``.mcp.json`` disclosure
+    Since #1311 ``sync_command`` is the runnable cd-prefixed CLI fan-out
+    (``cd <dst> && mm context sync --include=mcp-servers``); ``sync_hint``
+    is its prose mirror for surfaces that render the hint instead of the
+    command. ``notes`` carries the destination ``.mcp.json`` disclosure
     (same-name runtime entry that the destination's next sync will
     overwrite, or a broken ``.mcp.json`` its sync will refuse on).
     """
@@ -139,18 +144,33 @@ class McpServerCopyResult:
     provenance_reason_code: str | None = None
 
 
-def _sync_hint(dst_root: Path) -> str:
-    """Prose follow-up for the destination's ``.mcp.json`` fan-out.
+def _sync_command(dst_root: Path) -> str:
+    """Runnable follow-up: fan the copied canonical into the destination ``.mcp.json``.
 
-    Honest about the surface asymmetry: there is no ``mm context sync``
-    phase for mcp-servers, so the hint names the web affordances and the
-    exact API call (the scope_id makes it copy-pasteable).
+    cd-prefixed because the destination is a different project and sync runs
+    per-project (the cross-project ``--project`` selector is A-9 #1279, not yet
+    available); mirrors the artifact transfer's ``_sync_followup`` format.
+    Since #1311 ``mm context sync`` has an mcp-servers leg, so this is a real
+    command, not the web-only prose the result used to carry.
     """
     return (
-        f"fan out at the destination from its web panel (mm web → Context "
-        f"Gateway → MCP Servers → Sync) or `POST /api/context/mcp-servers/sync"
-        f"?project_scope_id={compute_scope_id(dst_root)}` — `mm context sync` "
-        f"has no mcp-servers phase."
+        f"cd {shlex.quote(str(dst_root))} && "
+        "mm context sync --include=mcp-servers --scope project_shared"
+    )
+
+
+def _sync_hint(dst_root: Path) -> str:
+    """Prose mirror of :func:`_sync_command` for surfaces that render the hint.
+
+    Since #1311 the runnable path is ``sync_command``; this prose carries the
+    same instruction and names the web panel / API as equivalents (the scope_id
+    keeps the API call copy-pasteable).
+    """
+    return (
+        f"run `mm context sync --include=mcp-servers --scope project_shared` in "
+        f"the destination project, or fan out from its web panel (mm web → "
+        f"Context Gateway → MCP Servers → Sync) / `POST /api/context/mcp-servers/"
+        f"sync?project_scope_id={compute_scope_id(dst_root)}`."
     )
 
 
@@ -351,6 +371,7 @@ def copy_mcp_server(
         )
 
     notes = _dst_mcp_json_notes(dst_root, name)
+    sync_command = _sync_command(dst_root)
     sync_hint = _sync_hint(dst_root)
 
     def _result(*, transferred: bool) -> McpServerCopyResult:
@@ -368,7 +389,7 @@ def copy_mcp_server(
             layout="flat",
             transferred=transferred,
             needs_sync=True,
-            sync_command=None,
+            sync_command=sync_command,
             sync_hint=sync_hint,
             notes=notes,
         )

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -1581,11 +1581,15 @@ def _format_transfer_result(result: TransferResult | McpServerCopyResult, *, app
     Mirrors the CLI's ``_print_transfer_result`` content: mode verb,
     copy-rename note, fan-out lists, the A-4 provenance carry outcome,
     engine ``notes``, and the engine's exact follow-up sync command
-    (``sync_command``, else the prose ``sync_hint`` for results with no
-    runnable command — mcp-servers fan-out is web-only). The dry-run
-    footer additionally names the confirmation flag(s) the destination
-    tier will require at apply time, so an agent learns the full
-    re-call shape from the preview.
+    (``sync_command``, else the prose ``sync_hint``). Since #1311 the
+    mcp-servers copy result carries a runnable ``sync_command``
+    (``cd <dst> && mm context sync --include=mcp-servers``) like every
+    other transfer; the MCP ``sync`` contract itself still rejects
+    ``include=mcp-servers`` (ADR-0021 §"Open questions" §5 scope-out), so
+    the follow-up is a shell command, not an ``mem_context_sync`` call.
+    The dry-run footer additionally names the confirmation flag(s) the
+    destination tier will require at apply time, so an agent learns the
+    full re-call shape from the preview.
     """
     layout_note = (
         " (flat layout)" if result.layout == "flat" and result.kind != "mcp-servers" else ""

--- a/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
@@ -461,7 +461,7 @@ async def _sync_mcp_servers_core(project_root: Path) -> dict:
     sync-all renders.
     """
     try:
-        result = generate_all_mcp_servers(project_root)
+        result = generate_all_mcp_servers(project_root, surface="web_context_mcp_servers_sync")
     except McpServerParseError as exc:
         raise SyncPhaseError(422, str(exc), error_kind="parse") from exc
     except McpServerPrivacyError as exc:

--- a/packages/memtomem/src/memtomem/web/routes/context_transfer.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_transfer.py
@@ -243,8 +243,10 @@ def _serialize(result: TransferResult | McpServerCopyResult) -> dict[str, Any]:
     human ``provenance_reason`` for tooltips, the stable
     ``provenance_reason_code`` for client matching. The mcp-servers copy
     result (A-12 #1282) implements the same attribute surface by pinned
-    contract; ``sync_hint`` is its prose follow-up (no CLI sync phase
-    exists for mcp-servers — engine results leave it ``null``).
+    contract; since #1311 it carries a runnable ``sync_command``
+    (``cd <dst> && mm context sync --include=mcp-servers``) with
+    ``sync_hint`` as its prose mirror (engine transfers leave both fields
+    for the artifact ``_sync_followup``; ``sync_hint`` stays ``null`` there).
     """
     return {
         "transferred": result.transferred,

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -3078,9 +3078,12 @@ function _ctxMissingCanonicalRemediationHtml(type, count, scannedDirs) {
     .replace('{count}', count)
     .replace(/\{type\}/g, _ctxTypeName(type))
     .replace('{scan_dirs}', scanList);
-  // The CLI bootstrap snippets cover skills/agents/commands only — there is
-  // no ``--include=mcp-servers`` in ``mm context``, so rendering them for the
-  // MCP section would hand the user commands that cannot touch MCP state.
+  // This is a MISSING-canonical banner: the generic snippets bootstrap a
+  // canonical from runtime (init/generate) for skills/agents/commands. MCP
+  // canonicals are not created that way (cross-project copy or hand-authored),
+  // and `mm context sync --include=mcp-servers` only fans an EXISTING canonical
+  // into .mcp.json — useless when the canonical is the thing that's missing —
+  // so the MCP row suppresses the snippets rather than prescribing a no-op.
   const commands = type === 'mcp-servers'
     ? ''
     : _ctxMissingCanonicalCommands(scope)

--- a/packages/memtomem/tests/test_cli_context_sync_all_projects.py
+++ b/packages/memtomem/tests/test_cli_context_sync_all_projects.py
@@ -175,6 +175,53 @@ def test_yes_executes_every_eligible_project(
     assert "Summary: 2 synced, 0 failed, 0 skipped." in result.output
 
 
+def _seed_mcp(root: Path) -> None:
+    store = root / ".memtomem" / "mcp-servers"
+    store.mkdir(parents=True, exist_ok=True)
+    (store / "pg.json").write_text(
+        json.dumps({"command": "npx", "args": ["-y", "server-pg"]}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_all_projects_mcp_servers_declined_skips_write(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The count-only "Sync N project(s)?" gate never discloses the .mcp.json
+    rewrite, so the mcp-servers leg confirms per target in a batch; declining
+    skips just that write and the project still succeeds (#1311)."""
+    a = _project(tmp_path, "proj-a")
+    _seed_mcp(a)
+    _seed_known_projects(known_projects_path, [(a, True)])
+    monkeypatch.chdir(a)
+
+    # "y" to the batch "Sync 1 project(s)?" gate, then "n" to the per-target
+    # mcp-servers fan-out confirm.
+    result = CliRunner().invoke(
+        context_group, ["sync", "--all-projects", "--include", "mcp-servers"], input="y\nn\n"
+    )
+    assert result.exit_code == 0, result.output
+    assert "Skipped mcp-servers sync (declined)." in result.output
+    assert not (a / ".mcp.json").exists()
+
+
+def test_all_projects_mcp_servers_yes_fans_out_without_prompt(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    a = _project(tmp_path, "proj-a")
+    _seed_mcp(a)
+    _seed_known_projects(known_projects_path, [(a, True)])
+    monkeypatch.chdir(a)
+
+    result = CliRunner().invoke(
+        context_group, ["sync", "--all-projects", "--include", "mcp-servers", "--yes"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "MCP servers fan-out: 1" in result.output
+    written = json.loads((a / ".mcp.json").read_text(encoding="utf-8"))
+    assert written["mcpServers"]["pg"]["command"] == "npx"
+
+
 def test_subdirectory_run_anchors_at_project_root(
     tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/packages/memtomem/tests/test_cli_context_sync_mcp_servers.py
+++ b/packages/memtomem/tests/test_cli_context_sync_mcp_servers.py
@@ -1,0 +1,149 @@
+"""CLI tests for the ``mm context sync --include=mcp-servers`` leg (#1311).
+
+The engine (:func:`memtomem.context.mcp_servers.generate_all_mcp_servers` —
+canonical-wins-per-name merge, the ``IN_SYNC`` no-op, the foreign-entry
+mode policy, Gate A) is pinned by ``test_context_mcp_servers.py``. This file
+covers what the CLI leg adds on top of that engine:
+
+- the opt-in contract: ``--include=mcp-servers`` fans out, while a bare
+  ``mm context sync`` (and any other ``--include``) never touches ``.mcp.json``
+  — the regression guard the #1311 decision turns on;
+- sync-only scoping: detect/init/generate/diff REJECT ``--include=mcp-servers``
+  (the kind has a canonical→``.mcp.json`` fan-out but no extract/init/diff, so
+  the shared ``_KNOWN_INCLUDES`` set is deliberately NOT widened);
+- the ``--scope`` ignore note (mcp-servers is single-tier project_shared);
+- a Gate A privacy hit surfaced as a red CLI error that aborts the leg, leaving
+  no ``.mcp.json`` behind.
+
+The ``--all-projects`` per-target confirm lives in
+``test_cli_context_sync_all_projects.py`` (its registry harness).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli.context_cmd import context as context_group
+
+_CLEAN = {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-postgres"],
+    "env": {"PG_HOST": "localhost"},
+}
+#: AWS-key shape — caught by Gate A's env-block scan.
+_SECRET = {"command": "npx", "env": {"AWS_ACCESS_KEY": "AKIA1234567890ABCDEF"}}
+
+
+@pytest.fixture()
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A project root (``.git`` marker so ``_find_project_root`` resolves it)
+    with an isolated HOME so the Gate A privacy audit stays hermetic."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    root = tmp_path / "proj"
+    (root / ".memtomem").mkdir(parents=True)
+    (root / ".git").mkdir()
+    monkeypatch.chdir(root)
+    return root
+
+
+def _seed(root: Path, name: str = "pg", definition: dict | None = None) -> Path:
+    store = root / ".memtomem" / "mcp-servers"
+    store.mkdir(parents=True, exist_ok=True)
+    path = store / f"{name}.json"
+    path.write_text(
+        json.dumps(definition if definition is not None else _CLEAN, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _run(args: list[str], **kw: object) -> object:
+    return CliRunner().invoke(context_group, args, **kw)  # type: ignore[arg-type]
+
+
+def test_include_mcp_servers_fans_into_mcp_json(project: Path) -> None:
+    _seed(project)
+    result = _run(["sync", "--include=mcp-servers"])
+    assert result.exit_code == 0, result.output
+    assert "MCP servers fan-out: 1" in result.output
+    written = json.loads((project / ".mcp.json").read_text(encoding="utf-8"))
+    assert written["mcpServers"]["pg"]["command"] == "npx"
+
+
+def test_canonical_wins_merge_preserves_foreign_entry(project: Path) -> None:
+    _seed(project)
+    (project / ".mcp.json").write_text(
+        json.dumps(
+            {"mcpServers": {"keepme": {"command": "stay"}, "pg": {"command": "OLD"}}},
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = _run(["sync", "--include=mcp-servers"])
+    assert result.exit_code == 0, result.output
+    written = json.loads((project / ".mcp.json").read_text(encoding="utf-8"))
+    # canonical wins for its own name; the foreign entry is carried verbatim.
+    assert written["mcpServers"]["pg"]["command"] == "npx"
+    assert written["mcpServers"]["keepme"] == {"command": "stay"}
+
+
+def test_rerun_is_in_sync_noop(project: Path) -> None:
+    _seed(project)
+    assert _run(["sync", "--include=mcp-servers"]).exit_code == 0
+    before = (project / ".mcp.json").read_bytes()
+    result = _run(["sync", "--include=mcp-servers"])
+    assert result.exit_code == 0, result.output
+    assert "already in sync" in result.output
+    assert (project / ".mcp.json").read_bytes() == before
+
+
+def test_bare_sync_never_touches_mcp_json(project: Path) -> None:
+    """The opt-in regression guard: mcp-servers fans out ONLY on --include."""
+    _seed(project)
+    (project / ".memtomem" / "context.md").write_text("## Notes\n\nhi\n", encoding="utf-8")
+    result = _run(["sync"])
+    assert result.exit_code == 0, result.output
+    assert not (project / ".mcp.json").exists()
+
+
+def test_other_include_does_not_touch_mcp_json(project: Path) -> None:
+    _seed(project)
+    result = _run(["sync", "--include=skills"])
+    assert result.exit_code == 0, result.output
+    assert not (project / ".mcp.json").exists()
+
+
+@pytest.mark.parametrize("subcommand", ["detect", "init", "generate", "diff"])
+def test_non_sync_commands_reject_mcp_servers(project: Path, subcommand: str) -> None:
+    """mcp-servers is a sync-only include token — the other four commands keep
+    the 4-kind _KNOWN_INCLUDES and reject it at parse time."""
+    _seed(project)
+    result = _run([subcommand, "--include=mcp-servers"])
+    assert result.exit_code != 0
+    assert "mcp-servers" in result.output
+    assert not (project / ".mcp.json").exists()
+
+
+def test_scope_note_when_non_project_shared_still_fans_project_shared(project: Path) -> None:
+    _seed(project)
+    result = _run(["sync", "--include=mcp-servers", "--scope", "user"])
+    assert result.exit_code == 0, result.output
+    assert "does not apply to mcp-servers" in result.output
+    # The ignored --scope does not block the fan-out; it lands project_shared.
+    assert (project / ".mcp.json").exists()
+
+
+def test_privacy_block_aborts_leg_and_writes_nothing(project: Path) -> None:
+    _seed(project, definition=_SECRET)
+    result = _run(["sync", "--include=mcp-servers"])
+    assert result.exit_code != 0
+    assert "Gate A" in result.output
+    assert not (project / ".mcp.json").exists()

--- a/packages/memtomem/tests/test_cli_context_transfer.py
+++ b/packages/memtomem/tests/test_cli_context_transfer.py
@@ -561,9 +561,11 @@ def test_mcp_copy_round_trip(cli_projects) -> None:
     dst = cli_projects["b"] / ".memtomem" / "mcp-servers" / "pg.json"
     assert dst.read_bytes() == src.read_bytes()
     assert "✓ copied mcp-servers/pg: project_shared → project_shared" in result.output
-    # Prose follow-up, not a runnable sync command — and no layout noise.
-    assert "Next: fan out at the destination from its web panel" in result.output
-    assert "`mm context sync` has no mcp-servers phase" in result.output
+    # Since #1311 the follow-up is a runnable cd-prefixed CLI command — and no
+    # layout noise for the single-layout kind.
+    assert "Next: run `cd " in result.output
+    assert "mm context sync --include=mcp-servers --scope project_shared`" in result.output
+    assert "web panel" not in result.output
     assert "(flat layout)" not in result.output
 
 
@@ -573,7 +575,8 @@ def test_mcp_dry_run_is_default_and_prints_hint(cli_projects) -> None:
     assert result.exit_code == 0, result.output
     assert not (cli_projects["b"] / ".memtomem" / "mcp-servers").exists()
     assert "Run with --apply --confirm-project-shared to execute." in result.output
-    assert "After apply, fan out at the destination from its web panel" in result.output
+    assert "After apply, run `cd " in result.output
+    assert "mm context sync --include=mcp-servers --scope project_shared`" in result.output
 
 
 def test_mcp_move_rejected(cli_projects) -> None:

--- a/packages/memtomem/tests/test_mcp_servers_copy.py
+++ b/packages/memtomem/tests/test_mcp_servers_copy.py
@@ -118,14 +118,17 @@ def test_dry_run_plan_mutates_nothing(roots) -> None:
     assert (result.from_scope, result.to_scope) == ("project_shared", "project_shared")
     assert result.layout == "flat"
     assert result.needs_sync is True
-    # No CLI sync phase exists for mcp-servers — the follow-up is prose,
-    # with the copy-pasteable API call carrying the destination scope_id.
-    assert result.sync_command is None
+    # Since #1311 the follow-up is a runnable cd-prefixed CLI command; the prose
+    # sync_hint mirrors it and still carries the copy-pasteable API call.
+    assert result.sync_command is not None
+    assert result.sync_command.startswith("cd ")
+    assert str(roots["b"]) in result.sync_command
+    assert "mm context sync --include=mcp-servers --scope project_shared" in result.sync_command
+    assert "mm context sync --include=mcp-servers" in result.sync_hint
     assert (
         f"POST /api/context/mcp-servers/sync?project_scope_id={compute_scope_id(roots['b'])}"
         in result.sync_hint
     )
-    assert "mm context sync` has no mcp-servers phase" in result.sync_hint
     assert result.notes == ()
     assert result.provenance == "not_applicable"
 

--- a/packages/memtomem/tests/test_server_tools_context_artifact_transfer.py
+++ b/packages/memtomem/tests/test_server_tools_context_artifact_transfer.py
@@ -629,9 +629,11 @@ async def test_mcp_copy_round_trip(projects) -> None:
     assert "✓ copied mcp-servers/pg: project_shared → project_shared" in out
     dst = projects["b"] / ".memtomem" / "mcp-servers" / "pg.json"
     assert dst.read_bytes() == src.read_bytes()
-    # Prose follow-up (web-only fan-out), not a runnable sync command — and
+    # Since #1311 the follow-up is a runnable cd-prefixed CLI command (the MCP
+    # sync contract itself still rejects include=mcp-servers; ADR-0021 §5) — and
     # no layout noise for the single-layout kind.
-    assert "Next: fan out at the destination from its web panel" in out
+    assert "Next: run `cd " in out
+    assert "mm context sync --include=mcp-servers --scope project_shared`" in out
     assert "(flat layout)" not in out
 
 
@@ -644,7 +646,8 @@ async def test_mcp_dry_run_names_required_flags(projects) -> None:
     )
     assert out.startswith("Plan: copy mcp-servers/pg")
     assert "Re-call with apply=True and confirm_project_shared=True to execute." in out
-    assert "After apply, fan out at the destination from its web panel" in out
+    assert "After apply, run `cd " in out
+    assert "mm context sync --include=mcp-servers --scope project_shared`" in out
     assert not (projects["b"] / ".memtomem" / "mcp-servers").exists()
 
 

--- a/packages/memtomem/tests/test_web_routes_context_transfer.py
+++ b/packages/memtomem/tests/test_web_routes_context_transfer.py
@@ -663,8 +663,9 @@ async def test_timeout_503_busy_with_bounded_lock_budget(
 # the route's mcp branch: the validation 400 matrix in mcp vocabulary,
 # the shared gates (confirm round-trip, eligibility, store check)
 # applying unchanged, the issue-pinned 422s (string privacy envelope /
-# object parse envelope), and the wire shape (``sync_hint`` prose with
-# ``sync_command`` null — no CLI sync phase exists for mcp-servers).
+# object parse envelope), and the wire shape (since #1311 a runnable
+# ``sync_command`` — ``cd <dst> && mm context sync --include=mcp-servers`` —
+# with ``sync_hint`` as its prose mirror).
 
 
 _MCP_CLEAN = {"command": "npx", "args": ["-y", "srv"], "env": {"PG_HOST": "localhost"}}
@@ -709,9 +710,11 @@ async def test_mcp_copy_ok(client, cwd_root: Path, tmp_path: Path) -> None:
     assert data["layout"] == "flat"
     assert (data["from_scope"], data["to_scope"]) == ("project_shared", "project_shared")
     assert data["dst_project_scope_id"] == scope_b
-    # Follow-up contract: needs_sync with prose (no runnable CLI command).
+    # Follow-up contract (#1311): needs_sync with a runnable cd-prefixed
+    # command; the prose sync_hint mirrors it and keeps the API call.
     assert data["needs_sync"] is True
-    assert data["sync_command"] is None
+    assert data["sync_command"].startswith("cd ")
+    assert "mm context sync --include=mcp-servers --scope project_shared" in data["sync_command"]
     assert f"project_scope_id={scope_b}" in data["sync_hint"]
     assert data["provenance"] == "not_applicable"
 
@@ -736,7 +739,11 @@ async def test_mcp_needs_confirmation_round_trip(client, cwd_root: Path, tmp_pat
     assert data["status"] == "needs_confirmation"
     assert data["confirm"] == "confirm_project_shared"
     assert data["plan"]["transferred"] is False
-    assert data["plan"]["sync_command"] is None
+    assert data["plan"]["sync_command"].startswith("cd ")
+    assert (
+        "mm context sync --include=mcp-servers --scope project_shared"
+        in data["plan"]["sync_command"]
+    )
     assert data["plan"]["sync_hint"]
     assert not dst.exists()
 


### PR DESCRIPTION
## What

Adds the opt-in, **sync-only** `mcp-servers` phase to `mm context sync` (and
`--all-projects`), closing the CLI/web surface asymmetry tracked in #1311
(item 3). `--include=mcp-servers` fans canonical `.memtomem/mcp-servers/*.json`
into the project `.mcp.json` via the same `generate_all_mcp_servers` core the
web Sync route already calls, so CLI and web stay byte-parallel
(canonical-wins-per-name merge, IN_SYNC no-op, foreign-entry mode policy).

Resolves the deferred **default-on vs opt-in** policy fork in favor of **opt-in**.

## Why opt-in (the deferred decision)

- A bare `mm context sync` never touches `.mcp.json`, and every artifact kind
  (skills/agents/commands/settings) is already `--include`-gated. Default-on
  would make `mcp-servers` the *only* default-fanning kind — a new intra-CLI
  asymmetry. Web "Sync All" is an explicit bundle, not the analog of bare CLI
  sync, so the parity argument points *at* opt-in.
- `.mcp.json` holds executable MCP-server config (foreign entries carried
  verbatim, unscanned) — a larger blast radius than the prose kinds, so the
  write stays explicitly requested.

## Design notes

- **Sync-only scoping.** `_KNOWN_INCLUDES` (the shared
  detect/init/generate/diff/sync contract, mirrored in the MCP tool) is
  unchanged; sync uses `_SYNC_INCLUDES = _KNOWN_INCLUDES | {mcp-servers}`. The
  other commands still reject `--include=mcp-servers` because the kind has a
  canonical→`.mcp.json` fan-out but no extract/init/diff engine — adding it to
  the shared set would have created silent no-op contracts on four surfaces.
- **`--all-projects` confirms per target** before each `.mcp.json` rewrite (the
  count-only "Sync N projects?" gate does not disclose the executable-config
  write); single-project runs treat the explicit `--include` as consent.
- **`--scope` is a no-op note** (mcp-servers is single-tier project_shared, ADR-0016 §3).
- **Copy follow-up.** The cross-project `mm context copy mcp-servers` result now
  prints a runnable `cd <dst> && mm context sync --include=mcp-servers --scope
  project_shared` command instead of web-only prose, closing the
  `sync_hint`/`sync_command` split for this kind (#1282 follow-up).
- **Out of scope (preserved):** the MCP `sync` contract (`mem_context_sync`)
  still rejects `include=mcp-servers`; that parity and an `all` alias remain an
  ADR-0021 §"Open questions" §5 scope-out. This PR narrows §5 to the MCP
  contract only.

## Tests

- New `test_cli_context_sync_mcp_servers.py`: the opt-in regression guard (bare
  `mm context sync` leaves `.mcp.json` untouched), canonical-wins merge through
  the CLI, IN_SYNC no-op, sync-only scoping (detect/init/generate/diff reject),
  the `--scope` note, and Gate A abort.
- `--all-projects` per-target confirm (declined skips, `--yes` bypasses) in
  `test_cli_context_sync_all_projects.py`.
- Updated copy-hint pins across the CLI / web / MCP transfer suites, plus
  ADR-0021/0023, `docs/guides/reference.md`, and the CHANGELOG.

Engine merge / IN_SYNC / mode / Gate-A behavior stays pinned by
`test_context_mcp_servers.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
