### PR TITLE
ci: add uv lock --check gate to fail closed on pyproject<->uv.lock drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           version: ${{ env.UV_VERSION }}
+      # Fail closed on pyproject <-> uv.lock drift (e.g. a Dependabot member-dep
+      # update that edits the lock's requires-dist but not the member manifest).
+      # dependabot.yml uses versioning-strategy: lockfile-only to prevent that at
+      # the source; this is the CI backstop, since every other job resolves with
+      # `uv sync --frozen` (which neither checks nor regenerates the lock).
+      - run: uv lock --check
       - run: uv sync --frozen
       - run: uv run ruff check packages/memtomem/src packages/memtomem/tests tools
       - run: uv run ruff format --check packages/memtomem/src packages/memtomem/tests tools


### PR DESCRIPTION
## What

Add `uv lock --check` as the first step of the required `lint` job — a fail-closed
CI gate for `pyproject.toml` ↔ `uv.lock` drift.

## Why

Every CI job resolves with `uv sync --frozen`, which neither verifies nor
regenerates the lockfile. So a manifest↔lock mismatch passes CI **silently** —
exactly how the Dependabot member-dep drift in #1337/#1338 (lock `requires-dist`
bumped, member `pyproject.toml` floor left behind) went undetected until a local
`uv lock --check`.

#1345 (`versioning-strategy: lockfile-only`) stops Dependabot from *creating* that
drift at the source. This PR is the **backstop** that catches drift from any other
source (manual edits, the open workspace-member defect dependabot-core#14004, etc.).

## How

`uv lock --check` exits 1 when `uv.lock` no longer matches the manifests. Placed in
the `lint` job (already required, already sets up `uv`, runs in seconds) so it gates
merges immediately without a branch-protection change.

## Verified (mutation-tested)

- Clean tree → `uv lock --check` exit **0**.
- Member floor diverged from the lock's `requires-dist` (the exact #1337/#1338
  shape) → exit **1**: *"The lockfile at `uv.lock` needs to be updated, but
  `--check` was provided."*
- Revert → exit **0**.
- `ci.yml` YAML parses; the step precedes `uv sync --frozen` in `lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
