### PR TITLE
fix(web): translate import-side Gate A privacy block to HTTP 422

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -7,7 +7,8 @@ import logging
 import shutil
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, Query
+import click
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 
@@ -943,6 +944,9 @@ async def import_agents(
         result = await _run(dry=dry_run)
     except TimeoutError:
         raise _error(503, "busy", "Agents import timed out — another sync may be in progress")
+    except click.ClickException as exc:
+        # project_shared Gate A privacy block → 422 (see context_skills.import_skills).
+        raise HTTPException(422, exc.message) from exc
     return _import_payload(result, project_root, target_scope, dry_run=dry_run)
 
 
@@ -1004,6 +1008,9 @@ async def import_agent(
         result = await _run(dry=False)
     except TimeoutError:
         raise _error(503, "busy", "Agent import timed out — another sync may be in progress")
+    except click.ClickException as exc:
+        # project_shared Gate A privacy block → 422 (see context_skills.import_skills).
+        raise HTTPException(422, exc.message) from exc
     if not result.imported and not result.skipped:
         raise _error(404, "missing", f"No runtime agent named {name!r} to import")
     return _import_payload(result, project_root, target_scope, dry_run=None)

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -7,7 +7,8 @@ import logging
 import shutil
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, Query
+import click
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 
@@ -933,6 +934,9 @@ async def import_commands(
         result = await _run(dry=dry_run)
     except TimeoutError:
         raise _error(503, "busy", "Commands import timed out — another sync may be in progress")
+    except click.ClickException as exc:
+        # project_shared Gate A privacy block → 422 (see context_skills.import_skills).
+        raise HTTPException(422, exc.message) from exc
     return _import_payload(result, project_root, target_scope, dry_run=dry_run)
 
 
@@ -994,6 +998,9 @@ async def import_command(
         result = await _run(dry=False)
     except TimeoutError:
         raise _error(503, "busy", "Command import timed out — another sync may be in progress")
+    except click.ClickException as exc:
+        # project_shared Gate A privacy block → 422 (see context_skills.import_skills).
+        raise HTTPException(422, exc.message) from exc
     if not result.imported and not result.skipped:
         raise _error(404, "missing", f"No runtime command named {name!r} to import")
     return _import_payload(result, project_root, target_scope, dry_run=None)

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -8,7 +8,8 @@ import re
 import shutil
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, Query
+import click
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
@@ -814,6 +815,14 @@ async def import_skills(
         result = await _run(dry=dry_run)
     except TimeoutError:
         raise _error(503, "busy", "Skills import timed out — another sync may be in progress")
+    except click.ClickException as exc:
+        # The import engine's only ClickException is the project_shared Gate A
+        # privacy hard-abort (ADR-0011 §5 — no force bypass; _gate_a.py). Render
+        # it as the same string-detail 422 the sync route gives PrivacyScanError
+        # and the MCP import tool gives this exact exception, rather than letting
+        # it fall through to the generic 500 handler (the PrivacyScanError
+        # docstring's stated intent: non-CLI surfaces translate, never 500).
+        raise HTTPException(422, exc.message) from exc
     return _import_payload(result, project_root, target_scope, dry_run=dry_run)
 
 
@@ -878,6 +887,9 @@ async def import_skill(
         result = await _run(dry=False)
     except TimeoutError:
         raise _error(503, "busy", "Skill import timed out — another sync may be in progress")
+    except click.ClickException as exc:
+        # project_shared Gate A privacy block → 422 (see import_skills).
+        raise HTTPException(422, exc.message) from exc
     if not result.imported and not result.skipped:
         raise _error(404, "missing", f"No runtime skill named {name!r} to import")
     return _import_payload(result, project_root, target_scope, dry_run=None)

--- a/packages/memtomem/tests/test_import_privacy_block_surfaces.py
+++ b/packages/memtomem/tests/test_import_privacy_block_surfaces.py
@@ -1,0 +1,127 @@
+"""Regression pins: the import-side ``project_shared`` Gate A block must
+render as HTTP 422 at the web surface, never a 500.
+
+Sibling of ``test_sync_privacy_block_surfaces.py`` (#895, the sync
+direction). The reverse-import engine
+(``extract_{skills,agents,commands}_to_canonical``) hard-aborts a
+``project_shared`` privacy hit by raising ``click.ClickException`` inside
+``_gate_a.apply_gate_a`` (ADR-0011 §5 — git history is forever, so there is
+no force bypass for ``project_shared``). The MCP import tool already catches
+that exception (``server/tools/context.py``) and the CLI runs under Click,
+but the three web import routes caught only ``TimeoutError`` — so a real
+secret inside a skill the user clicked "Import" on fell through to the
+generic ``Exception`` handler and came back as
+``{"detail": "Internal server error"}`` (HTTP 500). These pin the 422
+translation across all three artifact kinds plus the single-item route.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+# Echoes the project_shared block wording; never carries the matched bytes
+# (the ``never echo secrets`` contract — only the hit count + file name).
+_MSG = (
+    "Gate A: SKILL.md contains 2 privacy pattern hit(s); import to scope='project_shared' rejected."
+)
+
+
+def _raise_click(*args, **kwargs):
+    raise click.ClickException(_MSG)
+
+
+def _build_app_with(router) -> FastAPI:
+    """Minimal FastAPI app + ``get_project_root`` override + the production
+    generic handler.
+
+    Mirrors ``test_sync_privacy_block_surfaces.py`` (booting the prod factory
+    pulls in storage/embedder the import route does not need). The generic
+    ``Exception`` handler is registered to mirror ``web/app.py`` so a route
+    that fails to translate ``ClickException`` reproduces the production 500
+    fall-through — without it, ``TestClient`` would re-raise the exception
+    instead of returning the response the user actually saw.
+    """
+    from memtomem.web.deps import get_project_root
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_project_root] = lambda: Path("/tmp/p")
+
+    @app.exception_handler(Exception)
+    async def _generic(request, exc):  # pragma: no cover - mirrors app.py:261
+        return JSONResponse(status_code=500, content={"detail": "Internal server error"})
+
+    return app
+
+
+class TestWebImportTranslatesTo422:
+    def test_skills_section_import_returns_422(self, monkeypatch) -> None:
+        from memtomem.web.routes import context_skills
+
+        monkeypatch.setattr(context_skills, "extract_skills_to_canonical", _raise_click)
+        client = TestClient(_build_app_with(context_skills.router))
+
+        res = client.post("/context/skills/import", json={})
+
+        assert res.status_code == 422, res.text
+        assert _MSG in res.json()["detail"]
+
+    def test_skills_single_import_returns_422(self, monkeypatch) -> None:
+        from memtomem.web.routes import context_skills
+
+        monkeypatch.setattr(context_skills, "extract_skills_to_canonical", _raise_click)
+        client = TestClient(_build_app_with(context_skills.router))
+
+        res = client.post("/context/skills/leak/import", json={})
+
+        assert res.status_code == 422, res.text
+        assert _MSG in res.json()["detail"]
+
+    def test_agents_section_import_returns_422(self, monkeypatch) -> None:
+        from memtomem.web.routes import context_agents
+
+        monkeypatch.setattr(context_agents, "extract_agents_to_canonical", _raise_click)
+        client = TestClient(_build_app_with(context_agents.router))
+
+        res = client.post("/context/agents/import", json={})
+
+        assert res.status_code == 422, res.text
+        assert _MSG in res.json()["detail"]
+
+    def test_agents_single_import_returns_422(self, monkeypatch) -> None:
+        from memtomem.web.routes import context_agents
+
+        monkeypatch.setattr(context_agents, "extract_agents_to_canonical", _raise_click)
+        client = TestClient(_build_app_with(context_agents.router))
+
+        res = client.post("/context/agents/leak/import", json={})
+
+        assert res.status_code == 422, res.text
+        assert _MSG in res.json()["detail"]
+
+    def test_commands_section_import_returns_422(self, monkeypatch) -> None:
+        from memtomem.web.routes import context_commands
+
+        monkeypatch.setattr(context_commands, "extract_commands_to_canonical", _raise_click)
+        client = TestClient(_build_app_with(context_commands.router))
+
+        res = client.post("/context/commands/import", json={})
+
+        assert res.status_code == 422, res.text
+        assert _MSG in res.json()["detail"]
+
+    def test_commands_single_import_returns_422(self, monkeypatch) -> None:
+        from memtomem.web.routes import context_commands
+
+        monkeypatch.setattr(context_commands, "extract_commands_to_canonical", _raise_click)
+        client = TestClient(_build_app_with(context_commands.router))
+
+        res = client.post("/context/commands/leak/import", json={})
+
+        assert res.status_code == 422, res.text
+        assert _MSG in res.json()["detail"]


### PR DESCRIPTION
## Problem

Clicking **Import** on a runtime skill/agent/command in the `mm web` Context Gateway returned a bare **HTTP 500 "Internal server error"** whenever the artifact tripped a privacy pattern (e.g. a `neo4j-graphrag` skill whose `references/*.md` carry `password=` / `api_key=` placeholders in connection examples).

### Root cause

The reverse-import engine (`extract_{skills,agents,commands}_to_canonical`) hard-aborts a `project_shared` privacy hit by raising `click.ClickException` inside `_gate_a.apply_gate_a` (ADR-0011 §5 — git history is forever, so there is no force bypass for `project_shared`).

- The **MCP** import tool already catches that exception, and the **CLI** runs under Click — both render it cleanly.
- The three **web import routes** caught only `TimeoutError`, so the exception fell through to `web/app.py`'s generic `@app.exception_handler(Exception)` → `500 {"detail": "Internal server error"}`.

This is the import-direction counterpart of the #895 sync-side fold: the **sync** routes already translate `PrivacyScanError` into a `422` with a string detail. The import path was simply never given the symmetric translation (and had no web-surface test, so it lingered latent).

## Fix

Add `except click.ClickException -> HTTPException(422, exc.message)` to all **six** import handlers (section + single-item, across skills / agents / commands). The `422` keeps a **string** detail to match the issue-pinned privacy convention (never routes through `_error`), mirroring what the sync routes do for `PrivacyScanError`.

Users now see the actionable engine message instead of a server error:

> Gate A: SKILL.md contains N privacy pattern hit(s); import to scope='project_shared' rejected. … Retry with --scope=user or --scope=project_local, or remove the secret first.

## Tests

`tests/test_import_privacy_block_surfaces.py` (sibling of `test_sync_privacy_block_surfaces.py`) pins **all six handlers** — verified red (500) before the catch, green (422) after.

## Scope sweep

Audited the other context web routes (`context_mcp_servers`, `context_mutations`, `settings_sync`, `wiki_mutations`, `context_versions`, `context_sync_all`, `context_gateway`, `context_projects`, `context_transfer`) for the same shape. **No further leak** — their engine exceptions are either `ValueError` subclasses (caught by the app's `ValueError → 400` handler) or `PrivacyScanError` (explicitly translated → 422); only the import path raised the CLI-shaped `click.ClickException` that no web handler caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
