### PR TITLE
fix(web): give the Context Gateway status-legend help-tip a static aria-label (#1352)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -572,7 +572,7 @@
           <div class="ctx-header">
             <div class="ctx-header-title">
               <h2 data-i18n="settings.ctx.overview_title">Context Gateway</h2>
-              <span class="help-tip" data-help-i18n="settings.ctx.status_legend" tabindex="0" role="img">i</span>
+              <span class="help-tip" data-help-i18n="settings.ctx.status_legend" tabindex="0" role="img" aria-label="In sync — nothing to do. Out of sync — Sync to update the runtime. Not in runtime — Sync to add it. Not yet imported — Import to pull it into the Store.">i</span>
             </div>
             <div>
               <button id="ctx-mode-toggle" class="btn-ghost ctx-mode-toggle" type="button"

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -1042,6 +1042,43 @@ class TestNoHardcodedStrings:
             "add a sidebar CTA (staying tile-agnostic):\n" + "\n".join(leaks)
         )
 
+    def test_ctx_static_helptip_icons_have_accessible_name(self, en: dict[str, str]) -> None:
+        """#1352 a11y (item 13): the Context Gateway help-tip "i" icons carry
+        ``role="img"`` + ``tabindex="0"``, so each needs an accessible name. The
+        status-legend tip in the overview header used ``data-help-i18n`` alone —
+        i18n.js does set its ``aria-label`` at runtime from the key, but until the
+        locale JSON loads the icon is a nameless focusable ``role="img"``. Every
+        other static help-tip already ships a static ``aria-label`` fallback; this
+        pins that none ship nameless, and that the status-legend tip's fallback
+        matches its en value (the i18n 3-fallback-layer lesson).
+
+        The broader item-13 surface — tier controls, status badges, dialogs, and
+        toasts (per-element role, banner-heading-only alert) — was already
+        satisfied by #1315 and the ctx a11y conventions; this closes the one
+        residual pre-hydration gap rather than re-doing covered ground."""
+        index_html = (_STATIC_JS_DIR / "index.html").read_text(encoding="utf-8")
+        leaks: list[str] = []
+
+        # Every static help-tip rendered as role="img" must carry an accessible
+        # name in the markup (not only via runtime JS).
+        for match in re.finditer(r'<span\b[^>]*class="help-tip"[^>]*>', index_html):
+            tag = match.group(0)
+            if 'role="img"' in tag and 'aria-label="' not in tag:
+                leaks.append(f"  help-tip role=img with no static aria-label: {tag}")
+
+        # The status-legend tip's static fallback must match its en value.
+        legend = en["settings.ctx.status_legend"]
+        if f'aria-label="{legend}"' not in index_html:
+            leaks.append(
+                "  index.html: status-legend help-tip aria-label fallback is stale — "
+                "must match en['settings.ctx.status_legend']"
+            )
+
+        assert not leaks, (
+            "#1352 a11y: every static role=img help-tip needs an aria-label, and "
+            "the status-legend fallback must match en:\n" + "\n".join(leaks)
+        )
+
     def test_command_palette_keys_present(self, en: dict[str, str], ko: dict[str, str]) -> None:
         """The Cmd+K command palette labels (#1026) — nav/settings/action
         commands, group headers, the open-source label, and the empty state —


### PR DESCRIPTION
## Summary

Part of the #1352 first-time-user wording campaign — the **a11y (ARIA)** item.
This does **not** close #1352 (umbrella checklist).

I audited the Context Gateway's ARIA surface (nav, overview, badges, the tier /
"Stored-in" filter, the Move/Copy + wiki dialogs, toasts, and banners). The
broad item-13 surface was **already accessible**, courtesy of #1315 and the ctx
a11y conventions:

- toasts set a **per-element** `role` (`alert` for errors, else `status`) — not a container live-region;
- banners scope `role="alert"` to the short heading only;
- the tier filter is a `role="group"` with `aria-label`; badges carry text + `title`; dialogs have `role="dialog"` / `aria-modal` / `aria-labelledby`;
- every action button has text or an `aria-label`.

### The one residual gap

The status-legend **"i" help-tip** in the overview header (`index.html:575`)
used `data-help-i18n` alone. `i18n.js` *does* set its `aria-label` at runtime
from that key — but until the locale JSON loads, the icon is a nameless
focusable `role="img"`. Every *other* static help-tip (lines 204, 247, 962,
1215) already ships a static `aria-label` fallback; this one didn't. Added it
(matching the en `status_legend` value, so the runtime re-translation is a no-op
for en).

### Checklist item addressed (#1352)

- [x] Missing ARIA labels on tier dropdowns / status badges (item 13) → audited; the surface was already covered, and the one residual help-tip pre-hydration gap is now closed.

## Testing

- New guard `test_ctx_static_helptip_icons_have_accessible_name`: asserts **no**
  static `role="img"` help-tip ships without an `aria-label`, and pins the
  status-legend fallback to its en value (i18n 3-fallback-layer). Mutation-
  validated (stripping the `aria-label` fails both clauses).
- `uv run pytest packages/memtomem/tests/test_i18n.py` → 77 passed.
- `ruff check` clean. HTML + test only; no `.js` touched, so no `?v=` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
