### PR TITLE
feat(wiki): expose kimi vendor; derive mm wiki --vendor Choice from OVERRIDE_FORMATS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+- **`mm wiki` exposes the Kimi vendor; `--vendor` Choices derive from the
+  matrix (ADR-0008).** `mm wiki skill|agent {override,diff,lint} --vendor kimi`
+  now works. Kimi skills/agents have had `OVERRIDE_FORMATS` rows and renderers
+  (`kimi_skills` / `kimi_agents`) since PR-D, but the `mm wiki` CLI hard-coded
+  every `--vendor` Choice to `claude|gemini|codex` and silently dropped kimi.
+  Each verb's Choice is now derived per asset type from `OVERRIDE_FORMATS`
+  (`override_vendors`), so it can never drift from the matrix again: kimi is
+  offered for skills and agents but not commands (Kimi has no commands surface),
+  and codex stays the documented placeholder for commands.
+
 - **`mm wiki <type> {diff, lint}` — inspect wiki overrides (ADR-0008 PR-D; #1332).**
   Two read-only verbs round out the per-asset `mm wiki skill|agent|command`
   group. `diff <name> --vendor <vendor>` renders the canonical the way

--- a/docs/adr/0008-wiki-layer.md
+++ b/docs/adr/0008-wiki-layer.md
@@ -116,7 +116,7 @@ be reconsidered in v2 if a real workflow demands it.
 
          │  existing fan-out + override resolution (Invariant 4)
          ▼
-.claude/, .gemini/, .agents/, .codex/    ← runtime dirs (unchanged from ADR-0001)
+.claude/, .gemini/, .agents/, .codex/, .kimi/  ← runtime dirs (fan-out mechanism unchanged from ADR-0001)
 ```
 
 ## Subcommands
@@ -268,8 +268,11 @@ applies to `known_projects.json` mutations (`KnownProjectsCorruptError`).
 
 `OVERRIDE_FORMATS = { (asset_type, vendor): (alias, extension) }` lives
 in `packages/memtomem/src/memtomem/context/_names.py`. v1 covers Claude,
-Gemini, Codex across skills, agents, commands. Cursor and Copilot are
-excluded — their skill/agent/command surfaces are too thin to justify
+Gemini, Codex across skills, agents, and commands, plus Kimi for skills
+and agents (Kimi has no commands surface). The `mm wiki` `--vendor` choices
+derive from this matrix per asset type (`override_vendors`), so the CLI
+offers exactly the registered vendors and never drifts. Cursor and Copilot
+are excluded — their skill/agent/command surfaces are too thin to justify
 override slots. They can be added in v2 if their runtime surface grows.
 
 ## PR Breakdown

--- a/packages/memtomem/src/memtomem/cli/wiki_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/wiki_cmd.py
@@ -9,7 +9,7 @@ from typing import Literal
 
 import click
 
-from memtomem.context._names import InvalidNameError
+from memtomem.context._names import InvalidNameError, override_vendors
 from memtomem.wiki import (
     WIKI_ASSET_TYPES,
     WikiAlreadyExistsError,
@@ -24,6 +24,14 @@ from memtomem.wiki.override import (
     OverrideExistsError,
     seed_override,
 )
+
+# ``--vendor`` Choices derive from OVERRIDE_FORMATS (the single source of
+# truth) so they never drift from the matrix: kimi is valid for skills/agents
+# but not commands. See ADR-0008 "Vendor format matrix". Computed once at
+# import — the matrix is a module-level constant.
+_SKILL_VENDORS = override_vendors("skills")
+_AGENT_VENDORS = override_vendors("agents")
+_COMMAND_VENDORS = override_vendors("commands")
 
 
 @click.group("wiki")
@@ -270,7 +278,7 @@ def skill_group() -> None:
 @click.option(
     "--vendor",
     "-v",
-    type=click.Choice(["claude", "gemini", "codex"]),
+    type=click.Choice(_SKILL_VENDORS),
     required=True,
     help="Which runtime this override targets.",
 )
@@ -289,7 +297,7 @@ def skill_group() -> None:
 def skill_override_cmd(name: str, vendor: str, force: bool, editor: bool) -> None:
     """Seed a wiki override file from the canonical skill content.
 
-    ``mm wiki skill override <name> --vendor <claude|gemini|codex>`` writes
+    ``mm wiki skill override <name> --vendor <claude|gemini|codex|kimi>`` writes
     ``<wiki>/skills/<name>/overrides/<vendor>.md`` using the canonical
     ``SKILL.md`` as the working baseline. Edit the file (``--editor`` opens
     ``$EDITOR``) and commit it inside the wiki repo so that future
@@ -303,7 +311,7 @@ def skill_override_cmd(name: str, vendor: str, force: bool, editor: bool) -> Non
 @click.option(
     "--vendor",
     "-v",
-    type=click.Choice(["claude", "gemini", "codex"]),
+    type=click.Choice(_SKILL_VENDORS),
     required=True,
     help="Which runtime override to diff against the canonical render.",
 )
@@ -323,7 +331,7 @@ def skill_diff_cmd(name: str, vendor: str) -> None:
 @click.option(
     "--vendor",
     "-v",
-    type=click.Choice(["claude", "gemini", "codex"]),
+    type=click.Choice(_SKILL_VENDORS),
     default=None,
     help="Restrict representability checks to one runtime (default: every override on disk).",
 )
@@ -350,7 +358,7 @@ def agent_group() -> None:
 @click.option(
     "--vendor",
     "-v",
-    type=click.Choice(["claude", "gemini", "codex"]),
+    type=click.Choice(_AGENT_VENDORS),
     required=True,
     help="Which runtime this override targets.",
 )
@@ -369,7 +377,7 @@ def agent_group() -> None:
 def agent_override_cmd(name: str, vendor: str, force: bool, editor: bool) -> None:
     """Seed a wiki override file from the canonical agent content.
 
-    ``mm wiki agent override <name> --vendor <claude|gemini|codex>`` writes
+    ``mm wiki agent override <name> --vendor <claude|gemini|codex|kimi>`` writes
     ``<wiki>/agents/<name>/overrides/<vendor>.<ext>``. Bytes come from the
     vendor renderer applied to the canonical ``agent.md`` so the seed
     matches what the runtime would produce. Fields the vendor format
@@ -385,7 +393,7 @@ def agent_override_cmd(name: str, vendor: str, force: bool, editor: bool) -> Non
 @click.option(
     "--vendor",
     "-v",
-    type=click.Choice(["claude", "gemini", "codex"]),
+    type=click.Choice(_AGENT_VENDORS),
     required=True,
     help="Which runtime override to diff against the canonical render.",
 )
@@ -405,7 +413,7 @@ def agent_diff_cmd(name: str, vendor: str) -> None:
 @click.option(
     "--vendor",
     "-v",
-    type=click.Choice(["claude", "gemini", "codex"]),
+    type=click.Choice(_AGENT_VENDORS),
     default=None,
     help="Restrict representability checks to one runtime (default: every override on disk).",
 )
@@ -432,7 +440,7 @@ def command_group() -> None:
 @click.option(
     "--vendor",
     "-v",
-    type=click.Choice(["claude", "gemini", "codex"]),
+    type=click.Choice(_COMMAND_VENDORS),
     required=True,
     help="Which runtime this override targets.",
 )
@@ -467,7 +475,7 @@ def command_override_cmd(name: str, vendor: str, force: bool, editor: bool) -> N
 @click.option(
     "--vendor",
     "-v",
-    type=click.Choice(["claude", "gemini", "codex"]),
+    type=click.Choice(_COMMAND_VENDORS),
     required=True,
     help="Which runtime override to diff against the canonical render.",
 )
@@ -488,7 +496,7 @@ def command_diff_cmd(name: str, vendor: str) -> None:
 @click.option(
     "--vendor",
     "-v",
-    type=click.Choice(["claude", "gemini", "codex"]),
+    type=click.Choice(_COMMAND_VENDORS),
     default=None,
     help="Restrict representability checks to one runtime (default: every override on disk).",
 )

--- a/packages/memtomem/src/memtomem/context/_names.py
+++ b/packages/memtomem/src/memtomem/context/_names.py
@@ -29,6 +29,7 @@ __all__ = [
     "Layout",
     "OVERRIDE_FORMATS",
     "is_internal_artifact_dir",
+    "override_vendors",
     "validate_name",
 ]
 
@@ -47,7 +48,8 @@ _MAX_LEN = 64
 # (e.g. cursor sharing claude's surface) and ``extension`` is what
 # ``override.resolve`` joins to ``<vendor>.<ext>``.
 #
-# v1 covers Claude / Gemini / Codex across skills, agents, commands. The
+# v1 covers Claude / Gemini / Codex across skills, agents, commands, plus
+# Kimi for skills and agents (Kimi has no commands surface). The
 # ``("commands", "codex")`` row is a placeholder — there is no
 # ``codex_commands`` generator yet (Codex slash prompts are user-scope and
 # upstream-deprecated). The matrix entry stays for the day Codex commands
@@ -66,6 +68,24 @@ OVERRIDE_FORMATS: dict[tuple[str, str], tuple[str, str]] = {
     ("commands", "gemini"): ("gemini", "toml"),
     ("commands", "codex"): ("codex", "md"),
 }
+
+
+def override_vendors(asset_type: str) -> list[str]:
+    """Vendors with a registered override format for ``asset_type``.
+
+    Returned in :data:`OVERRIDE_FORMATS` insertion order
+    (``claude → gemini → codex → kimi``), the deterministic vendor order used
+    across fan-out. This is the single source of truth for the ``mm wiki``
+    ``--vendor`` Choice, so the CLI can never drift from the matrix — e.g.
+    kimi is offered for skills/agents but not commands, which have no kimi row.
+
+    Placeholder rows (``("commands", "codex")``, whose ``render_seed_bytes``
+    raises :class:`NotImplementedError`) are still returned: they are valid
+    *selections* that fail loudly at render time, matching the behavior from
+    when these Choices were hardcoded to ``["claude", "gemini", "codex"]``.
+    """
+    return [vendor for (at, vendor) in OVERRIDE_FORMATS if at == asset_type]
+
 
 # Maps generator name (`gen.name` — e.g. ``"claude_skills"``) to the
 # vendor key shared with :data:`OVERRIDE_FORMATS`. Centralizing here so

--- a/packages/memtomem/tests/test_context_names.py
+++ b/packages/memtomem/tests/test_context_names.py
@@ -1,10 +1,15 @@
-"""Tests for memtomem.context._names.validate_name."""
+"""Tests for memtomem.context._names — ``validate_name`` and ``override_vendors``."""
 
 from __future__ import annotations
 
 import pytest
 
-from memtomem.context._names import InvalidNameError, validate_name
+from memtomem.context._names import (
+    OVERRIDE_FORMATS,
+    InvalidNameError,
+    override_vendors,
+    validate_name,
+)
 
 
 @pytest.mark.parametrize(
@@ -69,3 +74,26 @@ def test_dot_and_dotdot_rejected_explicitly() -> None:
         validate_name(".")
     with pytest.raises(InvalidNameError, match="reserved path token"):
         validate_name("..")
+
+
+# ── override_vendors ─────────────────────────────────────────────────────
+
+
+def test_override_vendors_per_asset_type() -> None:
+    # Insertion order preserved: claude → gemini → codex → kimi.
+    assert override_vendors("skills") == ["claude", "gemini", "codex", "kimi"]
+    assert override_vendors("agents") == ["claude", "gemini", "codex", "kimi"]
+    # commands has no kimi row — Kimi exposes no commands surface.
+    assert override_vendors("commands") == ["claude", "gemini", "codex"]
+
+
+def test_override_vendors_matches_matrix() -> None:
+    """The derived list must equal exactly the OVERRIDE_FORMATS rows for the
+    asset type, so the helper and the matrix can never drift apart."""
+    for asset_type in ("skills", "agents", "commands"):
+        expected = [vendor for (at, vendor) in OVERRIDE_FORMATS if at == asset_type]
+        assert override_vendors(asset_type) == expected
+
+
+def test_override_vendors_unknown_asset_type_is_empty() -> None:
+    assert override_vendors("widgets") == []

--- a/packages/memtomem/tests/test_wiki_cmd_override.py
+++ b/packages/memtomem/tests/test_wiki_cmd_override.py
@@ -15,10 +15,12 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import click
 import pytest
 from click.testing import CliRunner
 
 from memtomem.cli.wiki_cmd import wiki as wiki_group
+from memtomem.context._names import override_vendors
 from memtomem.wiki.store import WikiStore
 
 
@@ -671,3 +673,80 @@ def test_wiki_command_override_stdout_contract(wiki_root: Path) -> None:
     assert target_path.as_posix() in out
     assert "git commit" in out
     assert "git add commands/demo/overrides/gemini.toml" in out
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# ── kimi vendor — derived Choice (ADR-0008 vendor matrix) ────────────────
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_wiki_skill_override_kimi_accepted(wiki_root: Path) -> None:
+    """kimi is a registered skills vendor; the CLI accepts ``--vendor kimi``
+    and seeds ``overrides/kimi.md`` (skills byte-copy the canonical)."""
+    _initialized_wiki()
+    canonical_bytes = b"# hello kimi\nbody\n"
+    _seed_skill(wiki_root, "hello", canonical_bytes)
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "override", "hello", "--vendor", "kimi"])
+
+    assert result.exit_code == 0, result.output
+    target = wiki_root / "skills" / "hello" / "overrides" / "kimi.md"
+    assert target.is_file()
+    assert target.read_bytes() == canonical_bytes
+
+
+def test_wiki_agent_override_kimi_accepted(wiki_root: Path) -> None:
+    """kimi agents render to ``overrides/kimi.yaml`` via the ``kimi_agents``
+    generator — the CLI accepts ``--vendor kimi`` for agents."""
+    _initialized_wiki()
+    _seed_agent(wiki_root, "demo")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["agent", "override", "demo", "--vendor", "kimi"])
+
+    assert result.exit_code == 0, result.output
+    target = wiki_root / "agents" / "demo" / "overrides" / "kimi.yaml"
+    assert target.is_file()
+
+
+def test_wiki_command_override_kimi_rejected(wiki_root: Path) -> None:
+    """commands have no kimi row in OVERRIDE_FORMATS, so the derived Choice
+    rejects ``--vendor kimi`` as a click usage error — kimi never reaches the
+    renderer for commands."""
+    _initialized_wiki()
+    _seed_command(wiki_root, "demo")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["command", "override", "demo", "--vendor", "kimi"])
+
+    assert result.exit_code != 0
+    assert "kimi" in result.output  # click.Choice error references the rejected value
+
+
+# ── vendor Choice derives from the matrix (anti-re-hardcode guard) ───────
+
+
+def _vendor_choices(cmd: click.Command) -> tuple[str, ...]:
+    for param in cmd.params:
+        if param.name == "vendor":
+            assert isinstance(param.type, click.Choice)
+            return tuple(param.type.choices)
+    raise AssertionError(f"{cmd.name!r} has no --vendor option")
+
+
+@pytest.mark.parametrize("verb", ["override", "diff", "lint"])
+@pytest.mark.parametrize(
+    "group_name, asset_type",
+    [("skill", "skills"), ("agent", "agents"), ("command", "commands")],
+)
+def test_wiki_vendor_choices_derive_from_matrix(
+    group_name: str, asset_type: str, verb: str
+) -> None:
+    """Every ``mm wiki <type> {override,diff,lint}`` ``--vendor`` Choice must
+    equal ``override_vendors(asset_type)`` — a guard against re-hardcoding the
+    list (the regression that originally dropped kimi for skills/agents)."""
+    group = wiki_group.commands[group_name]
+    assert isinstance(group, click.Group)
+    cmd = group.commands[verb]
+    assert _vendor_choices(cmd) == tuple(override_vendors(asset_type))


### PR DESCRIPTION
## What

Expose the **Kimi** vendor in the `mm wiki` CLI and stop hard-coding the `--vendor` list.

Kimi skills/agents have had `OVERRIDE_FORMATS` rows and renderers (`kimi_skills` / `kimi_agents`) since ADR-0008 PR-D, but every `mm wiki <type> {override,diff,lint}` command hard-coded `type=click.Choice(["claude","gemini","codex"])` — so `--vendor kimi` was rejected even though the renderers exist. Nine separate hard-coded lists also meant the CLI could silently drift from the matrix.

## Change

- **`context/_names.py`**: add `override_vendors(asset_type)` (next to `OVERRIDE_FORMATS`), returning the registered vendors for an asset type in matrix insertion order (`claude → gemini → codex → kimi`, the same deterministic order fan-out uses).
- **`cli/wiki_cmd.py`**: derive all nine `--vendor` Choices from `override_vendors` per asset type. Result, straight from the matrix:
  - **skills / agents** → now offer `kimi` (`overrides/kimi.md` / `overrides/kimi.yaml`)
  - **commands** → no `kimi` (Kimi has no commands surface); `codex` stays the documented `NotImplementedError` placeholder
- **Docs**: ADR-0008 vendor-matrix prose + architecture diagram (`.kimi/` runtime dir) + `_names.py` matrix comment + CHANGELOG.

## Tests

- `override_vendors` unit coverage (per-asset-type lists; equality with the raw matrix; unknown type → `[]`).
- **Anti-re-hardcode parity guard**: parametrized over all 9 commands, asserting each CLI `--vendor` Choice equals `override_vendors(asset_type)` — a future re-hardcode fails loudly.
- Behavioral: `--vendor kimi` accepted for skill/agent override (file seeded), rejected for command override (click usage error).

## Verification

- Affected suites: 121 passed. Full non-ollama sweep: **6956 passed**, 2 failed — both (`test_session_cli::TestSessionListJson::test_happy_path`, `test_web_routes_extended::TestConfigPatch::test_save_config`) **reproduce identically on clean `origin/main`** (local real-`~/.memtomem/` HOME-isolation failures; green in CI's isolated HOME). Not caused by this change.
- `ruff check` + `ruff format --check` clean; `mypy` clean (advisory).
- Codex review (`origin/main..feat/wiki-kimi-vendor`): **SHIP**, no blockers/majors; the one nit (ADR diagram missing `.kimi/`) is folded in.

## Out of scope

The `mm context sync` host fan-out docs (`~/.{claude,gemini,codex}/` in `docs/guides/reference.md` and an old CHANGELOG line) may also omit kimi — that's the context-sync surface, not wiki overrides, so it's left for a separate doc pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
