### PR TITLE
ci(dependabot): versioning-strategy lockfile-only for uv (stop member-dep drift)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,14 +18,30 @@ updates:
       github-actions:
         patterns: ["*"]
 
-  # uv workspace: the single lockfile is the root uv.lock (member deps are
-  # declared in packages/memtomem/pyproject.toml but locked here), so the
-  # updater points at "/". NB: Dependabot doesn't yet document uv-workspace
-  # traversal — confirm the first weekly uv run actually proposes member-dep
-  # bumps (the security fixes tracked in #1331) and move the directory to
-  # "/packages/memtomem" if it comes up empty.
+  # uv workspace: the single root uv.lock holds everything (member runtime deps
+  # are declared in packages/memtomem/pyproject.toml but resolved/locked here;
+  # dev deps live in the root [dependency-groups]). directory:"/" is where
+  # [tool.uv.workspace] and uv.lock live — member-dep bumps do surface from here,
+  # so do NOT split to "/packages/memtomem" (no colocated lockfile there).
+  #
+  # versioning-strategy: lockfile-only — Dependabot updates only the resolved
+  # versions in uv.lock and "ignores any new versions that would require package
+  # manifest changes" (uv is in this option's supported list). It removes the
+  # manifest-edit step entirely, so pyproject<->uv.lock drift is impossible by
+  # construction. Without it, member-package requirement updates edited uv.lock's
+  # requires-dist but not the member pyproject (dependabot-core#12788), so
+  # `uv lock --check` failed — see #1337/#1338, corrected by #1343. Nothing is
+  # lost: `>=` floors are minimums (a satisfied floor is never rewritten anyway),
+  # and security floors are owned by root [tool.uv] constraint-dependencies (#1331).
+  #
+  # Caveat: lockfile-only never RAISES an authored floor, so an advisory needing
+  # a floor above the member manifest must be done by hand / via the root
+  # constraint list. CI also still resolves with `uv sync --frozen` (not
+  # `uv lock --check`), so this fixes the drift source but isn't a fail-closed
+  # gate — adding `uv lock --check` to CI is a tracked follow-up.
   - package-ecosystem: "uv"
     directory: "/"
+    versioning-strategy: "lockfile-only"
     schedule:
       interval: "weekly"
     # Group routine minor/patch bumps into one PR; majors still arrive


### PR DESCRIPTION
## What

Set `versioning-strategy: lockfile-only` on the `uv` Dependabot updater so it
updates only `uv.lock` resolved versions and never edits a `pyproject.toml` manifest.

## Why

In this uv **workspace**, runtime deps are declared in the member manifest
`packages/memtomem/pyproject.toml` but locked in the root `uv.lock`. Dependabot's
*requirement-update* PRs for those member deps edited `uv.lock`'s `requires-dist`
floor **without** editing the member `pyproject.toml`, so the two disagreed and
**`uv lock --check` exits 1** (dependabot-core#12788). CI didn't catch it — every
job resolves with `uv sync --frozen`, never `--check`/`--locked`.

This bit #1337 (mcp) and #1338 (uvicorn); I corrected the resulting state by hand
in #1343. This PR fixes the **source** so it can't recur.

## How `lockfile-only` fixes it

Per the GitHub docs, `lockfile-only` = *"Only create pull requests to update
lockfiles. Ignore any new versions that would require package manifest changes."*
`uv` is explicitly in this option's supported-by list (support landed via
dependabot-core#12162; this repo is github.com-hosted, so it's honored). Removing
the manifest-edit step makes `pyproject` ↔ `uv.lock` drift **impossible by
construction**, independent of which direction Dependabot would otherwise drift.

**Nothing is lost:** `>=` floors are minimums (a satisfied floor is never rewritten
anyway), routine version bumps still flow as lockfile updates (incl. majors — `>=`
admits them), the `python-minor-patch` grouping and the `github-actions` updater are
unchanged, and security floors are owned separately by root
`[tool.uv] constraint-dependencies` (#1331).

## Verification

- Researched + adversarially verified (5-agent workflow) against the **live**
  GitHub options-reference: `versioning-strategy` is "Supported by: …and uv", and
  `lockfile-only` is a documented value.
- `dependabot.yml` parses; `uv` block keys correct; `github-actions` block untouched.
- Fully confirmable only on the next weekly Dependabot run: PRs touch only
  `uv.lock`, the group still yields one PR, and dev-group deps still receive bumps.

## Follow-up (separate PR)

CI's `uv sync --frozen` masks lockfile drift. A follow-up should add
`uv lock --check` (or `uv sync --locked`) to CI as a fail-closed gate, so any
residual drift (e.g. the orthogonal workspace-member defect dependabot-core#14004)
fails loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
