### PR TITLE
docs(reference): include kimi in mm context sync user-scope fan-out targets

### DIFF
--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -1211,7 +1211,7 @@ mm context diff                        # check sync status
 mm context status                      # installed wiki assets + their drift state (read-only)
 mm context status --all-projects       # aggregated drift across enrolled on-disk projects (read-only; same data as GET /api/context/status-all)
 mm context sync                        # sync context.md → agent files (project_shared default)
-mm context sync --scope user           # fan out from ~/.memtomem/... → ~/.{claude,gemini,codex}/...
+mm context sync --scope user           # fan out from ~/.memtomem/... → ~/.{claude,gemini,codex,kimi}/...
 mm context sync --include=skills --scope project_local   # NO_FANOUT skip (no runtime per ADR §3)
 mm context sync --include=agents,commands --label production # sync using the 'production' labeled version (agents/commands only)
 mm context sync --all-projects --yes   # batch over every enrolled on-disk project (project_shared only, ADR-0025)


### PR DESCRIPTION
## What

One-line docs fix: the `mm context sync --scope user` example in `docs/guides/reference.md` listed the host fan-out targets as `~/.{claude,gemini,codex}/` — omitting **kimi**.

## Why

`mm context sync --scope user` fans skills/agents out to `~/.kimi/` as well:
- `context/_runtime_targets.py`: `("skills","kimi","user") → ~/.kimi/skills`, `("agents","kimi","user") → ~/.kimi/agents`
- `KNOWN_RUNTIMES = ("claude", "gemini", "codex", "kimi")`

So the documented fan-out set drifted from the code. `commands/kimi` is `NO_FANOUT` (Kimi has no commands surface), so it's correctly absent.

This is the follow-up noted while exposing kimi in the `mm wiki` CLI (#1340) — the wiki override surface there, the context-sync host fan-out doc surface here.

## Scope

Verified this is the **only** kimi-omitting runtime enumeration across `docs/`, `README.md`, `packages/memtomem/README.md`, `CONTRIBUTING.md` (kimi is otherwise documented as a first-class runtime in `mcp-clients.md`, the integration guides, and the READMEs). The historical `CHANGELOG.md` entry that predates kimi is intentionally left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
