### PR TITLE
docs(readme): cross-ref Context Gateway scan vs memory indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ mm init                               # preset picker, then memory_dir + MCP
 
 The interactive picker starts with three presets — **Minimal** (BM25, no downloads), **English (Recommended)** (ONNX `bge-small-en-v1.5` + English reranker + auto-discover providers), **Korean-optimized** (ONNX `bge-m3` + `kiwipiepy` tokenizer + multilingual reranker) — plus an **Advanced** entry that opens the full 10-step wizard. Preset paths only ask about the memory directory and MCP registration; everything else is set from the preset.
 
+> **Indexing vs. discovery (Claude Code):** provider memory folders that setup auto-discovers (e.g. `~/.claude/projects/*/memory/`) are added to the search *index*. That is separate from the Web UI's opt-in Context Gateway scan of `~/.claude/projects/`, which discovers project *roots* for Skills, Custom Commands, and Subagents — see [Configuration → Context Gateway](docs/guides/configuration.md#context-gateway) for the distinction and the lossy-slug caveats.
+
 For automation / CI:
 
 ```bash

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -39,6 +39,8 @@ The picker offers three presets and an Advanced fallback:
 
 Pick a preset interactively, or use `mm init -y` (minimal), `mm init --preset korean -y`, or `mm init --advanced` for scripted runs. See [Embeddings](https://github.com/memtomem/memtomem/blob/main/docs/guides/embeddings.md) for the full model matrix.
 
+> **Claude Code — indexing vs. discovery:** the memory folders `mm init` indexes are added to the search *index*. That is separate from the Web UI's opt-in Context Gateway scan of `~/.claude/projects/`, which discovers project *roots* for Skills, Custom Commands, and Subagents — see [Configuration → Context Gateway](https://github.com/memtomem/memtomem/blob/main/docs/guides/configuration.md#context-gateway) for the opt-in behavior and lossy-slug caveats.
+
 Then in your AI editor, ask:
 
 ```


### PR DESCRIPTION
## What

Adds a short README cross-reference distinguishing two easily-confused Claude
Code surfaces:

- **`mm init` provider auto-discovery** — adds AI-tool memory *folders* (e.g.
  `~/.claude/projects/*/memory/`) to the search **index**.
- **Web UI Context Gateway scan** of `~/.claude/projects/` (opt-in,
  `EXPERIMENTAL_CLAUDE_PROJECTS_SCAN`) — discovers project **roots** for Skills,
  Custom Commands, and Subagents.

Both the root README and the PyPI README now point readers to
[`docs/guides/configuration.md#context-gateway`](docs/guides/configuration.md#context-gateway)
for the indexing-vs-discovery distinction and the lossy-slug caveats.

## Why

This salvages the one genuinely-unmerged piece from the abandoned, never-PR'd
branch `docs/claude-discovery`. An audit found that branch's substantive
documentation (provider-folder `mm init` behavior, `mm sync-doctor` report-only
note, the `EXPERIMENTAL_CLAUDE_PROJECTS_SCAN` gateway scan, the lossy
slug-encoding) had **already landed in `main` via other PRs in reworded form** —
the *only* content missing from `main` was this README cross-reference. Rather
than carry a stale draft branch, the useful bit is ported here (adapted to
current `main`, terminology matched to the Configuration guide's Context Gateway
section, anchor verified) and the draft branch is retired.

Docs-only; touches no guarded doc (`test_docs_guards.py` covers the integration
guides, not the READMEs) and no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
