### PR TITLE
fix(web): de-jargon the Context Gateway overview blurb + add a first-action CTA (#1352)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -564,7 +564,7 @@
 
         <!-- Context Gateway: Overview -->
         <div class="settings-section active" id="settings-ctx-overview">
-          <p class="settings-section-desc" data-i18n="settings.ctx.overview_desc">Sync memtomem agent runtime artifacts to Claude Code, Codex, and other detected runtimes.</p>
+          <p class="settings-section-desc" data-i18n="settings.ctx.overview_desc">memtomem keeps one master copy of everything it manages and syncs it out to Claude Code, Codex, and other detected runtimes. Pick a section in the sidebar to import what you already have or create something new.</p>
           <div class="tab-help-bar" id="help-ctx-overview" role="status" hidden>
             <span class="tab-help-bar-text" data-i18n="settings.ctx.primer">memtomem keeps your master copies in one Store (.memtomem/) and Syncs them out to your Runtimes — Claude Code, Codex, Kimi, and other detected tools. Import pulls a runtime's copy back in. It's one-way: edit in the Store, then Sync.</span>
             <button class="tab-help-bar-dismiss" data-help-tab="ctx-overview" data-i18n-title="common.dismiss_help" data-i18n-aria-label="common.dismiss_help" title="Dismiss help" aria-label="Dismiss help">✕</button>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -719,7 +719,7 @@
   "settings.hooks.detail.timeout": "Timeout",
   "settings.hooks.detail.rule_json": "Rule JSON",
   "settings.hooks.detail.click_hint": "Click a rule to view details.",
-  "settings.ctx.overview_desc": "Sync memtomem agent runtime artifacts to Claude Code, Codex, and other detected runtimes.",
+  "settings.ctx.overview_desc": "memtomem keeps one master copy of everything it manages and syncs it out to Claude Code, Codex, and other detected runtimes. Pick a section in the sidebar to import what you already have or create something new.",
   "settings.ctx.refresh_tooltip": "Refresh detected Claude Code / Codex / Kimi runtime status",
   "settings.ctx.refresh_aria": "Refresh detected runtime status",
   "settings.ctx.sync_all_tooltip": "Push memtomem's stored artifacts to the runtimes configured for this store",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -719,7 +719,7 @@
   "settings.hooks.detail.timeout": "타임아웃",
   "settings.hooks.detail.rule_json": "Rule JSON",
   "settings.hooks.detail.click_hint": "규칙을 클릭하면 상세 내용이 표시됩니다.",
-  "settings.ctx.overview_desc": "memtomem 의 에이전트 런타임 아티팩트를 Claude Code, Codex 등 감지된 런타임으로 동기화합니다.",
+  "settings.ctx.overview_desc": "memtomem 은 관리하는 모든 항목의 마스터 사본을 하나로 보관하고, 이를 Claude Code · Codex 등 감지된 런타임으로 동기화합니다. 사이드바에서 섹션을 선택해 기존 항목을 가져오거나 새로 만들어 시작하세요.",
   "settings.ctx.refresh_tooltip": "감지된 Claude Code · Codex 런타임 상태를 새로고침합니다",
   "settings.ctx.refresh_aria": "감지된 런타임 상태 새로고침",
   "settings.ctx.sync_all_tooltip": "memtomem 저장소의 아티팩트를 이 저장소에 구성된 런타임으로 내보냅니다",

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -995,6 +995,53 @@ class TestNoHardcodedStrings:
             "and the wiki nav must define 'canonical':\n" + "\n".join(leaks)
         )
 
+    def test_ctx_overview_desc_dejargoned_with_cta(
+        self, en: dict[str, str], ko: dict[str, str]
+    ) -> None:
+        """#1352 overview/empty-state copy: the always-visible Context Gateway
+        blurb greeted a first-time user with the jargon "agent runtime artifacts"
+        / "에이전트 런타임 아티팩트" and offered no next step. Replace the jargon with
+        plain "everything it manages" wording and add a "pick a section in the
+        sidebar" first action, so it does the why/next job before the
+        (dismissible) ``primer`` help-bar.
+
+        This complements — and must not collide with — the deliberate
+        ``test_q_pr2_overview_desc_is_tier_agnostic`` contract (Q-PR2 Drift-3):
+        the desc renders unconditionally as the tile set evolves, so it must NOT
+        enumerate tile names. So this guard pins the de-jargon + CTA only, and
+        leaves tile-agnosticism to that test — do not assert any tile name here.
+
+        Pins the index.html inline default too (the i18n 3-fallback-layer lesson:
+        the inline text is what renders before the locale JSON loads)."""
+        key = "settings.ctx.overview_desc"
+        assert key in en and key in ko, f"missing {key}"
+        en_val, ko_val = en[key], ko[key]
+        index_html = (_STATIC_JS_DIR / "index.html").read_text(encoding="utf-8")
+        leaks: list[str] = []
+
+        # No "agent runtime artifacts" jargon (the first-run complaint).
+        if "agent runtime artifact" in en_val.lower():
+            leaks.append(f"  en {key}: still says 'agent runtime artifacts' — {en_val!r}")
+        if "에이전트 런타임 아티팩트" in ko_val:
+            leaks.append(f"  ko {key}: still says '에이전트 런타임 아티팩트' — {ko_val!r}")
+
+        # Offers a concrete next action (orient to the sidebar).
+        if "sidebar" not in en_val.lower():
+            leaks.append(f"  en {key}: must point at a first action (sidebar) — {en_val!r}")
+        if "사이드바" not in ko_val:
+            leaks.append(f"  ko {key}: must point at a first action (사이드바) — {ko_val!r}")
+
+        # Inline default must match en (pre-hydration fallback).
+        if f">{en_val}</p>" not in index_html:
+            leaks.append(
+                "  index.html: overview_desc inline default is stale — must match en value"
+            )
+
+        assert not leaks, (
+            "#1352 overview_desc must drop 'agent runtime artifacts' jargon and "
+            "add a sidebar CTA (staying tile-agnostic):\n" + "\n".join(leaks)
+        )
+
     def test_command_palette_keys_present(self, en: dict[str, str], ko: dict[str, str]) -> None:
         """The Cmd+K command palette labels (#1026) — nav/settings/action
         commands, group headers, the open-source label, and the empty state —


### PR DESCRIPTION
## Summary

Part of the #1352 first-time-user wording campaign — the **empty/overview-state** item.
This does **not** close #1352 (umbrella checklist).

The always-visible Context Gateway overview blurb greeted a newcomer with the
jargon **"agent runtime artifacts" / "에이전트 런타임 아티팩트"** and offered no next
step. (The deeper Store→Runtime explanation already exists in the `primer`
help-bar, but it's dismissible and `hidden` by default.) This rewords the blurb
in plain language and adds a concrete first action.

| | Before | After |
| --- | --- | --- |
| en | `Sync memtomem agent runtime artifacts to Claude Code, Codex, and other detected runtimes.` | `memtomem keeps one master copy of everything it manages and syncs it out to Claude Code, Codex, and other detected runtimes. Pick a section in the sidebar to import what you already have or create something new.` |

### Stays tile-agnostic (important)

There is a deliberate, tested contract — `test_q_pr2_overview_desc_is_tier_agnostic`
(Q-PR2 Drift-3) — that the desc must **not** enumerate tile names, because it
renders unconditionally and the tile set evolves over time. My first draft listed
"skills, commands, subagents…" and that test correctly caught it. The shipped copy
says **"everything it manages"** instead and keeps the `Claude Code` / `Codex`
runtime anchors the contract also requires.

### Checklist item addressed (#1352)

- [x] Overview copy too abstract / no CTA (item 9) → de-jargoned + sidebar first-action

(Audited the sibling empty-states too: `empty_hint` already interpolates a real
`{canonical}` path and names Sync/Import, and `no_artifacts_hint` is already
concrete — left untouched.)

## Testing

- New guard `test_ctx_overview_desc_dejargoned_with_cta` pins the de-jargon, the
  sidebar CTA, and the index.html inline pre-hydration default; its docstring
  cross-references the tier-agnostic contract so the two guards can't drift into
  conflict. Mutation-validated (reintroducing the jargon fails it).
- `uv run pytest packages/memtomem/tests/test_i18n.py` → 77 passed (both guards +
  en/ko parity).
- `ruff check` clean. HTML + i18n JSON only; no `.js` touched, so no `?v=` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
