### PR TITLE
docs(adr-0008): correct stale PR-status line — PR-C/D merged, gate removed

### DIFF
--- a/docs/adr/0008-wiki-layer.md
+++ b/docs/adr/0008-wiki-layer.md
@@ -1,6 +1,6 @@
 # ADR-0008: Wiki layer for shared canonical artifacts
 
-**Status:** Accepted (PR-A merged, PR-B merged, PR-C in flight; PR-D/E sequenced — see PR Breakdown)
+**Status:** Accepted (PR-A/B/C/D merged; PR-E Web UI not started — see PR Breakdown)
 **Date:** 2026-04-30
 **Context:** Context gateway today is a per-project canonical → multi-runtime
 fan-out router (ADR-0001). Users with several projects must re-author the
@@ -279,7 +279,7 @@ override slots. They can be added in v2 if their runtime surface grows.
 | **A** | Wiki scaffold: `wiki/store.py`, `mm wiki init [--from]`, `mm wiki list`, this ADR | scaffolding only |
 | **B** | `mm context install`, lockfile schema, `shutil.copytree`, lockfile concurrency | Inv 1 (copytree), Inv 3 (graceful absence) |
 | **C** | Install widening to agents/commands + dir-layout fan-out BC read; `OVERRIDE_FORMATS`, `context/override.py` resolver, skills override hook; `mm wiki skill override` seed CLI. Override resolution active for skills only — agents/commands gated by `_PR_C_ACTIVE_TYPES` until a follow-up PR opens them. | Inv 4 (skills) |
-| **D** | `mm context {update, install --all, status, migrate}`, `mm wiki <type> {diff, lint}`, dirty detection, flip the `_PR_C_ACTIVE_TYPES` gate to activate agents/commands override | Inv 2 (refuse-if-dirty + `--force` + `.bak`) |
+| **D** | `mm context {update, install --all, status, migrate}`, `mm wiki <type> {diff, lint}`, dirty detection, remove the `_PR_C_ACTIVE_TYPES` gate to activate agents/commands override | Inv 2 (refuse-if-dirty + `--force` + `.bak`) |
 | **E** | Web UI (mirrors `web/routes/context_*` patterns post-#488) | — |
 
 ## Consequences


### PR DESCRIPTION
## What

Correct the stale PR-progress narrative in ADR-0008 (wiki layer). Doc-only, two lines.

1. **Top-line Status** still read `PR-C in flight; PR-D/E sequenced`. Verified against source + merged PRs: PR-C (#627/#628/#629) and **all** of PR-D have merged — #631 (`mm context update`), #635 (`status` + `install --all`), #642 (`migrate`), #628 (override activation), #1332 (`mm wiki <type> {diff, lint}`). Only **PR-E (Web UI)** remains, and it is not started (no `web/routes/*wiki*`). New line:
   `**Status:** Accepted (PR-A/B/C/D merged; PR-E Web UI not started — see PR Breakdown)`

2. **PR-D breakdown row** said PR-D would *flip* the `_PR_C_ACTIVE_TYPES` gate. #628 actually **removed** the gate and its `if`-branch (`context/override.py`) outright. No production source references `_PR_C_ACTIVE_TYPES` anymore (only archival test docstrings), so the ADR was the last place implying it still exists — a reader grepping for it per the ADR-contract source-grep habit would come up empty. `flip` → `remove` keeps the removal traceable from the breakdown.

## Why now

The PR breakdown is what the Status line points to; updating Status to "PR-D merged" while the breakdown still said PR-D "will flip the gate" would leave the ADR internally inconsistent. Both fixes are the same change: make ADR-0008's PR-status match what shipped.

## Out of scope (noted, deferred)

The Vendor format matrix section still says "v1 covers Claude, Gemini, Codex" but `OVERRIDE_FORMATS` now also has **kimi** (skills `.md`, agents `.yaml`). That drift belongs with the separate kimi-CLI-exposure follow-up (`mm wiki` hard-codes `Choice(["claude","gemini","codex"])`), not this status fix — left untouched here.

## Verification

- `git show eee39484` (#628) confirms `drop _PR_C_ACTIVE_TYPES + the if-branch`.
- `grep -rn _PR_C_ACTIVE_TYPES packages/` → only test docstrings (archival) + the ADR.
- `gh pr list` confirms #631/#635/#642/#628/#1332 all MERGED; no wiki web route → PR-E not started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
