### PR TITLE
fix(web): route move/copy modal prose through i18n (#1348, #1350)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -3302,10 +3302,11 @@ function _ctxKindDetailText(errorKind, message) {
 // Precedence, in order:
 //   1. string detail → returned verbatim (legacy routes + the central app.py
 //      KeyError/ValueError/Exception handlers, and the issue-pinned privacy 422).
-//   2. #1210 write-guard 409 ``{reason_code: sync_paused|sync_not_enrolled}`` →
-//      the specific localized copy — checked BEFORE error_kind because those
-//      409s carry BOTH error_kind:"conflict" and the reason_code, and the
-//      reason_code copy is more precise than the generic "conflict" label.
+//   2. localized reason_code 409s ``{reason_code: sync_paused|sync_not_enrolled
+//      |no_memtomem_store}`` → the specific localized copy — checked BEFORE
+//      error_kind because those 409s carry BOTH error_kind:"conflict" and the
+//      reason_code, and the reason_code copy is more precise than the generic
+//      "conflict" label (#1210 paused/not-enrolled; #1350 no-store).
 //   3. B-1 #1284 object envelope ``{error_kind, message, reason_code?}`` →
 //      localized kind label + the server message as secondary detail.
 //   4. bare ``{message}`` → the server prose.
@@ -3316,6 +3317,7 @@ function _ctxErrDetail(detail, fallback) {
     const rc = detail.reason_code;
     if (rc === 'sync_paused') return t('settings.ctx.error_sync_paused');
     if (rc === 'sync_not_enrolled') return t('settings.ctx.error_sync_not_enrolled');
+    if (rc === 'no_memtomem_store') return t('settings.ctx.error_no_memtomem_store');
     if (typeof detail.error_kind === 'string' && detail.error_kind) {
       const composed = _ctxKindDetailText(detail.error_kind, detail.message);
       if (composed) return composed;
@@ -4525,9 +4527,15 @@ async function _ctxMoveCopyApply(state) {
         r = await _ctxConfirmHostWrite(data, () => send({ allow_host_writes: true }));
       } else {
         // project_shared Gate B — disclose the git-tracked write, then re-POST.
+        // Render the localized key, NOT ``data.reason``: the backend reason is
+        // raw developer prose ("Re-POST with confirm_project_shared=true …") and,
+        // being always non-empty, shadowed the i18n fallback in every locale so
+        // non-English users never saw their translation (#1348). The envelope's
+        // ``confirm`` flag already told us this is the project_shared gate, so we
+        // don't need the prose to pick the right copy.
         const ok = await showConfirm({
           title: t('settings.ctx.move_copy_shared_confirm_title'),
-          message: data.reason || t('settings.ctx.move_copy_shared_confirm_message'),
+          message: t('settings.ctx.move_copy_shared_confirm_message'),
           confirmText: t('settings.ctx.move_copy_shared_confirm_btn'),
           danger: false,
         });

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -390,6 +390,7 @@
   "settings.ctx.matrix_sync_paused_title": "Sync paused — resume it on the Projects board",
   "settings.ctx.error_sync_paused": "Project sync is paused — resume it on the Projects board.",
   "settings.ctx.error_sync_not_enrolled": "Project is not enrolled for sync — enroll it on the Projects board.",
+  "settings.ctx.error_no_memtomem_store": "The destination project isn't a memtomem store yet — run \"mm context init\" in it first.",
   "settings.ctx.cascade_unavailable_hint": "Sync is paused or not enrolled for this project, so only the stored copy is deleted — runtime files are left in place.",
   "settings.ctx.import": "Import",
   "settings.ctx.create": "Create",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -390,6 +390,7 @@
   "settings.ctx.matrix_sync_paused_title": "동기화 중지됨 — 프로젝트 보드에서 재개하세요",
   "settings.ctx.error_sync_paused": "프로젝트 동기화가 중지되었습니다 — 프로젝트 보드에서 재개하세요.",
   "settings.ctx.error_sync_not_enrolled": "프로젝트가 동기화에 미등록 상태입니다 — 프로젝트 보드에서 등록하세요.",
+  "settings.ctx.error_no_memtomem_store": "대상 프로젝트가 아직 memtomem 저장소가 아닙니다 — 먼저 그 위치에서 \"mm context init\" 을 실행하세요.",
   "settings.ctx.cascade_unavailable_hint": "이 프로젝트는 동기화가 중지되었거나 미등록 상태라 저장된 사본만 삭제됩니다 — 런타임 파일은 그대로 남습니다.",
   "settings.ctx.import": "가져오기",
   "settings.ctx.create": "만들기",

--- a/packages/memtomem/tests-js/ctx-move-copy-modal.test.mjs
+++ b/packages/memtomem/tests-js/ctx-move-copy-modal.test.mjs
@@ -166,6 +166,31 @@ describe('Move/Copy modal — open + dry-run preview (#1289)', () => {
     expect(ctx.transferCalls.every((c) => c.isDry)).toBe(true);
   });
 
+  it('localizes the no_memtomem_store transfer conflict (#1350)', async () => {
+    // A cross-project destination without a ``.memtomem/`` store 409s with the
+    // ``no_memtomem_store`` reason_code, whose backend ``message`` is raw English
+    // prose carrying an absolute path and a CLI command. The inline warning must
+    // render the localized copy, not that prose.
+    const NO_STORE_409 = {
+      ok: false, status: 409,
+      body: { detail: {
+        error_kind: 'conflict', reason_code: 'no_memtomem_store',
+        message: 'destination project has no .memtomem/ store: /srv/bare. '
+          + 'Initialize it first: cd /srv/bare && mm context init',
+      } },
+    };
+    const ctx = await bootModal({ dryRun: NO_STORE_409 });
+    await openModal(ctx);
+    const warn = ctx.window.document.getElementById('ctx-mc-warning');
+    expect(warn.hidden).toBe(false);
+    expect(warn.textContent).toBe(ctx.window.I18N.t('settings.ctx.error_no_memtomem_store'));
+    // The raw backend prose — the absolute path and ``cd …`` shell fragment — must
+    // not leak through (the localized copy keeps only the ``mm context init`` hint).
+    expect(warn.textContent).not.toContain('/srv/bare');
+    expect(warn.textContent).not.toContain('cd ');
+    expect(ctx.window.document.getElementById('ctx-mc-apply-btn').disabled).toBe(true);
+  });
+
   it('hides the rename row in Move mode and sends no as_name', async () => {
     const ctx = await bootModal();
     await openModal(ctx);
@@ -211,6 +236,11 @@ describe('Move/Copy modal — apply gate round-trips (#1289)', () => {
     expect(applies[1].body.confirm_project_shared).toBe(true);
     // The gate uses the shared confirm dialog (not the host-write disclosure).
     expect(ctx.confirms.length).toBe(1);
+    // #1348: the disclosure shows the localized copy, NOT the backend ``reason``
+    // prose ('shared write'). Before the fix ``data.reason ||`` shadowed the i18n
+    // key in every locale, so the dialog leaked developer-facing English.
+    expect(ctx.confirms[0].message).toBe(ctx.window.I18N.t('settings.ctx.move_copy_shared_confirm_message'));
+    expect(ctx.confirms[0].message).not.toBe('shared write');
     expect(modalOf(ctx.window).hidden).toBe(true);
     expect(ctx.toasts.some((x) => x.sev === 'success')).toBe(true);
   });


### PR DESCRIPTION
## Summary

Routes the last two raw-English-prose leaks in the Context Gateway **move/copy
modal** through i18n. Both were found via a first-time-user Playwright e2e smoke
test (#1348, #1350).

- **#1348 — project_shared confirm dialog.** `_ctxMoveCopyApply` built the
  disclosure with `data.reason || t('settings.ctx.move_copy_shared_confirm_message')`.
  The backend `reason` is always a non-empty developer string
  (`"… Re-POST with confirm_project_shared=true …"`), so the `||` fallback never
  fired and the localized key was dead code — non-English users saw English
  implementation detail. Fixed by rendering the i18n key directly; the envelope's
  `confirm` flag already identifies the gate, so the prose isn't needed.

- **#1350 — `no_memtomem_store` transfer conflict.** A cross-project move/copy to a
  destination without a `.memtomem/` store 409s with
  `reason_code: "no_memtomem_store"` and an English `message` carrying an absolute
  path and a `cd … && mm context init` shell fragment. It flowed through
  `_ctxMoveCopyErrorOutcome` → `_ctxErrDetail`, which had no mapping for it and so
  rendered `"Conflict — destination project has no .memtomem/ store: /abs/path. …"`
  verbatim in every locale. Added a `reason_code → i18n` mapping in `_ctxErrDetail`,
  alongside the existing `sync_paused` / `sync_not_enrolled` entries.

## Scope note — the rest of #1350 was already handled or has no web consumer

#1350 enumerated six sites; investigation against current `main` found only the one
above is a live web-facing leak:

| #1350 site | State |
| --- | --- |
| `context_transfer.py` / `context_projects.py` 409 `sync_paused`·`sync_not_enrolled` | **Already localized** — `_ctxErrDetail` maps these reason codes (added with the #1210 write-guard); `error_sync_paused` / `error_sync_not_enrolled` keys exist in en/ko. |
| `context_gateway.py` `_STATUS_ALL_SKIP_MESSAGES` (`/api/context/status-all`) | **No web consumer** — the endpoint is not called from any `web/static` JS (CLI/API-facing). |
| `context_sync_all.py` `_SKIP_MESSAGES` + sync-timeout (`/api/context/sync-all-projects`) | **No web consumer** — same; the CLI is English-only and not i18n'd. |
| `context_transfer.py` `no_memtomem_store` | **Fixed here.** |

Localizing the CLI/API-only messages would add web i18n keys with no current
consumer (dead code) and run against the existing decision at
`context-gateway.js` (single-item import skip toast) not to multiply skip-reason
keys. If `status-all` / `sync-all-projects` later gain a portal consumer, their
skip rows can adopt the same `reason_code → i18n` pattern at that point.

The `no_memtomem_store` copy follows the established `error_sync_paused`
convention: a short, actionable, **path-less** sentence (the runtime path/command
that the backend `message` interpolates is dropped from the localized copy, as the
modal user already picked the destination).

## Tests

- `ctx-move-copy-modal.test.mjs`:
  - extends the project_shared confirm round-trip test to assert the dialog renders
    the localized key, not the backend `reason` (`#1348`);
  - adds a `no_memtomem_store` dry-run case asserting the inline warning shows the
    localized copy and the absolute path / `cd …` prose does not leak (`#1350`).
  - Both pins verified RED against the pre-fix source.
- `test_i18n.py` en/ko key + placeholder parity holds (new key added to both
  locales, no placeholders).

Closes #1348
Closes #1350

🤖 Generated with [Claude Code](https://claude.com/claude-code)
