### PR TITLE
feat(wiki): mm wiki <type> {diff, lint} — inspect overrides (ADR-0008 PR-D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+- **`mm wiki <type> {diff, lint}` — inspect wiki overrides (ADR-0008 PR-D; #1332).**
+  Two read-only verbs round out the per-asset `mm wiki skill|agent|command`
+  group. `diff <name> --vendor <vendor>` renders the canonical the way
+  `override` would seed it and prints a unified diff against the committed
+  `overrides/<vendor>.<ext>`, surfacing both your hand-edits and any canonical
+  drift since seeding (always exits 0; canonical fields the vendor format cannot
+  carry are noted on stderr). `lint <name> [--vendor <vendor>]` validates the
+  asset is well-formed and installable — name, canonical presence + parse, and
+  per-vendor representability + override UTF-8 — exiting non-zero on any error so
+  it is usable as a CI gate while dropped-field warnings stay exit 0. Both reuse
+  the PR-C `render_seed_bytes` / `OVERRIDE_FORMATS` machinery, so
+  `diff` / `lint` / `override` never disagree about what the runtime sees.
+
 - **`mm context sync --include=mcp-servers` — CLI mcp-servers fan-out (#1311).**
   `mm context sync` (and `--all-projects`) gained an opt-in mcp-servers phase:
   `--include=mcp-servers` fans canonical `.memtomem/mcp-servers/*.json`

--- a/packages/memtomem/src/memtomem/cli/wiki_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/wiki_cmd.py
@@ -16,6 +16,10 @@ from memtomem.wiki import (
     WikiNotFoundError,
     WikiStore,
 )
+from memtomem.wiki.inspect import (
+    diff_override,
+    lint_asset,
+)
 from memtomem.wiki.override import (
     OverrideExistsError,
     seed_override,
@@ -86,6 +90,113 @@ def _run_seed_override(
 
     if editor:
         click.edit(filename=str(result.path), require_save=False)
+
+
+def _echo_diff_line(line: str) -> None:
+    """Colorize one ``difflib.unified_diff`` line the way git does — added
+    green, removed red, hunk header cyan, file headers / context plain."""
+    text = line.rstrip("\n")
+    if line.startswith("+") and not line.startswith("+++"):
+        click.secho(text, fg="green")
+    elif line.startswith("-") and not line.startswith("---"):
+        click.secho(text, fg="red")
+    elif line.startswith("@@"):
+        click.secho(text, fg="cyan")
+    else:
+        click.echo(text)
+
+
+def _note_dropped(dropped: list[str], vendor: str) -> None:
+    """Stderr note listing canonical fields the vendor format cannot carry.
+
+    ``diff`` surfaces these so a side-by-side reader is not surprised that an
+    override never contains them — the override could not represent them even
+    if the user wanted. Stderr keeps stdout a clean diff for capture.
+    """
+    if dropped:
+        click.secho(
+            f"note: vendor {vendor!r} does not represent: {', '.join(dropped)}",
+            fg="yellow",
+            err=True,
+        )
+
+
+def _run_diff(
+    asset_type: Literal["skills", "agents", "commands"],
+    name: str,
+    vendor: str,
+) -> None:
+    """Shared body for ``mm wiki {skill,agent,command} diff``.
+
+    Prints the unified diff between the canonical render and the committed
+    override (``mm context diff``-style), classifies wiki / canonical errors
+    as a :class:`click.ClickException` so no traceback leaks, and always exits
+    0 — ``diff`` is informational, not a gate.
+    """
+    store = WikiStore.at_default()
+    try:
+        result = diff_override(store, asset_type, name, vendor)
+    except (
+        WikiNotFoundError,
+        FileNotFoundError,
+        InvalidNameError,
+        NotImplementedError,
+        ValueError,
+    ) as exc:
+        # Same disjoint sibling set as ``_run_seed_override`` plus ValueError
+        # for an unregistered (asset_type, vendor); ordering irrelevant.
+        raise click.ClickException(str(exc)) from exc
+
+    # ``override_path`` is built under ``store.root`` by construction — a
+    # violation is a real bug worth surfacing, so no is_relative_to fallback.
+    rel = result.override_path.relative_to(store.root).as_posix()
+    if not result.exists:
+        click.secho(f"No override at {rel}", fg="yellow")
+        click.echo(
+            f"# seed one: mm wiki {asset_type.removesuffix('s')} override {name} --vendor {vendor}"
+        )
+    elif result.in_sync:
+        click.secho(f"{rel} is in sync with the canonical render.", fg="green")
+    else:
+        for line in result.diff_lines:
+            _echo_diff_line(line)
+
+    _note_dropped(result.dropped, vendor)
+
+
+def _run_lint(
+    asset_type: Literal["skills", "agents", "commands"],
+    name: str,
+    vendor: str | None,
+) -> None:
+    """Shared body for ``mm wiki {skill,agent,command} lint``.
+
+    Prints one line per finding to stdout and exits non-zero when the report
+    carries any error, so the verb is usable as a CI gate. The whole report
+    is the output; the exit code is the machine signal. Only the absent-wiki
+    case is a :class:`click.ClickException` (it is not asset-specific).
+    """
+    store = WikiStore.at_default()
+    try:
+        report = lint_asset(store, asset_type, name, vendor)
+    except WikiNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    for finding in report.findings:
+        if finding.level == "error":
+            click.secho(f"  error: {finding.message}", fg="red")
+        else:
+            click.secho(f"  warning: {finding.message}", fg="yellow")
+
+    target = f"{asset_type}/{name}"
+    if report.ok:
+        n_warn = sum(1 for f in report.findings if f.level == "warning")
+        suffix = f" ({n_warn} warning{'s' if n_warn != 1 else ''})" if n_warn else ""
+        click.secho(f"{target}: OK{suffix}", fg="green")
+        return
+    n_err = sum(1 for f in report.findings if f.level == "error")
+    click.secho(f"{target}: lint failed ({n_err} error{'s' if n_err != 1 else ''})", fg="red")
+    click.get_current_context().exit(1)
 
 
 @wiki.command("init")
@@ -187,6 +298,45 @@ def skill_override_cmd(name: str, vendor: str, force: bool, editor: bool) -> Non
     _run_seed_override("skills", name, vendor, force=force, editor=editor)
 
 
+@skill_group.command("diff")
+@click.argument("name")
+@click.option(
+    "--vendor",
+    "-v",
+    type=click.Choice(["claude", "gemini", "codex"]),
+    required=True,
+    help="Which runtime override to diff against the canonical render.",
+)
+def skill_diff_cmd(name: str, vendor: str) -> None:
+    """Show how a skill override diverges from the canonical render.
+
+    ``mm wiki skill diff <name> --vendor <vendor>`` re-renders the canonical
+    ``SKILL.md`` the way ``override`` would seed it and prints a unified diff
+    against the committed ``overrides/<vendor>.md`` — surfacing both your
+    hand-edits and any canonical drift since the override was seeded. Exits 0.
+    """
+    _run_diff("skills", name, vendor)
+
+
+@skill_group.command("lint")
+@click.argument("name")
+@click.option(
+    "--vendor",
+    "-v",
+    type=click.Choice(["claude", "gemini", "codex"]),
+    default=None,
+    help="Restrict representability checks to one runtime (default: every override on disk).",
+)
+def skill_lint_cmd(name: str, vendor: str | None) -> None:
+    """Validate a wiki skill is well-formed and installable.
+
+    Checks the name, the canonical ``SKILL.md`` presence, and (per vendor)
+    representability + override UTF-8 validity. Exits non-zero on any error
+    so it is usable as a CI gate; dropped-field warnings leave the exit 0.
+    """
+    _run_lint("skills", name, vendor)
+
+
 # ── Agent subgroup ──────────────────────────────────────────────────────
 
 
@@ -230,6 +380,45 @@ def agent_override_cmd(name: str, vendor: str, force: bool, editor: bool) -> Non
     _run_seed_override("agents", name, vendor, force=force, editor=editor)
 
 
+@agent_group.command("diff")
+@click.argument("name")
+@click.option(
+    "--vendor",
+    "-v",
+    type=click.Choice(["claude", "gemini", "codex"]),
+    required=True,
+    help="Which runtime override to diff against the canonical render.",
+)
+def agent_diff_cmd(name: str, vendor: str) -> None:
+    """Show how an agent override diverges from the canonical render.
+
+    ``mm wiki agent diff <name> --vendor <vendor>`` feeds the canonical
+    ``agent.md`` through the vendor renderer (the same path ``override``
+    uses) and prints a unified diff against ``overrides/<vendor>.<ext>``.
+    Exits 0; canonical fields the vendor cannot represent are noted on stderr.
+    """
+    _run_diff("agents", name, vendor)
+
+
+@agent_group.command("lint")
+@click.argument("name")
+@click.option(
+    "--vendor",
+    "-v",
+    type=click.Choice(["claude", "gemini", "codex"]),
+    default=None,
+    help="Restrict representability checks to one runtime (default: every override on disk).",
+)
+def agent_lint_cmd(name: str, vendor: str | None) -> None:
+    """Validate a wiki agent is well-formed and installable.
+
+    Checks the name, that the canonical ``agent.md`` is present and parses,
+    and (per vendor) representability + override UTF-8 validity. Exits
+    non-zero on any error; dropped-field warnings leave the exit 0.
+    """
+    _run_lint("agents", name, vendor)
+
+
 # ── Command subgroup ────────────────────────────────────────────────────
 
 
@@ -271,3 +460,44 @@ def command_override_cmd(name: str, vendor: str, force: bool, editor: bool) -> N
     stderr warning so the editor knows what the runtime won't see.
     """
     _run_seed_override("commands", name, vendor, force=force, editor=editor)
+
+
+@command_group.command("diff")
+@click.argument("name")
+@click.option(
+    "--vendor",
+    "-v",
+    type=click.Choice(["claude", "gemini", "codex"]),
+    required=True,
+    help="Which runtime override to diff against the canonical render.",
+)
+def command_diff_cmd(name: str, vendor: str) -> None:
+    """Show how a command override diverges from the canonical render.
+
+    ``mm wiki command diff <name> --vendor <vendor>`` feeds the canonical
+    ``command.md`` through the vendor renderer and prints a unified diff
+    against ``overrides/<vendor>.<ext>``. ``--vendor codex`` is a permanent
+    placeholder (no ``codex_commands`` generator) and surfaces a classified
+    error rather than a traceback. Exits 0 on a real diff.
+    """
+    _run_diff("commands", name, vendor)
+
+
+@command_group.command("lint")
+@click.argument("name")
+@click.option(
+    "--vendor",
+    "-v",
+    type=click.Choice(["claude", "gemini", "codex"]),
+    default=None,
+    help="Restrict representability checks to one runtime (default: every override on disk).",
+)
+def command_lint_cmd(name: str, vendor: str | None) -> None:
+    """Validate a wiki command is well-formed and installable.
+
+    Checks the name, that the canonical ``command.md`` is present and parses,
+    and (per vendor) representability + override UTF-8 validity. A committed
+    ``codex`` command override is an error (no generator can render it).
+    Exits non-zero on any error; dropped-field warnings leave the exit 0.
+    """
+    _run_lint("commands", name, vendor)

--- a/packages/memtomem/src/memtomem/wiki/inspect.py
+++ b/packages/memtomem/src/memtomem/wiki/inspect.py
@@ -1,0 +1,361 @@
+"""Read-only inspection of wiki assets — ``mm wiki <type> {diff, lint}``.
+
+Companion to :mod:`memtomem.wiki.override` (the *writer*, which seeds
+override files). This module is the *reader*: ``diff_override`` reports how
+a committed override diverges from the canonical-rendered baseline, and
+``lint_asset`` validates that a wiki asset is well-formed and installable.
+Neither helper mutates the wiki — both are pure functions over the working
+tree (ADR-0008 PR-D).
+
+Both reuse PR-C / PR-D machinery rather than re-deriving it, so ``diff`` /
+``lint`` / ``override`` can never disagree about what the runtime sees:
+
+- :func:`memtomem.wiki.override.render_seed_bytes` produces the canonical
+  baseline an override is measured against — the same bytes
+  ``mm wiki <type> override`` would seed — and reports the ``dropped``
+  canonical fields the vendor format cannot represent.
+- :data:`memtomem.context._names.OVERRIDE_FORMATS` /
+  :func:`memtomem.context._names.validate_name` are the single source of
+  truth for the per-(type, vendor) extension and name rules.
+- ``parse_canonical_{agent,command}`` is the canonical structural check
+  ``lint`` runs (agents / commands only — skills are byte-copied, so there
+  is nothing to parse).
+"""
+
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from memtomem.context._names import (
+    OVERRIDE_FORMATS,
+    InvalidNameError,
+    validate_name,
+)
+from memtomem.wiki.override import render_seed_bytes
+from memtomem.wiki.store import WikiStore
+
+__all__ = [
+    "LintFinding",
+    "LintReport",
+    "OverrideDiff",
+    "diff_override",
+    "lint_asset",
+]
+
+LintLevel = Literal["error", "warning"]
+
+
+@dataclass(frozen=True)
+class OverrideDiff:
+    """Outcome of :func:`diff_override`.
+
+    ``override_path`` is the absolute ``<wiki>/<type>/<name>/overrides/<vendor>.<ext>``.
+    ``exists`` is whether that file is present; when ``False`` the caller has
+    not seeded an override yet (``in_sync`` / ``diff_lines`` are empty).
+    ``in_sync`` is ``True`` when the override is byte-identical to the
+    canonical render. ``diff_lines`` is the unified diff (canonical → override)
+    and is empty whenever ``in_sync`` or ``not exists``. ``dropped`` carries
+    the vendor-unrepresentable canonical fields so the caller can warn the
+    same way ``mm wiki <type> override`` does.
+    """
+
+    override_path: Path
+    exists: bool
+    in_sync: bool
+    diff_lines: list[str]
+    dropped: list[str]
+
+
+@dataclass(frozen=True)
+class LintFinding:
+    """A single lint result. ``level`` gates the exit code — any ``"error"``
+    means the asset is not well-formed; ``"warning"`` is advisory (e.g. a
+    vendor that drops a canonical field) and leaves the report ``ok``."""
+
+    level: LintLevel
+    message: str
+
+
+@dataclass(frozen=True)
+class LintReport:
+    """Aggregate of :func:`lint_asset`. ``ok`` is ``False`` iff any finding
+    is an error — that is the signal ``mm wiki <type> lint`` turns into a
+    non-zero exit so the verb is usable as a CI gate."""
+
+    asset_type: str
+    name: str
+    findings: list[LintFinding]
+
+    @property
+    def ok(self) -> bool:
+        return not any(f.level == "error" for f in self.findings)
+
+
+def _override_rel(asset_type: str, name: str, vendor: str, ext: str) -> str:
+    """POSIX-style ``<type>/<name>/overrides/<vendor>.<ext>`` for messages."""
+    return f"{asset_type}/{name}/overrides/{vendor}.{ext}"
+
+
+def diff_override(
+    store: WikiStore,
+    asset_type: str,
+    name: str,
+    vendor: str,
+) -> OverrideDiff:
+    """Diff the committed override against the freshly rendered canonical.
+
+    The baseline is what ``mm wiki <type> override`` would seed *now*, so the
+    diff surfaces both the user's hand-edits and any canonical drift since the
+    override was seeded — exactly the "what will install fan out vs. what did I
+    pin" question. Reads the working tree (uncommitted edits included), not a
+    git commit.
+
+    Raises (for the CLI to classify, never a traceback):
+    :class:`memtomem.wiki.store.WikiNotFoundError` (no wiki),
+    :class:`FileNotFoundError` (missing canonical),
+    :class:`memtomem.context._names.InvalidNameError` (bad name),
+    :class:`NotImplementedError` (``("commands", "codex")`` placeholder),
+    :class:`ValueError` (unregistered ``(asset_type, vendor)``).
+    """
+    store.require_exists()
+    validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
+    fmt = OVERRIDE_FORMATS.get((asset_type, vendor))
+    if fmt is None:
+        raise ValueError(f"no override format registered for ({asset_type!r}, {vendor!r})")
+    _, ext = fmt
+    override_path = store.root / asset_type / name / "overrides" / f"{vendor}.{ext}"
+
+    # ``render_seed_bytes`` re-validates the name and raises FileNotFoundError /
+    # NotImplementedError for missing-canonical / unsupported-vendor; let those
+    # propagate so the CLI classifies them identically to ``override``.
+    baseline, dropped = render_seed_bytes(store, asset_type, name, vendor)
+
+    if not override_path.is_file():
+        return OverrideDiff(
+            override_path=override_path,
+            exists=False,
+            in_sync=False,
+            diff_lines=[],
+            dropped=dropped,
+        )
+
+    override_bytes = override_path.read_bytes()
+    if override_bytes == baseline:
+        return OverrideDiff(
+            override_path=override_path,
+            exists=True,
+            in_sync=True,
+            diff_lines=[],
+            dropped=dropped,
+        )
+
+    rel = _override_rel(asset_type, name, vendor, ext)
+    # ``errors="replace"`` so a binary / mis-encoded override still produces a
+    # (lossy) diff instead of crashing; ``lint`` is where bad encodings are
+    # flagged as errors.
+    diff_lines = list(
+        difflib.unified_diff(
+            baseline.decode("utf-8", errors="replace").splitlines(keepends=True),
+            override_bytes.decode("utf-8", errors="replace").splitlines(keepends=True),
+            fromfile=f"{asset_type}/{name}: canonical (rendered for {vendor})",
+            tofile=rel,
+        )
+    )
+    return OverrideDiff(
+        override_path=override_path,
+        exists=True,
+        in_sync=False,
+        diff_lines=diff_lines,
+        dropped=dropped,
+    )
+
+
+def _lint_canonical_parse(asset_type: str, canonical: Path) -> list[LintFinding]:
+    """Structural parse of the canonical agent / command (skills are byte
+    copies — nothing to parse). ``AgentParseError`` / ``CommandParseError``
+    both subclass ``ValueError``; ``OSError`` covers a read race."""
+    # Function-body imports dodge the wiki ↔ context import cycle, same as
+    # ``render_seed_bytes`` (``context.install`` already imports ``wiki.store``).
+    try:
+        if asset_type == "agents":
+            from memtomem.context.agents import parse_canonical_agent
+
+            parse_canonical_agent(canonical, layout="dir")
+        elif asset_type == "commands":
+            from memtomem.context.commands import parse_canonical_command
+
+            parse_canonical_command(canonical, layout="dir")
+    except (ValueError, OSError) as exc:
+        return [LintFinding("error", f"canonical does not parse: {exc}")]
+    return []
+
+
+def _scan_overrides(asset_type: str, asset_dir: Path) -> tuple[list[str], list[str]]:
+    """Classify the files in ``<asset_dir>/overrides/`` against the registered
+    formats.
+
+    Returns ``(valid_vendors, stray_filenames)``:
+
+    * ``valid_vendors`` — files whose ``<vendor>.<ext>`` matches the registered
+      :data:`OVERRIDE_FORMATS` extension for this asset type. These are the
+      vendors ``install`` would actually fan out.
+    * ``stray_filenames`` — non-``.bak`` files that do *not* match a registered
+      ``<vendor>.<ext>`` (e.g. a wrong-extension ``gemini.md`` where commands
+      use ``.toml``). The runtime resolver silently ignores these
+      (``context.override.resolve`` only loads the exact registered name), so a
+      user who hand-named an override would otherwise see no effect and no
+      warning — lint flags them.
+
+    ``.bak`` siblings left by ``override --force`` are ignored.
+    """
+    overrides = asset_dir / "overrides"
+    if not overrides.is_dir():
+        return [], []
+    valid: set[str] = set()
+    stray: list[str] = []
+    for p in sorted(overrides.iterdir()):
+        if not p.is_file() or p.suffix == ".bak":
+            continue
+        vendor = p.stem
+        ext = p.suffix.lstrip(".")
+        fmt = OVERRIDE_FORMATS.get((asset_type, vendor))
+        if fmt is not None and fmt[1] == ext:
+            valid.add(vendor)
+        else:
+            stray.append(p.name)
+    return sorted(valid), stray
+
+
+def _lint_vendor(
+    store: WikiStore,
+    asset_type: str,
+    name: str,
+    vendor: str,
+    asset_dir: Path,
+) -> list[LintFinding]:
+    """Representability + override health for one vendor."""
+    out: list[LintFinding] = []
+    fmt = OVERRIDE_FORMATS.get((asset_type, vendor))
+    if fmt is None:
+        out.append(
+            LintFinding("error", f"no override format registered for ({asset_type}, {vendor})")
+        )
+        return out
+    _, ext = fmt
+    override_path = asset_dir / "overrides" / f"{vendor}.{ext}"
+
+    try:
+        _baseline, dropped = render_seed_bytes(store, asset_type, name, vendor)
+    except NotImplementedError as exc:
+        # e.g. ("commands", "codex") — no generator. This target can never be
+        # rendered or installed, so it is always an error: an explicit
+        # ``--vendor`` asked the representability question and the answer is
+        # "no", and a discovered override file is unusable. (Callers skip the
+        # vendor pass entirely when the canonical itself is broken, so this is
+        # the only "unrenderable" case that reaches here.)
+        out.append(LintFinding("error", str(exc)))
+        return out
+    except FileNotFoundError:
+        # Missing canonical is already reported by the canonical-presence check;
+        # don't double-report it per vendor.
+        return out
+    except (ValueError, OSError) as exc:
+        # Defense in depth: ``lint_asset`` skips this pass when the canonical
+        # did not parse, but a render that fails for any other reason
+        # (AgentParseError / CommandParseError both subclass ValueError) must
+        # surface as a finding, never a leaked traceback through ``mm wiki lint``.
+        out.append(LintFinding("error", f"cannot render for {vendor!r}: {exc}"))
+        return out
+
+    for field_name in dropped:
+        out.append(
+            LintFinding(
+                "warning",
+                f"vendor {vendor!r} will not represent canonical field {field_name!r}",
+            )
+        )
+
+    if override_path.is_file():
+        try:
+            override_path.read_bytes().decode("utf-8")
+        except UnicodeDecodeError:
+            out.append(LintFinding("error", f"override {vendor}.{ext} is not valid UTF-8"))
+    return out
+
+
+def lint_asset(
+    store: WikiStore,
+    asset_type: str,
+    name: str,
+    vendor: str | None = None,
+) -> LintReport:
+    """Validate a single wiki asset is well-formed and installable.
+
+    Checks, in order:
+
+    1. **Name** — :func:`validate_name`. An invalid name makes every path
+       join below unsafe, so this short-circuits to a single error.
+    2. **Canonical** — the ``SKILL.md`` / ``agent.md`` / ``command.md`` is
+       present and (agents / commands) parses.
+    3. **Stray override files** — anything in ``overrides/`` that is not a
+       registered ``<vendor>.<ext>`` (nor a ``.bak``) is an error: the runtime
+       resolver would silently ignore it. Scanned even when the canonical is
+       broken, since a misnamed override is independent of canonical health.
+    4. **Vendors** — only when the canonical parsed (rendering against a broken
+       canonical would just re-raise the error already reported). ``vendor``
+       given: just that vendor; otherwise every vendor with a valid override
+       file on disk. Each is checked for a registered format, renderability,
+       and (overrides) UTF-8 validity. Fields the vendor format drops are
+       advisory warnings; an unrenderable target (no generator) is an error.
+
+    Raises :class:`memtomem.wiki.store.WikiNotFoundError` if no wiki exists;
+    all other conditions are returned as :class:`LintFinding` rows so the CLI
+    can print them and pick an exit code from :attr:`LintReport.ok`.
+    """
+    store.require_exists()
+
+    try:
+        validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
+    except InvalidNameError as exc:
+        return LintReport(asset_type, name, [LintFinding("error", str(exc))])
+
+    asset_dir = store.root / asset_type / name
+    findings: list[LintFinding] = []
+    canonical_ok = True
+
+    if asset_type == "skills":
+        if not (asset_dir / "SKILL.md").is_file():
+            findings.append(LintFinding("error", f"missing canonical {asset_type}/{name}/SKILL.md"))
+            canonical_ok = False
+    else:
+        stem = asset_type[:-1]  # "agents" → "agent", "commands" → "command"
+        canonical = asset_dir / f"{stem}.md"
+        if not canonical.is_file():
+            findings.append(
+                LintFinding("error", f"missing canonical {asset_type}/{name}/{stem}.md")
+            )
+            canonical_ok = False
+        else:
+            parse_findings = _lint_canonical_parse(asset_type, canonical)
+            findings.extend(parse_findings)
+            canonical_ok = not parse_findings
+
+    valid_vendors, stray = _scan_overrides(asset_type, asset_dir)
+    for filename in stray:
+        findings.append(
+            LintFinding(
+                "error",
+                f"unexpected file in {asset_type}/{name}/overrides/: {filename} "
+                "(not a registered <vendor>.<ext>)",
+            )
+        )
+
+    if canonical_ok:
+        targets = [vendor] if vendor is not None else valid_vendors
+        for v in targets:
+            findings.extend(_lint_vendor(store, asset_type, name, v, asset_dir))
+
+    return LintReport(asset_type, name, findings)

--- a/packages/memtomem/tests/test_wiki_cmd_diff_lint.py
+++ b/packages/memtomem/tests/test_wiki_cmd_diff_lint.py
@@ -1,0 +1,413 @@
+"""Tests for ``mm wiki {skill,agent,command} {diff, lint}`` — ADR-0008 PR-D.
+
+``diff`` reports how a committed override diverges from the canonical render
+(reusing :func:`memtomem.wiki.override.render_seed_bytes`); ``lint`` validates
+that a wiki asset is well-formed and installable. The CLI delegates to
+:mod:`memtomem.wiki.inspect`; tests exercise the diff states (in-sync /
+out-of-sync / no-override), the dropped-field stderr note, the classified
+errors (no traceback leaks), and the lint exit-code gate.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from memtomem.cli.wiki_cmd import wiki as wiki_group
+from memtomem.wiki.inspect import diff_override, lint_asset
+from memtomem.wiki.store import WikiStore
+
+
+# ── seed helpers (local, mirroring test_wiki_cmd_override.py) ────────────
+
+
+def _git_commit(wiki_root_path: Path, message: str) -> None:
+    subprocess.run(["git", "-C", str(wiki_root_path), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root_path), "commit", "-m", message],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _initialized_wiki() -> WikiStore:
+    store = WikiStore.at_default()
+    store.init()
+    return store
+
+
+def _seed_skill(wiki_root_path: Path, name: str, body: bytes = b"# canonical\n") -> None:
+    skill_dir = wiki_root_path / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_bytes(body)
+    _git_commit(wiki_root_path, f"add {name}")
+
+
+def _seed_agent(
+    wiki_root_path: Path,
+    name: str,
+    *,
+    frontmatter_extra: str = "",
+    body: str = "Body of the agent.\n",
+) -> None:
+    fm_extra = frontmatter_extra
+    if fm_extra and not fm_extra.endswith("\n"):
+        fm_extra += "\n"
+    agent_dir = wiki_root_path / "agents" / name
+    agent_dir.mkdir(parents=True)
+    canonical = f"---\nname: {name}\ndescription: a test agent\n{fm_extra}---\n\n{body}"
+    (agent_dir / "agent.md").write_text(canonical, encoding="utf-8")
+    _git_commit(wiki_root_path, f"add agent {name}")
+
+
+def _seed_command(
+    wiki_root_path: Path,
+    name: str,
+    *,
+    frontmatter_extra: str = "",
+    body: str = "Command body.\n",
+) -> None:
+    fm_extra = frontmatter_extra
+    if fm_extra and not fm_extra.endswith("\n"):
+        fm_extra += "\n"
+    cmd_dir = wiki_root_path / "commands" / name
+    cmd_dir.mkdir(parents=True)
+    canonical = f"---\ndescription: a test command\n{fm_extra}---\n\n{body}"
+    (cmd_dir / "command.md").write_text(canonical, encoding="utf-8")
+    _git_commit(wiki_root_path, f"add command {name}")
+
+
+_AGENT_GEMINI_DROPS = "skills:\n  - foo\nisolation: workspace\n"
+_COMMAND_GEMINI_DROPS = "argument-hint: <arg>\nallowed-tools: [Read]\nmodel: claude-3-5\n"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# ── mm wiki <type> diff ──────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_skill_diff_in_sync(wiki_root: Path) -> None:
+    """A freshly seeded override is byte-identical to the canonical render."""
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello")
+    runner = CliRunner()
+    runner.invoke(wiki_group, ["skill", "override", "hello", "--vendor", "claude"])
+
+    result = runner.invoke(wiki_group, ["skill", "diff", "hello", "--vendor", "claude"])
+
+    assert result.exit_code == 0, result.output
+    assert "in sync" in result.output
+
+
+def test_skill_diff_out_of_sync_shows_unified_diff(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello", b"# canonical\nline one\n")
+    runner = CliRunner()
+    runner.invoke(wiki_group, ["skill", "override", "hello", "--vendor", "claude"])
+
+    target = wiki_root / "skills" / "hello" / "overrides" / "claude.md"
+    target.write_bytes(b"# canonical\nline one EDITED\n")
+
+    result = runner.invoke(wiki_group, ["skill", "diff", "hello", "--vendor", "claude"])
+
+    assert result.exit_code == 0, result.output
+    out = result.output
+    # Unified diff hunk markers + the edited line on the override (+) side.
+    assert "@@" in out
+    assert "EDITED" in out
+    assert "+line one EDITED" in out
+    assert "-line one" in out
+
+
+def test_skill_diff_no_override_prints_seed_hint(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "diff", "hello", "--vendor", "claude"])
+
+    assert result.exit_code == 0, result.output
+    out = result.output.replace("\\", "/")
+    assert "No override at skills/hello/overrides/claude.md" in out
+    assert "mm wiki skill override hello --vendor claude" in out
+
+
+def test_skill_diff_missing_canonical_classified_error(wiki_root: Path) -> None:
+    _initialized_wiki()
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "diff", "ghost", "--vendor", "claude"])
+
+    assert result.exit_code != 0
+    assert "Traceback" not in result.output
+    assert "ghost" in result.output
+
+
+def test_skill_diff_missing_wiki_classified_error(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(tmp_path / "no-wiki"))
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "diff", "hello", "--vendor", "claude"])
+
+    assert result.exit_code != 0
+    assert "wiki not found" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_skill_diff_requires_vendor(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "diff", "hello"])
+
+    assert result.exit_code != 0  # click UsageError: --vendor is required
+    assert "vendor" in result.output.lower()
+
+
+def test_agent_diff_notes_dropped_fields_on_stderr(wiki_root: Path) -> None:
+    """Gemini agents drop ``skills`` / ``isolation``. ``diff`` notes them on
+    stderr so a reader is not surprised the override omits them."""
+    _initialized_wiki()
+    _seed_agent(wiki_root, "demo", frontmatter_extra=_AGENT_GEMINI_DROPS)
+    runner = CliRunner()
+    runner.invoke(wiki_group, ["agent", "override", "demo", "--vendor", "gemini"])
+
+    result = runner.invoke(wiki_group, ["agent", "diff", "demo", "--vendor", "gemini"])
+
+    assert result.exit_code == 0, result.output
+    assert "in sync" in result.output  # seed == render
+    assert "note:" in result.stderr
+    assert "skills" in result.stderr
+    assert "isolation" in result.stderr
+
+
+def test_command_diff_codex_classified_error(wiki_root: Path) -> None:
+    """``("commands", "codex")`` has no generator — diff surfaces the
+    NotImplementedError as a classified error, not a traceback."""
+    _initialized_wiki()
+    _seed_command(wiki_root, "demo")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["command", "diff", "demo", "--vendor", "codex"])
+
+    assert result.exit_code != 0
+    assert "Traceback" not in result.output
+    assert "not yet supported" in result.output
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# ── mm wiki <type> lint ──────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_skill_lint_clean_ok(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "lint", "hello"])
+
+    assert result.exit_code == 0, result.output
+    assert "skills/hello: OK" in result.output
+
+
+def test_skill_lint_missing_canonical_errors(wiki_root: Path) -> None:
+    _initialized_wiki()
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "lint", "ghost"])
+
+    assert result.exit_code != 0
+    assert "error:" in result.output
+    assert "missing canonical" in result.output
+    assert "lint failed" in result.output
+
+
+def test_lint_invalid_name_single_error(wiki_root: Path) -> None:
+    _initialized_wiki()
+    runner = CliRunner()
+
+    # A name with a path separator fails validate_name before any path join.
+    result = runner.invoke(wiki_group, ["skill", "lint", "bad/name"])
+
+    assert result.exit_code != 0
+    assert "error:" in result.output
+
+
+def test_agent_lint_unparseable_canonical_errors(wiki_root: Path) -> None:
+    """An agent.md with no frontmatter raises AgentParseError → lint error."""
+    _initialized_wiki()
+    agent_dir = wiki_root / "agents" / "broken"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "agent.md").write_text("no frontmatter here\n", encoding="utf-8")
+    _git_commit(wiki_root, "add broken agent")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["agent", "lint", "broken"])
+
+    assert result.exit_code != 0
+    assert "does not parse" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_agent_lint_vendor_drops_are_warnings_not_errors(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_agent(wiki_root, "demo", frontmatter_extra=_AGENT_GEMINI_DROPS)
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["agent", "lint", "demo", "--vendor", "gemini"])
+
+    assert result.exit_code == 0, result.output  # warnings keep exit 0
+    assert "warning:" in result.output
+    assert "skills" in result.output
+    assert "agents/demo: OK" in result.output
+
+
+def test_lint_without_vendor_scans_existing_overrides(wiki_root: Path) -> None:
+    """No ``--vendor`` → lint inspects every override file on disk; a seeded
+    gemini override with drops surfaces its warnings."""
+    _initialized_wiki()
+    _seed_agent(wiki_root, "demo", frontmatter_extra=_AGENT_GEMINI_DROPS)
+    runner = CliRunner()
+    runner.invoke(wiki_group, ["agent", "override", "demo", "--vendor", "gemini"])
+
+    result = runner.invoke(wiki_group, ["agent", "lint", "demo"])
+
+    assert result.exit_code == 0, result.output
+    assert "warning:" in result.output
+    assert "'gemini'" in result.output
+
+
+def test_command_lint_committed_codex_override_errors(wiki_root: Path) -> None:
+    """A codex command override can never be rendered/installed → error."""
+    _initialized_wiki()
+    _seed_command(wiki_root, "demo")
+    overrides = wiki_root / "commands" / "demo" / "overrides"
+    overrides.mkdir(parents=True)
+    (overrides / "codex.md").write_text("hand-written codex override\n", encoding="utf-8")
+    _git_commit(wiki_root, "add codex override")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["command", "lint", "demo"])
+
+    assert result.exit_code != 0
+    assert "error:" in result.output
+    assert "lint failed" in result.output
+
+
+def test_agent_lint_broken_canonical_with_vendor_no_traceback(wiki_root: Path) -> None:
+    """Regression: a broken canonical + explicit --vendor must NOT re-enter the
+    renderer and leak an AgentParseError traceback — the canonical error is
+    reported and the vendor pass is skipped."""
+    _initialized_wiki()
+    agent_dir = wiki_root / "agents" / "broken"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "agent.md").write_text("no frontmatter here\n", encoding="utf-8")
+    _git_commit(wiki_root, "add broken agent")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["agent", "lint", "broken", "--vendor", "gemini"])
+
+    assert result.exit_code != 0
+    assert "does not parse" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_agent_lint_broken_canonical_with_override_no_traceback(wiki_root: Path) -> None:
+    """Regression: a broken canonical that already has an override file must
+    not crash the per-vendor render pass."""
+    _initialized_wiki()
+    agent_dir = wiki_root / "agents" / "broken"
+    (agent_dir / "overrides").mkdir(parents=True)
+    (agent_dir / "agent.md").write_text("still no frontmatter\n", encoding="utf-8")
+    (agent_dir / "overrides" / "claude.md").write_text("hand override\n", encoding="utf-8")
+    _git_commit(wiki_root, "add broken agent with override")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["agent", "lint", "broken"])
+
+    assert result.exit_code != 0
+    assert "does not parse" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_command_lint_explicit_codex_vendor_errors(wiki_root: Path) -> None:
+    """An explicit --vendor codex asks "can codex represent this command?" — the
+    answer is no (no generator), so it must be an error even with no override."""
+    _initialized_wiki()
+    _seed_command(wiki_root, "demo")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["command", "lint", "demo", "--vendor", "codex"])
+
+    assert result.exit_code != 0
+    assert "error:" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_lint_flags_stray_override_file(wiki_root: Path) -> None:
+    """A wrong-extension override (commands use .toml for gemini) is silently
+    ignored by the runtime resolver — lint must flag it as a stray file."""
+    _initialized_wiki()
+    _seed_command(wiki_root, "demo")
+    overrides = wiki_root / "commands" / "demo" / "overrides"
+    overrides.mkdir(parents=True)
+    (overrides / "gemini.md").write_text("misnamed (should be .toml)\n", encoding="utf-8")
+    _git_commit(wiki_root, "add stray override")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["command", "lint", "demo"])
+
+    assert result.exit_code != 0
+    assert "unexpected file" in result.output
+    assert "gemini.md" in result.output
+
+
+def test_command_lint_missing_wiki_classified_error(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(tmp_path / "no-wiki"))
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["command", "lint", "demo"])
+
+    assert result.exit_code != 0
+    assert "wiki not found" in result.output
+    assert "Traceback" not in result.output
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# ── logic layer (memtomem.wiki.inspect) ──────────────────────────────────
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_diff_override_in_sync_and_missing(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello")
+    store = WikiStore.at_default()
+
+    missing = diff_override(store, "skills", "hello", "claude")
+    assert missing.exists is False
+    assert missing.in_sync is False
+    assert missing.diff_lines == []
+
+    CliRunner().invoke(wiki_group, ["skill", "override", "hello", "--vendor", "claude"])
+    synced = diff_override(store, "skills", "hello", "claude")
+    assert synced.exists is True
+    assert synced.in_sync is True
+    assert synced.diff_lines == []
+
+
+def test_lint_report_ok_false_on_error_true_on_warning(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_agent(wiki_root, "demo", frontmatter_extra=_AGENT_GEMINI_DROPS)
+    store = WikiStore.at_default()
+
+    warn_only = lint_asset(store, "agents", "demo", "gemini")
+    assert warn_only.ok is True
+    assert any(f.level == "warning" for f in warn_only.findings)
+
+    missing = lint_asset(store, "agents", "ghost")
+    assert missing.ok is False
+    assert any(f.level == "error" for f in missing.findings)


### PR DESCRIPTION
## What

Completes the `mm wiki <type> {diff, lint}` deliverable from ADR-0008's
PR-D breakdown — the two read-only verbs that round out the per-asset
`mm wiki skill|agent|command` group (which until now had only `override`).

- **`mm wiki <type> diff <name> --vendor <vendor>`** — re-renders the
  canonical the way `override` would seed it (reusing `render_seed_bytes`)
  and prints a unified diff against the committed `overrides/<vendor>.<ext>`,
  surfacing both the user's hand-edits and any canonical drift since seeding.
  Always exits 0 (informational, mirroring `mm context diff`); canonical
  fields the vendor format cannot carry are noted on stderr.
- **`mm wiki <type> lint <name> [--vendor <vendor>]`** — validates the asset
  is well-formed and installable: name, canonical presence + parse
  (agents/commands), stray-override-file detection, and per-vendor
  representability + override UTF-8. Exits non-zero on any error so the verb
  is usable as a CI gate; dropped-field warnings leave the exit 0.

## How

Read-only logic lives in a new `wiki/inspect.py` — the *reader* counterpart
to `wiki/override.py` (the *writer*). Both sides reuse `render_seed_bytes` /
`OVERRIDE_FORMATS` / `parse_canonical_*`, so `diff` / `lint` / `override` can
never disagree about what the runtime actually sees. The CLI bodies mirror
`_run_seed_override`'s classified-error (no-traceback) contract.

`lint` is deliberately conservative about edge cases it is meant to classify:
a broken canonical skips the per-vendor render pass (rather than re-raising
its parse error as a traceback), an unrenderable target (no generator, e.g.
`commands/codex`) is an error, and a misnamed override file the runtime
resolver would silently ignore (e.g. a `.md` where the format is `.toml`) is
flagged as a stray file.

## Tests

`test_wiki_cmd_diff_lint.py` covers the diff states (in-sync / out-of-sync /
no-override), the dropped-field stderr note, the classified errors (no
traceback leaks), the lint exit-code gate, and the edge cases above
(broken-canonical-with-vendor, explicit-unrenderable-vendor, stray override
file). Full wiki suite (135 tests) green; `ruff check` + `ruff format --check`
+ `mypy` clean.

## Review

Gated through a Codex review (NEEDS-FIX): fixed three issues it surfaced — a
traceback leak on a broken canonical with `--vendor`/override, a stray
wrong-extension override passing silently, and an explicit `--vendor codex`
false-passing — each with a regression test. One finding declined: the
`--vendor` choice list (`claude/gemini/codex`) matches the existing
`mm wiki <type> override` commands exactly; widening it to the registered
`kimi` formats is a pre-existing asymmetry across the whole `mm wiki` group
and is better fixed uniformly (override included) in a separate change.

## Out of scope (follow-ups)

- Exposing `kimi` across the `mm wiki` CLI vendor choices (override + diff/lint).
- ADR-0008's top-line Status string is stale (says "PR-C in flight") and wants
  a separate doc-hygiene pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
