### PR TITLE
fix(web): context skills + mcp-servers _safe_rel returns POSIX paths (latent #1256 shape)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
@@ -42,10 +42,19 @@ router = APIRouter(tags=["context-mcp-servers"])
 
 
 def _safe_rel(p: Path, project_root: Path) -> str:
+    """Project-relative path as a POSIX string for API payloads.
+
+    ``.as_posix()`` (not ``str``) so ``canonical_path`` / ``path`` fields come
+    back ``/``-separated on every platform — the Web UI and diff payloads pin
+    POSIX separators (#1256). Falls back to the absolute POSIX path outside
+    ``project_root``. Parity with ``context_agents`` / ``context_commands``
+    (#1264); this route was never covered by #1256's diff tests, so the
+    ``str()`` form lingered latent (#1325).
+    """
     try:
-        return str(p.relative_to(project_root))
+        return p.relative_to(project_root).as_posix()
     except ValueError:
-        return str(p)
+        return p.as_posix()
 
 
 def _reject_non_shared_write(target_scope: TargetScope, action: str) -> None:

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -137,10 +137,19 @@ def _user_sync_host_targets(project_root: Path) -> list[str]:
 
 
 def _safe_rel(p: Path, project_root: Path) -> str:
+    """Project-relative path as a POSIX string for API payloads.
+
+    ``.as_posix()`` (not ``str``) so canonical/runtime paths come back
+    ``/``-separated on every platform — the Web UI and diff payloads pin POSIX
+    separators (#1256). Falls back to the absolute POSIX path for user-tier
+    locations outside ``project_root``. Parity with ``context_agents`` /
+    ``context_commands`` (#1264); this route was just never covered by #1256's
+    diff tests, so the ``str()`` form lingered latent (#1325).
+    """
     try:
-        return str(p.relative_to(project_root))
+        return p.relative_to(project_root).as_posix()
     except ValueError:
-        return str(p)
+        return p.as_posix()
 
 
 # ── List ─────────────────────────────────────────────────────────────────
@@ -277,7 +286,10 @@ async def read_skill(
         if p.is_file() and p.name != SKILL_MANIFEST:
             files.append(
                 {
-                    "path": str(p.relative_to(skill_dir)),
+                    # ``.as_posix()`` (not ``str``) — same POSIX-separator
+                    # contract as ``_safe_rel``; ``str(PurePath)`` is
+                    # backslash-joined on Windows (#1325).
+                    "path": p.relative_to(skill_dir).as_posix(),
                     "size": p.stat().st_size,
                 }
             )

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -3,10 +3,15 @@
 Diff-payload contract pinned by ``TestDiffCommand`` / ``TestDiffAgent`` (#1256):
 
 - **Paths** are normalized to POSIX separators on every platform. The route
-  helpers ``_safe_rel`` in ``context_commands`` / ``context_agents`` return
-  ``.as_posix()`` so the Web UI receives stable ``/``-separated paths; the diff
-  tests assert literal POSIX strings (e.g. ``.claude/commands/ghost.md``) rather
-  than ``str(Path(...))``, which would be backslash-joined on Windows.
+  helpers ``_safe_rel`` in ``context_commands`` / ``context_agents`` /
+  ``context_skills`` return ``.as_posix()`` so the Web UI receives stable
+  ``/``-separated paths; the diff tests assert literal POSIX strings (e.g.
+  ``.claude/commands/ghost.md``) rather than ``str(Path(...))``, which would be
+  backslash-joined on Windows. The literal-POSIX route assertions only fail on
+  ``windows-latest`` (``str(PosixPath)`` already ``/``-joins on macOS/Linux);
+  ``test_safe_rel_joins_with_posix_separators`` is the cross-platform guard —
+  it drives ``_safe_rel`` with a ``PureWindowsPath`` so a regression to
+  ``str()`` fails on any host (#1325, same shape as #1256).
 - **Content** is LF, not platform-native. Canonical generators and sync write
   LF bytes, so fixtures here use ``_write_text_lf`` (raw bytes) instead of
   ``Path.write_text`` (text mode translates ``\\n`` -> ``\\r\\n`` on Windows).
@@ -17,7 +22,7 @@ Diff-payload contract pinned by ``TestDiffCommand`` / ``TestDiffAgent`` (#1256):
 from __future__ import annotations
 
 import os
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from unittest.mock import AsyncMock
 
 import pytest
@@ -90,6 +95,26 @@ def _make_runtime_skill(
 def _write_text_lf(path: Path, content: str) -> None:
     """Write fixtures with sync-style LF bytes on every platform."""
     path.write_bytes(content.encode("utf-8"))
+
+
+def test_safe_rel_joins_with_posix_separators() -> None:
+    """Cross-platform guard for the skills ``_safe_rel`` POSIX contract (#1325).
+
+    The route-level literal-POSIX assertions in this file only fail on
+    ``windows-latest`` — ``str(PosixPath("a/b"))`` already yields ``"a/b"`` on
+    macOS/Linux, so a regression to ``str()`` is invisible there. Driving the
+    helper with a ``PureWindowsPath`` (whose ``str()`` is backslash-joined on
+    every host) makes the assertion fail on any platform if ``.as_posix()``
+    reverts to ``str()`` — the exact gap that let this bug slip past #1256.
+    """
+    from memtomem.web.routes.context_skills import _safe_rel
+
+    root = PureWindowsPath(r"C:\proj")
+    nested = PureWindowsPath(r"C:\proj\.memtomem\skills\demo\SKILL.md")
+    assert _safe_rel(nested, root) == ".memtomem/skills/demo/SKILL.md"
+    # Outside project_root → absolute POSIX fallback, still backslash-free.
+    outside = PureWindowsPath(r"C:\other\skills\x")
+    assert "\\" not in _safe_rel(outside, root)
 
 
 # ---------------------------------------------------------------------------
@@ -765,7 +790,10 @@ class TestReadSkill:
         r = await client.get("/api/context/skills/rich")
         data = r.json()
         paths = [f["path"] for f in data["files"]]
-        assert any("run.sh" in p for p in paths)
+        # Multi-segment intra-skill path pins POSIX separators — the inline
+        # ``relative_to(skill_dir).as_posix()`` (not ``str``) at
+        # context_skills.py would emit ``scripts\\run.sh`` on Windows (#1325).
+        assert "scripts/run.sh" in paths
 
 
 # ---------------------------------------------------------------------------
@@ -783,6 +811,9 @@ class TestCreateSkill:
         assert r.status_code == 200
         data = r.json()
         assert data["name"] == "new-skill"
+        # Multi-segment ``canonical_path`` pins POSIX separators — ``_safe_rel``
+        # would emit ``.memtomem\\skills\\new-skill`` on Windows pre-fix (#1325).
+        assert data["canonical_path"] == ".memtomem/skills/new-skill"
         # Verify file exists on disk
         assert (tmp_path / ".memtomem" / "skills" / "new-skill" / SKILL_MANIFEST).is_file()
 
@@ -870,6 +901,11 @@ class TestDeleteSkill:
         assert r.status_code == 200
         assert not (tmp_path / ".memtomem" / "skills" / "cascade").exists()
         assert not (tmp_path / ".claude" / "skills" / "cascade").exists()
+        # ``deleted`` entries are ``_safe_rel`` results — literal POSIX, not
+        # ``.memtomem\\skills\\cascade`` (#1325; mirrors the commands route pin).
+        data = r.json()
+        assert ".memtomem/skills/cascade" in data["deleted"]
+        assert ".claude/skills/cascade" in data["deleted"]
 
     @pytest.mark.anyio
     async def test_delete_missing_is_idempotent(self, client: AsyncClient):

--- a/packages/memtomem/tests/test_web_routes_context_mcp_servers.py
+++ b/packages/memtomem/tests/test_web_routes_context_mcp_servers.py
@@ -1,8 +1,21 @@
+"""Tests for the Context Gateway MCP-servers web route.
+
+Path-payload contract (#1325, same shape as #1256): ``canonical_path`` /
+``path`` / delete-``removed`` fields are normalized to POSIX separators on
+every platform. The route helper ``_safe_rel`` returns ``.as_posix()`` (parity
+with ``context_agents`` / ``context_commands`` / ``context_skills``), so the
+assertions below pin literal ``/``-joined strings rather than
+``Path(...) == Path(...)``, which would have masked the backslash-joined
+Windows form. The literal-string route assertions only fail on
+``windows-latest`` (``str(PosixPath)`` already ``/``-joins on macOS/Linux);
+``test_safe_rel_joins_with_posix_separators`` is the cross-platform guard.
+"""
+
 from __future__ import annotations
 
 import json
 import logging
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from unittest.mock import AsyncMock
 
 import pytest
@@ -10,6 +23,7 @@ from httpx import ASGITransport, AsyncClient
 
 from memtomem.config import Mem2MemConfig
 from memtomem.web.app import create_app
+from memtomem.web.routes.context_mcp_servers import _safe_rel
 
 
 @pytest.fixture
@@ -43,10 +57,10 @@ async def test_create_list_read_sync_and_overview(client: AsyncClient, tmp_path:
         json={"name": "demo", "content": _definition()},
     )
     assert create.status_code == 200
-    # ``_safe_rel`` returns OS-native separators (matching the skills/commands/
-    # agents routes), so compare component-wise rather than against a literal
-    # forward-slash string — ``.memtomem\\mcp-servers\\demo.json`` on Windows.
-    assert Path(create.json()["canonical_path"]) == Path(".memtomem/mcp-servers/demo.json")
+    # ``_safe_rel`` returns POSIX separators on every platform (#1325) — pin the
+    # literal ``/``-joined string, not ``Path(...) == Path(...)``, which would
+    # mask the ``.memtomem\\mcp-servers\\demo.json`` Windows form.
+    assert create.json()["canonical_path"] == ".memtomem/mcp-servers/demo.json"
 
     listing = await client.get("/api/context/mcp-servers")
     assert listing.status_code == 200
@@ -251,7 +265,8 @@ async def test_diff_reasons_distinguish_canonical_vs_mcp_json(
     r = await client.get("/api/context/mcp-servers/bad/diff")
     assert r.status_code == 200
     data = r.json()
-    assert Path(data["canonical_path"]) == Path(".memtomem/mcp-servers/bad.json")
+    # Literal POSIX pin (#1325) — see ``test_create_list_read_sync_and_overview``.
+    assert data["canonical_path"] == ".memtomem/mcp-servers/bad.json"
     rt = data["runtimes"][0]
     assert rt["status"] == "parse error"
     assert "bad.json" in rt["reason"]
@@ -284,7 +299,8 @@ async def test_list_tolerates_invalid_named_canonical(client: AsyncClient, tmp_p
     listing = await client.get("/api/context/mcp-servers")
     assert listing.status_code == 200
     rows = {row["name"]: row for row in listing.json()["mcp-servers"]}
-    assert rows["good"]["canonical_path"] is not None
+    # POSIX-pinned (#1325) — the valid canonical's list-row path stays ``/``-joined.
+    assert rows["good"]["canonical_path"] == ".memtomem/mcp-servers/good.json"
     assert rows["my server"]["canonical_path"] is None
     assert rows["my server"]["runtimes"][0]["status"] == "invalid name"
 
@@ -351,3 +367,36 @@ async def test_sync_payload_carries_names_and_in_sync_rerun_skips(
     assert len(body["skipped"]) == 1
     assert body["skipped"][0]["reason_code"] == "in_sync"
     assert (tmp_path / ".mcp.json").stat().st_mtime_ns == mtime_before
+
+
+# ── #1325: POSIX-separator path payloads (same shape as #1256) ───────────────
+
+
+@pytest.mark.anyio
+async def test_delete_removed_entry_is_posix(client: AsyncClient, tmp_path: Path) -> None:
+    """The delete ``removed`` entry is a ``_safe_rel`` result — multi-segment
+    and literal POSIX, not the backslash-joined ``.memtomem\\mcp-servers\\
+    gone.json`` Windows form (#1325; mirrors the skills/commands cascade pins)."""
+    _seed_canonical(tmp_path, "gone")
+    r = await client.delete("/api/context/mcp-servers/gone")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["deleted"] == [".memtomem/mcp-servers/gone.json"]
+    assert data["skipped"] == []
+
+
+def test_safe_rel_joins_with_posix_separators() -> None:
+    """Cross-platform guard for the MCP-servers ``_safe_rel`` POSIX contract.
+
+    The literal-string route assertions only fail on ``windows-latest``
+    (``str(PosixPath("a/b"))`` already yields ``"a/b"`` on macOS/Linux). Driving
+    the helper with a ``PureWindowsPath`` — whose ``str()`` is backslash-joined
+    on every host — makes a regression to ``str()`` fail on any platform, the
+    exact gap that let this slip past #1256 (#1325).
+    """
+    root = PureWindowsPath(r"C:\proj")
+    nested = PureWindowsPath(r"C:\proj\.memtomem\mcp-servers\demo.json")
+    assert _safe_rel(nested, root) == ".memtomem/mcp-servers/demo.json"
+    # Outside project_root → absolute POSIX fallback, still backslash-free.
+    outside = PureWindowsPath(r"C:\other\mcp-servers\x.json")
+    assert "\\" not in _safe_rel(outside, root)

--- a/packages/memtomem/tests/test_web_routes_context_user_tier.py
+++ b/packages/memtomem/tests/test_web_routes_context_user_tier.py
@@ -360,7 +360,10 @@ class TestUserTierCreate:
         manifest = home / ".memtomem" / "skills" / "newskill" / SKILL_MANIFEST
         assert manifest.is_file()
         # Regression: bare relative_to(project_root) 500'd on user-tier paths.
-        assert r.json()["canonical_path"] == str(manifest.parent)
+        # The POSIX fallback (``p.as_posix()``) keeps ``canonical_path``
+        # ``/``-joined on every platform — parity with the agents user-tier
+        # assertion below and the #1325 separator contract.
+        assert r.json()["canonical_path"] == manifest.parent.as_posix()
 
     @pytest.mark.anyio
     async def test_duplicate_is_409_not_confirmation_prompt(self, client: AsyncClient, home: Path):
@@ -623,8 +626,9 @@ class TestUserTierImport:
         body = r.json()
         canonical = home / ".memtomem" / "skills" / "imp1"
         assert (canonical / SKILL_MANIFEST).is_file()
-        # Regression: bare relative_to(project_root) 500'd on user-tier paths.
-        assert body["imported"] == [{"name": "imp1", "canonical_path": str(canonical)}]
+        # Regression: bare relative_to(project_root) 500'd on user-tier paths;
+        # the POSIX fallback keeps ``canonical_path`` ``/``-joined (#1325).
+        assert body["imported"] == [{"name": "imp1", "canonical_path": canonical.as_posix()}]
         assert body["dry_run"] is False
 
     @pytest.mark.anyio


### PR DESCRIPTION
## What

The `_safe_rel` helpers in `context_skills.py` and `context_mcp_servers.py`
returned OS-native path strings (`str(p.relative_to(...))`), so on Windows the
`canonical_path` / per-runtime `path` / delete-`removed` payload fields came
back backslash-joined (`.memtomem\skills\foo`) — the exact shape #1256 fixed
for the **agents** / **commands** routes in #1264. These two routes were never
covered by #1256's diff tests, so the `str()` form lingered **latent**, not
regressed.

## Fix

Switch both `_safe_rel` helpers — and the inline intra-skill file list in
`read_skill` (`context_skills.py`, source line ~280) — to `.as_posix()`, at
full parity with `context_agents` / `context_commands`. The `except ValueError`
fallback also moves to `p.as_posix()` (parity again), so user-tier
`canonical_path` values are POSIX too.

Deliberately **left** as OS-native `str(...)`, matching the #1264 reference:
`host_targets`, the `project_root` payload field, `mtime_ns` (an int), and
`str(exc)` reasons — these are absolute host paths / non-paths, not relative
artifact paths.

## Tests

- **Route-level literal-POSIX pins** on a multi-segment `canonical_path` /
  `path` / `deleted` for each route (skills create + cascade-delete + aux-file
  list; mcp-servers create/list/diff + delete-`removed`), mirroring the
  literal-POSIX assertions #1264 added.
- **Cross-platform guard** — `test_safe_rel_joins_with_posix_separators` drives
  `_safe_rel` with a `PureWindowsPath` (whose `str()` is backslash-joined on
  every host), so a regression to `str()` fails on **any** platform. The
  route-level literal-string pins are green on macOS/Linux either way
  (`str(PosixPath)` already `/`-joins) — which is exactly why this slipped past
  #1256; this guard closes that gap. Verified by reverting the source to
  `str()`: both guards fail, the route pins stay green.
- Replaced the two `Path(...) == Path(...)` **separator-masking** assertions in
  the mcp-servers tests (their own comments acknowledged the workaround) with
  literal-POSIX pins, and updated the skills user-tier fallback assertions to
  `.as_posix()` (agents parity).

## Contract

The diff-payload POSIX contract docstring in `test_web_routes_context.py`
(#1324) now names `context_skills` alongside commands/agents, and a parallel
contract note was added to `test_web_routes_context_mcp_servers.py`.

Refs #1256, #1264, #1324. Closes #1325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
