### PR TITLE
fix(context): fail closed when skills-import Gate A can't read a source file or subtree

### DIFF
--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -25,6 +25,7 @@ import os
 import secrets
 import shutil
 import time
+from collections.abc import Iterator
 from contextlib import ExitStack
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -807,6 +808,43 @@ def generate_all_skills(
 # ── Reverse: runtimes → canonical ─────────────────────────────────────
 
 
+def _iter_scannable_skill_files(root: Path) -> Iterator[Path]:
+    """Yield every file under *root* that the extract copy would mirror.
+
+    Gate A must inspect the EXACT byte surface the import promotes, and it
+    must never silently shrink that surface. :meth:`Path.rglob` fails both
+    ways and must not be used here:
+
+    * it SUPPRESSES per-directory ``OSError`` — an unreadable subtree just
+      vanishes from the results, yet :func:`_copy_tree_collect` re-walks the
+      source and can still copy that subtree's bytes into the canonical
+      (a Gate A bypass, demonstrated under Python 3.13's glob);
+    * it does not apply the copier's skip rules, so the scanned set drifts
+      from the copied set.
+
+    This mirrors :func:`memtomem.context._atomic._copy_tree_collect` for the
+    extract copy config — ``_stage_skill(skill_dir, dst)`` passes
+    ``skip_top_level=None`` and the default empty ``skip_suffixes``, so
+    ``.bak`` files ARE copied and therefore ARE scanned (using
+    :func:`iter_installed_files`, which drops ``DIRTY_SKIP_SUFFIXES``, would
+    leave a ``secret.bak`` unscanned-but-copied). Only :data:`COPY_SKIP_NAMES`
+    and symlinks are excluded, exactly as the copier excludes them. Any
+    ``iterdir`` / ``stat`` ``OSError`` propagates so the caller fails CLOSED
+    (skip the whole skill) instead of promoting an unscanned subtree.
+    """
+    for entry in sorted(root.iterdir()):
+        if entry.name in COPY_SKIP_NAMES:
+            continue
+        if entry.is_symlink():
+            # The copier skips symlinks (never dereferences out-of-tree bytes
+            # into canonical), so neither does the scan.
+            continue
+        if entry.is_file():
+            yield entry
+        elif entry.is_dir():
+            yield from _iter_scannable_skill_files(entry)
+
+
 def extract_skills_to_canonical(
     project_root: Path,
     overwrite: bool = False,
@@ -864,10 +902,17 @@ def extract_skills_to_canonical(
     the DESTINATION ``scope`` (so a ``user`` dest stays force-bypassable),
     never ``source_scope``.
 
-    Gate A walks every file in the source skill tree (``rglob``) — secrets
-    routinely live in ``scripts/*.py`` and ``references/*.md`` rather
-    than just ``SKILL.md``. The skill is **atomic**: a single blocked
-    file aborts that skill's import without copying any of its files.
+    Gate A walks every file in the source skill tree
+    (:func:`_iter_scannable_skill_files`, which mirrors the copier's surface
+    and fails closed on an enumeration error — see why ``rglob`` is unsafe
+    there) — secrets routinely live in ``scripts/*.py`` and
+    ``references/*.md`` rather than just ``SKILL.md``. The skill is
+    **atomic**: a single blocked file aborts that skill's import without
+    copying any of its files. A source file or subtree Gate A cannot READ
+    (a genuine I/O / permission error, or a path vanishing mid-walk) aborts
+    the skill the same way — fail-closed, never copied unscanned (a
+    ``parse_error`` skip, source-runtime-specific so a later runtime's
+    readable copy of the same name still imports).
     ``project_shared`` destinations hard-abort via :class:`click.ClickException`
     on the first hit (with or without ``force_unsafe_import``).
 
@@ -966,20 +1011,36 @@ def extract_skills_to_canonical(
             # One blocked file aborts the whole skill (atomic — never
             # leave a partial copy in canonical). The project_shared
             # hard-abort path raises ClickException inside apply_gate_a;
-            # the rglob loop only sees ``proceed=False`` for non-
-            # project_shared scopes.
+            # the loop only sees ``proceed=False`` for non-project_shared
+            # scopes.
+            #
+            # The enumeration FAILS CLOSED: ``_iter_scannable_skill_files``
+            # mirrors the copier's surface and lets an unreadable-subtree
+            # ``OSError`` propagate (``rglob`` would silently SUPPRESS it,
+            # dropping the subtree from the scan while ``copy_tree_atomic``
+            # re-walks and still copies it — a Gate A bypass). A per-file
+            # read OSError fails closed the same way: a file we cannot read
+            # cannot be proven free of secrets, so the WHOLE skill is skipped
+            # rather than copied unscanned (``errors="replace"`` already
+            # absorbs non-UTF8 bytes, so this fires only on a genuine I/O /
+            # permission error or a file vanishing mid-walk). Mirrors the
+            # sync side's ``scan_artifact_tree`` ``PrivacyScanReadError`` and
+            # the agents/commands OSError → whole-artifact skip. (The waived
+            # double-read byte-swap TOCTOU above is a separate, adversarial-FS
+            # concern; this closes the accidental-unreadable holes.)
             blocked: tuple[Path, GateABlocked] | None = None
-            for src_file in sorted(skill_dir.rglob("*")):
-                if not src_file.is_file():
-                    continue
+            unreadable: tuple[Path, OSError] | None = None
+            try:
+                scan_files = sorted(_iter_scannable_skill_files(skill_dir))
+            except OSError as walk_exc:
+                unreadable = (skill_dir, walk_exc)
+                scan_files = []
+            for src_file in scan_files:
                 try:
                     content_text = src_file.read_text(encoding="utf-8", errors="replace")
-                except OSError:
-                    # Truly unreadable file — skip the scan; _stage_skill
-                    # will surface the OSError during the actual copy as a
-                    # typed ``parse_error`` skip if it is real, otherwise
-                    # the file passes through as a binary asset.
-                    continue
+                except OSError as read_exc:
+                    unreadable = (src_file, read_exc)
+                    break
                 outcome = apply_gate_a(
                     content_text=content_text,
                     src=src_file,
@@ -997,6 +1058,24 @@ def extract_skills_to_canonical(
                 if isinstance(outcome, GateABlocked):
                     blocked = (src_file, outcome)
                     break
+
+            if unreadable is not None:
+                unreadable_path, unreadable_exc = unreadable
+                # No ``seen`` mark: unreadability is source-runtime-specific
+                # (agents/commands parity, and the ``_stage_skill`` OSError
+                # skip below), so a later runtime's readable+clean copy of
+                # the same name still imports.
+                skipped.append(
+                    (skill_name, f"unreadable: {unreadable_exc}", skip_codes.PARSE_ERROR)
+                )
+                logger.warning(
+                    "skip %s from %s: unreadable %s: %s",
+                    skill_name,
+                    runtime_label,
+                    unreadable_path,
+                    unreadable_exc,
+                )
+                continue
 
             if blocked is not None:
                 blocked_file, blocked_outcome = blocked

--- a/packages/memtomem/tests/test_context_skills_staging.py
+++ b/packages/memtomem/tests/test_context_skills_staging.py
@@ -30,6 +30,7 @@ from memtomem.context.scope_resolver import canonical_artifact_dir
 from memtomem.context.skills import (
     SKILL_GENERATORS,
     SKILL_MANIFEST,
+    _iter_scannable_skill_files,
     _promote_staging,
     _stage_skill,
     canonical_skills_root,
@@ -1019,6 +1020,151 @@ class TestExtractLock:
 
         assert [p.name for p in result.imported] == ["foo"]
         assert not canonical.exists(), "dry_run touched disk"
+
+
+class TestExtractGateAFailClosed:
+    """The reverse-import Gate A must FAIL CLOSED on a source file it cannot
+    READ. The old ``except OSError: continue`` skipped just that file's scan
+    and copied the whole skill anyway, so a file transiently unreadable at
+    scan time but readable by copy time promoted into the canonical UNSCANNED
+    — into ``project_shared`` (git history is forever). The sync side
+    (``scan_artifact_tree`` → ``PrivacyScanReadError``) and the agents/commands
+    importers already fail closed on the same OSError; this pins parity.
+    """
+
+    @staticmethod
+    def _patch_secret_unreadable(monkeypatch: pytest.MonkeyPatch) -> None:
+        import errno as _errno
+        import pathlib
+
+        orig_read_text = pathlib.Path.read_text
+
+        def failing_read_text(self: Path, *args: object, **kwargs: object) -> str:
+            # Only the would-be secret file is unreadable at scan time; its
+            # bytes (read via read_bytes during the copy) are NOT patched, so
+            # pre-fix the unscanned secret would still copy into canonical.
+            if self.name == "secret.py":
+                raise OSError(_errno.EIO, "Input/output error", str(self))
+            return orig_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(pathlib.Path, "read_text", failing_read_text)
+
+    def test_unreadable_source_at_scan_does_not_promote_unscanned(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unreadable-at-scan source file aborts the whole skill (typed
+        ``parse_error`` skip) and nothing lands in the ``project_shared``
+        canonical — the unscanned secret never reaches git-tracked storage."""
+        skill_dir = _seed_runtime_skill(tmp_path, name="foo")
+        secret_file = skill_dir / "scripts" / "secret.py"
+        secret_file.parent.mkdir(parents=True, exist_ok=True)
+        secret_file.write_text(f"TOKEN = {SECRET!r}\n", encoding="utf-8")
+        canonical = canonical_skills_root(tmp_path)
+
+        self._patch_secret_unreadable(monkeypatch)
+        result = extract_skills_to_canonical(tmp_path)  # default scope=project_shared
+
+        assert [p.name for p in result.imported] == []
+        assert not (canonical / "foo").exists(), "unscanned skill promoted — Gate A bypass"
+        parse_skips = [s for s in result.skipped if s[2] == skip_codes.PARSE_ERROR]
+        assert len(parse_skips) == 1, result.skipped
+        assert parse_skips[0][0] == "foo"
+        assert parse_skips[0][1].startswith("unreadable:")
+
+    def test_unreadable_source_at_scan_surfaces_in_dry_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The scan runs in dry-run too, so the fail-closed skip shows in the
+        preview — preview and apply agree (pre-fix the OSError only surfaced
+        at real-run copy time, so the preview wrongly looked importable)."""
+        skill_dir = _seed_runtime_skill(tmp_path, name="foo")
+        secret_file = skill_dir / "scripts" / "secret.py"
+        secret_file.parent.mkdir(parents=True, exist_ok=True)
+        secret_file.write_text(f"TOKEN = {SECRET!r}\n", encoding="utf-8")
+
+        self._patch_secret_unreadable(monkeypatch)
+        result = extract_skills_to_canonical(tmp_path, dry_run=True)
+
+        assert [p.name for p in result.imported] == []
+        parse_skips = [s for s in result.skipped if s[2] == skip_codes.PARSE_ERROR]
+        assert len(parse_skips) == 1 and parse_skips[0][0] == "foo", result.skipped
+
+    def test_unreadable_source_at_scan_leaves_no_seen_mark(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Source-runtime-specific: the unreadable claude copy fails closed
+        without marking the name ``seen``, so the readable+clean gemini copy
+        of the same skill still imports (agents/commands fallback parity)."""
+        claude = _seed_runtime_skill(tmp_path, runtime_dir=".claude/skills", name="foo")
+        (claude / "scripts").mkdir(parents=True, exist_ok=True)
+        (claude / "scripts" / "secret.py").write_text(f"TOKEN = {SECRET!r}\n", encoding="utf-8")
+        _seed_runtime_skill(
+            tmp_path,
+            runtime_dir=".gemini/skills",
+            name="foo",
+            body="---\nname: foo\n---\ngemini clean\n",
+        )
+        canonical = canonical_skills_root(tmp_path)
+
+        self._patch_secret_unreadable(monkeypatch)
+        result = extract_skills_to_canonical(tmp_path)
+
+        assert [p.name for p in result.imported] == ["foo"]
+        text = (canonical / "foo" / SKILL_MANIFEST).read_text(encoding="utf-8")
+        assert text == "---\nname: foo\n---\ngemini clean\n"
+        parse_skips = [s for s in result.skipped if s[2] == skip_codes.PARSE_ERROR]
+        assert len(parse_skips) == 1 and parse_skips[0][0] == "foo", result.skipped
+        assert skip_codes.ALREADY_IMPORTED not in [s[2] for s in result.skipped], result.skipped
+
+
+class TestScannableSkillFilesWalker:
+    """``_iter_scannable_skill_files`` replaces ``Path.rglob`` for the Gate A
+    enumeration. ``rglob`` SUPPRESSED a per-directory ``OSError`` (an
+    unreadable subtree silently vanished from the scan while
+    ``copy_tree_atomic`` re-walked and still copied it — a Gate A bypass) and
+    did not apply the copier's skip rules. The walker must fail LOUD on an
+    enumeration error and mirror the copier's exact surface.
+    """
+
+    def test_propagates_oserror_from_unreadable_subdir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unreadable subtree raises out of the walker (the caller then
+        fails closed) — it is NOT silently dropped the way ``rglob`` did."""
+        import errno as _errno
+        import pathlib
+
+        root = tmp_path / "skill"
+        (root / "scripts").mkdir(parents=True)
+        (root / SKILL_MANIFEST).write_text("---\nname: x\n---\n", encoding="utf-8")
+        (root / "scripts" / "run.sh").write_text("echo hi\n", encoding="utf-8")
+
+        orig_iterdir = pathlib.Path.iterdir
+
+        def failing_iterdir(self: Path):
+            if self.name == "scripts":
+                raise OSError(_errno.EACCES, "Permission denied", str(self))
+            return orig_iterdir(self)
+
+        monkeypatch.setattr(pathlib.Path, "iterdir", failing_iterdir)
+        with pytest.raises(OSError):
+            list(_iter_scannable_skill_files(root))
+
+    def test_mirrors_copier_surface_includes_bak_excludes_skip_names(self, tmp_path: Path) -> None:
+        """Scans exactly what ``_stage_skill``'s copy mirrors: ``.bak`` IS
+        included (the copy uses an empty ``skip_suffixes``, so dropping it
+        like ``iter_installed_files`` would leave a ``secret.bak``
+        unscanned-but-copied); ``COPY_SKIP_NAMES`` dirs are excluded."""
+        root = tmp_path / "skill"
+        (root / "scripts").mkdir(parents=True)
+        (root / "__pycache__").mkdir()
+        (root / SKILL_MANIFEST).write_text("a", encoding="utf-8")
+        (root / "secret.bak").write_text("b", encoding="utf-8")
+        (root / "scripts" / "run.sh").write_text("c", encoding="utf-8")
+        (root / "__pycache__" / "x.pyc").write_text("d", encoding="utf-8")
+
+        rels = sorted(p.relative_to(root).as_posix() for p in _iter_scannable_skill_files(root))
+        assert rels == [SKILL_MANIFEST, "scripts/run.sh", "secret.bak"]
 
 
 class TestSyncPromoteRaceClassification:


### PR DESCRIPTION
## Problem

The reverse-import Gate A (`extract_skills_to_canonical`) could let secrets bypass the privacy scan into the canonical store — including `project_shared`, where git history is forever.

It scanned the source skill tree with `Path.rglob("*")` and, on a per-file read error, did `except OSError: continue` — skipping that file's scan but copying the whole skill anyway. Two distinct fail-open holes:

1. **Per-file (read):** a file transiently unreadable at scan time (NFS hiccup, a lock, a racing chmod) but readable by copy time was promoted **unscanned** — the copy step (`_stage_skill` → `copy_tree_atomic`) re-reads bytes independently, at a different time.
2. **Per-directory (enumeration):** `Path.rglob` **suppresses** `OSError` during recursive directory enumeration (Python 3.13 glob). An unreadable subtree silently vanished from the scan while `copy_tree_atomic` re-walked and still copied it.

The sync side (`scan_artifact_tree` → `PrivacyScanReadError`) and the agents/commands importers already fail **closed** on the same `OSError`. Skills import was the lone fail-open, and skills are the only directory-shaped artifact — so the only importer exposed to the enumeration hole.

## Fix

- Replace the `rglob` scan with **`_iter_scannable_skill_files`**, a fail-closed walker that mirrors `_copy_tree_collect`'s exact surface for the extract copy config: skip `COPY_SKIP_NAMES` + symlinks, **no** suffix skip — so `.bak` IS scanned, matching the copy's empty `skip_suffixes` (reusing `iter_installed_files` would have under-scanned `.bak` and reopened the hole). Any `iterdir`/`stat` `OSError` propagates.
- The caller fails closed on a **walk** OR a **per-file read** `OSError`: the whole skill is skipped with a typed `parse_error`, with **no `seen` mark** so a later runtime's readable+clean copy of the same name still imports (agents/commands parity). The scan now runs in dry-run too, so preview and apply agree.

The waived double-read byte-swap TOCTOU (adversarial-FS, documented in the module threat model) is unchanged — this closes only the **accidental-unreadable** holes.

## Tests

- `TestExtractGateAFailClosed`: per-file unreadable → not promoted into `project_shared`; surfaces in dry-run; no-`seen`-mark runtime fallback.
- `TestScannableSkillFilesWalker`: walker propagates an enumeration `OSError` (vs `rglob`'s suppression) and mirrors the copier surface (incl. `.bak`, excl. `COPY_SKIP_NAMES`).

Verified load-bearing: the per-file tests fail on the pre-fix code. `ruff` + `mypy` clean; broader skills/import suite green.

## Note (out of scope, follow-up)

`privacy_scan.scan_artifact_tree` (`privacy_scan.py:182`) also enumerates with `rglob`, but it scans the **staged** tree — a fresh, same-process copy whose directories are always readable — so its practical exposure is negligible. Flagging for a separate look; not changed here to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
