### PR TITLE
feat(cli): add `mm wiki ... commit` for web-Commit parity (ADR-0027 §3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+- **CLI: `mm wiki {skill,agent,command} commit` (ADR-0027 §3).** The terminal
+  parity of the in-browser wiki **Commit** affordance. After editing a canonical
+  asset or a vendor override (e.g. with `mm wiki skill override <name> --vendor
+  <v> --editor`), `mm wiki skill commit <name> --canonical --vendor claude` writes
+  **one isolated git commit** of only the selected paths layered onto HEAD — never
+  a bare `git add . && git commit`, so unrelated staged changes in the wiki are
+  left untouched. Select targets with `--canonical`/`-c` and repeatable
+  `--vendor`/`-v`; `--message`/`-m` overrides the generated default. Bytes already
+  matching HEAD are a no-op (nothing committed); a concurrent `mm web` commit, a
+  moved HEAD, or a file that changed mid-commit aborts cleanly so you can re-run.
+  The commit message is privacy-scanned (a soft, non-blocking warning). The web
+  route and CLI now share one commit engine (`memtomem.wiki.commit.commit_targets`,
+  including the cross-process wiki lock) so the two surfaces cannot drift.
+
 - **Web UI: dev-tier override-seed in the wiki browser (ADR-0008 PR-E E-2).**
   The Context Gateway **Wiki** section gains a per-vendor **Seed override** action
   (dev mode only) — the web parity of `mm wiki <type> override`. It renders the

--- a/packages/memtomem/src/memtomem/cli/wiki_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/wiki_cmd.py
@@ -9,12 +9,23 @@ from typing import Literal
 
 import click
 
-from memtomem.context._names import InvalidNameError, override_vendors
+from memtomem import privacy
+from memtomem.context._names import (
+    OVERRIDE_FORMATS,
+    InvalidNameError,
+    override_vendors,
+    validate_name,
+)
 from memtomem.wiki import (
     WIKI_ASSET_TYPES,
     WikiAlreadyExistsError,
     WikiNotFoundError,
     WikiStore,
+)
+from memtomem.wiki.commit import (
+    ResolvedTarget,
+    WikiTargetChangedError,
+    commit_targets,
 )
 from memtomem.wiki.inspect import (
     diff_override,
@@ -22,8 +33,10 @@ from memtomem.wiki.inspect import (
 )
 from memtomem.wiki.override import (
     OverrideExistsError,
+    canonical_asset_file,
     seed_override,
 )
+from memtomem.wiki.store import WikiHeadMovedError
 
 # ``--vendor`` Choices derive from OVERRIDE_FORMATS (the single source of
 # truth) so they never drift from the matrix: kimi is valid for skills/agents
@@ -207,6 +220,114 @@ def _run_lint(
     click.get_current_context().exit(1)
 
 
+def _run_commit(
+    asset_type: Literal["skills", "agents", "commands"],
+    name: str,
+    vendors: tuple[str, ...],
+    *,
+    canonical: bool,
+    message: str | None,
+) -> None:
+    """Shared body for ``mm wiki {skill,agent,command} commit``.
+
+    Parity with the web Commit affordance (ADR-0027 §3): commits ONLY the
+    selected canonical / override paths layered onto HEAD via the shared
+    :func:`memtomem.wiki.commit.commit_targets` engine — never a bare
+    ``git add . && git commit`` that would sweep unrelated staged changes. The
+    paths are server-resolved from the typed ``--canonical`` / ``--vendor`` flags
+    (a raw path is never accepted), and every engine error maps to a classified
+    :class:`click.ClickException` so no traceback — and no absolute wiki path —
+    leaks. Unlike the web route there is no client Save token, so the commit
+    takes the bytes currently on disk and lands on the freshest HEAD (the
+    cross-process lock + ref CAS still guard a concurrent ``mm web`` / second
+    ``mm wiki`` commit).
+    """
+    store = WikiStore.at_default()
+    try:
+        store.require_exists()
+    except WikiNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    try:
+        validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
+    except InvalidNameError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if not canonical and not vendors:
+        raise click.ClickException(
+            "nothing to commit: pass --canonical and/or --vendor <vendor> to select targets"
+        )
+
+    targets: list[ResolvedTarget] = []
+    if canonical:
+        path = canonical_asset_file(store, asset_type, name)
+        targets.append(ResolvedTarget(rel=path.relative_to(store.root).as_posix(), path=path))
+    for vendor in vendors:
+        fmt = OVERRIDE_FORMATS.get((asset_type, vendor))
+        if fmt is None:
+            # Unreachable via the Click Choices (derived from OVERRIDE_FORMATS),
+            # but stay classified rather than KeyError if called directly.
+            raise click.ClickException(f"no override format registered for vendor {vendor!r}")
+        _, ext = fmt
+        path = store.root / asset_type / name / "overrides" / f"{vendor}.{ext}"
+        targets.append(ResolvedTarget(rel=path.relative_to(store.root).as_posix(), path=path))
+
+    # Friendly pre-check: a selected file that never existed on disk gets a clear
+    # "create it first" message instead of the engine's generic
+    # WikiTargetChangedError(rel, 0). Re-checked authoritatively under the lock.
+    missing = [t.rel for t in targets if not t.path.is_file()]
+    if missing:
+        raise click.ClickException(
+            "no such file in the wiki: "
+            + ", ".join(missing)
+            + " — create the canonical or seed an override before committing"
+        )
+
+    msg = (message or "").strip() or f"wiki: update {asset_type}/{name}"
+    privacy_warning = len(privacy.scan(msg))
+
+    try:
+        outcome = commit_targets(store, targets, message=msg, expected_head=None)
+    except WikiTargetChangedError as exc:
+        raise click.ClickException(
+            f"{exc.rel} changed on disk during the commit; re-run to pick up the new bytes"
+        ) from exc
+    except WikiHeadMovedError as exc:
+        raise click.ClickException(
+            f"the wiki HEAD moved during the commit ({exc}); re-run to commit onto the new HEAD"
+        ) from exc
+    except WikiNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except TimeoutError as exc:
+        # The shared cross-process wiki lock is held past ``_COMMIT_LOCK_TIMEOUT``
+        # by a concurrent committer (another ``mm wiki`` / an ``mm web`` commit).
+        # ``TimeoutError`` is an ``OSError``, not a ``RuntimeError``, so it needs
+        # its own clause; the web route maps the same path to a 503.
+        raise click.ClickException(
+            "wiki commit timed out — another wiki operation may be in progress; retry shortly"
+        ) from exc
+    except RuntimeError as exc:
+        # git failure (e.g. missing git identity) — surface the git error the way
+        # the sibling ``mm wiki init`` does. The embedded wiki path is the user's
+        # own local path, not a secret as it would be in the web route's HTTP
+        # response (which uses a fixed, path-free message instead).
+        raise click.ClickException(str(exc)) from exc
+
+    rels = ", ".join(t.rel for t in targets)
+    if outcome.committed:
+        click.secho(f"Committed {outcome.wiki_head[:12]} ({rels})", fg="green")
+    else:
+        click.secho(f"Nothing to commit — {rels} already match HEAD.", fg="yellow")
+
+    if privacy_warning:
+        click.secho(
+            f"warning: commit message has {privacy_warning} possible "
+            f"secret/PII match{'es' if privacy_warning != 1 else ''} (committed anyway)",
+            fg="yellow",
+            err=True,
+        )
+
+
 @wiki.command("init")
 @click.option(
     "--from",
@@ -345,6 +466,42 @@ def skill_lint_cmd(name: str, vendor: str | None) -> None:
     _run_lint("skills", name, vendor)
 
 
+@skill_group.command("commit")
+@click.argument("name")
+@click.option(
+    "--vendor",
+    "-v",
+    "vendors",
+    type=click.Choice(_SKILL_VENDORS),
+    multiple=True,
+    help="Commit this vendor's override file (repeatable).",
+)
+@click.option(
+    "--canonical",
+    "-c",
+    is_flag=True,
+    help="Also commit the canonical SKILL.md.",
+)
+@click.option(
+    "--message",
+    "-m",
+    default=None,
+    help="Commit message (default: 'wiki: update skills/<name>').",
+)
+def skill_commit_cmd(
+    name: str, vendors: tuple[str, ...], canonical: bool, message: str | None
+) -> None:
+    """Commit a skill's canonical and/or override files as one isolated wiki commit.
+
+    Parity with the web Commit affordance (ADR-0027 §3): commits ONLY the
+    selected paths layered onto HEAD — never a bare ``git add . && git commit``
+    that would sweep unrelated staged changes. Edit the files first (e.g.
+    ``mm wiki skill override <name> --vendor <v> --editor``), then select targets
+    with ``--canonical`` and/or one or more ``--vendor`` flags.
+    """
+    _run_commit("skills", name, vendors, canonical=canonical, message=message)
+
+
 # ── Agent subgroup ──────────────────────────────────────────────────────
 
 
@@ -425,6 +582,42 @@ def agent_lint_cmd(name: str, vendor: str | None) -> None:
     non-zero on any error; dropped-field warnings leave the exit 0.
     """
     _run_lint("agents", name, vendor)
+
+
+@agent_group.command("commit")
+@click.argument("name")
+@click.option(
+    "--vendor",
+    "-v",
+    "vendors",
+    type=click.Choice(_AGENT_VENDORS),
+    multiple=True,
+    help="Commit this vendor's override file (repeatable).",
+)
+@click.option(
+    "--canonical",
+    "-c",
+    is_flag=True,
+    help="Also commit the canonical agent.md.",
+)
+@click.option(
+    "--message",
+    "-m",
+    default=None,
+    help="Commit message (default: 'wiki: update agents/<name>').",
+)
+def agent_commit_cmd(
+    name: str, vendors: tuple[str, ...], canonical: bool, message: str | None
+) -> None:
+    """Commit an agent's canonical and/or override files as one isolated wiki commit.
+
+    Parity with the web Commit affordance (ADR-0027 §3): commits ONLY the
+    selected paths layered onto HEAD — never a bare ``git add . && git commit``
+    that would sweep unrelated staged changes. Edit the files first (e.g.
+    ``mm wiki agent override <name> --vendor <v> --editor``), then select targets
+    with ``--canonical`` and/or one or more ``--vendor`` flags.
+    """
+    _run_commit("agents", name, vendors, canonical=canonical, message=message)
 
 
 # ── Command subgroup ────────────────────────────────────────────────────
@@ -509,3 +702,39 @@ def command_lint_cmd(name: str, vendor: str | None) -> None:
     Exits non-zero on any error; dropped-field warnings leave the exit 0.
     """
     _run_lint("commands", name, vendor)
+
+
+@command_group.command("commit")
+@click.argument("name")
+@click.option(
+    "--vendor",
+    "-v",
+    "vendors",
+    type=click.Choice(_COMMAND_VENDORS),
+    multiple=True,
+    help="Commit this vendor's override file (repeatable).",
+)
+@click.option(
+    "--canonical",
+    "-c",
+    is_flag=True,
+    help="Also commit the canonical command.md.",
+)
+@click.option(
+    "--message",
+    "-m",
+    default=None,
+    help="Commit message (default: 'wiki: update commands/<name>').",
+)
+def command_commit_cmd(
+    name: str, vendors: tuple[str, ...], canonical: bool, message: str | None
+) -> None:
+    """Commit a command's canonical and/or override files as one isolated wiki commit.
+
+    Parity with the web Commit affordance (ADR-0027 §3): commits ONLY the
+    selected paths layered onto HEAD — never a bare ``git add . && git commit``
+    that would sweep unrelated staged changes. Edit the files first (e.g.
+    ``mm wiki command override <name> --vendor <v> --editor``), then select
+    targets with ``--canonical`` and/or one or more ``--vendor`` flags.
+    """
+    _run_commit("commands", name, vendors, canonical=canonical, message=message)

--- a/packages/memtomem/src/memtomem/web/routes/wiki_mutations.py
+++ b/packages/memtomem/src/memtomem/web/routes/wiki_mutations.py
@@ -36,9 +36,7 @@ stay two acts — auto-commit-on-save is never introduced.
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import logging
-import tempfile
 from pathlib import Path
 from typing import Literal
 
@@ -47,8 +45,12 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from memtomem import privacy
-from memtomem.context._atomic import _file_lock
 from memtomem.context._names import OVERRIDE_FORMATS, renderable_vendors
+from memtomem.wiki.commit import (
+    ResolvedTarget,
+    WikiTargetChangedError,
+    commit_targets,
+)
 from memtomem.wiki.inspect import (
     CanonicalParseError,
     read_canonical,
@@ -65,7 +67,6 @@ from memtomem.wiki.override import (
 )
 from memtomem.wiki.store import (
     WikiHeadMovedError,
-    WikiNothingToCommitError,
     WikiNotFoundError,
     WikiStore,
 )
@@ -539,18 +540,6 @@ class WikiCommitRequest(BaseModel):
     force: bool = False
 
 
-class _StaleTarget(Exception):
-    """Internal signal: a target's working-tree bytes changed since Save.
-
-    Carries the current ``mtime_ns`` so the handler can echo it in the 409
-    (mirrors the editor's ``stale_mtime`` conflict shape).
-    """
-
-    def __init__(self, rel: str, current_mtime_ns: int) -> None:
-        super().__init__(rel)
-        self.current_mtime_ns = current_mtime_ns
-
-
 def _commit_target_conflict(current_mtime_ns: int) -> JSONResponse:
     # Same conflict envelope as the editor (stale_mtime), with a commit-specific
     # reason_code so the SPA can tell a per-file race from a HEAD race.
@@ -577,20 +566,6 @@ def _commit_head_conflict(fresh_head: str) -> JSONResponse:
             "reason_code": "stale_head",
         },
     )
-
-
-def _wiki_commit_lock_path(root: Path) -> Path:
-    """Cross-process commit lock path, in system-temp keyed by the wiki root.
-
-    Kept **outside** the wiki tree on purpose: ``_file_lock`` ``mkdir``s the lock
-    file's parent, so a lock under ``<wiki>/.git/`` could forge a bogus ``.git/``
-    if the wiki were removed (``WikiStore.exists()`` only checks ``.git`` is a
-    dir). A system-temp path also can never show up in ``git status``. Two
-    processes derive the same path from the same resolved root, so the lock is
-    genuinely cross-process.
-    """
-    digest = hashlib.sha256(str(root.resolve()).encode("utf-8")).hexdigest()[:16]
-    return Path(tempfile.gettempdir()) / "memtomem" / f"wiki-commit-{digest}.lock"
 
 
 def _resolve_commit_target(
@@ -631,80 +606,32 @@ def _do_commit_blocking(
     expected_head: str,
     force: bool,
 ) -> dict:
-    """Synchronous commit body — runs in a worker thread under the cross-process lock.
+    """Synchronous commit body — runs in a worker thread so the event loop is
+    never blocked by the cross-process lock poll or the git subprocesses.
 
-    Holds the wiki-root file lock for the whole read→commit→reconcile→cleanup
-    window, so a concurrent CLI ``mm wiki`` / second ``mm web`` commit cannot
-    interleave. Per-target the bytes are read under a ``stat → read → stat``
-    verify so the committed blob is exactly the bytes whose ``mtime_ns`` matched
-    (a concurrent same-path Save → :class:`_StaleTarget` → 409, never a
-    stale-bytes commit). ``.bak`` cleanup is race-guarded and also runs on the
-    no-op path so a save-identical-bytes-then-commit never leaves the wiki dirty.
+    A thin adapter over :func:`memtomem.wiki.commit.commit_targets`, the shared
+    engine the ``mm wiki {skill,agent,command} commit`` CLI also calls. The web
+    supplies the client's per-target ``mtime_ns`` token (``expected_mtime_ns``)
+    and its ``expected_head`` CAS value; the engine holds the wiki-root file lock
+    for the whole read → commit → ``.bak``-cleanup window and may raise
+    :class:`~memtomem.wiki.commit.WikiTargetChangedError` (→ 409 ``stale_target``)
+    or :class:`~memtomem.wiki.store.WikiHeadMovedError` (→ 409 ``stale_head``).
     """
-    lock_path = _wiki_commit_lock_path(store.root)
-    # Bounded well below the handler's asyncio.timeout(60) so the thread returns
-    # a clean TimeoutError instead of being orphaned past the handler deadline.
-    with _file_lock(lock_path, timeout=30):
-        files: dict[str, bytes] = {}
-        cleanup: list[tuple[Path, int]] = []  # (path, committed_mtime_ns)
-        for rel, path, token in resolved:
-            if not path.is_file():
-                # A target the editor saved is gone — unrecoverable, even with force.
-                raise _StaleTarget(rel, 0)
-            before = path.stat().st_mtime_ns
-            if before != token:
-                if not force:
-                    raise _StaleTarget(rel, before)
-                logger.warning(
-                    "force-commit bypassed stale mtime on %s (client=%s server=%s)",
-                    rel,
-                    token,
-                    before,
-                )
-            data = path.read_bytes()
-            after = path.stat().st_mtime_ns
-            if after != before:
-                # The file changed during the read (concurrent writer).
-                if not force:
-                    raise _StaleTarget(rel, after)
-                data = path.read_bytes()
-                after = path.stat().st_mtime_ns
-            files[rel] = data
-            # Snapshot the target's own .bak (the one this asset's last Save left)
-            # so cleanup can unlink ONLY that exact backup. Save writes the .bak
-            # *before* replacing the target and does NOT take this commit lock, so a
-            # concurrent cross-process Save can drop a *fresh* .bak while the target
-            # mtime still matches; matching the snapshot avoids deleting it.
-            bak = path.with_suffix(path.suffix + ".bak")
-            bak_mtime = bak.stat().st_mtime_ns if bak.is_file() else None
-            cleanup.append((path, after, bak, bak_mtime))
-
-        try:
-            store.commit_paths(files, message=message, expected_head=expected_head)
-            committed = True
-        except WikiNothingToCommitError:
-            committed = False
-
-        # Race-guarded .bak cleanup: remove a committed target's own backup only
-        # when (a) one existed at commit time, (b) the target is still the bytes we
-        # committed, and (c) the .bak is byte-for-byte the same file (mtime
-        # unchanged) — never a fresh backup a concurrent Save just wrote.
-        for path, expect_mtime, bak, bak_snapshot in cleanup:
-            if bak_snapshot is None:
-                continue  # no editor backup at commit time → never delete one now
-            try:
-                target_unchanged = path.is_file() and path.stat().st_mtime_ns == expect_mtime
-                bak_unchanged = bak.is_file() and bak.stat().st_mtime_ns == bak_snapshot
-                if target_unchanged and bak_unchanged:
-                    bak.unlink(missing_ok=True)
-            except OSError:
-                logger.warning("wiki commit: .bak cleanup failed for %s", path.name)
-
-        return {
-            "committed": committed,
-            "wiki_head": store.current_commit(),
-            "wiki_dirty": store.is_dirty(),
-        }
+    targets = [
+        ResolvedTarget(rel=rel, path=path, expected_mtime_ns=token) for rel, path, token in resolved
+    ]
+    outcome = commit_targets(
+        store,
+        targets,
+        message=message,
+        expected_head=expected_head,
+        force=force,
+    )
+    return {
+        "committed": outcome.committed,
+        "wiki_head": outcome.wiki_head,
+        "wiki_dirty": outcome.wiki_dirty,
+    }
 
 
 @router.post("/{asset_type}/{name}/commit")
@@ -773,7 +700,7 @@ async def commit_wiki(asset_type: AssetType, name: str, body: WikiCommitRequest)
                     expected_head=body.expected_head,
                     force=body.force,
                 )
-    except _StaleTarget as exc:
+    except WikiTargetChangedError as exc:
         return _commit_target_conflict(exc.current_mtime_ns)
     except WikiHeadMovedError:
         try:

--- a/packages/memtomem/src/memtomem/wiki/commit.py
+++ b/packages/memtomem/src/memtomem/wiki/commit.py
@@ -1,0 +1,222 @@
+"""Cross-process-safe isolated commit orchestration for the wiki.
+
+Both the web **Commit affordance** (ADR-0027 §3, ``web/routes/wiki_mutations.py``)
+and the ``mm wiki {skill,agent,command} commit`` CLI funnel through
+:func:`commit_targets` so the two surfaces share **one** commit code path: the
+same wiki-root cross-process file lock (they MUST derive the *same* lock path or
+they would not mutually exclude each other), the same read → ``commit_paths`` →
+``.bak``-cleanup window, and the same race guards. Layer-specific concerns stay
+in each caller — HTTP envelopes + the in-process ``_gateway_lock`` + a worker
+thread for the web route; Click output + ``ClickException`` mapping for the CLI.
+
+The heavy lifting (out-of-worktree temp index → ``commit-tree`` → ref
+compare-and-swap) lives in :meth:`memtomem.wiki.store.WikiStore.commit_paths`;
+this module wraps it with the cross-process lock, the per-target byte read with a
+``stat → read → stat`` TOCTOU verify, and the race-guarded backup cleanup.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from memtomem.context._atomic import _file_lock
+from memtomem.wiki.store import WikiNothingToCommitError, WikiStore
+
+logger = logging.getLogger(__name__)
+
+_COMMIT_LOCK_TIMEOUT = 30.0
+"""Cross-process lock budget (seconds).
+
+Bounded well below the web handler's ``asyncio.timeout(60)`` so the worker
+thread returns a clean :class:`TimeoutError` instead of being orphaned past the
+handler deadline (#1145 precedent). The CLI is synchronous, so the same bound
+just caps how long it waits on a concurrent ``mm web`` / second ``mm wiki``
+commit before giving up.
+"""
+
+__all__ = [
+    "CommitOutcome",
+    "ResolvedTarget",
+    "WikiTargetChangedError",
+    "commit_targets",
+    "wiki_commit_lock_path",
+]
+
+
+class WikiTargetChangedError(RuntimeError):
+    """A target's on-disk bytes changed out from under the commit.
+
+    Carries the current ``mtime_ns`` so a caller can echo it: the web route maps
+    this to its 409 ``stale_target`` envelope; the CLI prints a re-run hint. Two
+    distinct triggers — a stale per-target token (the web client's Save handshake
+    no longer matches disk) or a write that landed *during* the byte read (the
+    TOCTOU guard). Both mean "don't commit bytes you didn't verify".
+    """
+
+    def __init__(self, rel: str, current_mtime_ns: int) -> None:
+        super().__init__(rel)
+        self.rel = rel
+        self.current_mtime_ns = current_mtime_ns
+
+
+@dataclass(frozen=True)
+class ResolvedTarget:
+    """One server-resolved file to commit.
+
+    ``rel`` is the wiki-relative POSIX path; ``path`` the absolute on-disk file.
+    ``expected_mtime_ns`` is the token the caller last saw (the web Save
+    response); ``None`` means **no stale-since-token check** — used by the CLI,
+    which reads current disk bytes directly with no prior Save handshake. The
+    read-during-read TOCTOU check (bytes changing *while* we read) still applies
+    in both modes.
+    """
+
+    rel: str
+    path: Path
+    expected_mtime_ns: int | None = None
+
+
+@dataclass(frozen=True)
+class CommitOutcome:
+    """Result of :func:`commit_targets`.
+
+    ``committed`` is ``False`` on the benign no-op path (the saved bytes already
+    match HEAD, so no new history was written); ``wiki_head`` / ``wiki_dirty``
+    are read back *after* the commit + ``.bak`` cleanup.
+    """
+
+    committed: bool
+    wiki_head: str
+    wiki_dirty: bool
+
+
+def wiki_commit_lock_path(root: Path) -> Path:
+    """Cross-process commit lock path, in system-temp keyed by the wiki root.
+
+    Kept **outside** the wiki tree on purpose: ``_file_lock`` ``mkdir``s the lock
+    file's parent, so a lock under ``<wiki>/.git/`` could forge a bogus ``.git/``
+    if the wiki were removed (``WikiStore.exists()`` only checks ``.git`` is a
+    dir). A system-temp path also can never show up in ``git status``.
+
+    ``root`` is ``.resolve()``-d here so callers can pass the raw ``store.root``
+    (which ``WikiStore.at_default`` leaves un-resolved): two processes deriving
+    the path from the same wiki — even via a symlink — land on the **same** lock
+    file, which is what makes the web↔CLI exclusion genuinely cross-process.
+    """
+    digest = hashlib.sha256(str(root.resolve()).encode("utf-8")).hexdigest()[:16]
+    return Path(tempfile.gettempdir()) / "memtomem" / f"wiki-commit-{digest}.lock"
+
+
+def commit_targets(
+    store: WikiStore,
+    targets: list[ResolvedTarget],
+    *,
+    message: str,
+    expected_head: str | None = None,
+    force: bool = False,
+) -> CommitOutcome:
+    """Commit *targets* in isolation onto HEAD, cross-process-locked.
+
+    Holds the wiki-root file lock for the whole read → commit → reconcile →
+    cleanup window, so a concurrent CLI ``mm wiki`` / second ``mm web`` commit
+    cannot interleave. Per target the bytes are read under a ``stat → read →
+    stat`` verify so the committed blob is exactly the bytes whose ``mtime_ns``
+    matched (a concurrent same-path write → :class:`WikiTargetChangedError`,
+    never a stale-bytes commit). ``.bak`` cleanup is race-guarded (it only
+    unlinks a backup whose mtime snapshot, taken *pre*-commit, still matches) and
+    also runs on the no-op path so a save-identical-bytes-then-commit never
+    leaves the wiki dirty.
+
+    ``expected_head`` is the compare-and-swap guard threaded to
+    :meth:`WikiStore.commit_paths`:
+
+    * a concrete SHA (the **web** route — the ``wiki_head`` the browser last saw)
+      commits *only* if HEAD still matches, else :class:`~memtomem.wiki.store.WikiHeadMovedError`;
+    * ``None`` (the **CLI**, which has no stale browser view) reads HEAD **inside
+      the lock** and commits onto that — i.e. onto the freshest HEAD. The atomic
+      ``update-ref`` CAS in ``commit_paths`` still guards the tiny window against
+      a truly external ``$EDITOR``+git that honours no lock.
+
+    Raises :class:`WikiTargetChangedError` (a target moved — caller → conflict),
+    :class:`~memtomem.wiki.store.WikiHeadMovedError` (HEAD advanced — propagated),
+    :class:`TimeoutError` (the cross-process lock is held past
+    ``_COMMIT_LOCK_TIMEOUT`` by a concurrent committer — the web route maps it to
+    a 503, the CLI to a retry hint), or :class:`RuntimeError` (git failure — the
+    caller MUST surface a fixed message; the raw stderr embeds the absolute wiki
+    path).
+    """
+    lock_path = wiki_commit_lock_path(store.root)
+    with _file_lock(lock_path, timeout=_COMMIT_LOCK_TIMEOUT):
+        # Read HEAD inside the lock when the caller supplied no CAS token, so the
+        # CLI commits onto the freshest HEAD rather than a value snapshotted
+        # before acquiring the lock. commit_paths re-validates the shape.
+        head = expected_head if expected_head is not None else store.current_commit()
+
+        files: dict[str, bytes] = {}
+        # (target_path, committed_mtime_ns, bak_path, bak_mtime_snapshot_or_None)
+        cleanup: list[tuple[Path, int, Path, int | None]] = []
+        for target in targets:
+            rel, path = target.rel, target.path
+            if not path.is_file():
+                # A target the caller resolved is gone — unrecoverable, even with force.
+                raise WikiTargetChangedError(rel, 0)
+            before = path.stat().st_mtime_ns
+            if target.expected_mtime_ns is not None and before != target.expected_mtime_ns:
+                # Stale since the caller's Save token (web only; CLI passes None).
+                if not force:
+                    raise WikiTargetChangedError(rel, before)
+                logger.warning(
+                    "force-commit bypassed stale mtime on %s (expected=%s actual=%s)",
+                    rel,
+                    target.expected_mtime_ns,
+                    before,
+                )
+            data = path.read_bytes()
+            after = path.stat().st_mtime_ns
+            if after != before:
+                # The file changed during the read (concurrent writer).
+                if not force:
+                    raise WikiTargetChangedError(rel, after)
+                data = path.read_bytes()
+                after = path.stat().st_mtime_ns
+            files[rel] = data
+            # Snapshot the target's own .bak (the one this asset's last Save left)
+            # so cleanup can unlink ONLY that exact backup. A Save writes the .bak
+            # *before* replacing the target and does NOT take this commit lock, so a
+            # concurrent cross-process Save can drop a *fresh* .bak while the target
+            # mtime still matches; matching the snapshot avoids deleting it.
+            bak = path.with_suffix(path.suffix + ".bak")
+            bak_mtime = bak.stat().st_mtime_ns if bak.is_file() else None
+            cleanup.append((path, after, bak, bak_mtime))
+
+        try:
+            store.commit_paths(files, message=message, expected_head=head)
+            committed = True
+        except WikiNothingToCommitError:
+            committed = False
+
+        # Race-guarded .bak cleanup: remove a committed target's own backup only
+        # when (a) one existed at commit time, (b) the target is still the bytes we
+        # committed, and (c) the .bak is byte-for-byte the same file (mtime
+        # unchanged) — never a fresh backup a concurrent Save just wrote. Runs
+        # outside the try/except so the no-op path cleans up too.
+        for path, expect_mtime, bak, bak_snapshot in cleanup:
+            if bak_snapshot is None:
+                continue  # no backup at commit time → never delete one now
+            try:
+                target_unchanged = path.is_file() and path.stat().st_mtime_ns == expect_mtime
+                bak_unchanged = bak.is_file() and bak.stat().st_mtime_ns == bak_snapshot
+                if target_unchanged and bak_unchanged:
+                    bak.unlink(missing_ok=True)
+            except OSError:
+                logger.warning("wiki commit: .bak cleanup failed for %s", path.name)
+
+        return CommitOutcome(
+            committed=committed,
+            wiki_head=store.current_commit(),
+            wiki_dirty=store.is_dirty(),
+        )

--- a/packages/memtomem/tests/test_wiki_cmd_commit.py
+++ b/packages/memtomem/tests/test_wiki_cmd_commit.py
@@ -1,0 +1,255 @@
+"""Tests for ``mm wiki {skill,agent,command} commit`` — the CLI parity of the
+web Commit affordance (ADR-0027 §3).
+
+The command server-resolves targets from ``--canonical`` / ``--vendor`` flags and
+delegates to the shared :func:`memtomem.wiki.commit.commit_targets` engine, so
+these focus on the CLI surface: the isolated commit (an unrelated staged file is
+never swept), multi-target single-commit, the no-op message, the friendly errors
+(no targets / missing file / absent wiki / invalid name), and the soft privacy
+warning on the commit message.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli.wiki_cmd import wiki as wiki_group
+from memtomem.context._atomic import _file_lock
+from memtomem.wiki import commit as wiki_commit
+from memtomem.wiki.store import WikiStore
+
+# ``wiki_root`` / ``git_identity`` fixtures come from conftest.py (which imports
+# them from _wiki_fixtures), so they need no import here.
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _init_wiki() -> WikiStore:
+    store = WikiStore.at_default()
+    store.init()
+    return store
+
+
+def _seed_skill(root: Path, name: str = "demo", body: bytes = b"# canonical\n") -> None:
+    d = root / "skills" / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_bytes(body)
+    _git(root, "add", ".")
+    _git(root, "commit", "-m", f"add {name}")
+
+
+def _combined(result) -> str:  # noqa: ANN001
+    """stdout + stderr, robust across Click's pre/post-8.2 ``mix_stderr`` change."""
+    out = result.output or ""
+    try:
+        out += result.stderr  # Click ≥8.2 exposes stderr separately
+    except ValueError:
+        pass  # Click <8.2 already mixed stderr into output
+    return out
+
+
+# ── happy paths ────────────────────────────────────────────────────────────
+
+
+def test_commit_override_happy(wiki_root: Path) -> None:
+    _init_wiki()
+    _seed_skill(wiki_root)
+    runner = CliRunner()
+    # seed an override (uncommitted) then commit just it
+    runner.invoke(wiki_group, ["skill", "override", "demo", "--vendor", "claude"])
+    head0 = _git(wiki_root, "rev-parse", "HEAD").strip()
+
+    result = runner.invoke(wiki_group, ["skill", "commit", "demo", "-v", "claude"])
+
+    assert result.exit_code == 0, _combined(result)
+    assert "Committed" in result.output
+    head1 = _git(wiki_root, "rev-parse", "HEAD").strip()
+    assert head1 != head0
+    files = _git(wiki_root, "show", "--name-only", "--format=", head1).split()
+    assert files == ["skills/demo/overrides/claude.md"]
+    assert not _git(wiki_root, "status", "--porcelain").strip()  # clean tree
+
+
+def test_commit_canonical(wiki_root: Path) -> None:
+    _init_wiki()
+    _seed_skill(wiki_root)
+    (wiki_root / "skills/demo/SKILL.md").write_bytes(b"# canonical v2\n")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "commit", "demo", "--canonical"])
+
+    assert result.exit_code == 0, _combined(result)
+    head = _git(wiki_root, "rev-parse", "HEAD").strip()
+    assert _git(wiki_root, "show", f"{head}:skills/demo/SKILL.md") == "# canonical v2\n"
+
+
+def test_multi_target_single_commit(wiki_root: Path) -> None:
+    _init_wiki()
+    _seed_skill(wiki_root)
+    runner = CliRunner()
+    runner.invoke(wiki_group, ["skill", "override", "demo", "--vendor", "claude"])
+    (wiki_root / "skills/demo/SKILL.md").write_bytes(b"# canonical v2\n")
+    n_before = _git(wiki_root, "rev-list", "--count", "HEAD").strip()
+
+    result = runner.invoke(wiki_group, ["skill", "commit", "demo", "-c", "-v", "claude"])
+
+    assert result.exit_code == 0, _combined(result)
+    head = _git(wiki_root, "rev-parse", "HEAD").strip()
+    files = sorted(_git(wiki_root, "show", "--name-only", "--format=", head).split())
+    assert files == ["skills/demo/SKILL.md", "skills/demo/overrides/claude.md"]
+    # exactly ONE new commit, not one per target
+    assert int(_git(wiki_root, "rev-list", "--count", "HEAD").strip()) == int(n_before) + 1
+
+
+def test_default_commit_message(wiki_root: Path) -> None:
+    _init_wiki()
+    _seed_skill(wiki_root)
+    (wiki_root / "skills/demo/SKILL.md").write_bytes(b"# v2\n")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "commit", "demo", "-c"])
+
+    assert result.exit_code == 0, _combined(result)
+    assert _git(wiki_root, "log", "-1", "--format=%s").strip() == "wiki: update skills/demo"
+
+
+def test_noop_when_unchanged(wiki_root: Path) -> None:
+    _init_wiki()
+    _seed_skill(wiki_root)
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "commit", "demo", "-c"])
+
+    assert result.exit_code == 0, _combined(result)
+    assert "Nothing to commit" in result.output
+
+
+def test_isolation_unrelated_staged_not_swept(wiki_root: Path) -> None:
+    _init_wiki()
+    _seed_skill(wiki_root)
+    runner = CliRunner()
+    runner.invoke(wiki_group, ["skill", "override", "demo", "--vendor", "claude"])
+    # stage an unrelated canonical edit in the real index
+    (wiki_root / "skills/demo/SKILL.md").write_bytes(b"# canonical EDITED\n")
+    _git(wiki_root, "add", "skills/demo/SKILL.md")
+
+    result = runner.invoke(wiki_group, ["skill", "commit", "demo", "-v", "claude"])
+
+    assert result.exit_code == 0, _combined(result)
+    head = _git(wiki_root, "rev-parse", "HEAD").strip()
+    files = _git(wiki_root, "show", "--name-only", "--format=", head).split()
+    assert files == ["skills/demo/overrides/claude.md"]  # canonical NOT swept in
+    assert b"EDITED" in (wiki_root / "skills/demo/SKILL.md").read_bytes()
+
+
+# ── privacy: soft warning on the commit message (valve, not gate) ──────────
+
+
+def test_commit_message_privacy_warning_is_soft(wiki_root: Path) -> None:
+    _init_wiki()
+    _seed_skill(wiki_root)
+    (wiki_root / "skills/demo/SKILL.md").write_bytes(b"# v2\n")
+    runner = CliRunner()
+
+    result = runner.invoke(
+        wiki_group,
+        ["skill", "commit", "demo", "-c", "-m", "leak AKIAIOSFODNN7EXAMPLE oops"],
+    )
+
+    assert result.exit_code == 0, _combined(result)  # warned, NOT blocked
+    assert "Committed" in result.output
+    assert "secret/PII" in _combined(result)
+    # the commit still landed with the user's message
+    assert "AKIAIOSFODNN7EXAMPLE" in _git(wiki_root, "log", "-1", "--format=%s")
+
+
+# ── classified errors (no traceback leaks) ─────────────────────────────────
+
+
+def test_no_targets_errors(wiki_root: Path) -> None:
+    _init_wiki()
+    _seed_skill(wiki_root)
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "commit", "demo"])
+
+    assert result.exit_code != 0
+    assert "nothing to commit: pass --canonical" in result.output
+
+
+def test_missing_file_friendly_error(wiki_root: Path) -> None:
+    _init_wiki()
+    _seed_skill(wiki_root)
+    runner = CliRunner()
+
+    # gemini override was never seeded → friendly "no such file"
+    result = runner.invoke(wiki_group, ["skill", "commit", "demo", "-v", "gemini"])
+
+    assert result.exit_code != 0
+    out = result.output.replace("\\", "/")
+    assert "no such file in the wiki: skills/demo/overrides/gemini.md" in out
+    assert "seed an override before committing" in out
+
+
+def test_absent_wiki_errors(wiki_root: Path) -> None:
+    # wiki_root sets MEMTOMEM_WIKI_PATH but we never init → require_exists fails
+    runner = CliRunner()
+    result = runner.invoke(wiki_group, ["skill", "commit", "demo", "-c"])
+    assert result.exit_code != 0
+    assert "wiki not found" in result.output
+
+
+def test_invalid_name_errors(wiki_root: Path) -> None:
+    _init_wiki()
+    runner = CliRunner()
+    result = runner.invoke(wiki_group, ["skill", "commit", "bad/name", "-c"])
+    assert result.exit_code != 0
+    assert "invalid skill name" in result.output
+
+
+def test_busy_lock_is_classified(wiki_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A concurrent committer holding the shared cross-process wiki lock makes
+    # ``_file_lock`` raise the builtin ``TimeoutError`` (an OSError, NOT a
+    # RuntimeError) — it must surface as a clean ClickException, never a traceback.
+    _init_wiki()
+    _seed_skill(wiki_root)
+    (wiki_root / "skills/demo/SKILL.md").write_bytes(b"# edited\n")
+    monkeypatch.setattr(wiki_commit, "_COMMIT_LOCK_TIMEOUT", 0.1)  # fail fast
+    runner = CliRunner()
+    with _file_lock(wiki_commit.wiki_commit_lock_path(wiki_root), timeout=None):
+        result = runner.invoke(wiki_group, ["skill", "commit", "demo", "-c"])
+    assert result.exit_code != 0
+    assert not isinstance(result.exception, TimeoutError)  # classified, not raw
+    assert "timed out" in result.output
+
+
+# ── agent / command parity (the shared helper covers all three types) ──────
+
+
+def test_agent_commit_canonical(wiki_root: Path) -> None:
+    _init_wiki()
+    d = wiki_root / "agents" / "beta"
+    d.mkdir(parents=True)
+    (d / "agent.md").write_text(
+        "---\nname: beta\ndescription: a test agent\n---\n\nBody.\n", encoding="utf-8"
+    )
+    _git(wiki_root, "add", ".")
+    _git(wiki_root, "commit", "-m", "add agent beta")
+    (d / "agent.md").write_text(
+        "---\nname: beta\ndescription: edited\n---\n\nBody v2.\n", encoding="utf-8"
+    )
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["agent", "commit", "beta", "-c"])
+
+    assert result.exit_code == 0, _combined(result)
+    assert "Committed" in result.output
+    assert "edited" in _git(wiki_root, "show", "HEAD:agents/beta/agent.md")

--- a/packages/memtomem/tests/test_wiki_commit.py
+++ b/packages/memtomem/tests/test_wiki_commit.py
@@ -1,0 +1,251 @@
+"""Tests for :mod:`memtomem.wiki.commit` — the shared isolated-commit engine.
+
+``commit_targets`` is the single code path behind both the web Commit affordance
+(ADR-0027 §3, ``web/routes/wiki_mutations.py``) and ``mm wiki ... commit``. These
+exercise it directly: the cross-process lock-path determinism that makes the
+web↔CLI exclusion real, the ``expected_head=None`` "commit onto current HEAD"
+mode the CLI uses, commit isolation (never a bare ``git add .``), the no-op path,
+the stale-token / TOCTOU guards, the ``expected_head`` CAS, and the race-guarded
+``.bak`` cleanup (including the no-op path and the concurrent-fresh-backup case).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from memtomem.wiki.commit import (
+    ResolvedTarget,
+    WikiTargetChangedError,
+    commit_targets,
+    wiki_commit_lock_path,
+)
+from memtomem.wiki.store import WikiHeadMovedError, WikiStore
+
+# ``wiki_root`` / ``git_identity`` fixtures come from conftest.py (which imports
+# them from _wiki_fixtures), so they need no import here.
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _committed_skill(root: Path, name: str = "demo", body: bytes = b"# canonical\n") -> WikiStore:
+    store = WikiStore.at_default()
+    store.init()
+    d = root / "skills" / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_bytes(body)
+    _git(root, "add", ".")
+    _git(root, "commit", "-m", f"add {name}")
+    return store
+
+
+def _target(store: WikiStore, rel: str, expected_mtime_ns: int | None = None) -> ResolvedTarget:
+    return ResolvedTarget(rel=rel, path=store.root / rel, expected_mtime_ns=expected_mtime_ns)
+
+
+# ── lock path determinism (the web↔CLI mutual-exclusion contract) ──────────
+
+
+def test_lock_path_is_deterministic_for_a_root(tmp_path: Path) -> None:
+    # Web and CLI must derive the SAME path from the same root or they would not
+    # exclude each other; the path is keyed by the resolved root.
+    a = wiki_commit_lock_path(tmp_path / "wiki")
+    b = wiki_commit_lock_path(tmp_path / "wiki")
+    assert a == b
+    assert a.suffix == ".lock"
+
+
+def test_lock_path_differs_by_root(tmp_path: Path) -> None:
+    assert wiki_commit_lock_path(tmp_path / "w1") != wiki_commit_lock_path(tmp_path / "w2")
+
+
+def test_lock_path_is_outside_the_wiki_tree(tmp_path: Path) -> None:
+    # Never under <wiki>/.git — _file_lock mkdir's the parent and would forge a
+    # bogus .git/ if the wiki were removed.
+    root = tmp_path / "wiki"
+    assert root not in wiki_commit_lock_path(root).parents
+
+
+# ── expected_head=None (CLI) commits onto current HEAD, isolated ───────────
+
+
+def test_commits_onto_current_head_with_none(wiki_root: Path) -> None:
+    store = _committed_skill(wiki_root)
+    head0 = store.current_commit()
+    target = store.root / "skills/demo/overrides/claude.md"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"# override\n")
+
+    outcome = commit_targets(
+        store, [_target(store, "skills/demo/overrides/claude.md")], message="add override"
+    )
+
+    assert outcome.committed is True
+    assert outcome.wiki_head != head0
+    assert outcome.wiki_dirty is False
+    blob = _git(wiki_root, "show", f"{outcome.wiki_head}:skills/demo/overrides/claude.md")
+    assert blob == "# override\n"
+
+
+def test_isolation_unrelated_staged_not_swept(wiki_root: Path) -> None:
+    store = _committed_skill(wiki_root)
+    # an unrelated change, staged in the REAL index
+    (wiki_root / "skills/demo/SKILL.md").write_bytes(b"# canonical EDITED\n")
+    _git(wiki_root, "add", "skills/demo/SKILL.md")
+    # a separate override to commit in isolation
+    ov = wiki_root / "skills/demo/overrides/claude.md"
+    ov.parent.mkdir(parents=True)
+    ov.write_bytes(b"# override\n")
+
+    outcome = commit_targets(
+        store, [_target(store, "skills/demo/overrides/claude.md")], message="iso"
+    )
+
+    # the commit contains ONLY the override, not the staged SKILL.md edit
+    files = _git(wiki_root, "show", "--name-only", "--format=", outcome.wiki_head).split()
+    assert files == ["skills/demo/overrides/claude.md"]
+    # the staged SKILL.md edit survives uncommitted in the working tree
+    assert b"EDITED" in (wiki_root / "skills/demo/SKILL.md").read_bytes()
+
+
+def test_multi_target_single_commit(wiki_root: Path) -> None:
+    store = _committed_skill(wiki_root)
+    (wiki_root / "skills/demo/SKILL.md").write_bytes(b"# canonical v2\n")
+    ov = wiki_root / "skills/demo/overrides/claude.md"
+    ov.parent.mkdir(parents=True)
+    ov.write_bytes(b"# override\n")
+
+    outcome = commit_targets(
+        store,
+        [_target(store, "skills/demo/SKILL.md"), _target(store, "skills/demo/overrides/claude.md")],
+        message="both",
+    )
+
+    # ONE new commit carrying BOTH files
+    files = sorted(_git(wiki_root, "show", "--name-only", "--format=", outcome.wiki_head).split())
+    assert files == ["skills/demo/SKILL.md", "skills/demo/overrides/claude.md"]
+    # exactly one commit ahead of the seed (the add-demo commit)
+    assert _git(wiki_root, "rev-list", "--count", "HEAD").strip() == "3"
+
+
+# ── no-op, stale-token, TOCTOU, CAS guards ─────────────────────────────────
+
+
+def test_noop_when_bytes_match_head(wiki_root: Path) -> None:
+    store = _committed_skill(wiki_root)
+    outcome = commit_targets(store, [_target(store, "skills/demo/SKILL.md")], message="noop")
+    assert outcome.committed is False
+    assert outcome.wiki_dirty is False
+
+
+def test_stale_token_raises_without_force(wiki_root: Path) -> None:
+    store = _committed_skill(wiki_root)
+    target_path = wiki_root / "skills/demo/SKILL.md"
+    target_path.write_bytes(b"# edited\n")
+    stale = target_path.stat().st_mtime_ns - 1  # a token that won't match disk
+    with pytest.raises(WikiTargetChangedError):
+        commit_targets(
+            store, [_target(store, "skills/demo/SKILL.md", expected_mtime_ns=stale)], message="x"
+        )
+
+
+def test_stale_token_committed_with_force(wiki_root: Path) -> None:
+    store = _committed_skill(wiki_root)
+    target_path = wiki_root / "skills/demo/SKILL.md"
+    target_path.write_bytes(b"# edited\n")
+    stale = target_path.stat().st_mtime_ns - 1
+    outcome = commit_targets(
+        store,
+        [_target(store, "skills/demo/SKILL.md", expected_mtime_ns=stale)],
+        message="forced",
+        force=True,
+    )
+    assert outcome.committed is True
+
+
+def test_missing_target_raises(wiki_root: Path) -> None:
+    store = _committed_skill(wiki_root)
+    with pytest.raises(WikiTargetChangedError) as ei:
+        commit_targets(store, [_target(store, "skills/demo/overrides/nope.md")], message="x")
+    assert ei.value.current_mtime_ns == 0
+
+
+def test_stale_expected_head_raises(wiki_root: Path) -> None:
+    store = _committed_skill(wiki_root)
+    stale_head = store.current_commit()
+    # advance HEAD out of band so the passed expected_head is stale
+    (wiki_root / "skills/demo/SKILL.md").write_bytes(b"# v2\n")
+    _git(wiki_root, "commit", "-am", "v2")
+    ov = wiki_root / "skills/demo/overrides/claude.md"
+    ov.parent.mkdir(parents=True)
+    ov.write_bytes(b"# ov\n")
+    with pytest.raises(WikiHeadMovedError):
+        commit_targets(
+            store,
+            [_target(store, "skills/demo/overrides/claude.md")],
+            message="x",
+            expected_head=stale_head,
+        )
+
+
+# ── race-guarded .bak cleanup ──────────────────────────────────────────────
+
+
+def test_bak_cleaned_after_commit(wiki_root: Path) -> None:
+    store = _committed_skill(wiki_root)
+    ov = wiki_root / "skills/demo/overrides/claude.md"
+    ov.parent.mkdir(parents=True)
+    ov.write_bytes(b"# override\n")
+    bak = ov.with_suffix(ov.suffix + ".bak")
+    bak.write_bytes(b"# old\n")
+
+    outcome = commit_targets(
+        store, [_target(store, "skills/demo/overrides/claude.md")], message="x"
+    )
+
+    assert outcome.committed is True
+    assert not bak.exists()  # the asset's own .bak was cleaned
+    assert outcome.wiki_dirty is False
+
+
+def test_bak_cleaned_on_noop_path(wiki_root: Path) -> None:
+    store = _committed_skill(wiki_root)
+    # SKILL.md == HEAD (no-op), but a stray .bak would keep the tree dirty
+    bak = wiki_root / "skills/demo/SKILL.md.bak"
+    bak.write_bytes(b"# old\n")
+    outcome = commit_targets(store, [_target(store, "skills/demo/SKILL.md")], message="noop")
+    assert outcome.committed is False
+    assert not bak.exists()
+    assert outcome.wiki_dirty is False
+
+
+def test_concurrent_fresh_bak_preserved(wiki_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _committed_skill(wiki_root)
+    ov = wiki_root / "skills/demo/overrides/claude.md"
+    ov.parent.mkdir(parents=True)
+    ov.write_bytes(b"# override\n")
+    bak = ov.with_suffix(ov.suffix + ".bak")
+    bak.write_bytes(b"# at-commit\n")  # snapshotted pre-commit
+
+    real = WikiStore.commit_paths
+
+    def _commit_then_fresh_bak(self, files, *, message, expected_head):  # noqa: ANN001
+        sha = real(self, files, message=message, expected_head=expected_head)
+        # a concurrent Save drops a FRESH .bak (distinct bytes + mtime) after the
+        # snapshot, before cleanup — cleanup must skip it.
+        bak.write_bytes(b"# fresh-from-concurrent-save\n")
+        os.utime(bak, ns=(0, 0))
+        return sha
+
+    monkeypatch.setattr(WikiStore, "commit_paths", _commit_then_fresh_bak)
+    commit_targets(store, [_target(store, "skills/demo/overrides/claude.md")], message="x")
+
+    assert bak.exists()  # the fresh backup was NOT deleted
+    assert bak.read_bytes() == b"# fresh-from-concurrent-save\n"


### PR DESCRIPTION
## What

Adds `mm wiki {skill,agent,command} commit <name>` — the terminal parity of the in-browser wiki **Commit** affordance (ADR-0027 §3, #1373). After editing a canonical asset or a vendor override you can commit it from the CLI instead of dropping to raw `git`:

```
mm wiki skill override demo --vendor claude --editor   # edit
mm wiki skill commit demo --canonical --vendor claude  # commit, isolated
```

It writes **one isolated git commit** of only the selected paths layered onto HEAD — never a bare `git add . && git commit` that would sweep unrelated staged changes in the wiki.

## Why

`mm wiki ... override` previously ended by printing `# next: cd <wiki> && git add ... && git commit` and left the user to run git themselves. The web gained a proper Commit affordance in #1373; this closes the gap so the edit → commit flow stays in the terminal with the same isolation guarantees.

## How

For **true** parity (not a re-implementation that drifts), the web route's locked commit orchestration (`_do_commit_blocking`) is extracted into a shared engine — **`memtomem.wiki.commit.commit_targets`** — that both the web route (now a thin adapter) and the CLI call. This is also *required* for correctness: the cross-process wiki lock only mutually excludes a concurrent `mm web` commit and a CLI commit if both derive the **same** lock path, so the lock-path derivation must be shared, not duplicated.

The web's commit machinery (hardened over two prior review rounds: system-temp lock keyed by the wiki root, commit-message privacy scan, `.bak` mtime-snapshot race guard, no-op cleanup, read-during-read TOCTOU, ref CAS) is preserved and still covered by the existing route tests.

**CLI specifics vs the web:**
- No client Save token, so the CLI commits the bytes currently on disk onto the freshest HEAD (HEAD is read *inside* the lock). The `expected_head` ref CAS + the cross-process lock still guard a concurrent committer.
- Targets: `--canonical`/`-c` and repeatable `--vendor`/`-v`; `--message`/`-m` overrides the generated default. At least one target is required.
- Every engine error maps to a classified `ClickException` (no traceback) — including a busy-lock `TimeoutError` → retry hint (the web maps that path to a 503). A git failure surfaces `str(exc)` like the sibling `mm wiki init` (the wiki path is the user's own local path, not a remote-HTTP secret).
- The commit message is privacy-scanned (a soft, non-blocking warning).

## Tests

- New `tests/test_wiki_commit.py` (engine): lock-path determinism, `expected_head=None` onto-current-HEAD, commit isolation, no-op, the stale-token / TOCTOU / `expected_head` CAS guards, and race-guarded `.bak` cleanup (incl. the no-op path and a concurrent-fresh-`.bak`).
- New `tests/test_wiki_cmd_commit.py` (CLI): happy override/canonical, multi-target single-commit, no-op, isolation, soft privacy warning, busy-lock classification, and the friendly error surfaces (no targets / missing file / absent wiki / invalid name).
- The existing web Commit + `WikiStore.commit_paths` + web-invariants tests stay green (the regression gate for the refactor).

Reviewed by Codex (designated reviewer): **SHIP** after one folded fix — mapping the busy-lock `TimeoutError` in the CLI (it is an `OSError`, not a `RuntimeError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
