### PR TITLE
fix(context): recheck target before cleaning source on the all-"exact" settings-migrate batch

### DIFF
--- a/packages/memtomem/src/memtomem/context/settings_migrate.py
+++ b/packages/memtomem/src/memtomem/context/settings_migrate.py
@@ -608,21 +608,37 @@ def apply_migration(plan: MigratePlan) -> MigrateResult:
                 # source entry.
                 sigs_to_drop.add(move.signature)
 
+            # Target mtime recheck (second layer, like generate_all_settings
+            # Step 3): catches a direct disk edit that bypassed the sidecar
+            # lock during classification. It must run before we mutate EITHER
+            # file — i.e. whenever ``sigs_to_drop`` is non-empty, not only when
+            # ``moves_to_write`` is. The all-"exact" batch writes nothing to
+            # the target but still drops the now-redundant entries from the
+            # source, and cleaning the source is only valid while the target
+            # provably still carries them. A stale target snapshot here would
+            # let the source entry be deleted while the target no longer holds
+            # it — the entry irrecoverably lost from BOTH tiers (no
+            # staging/backup). Pre-fix this guard lived inside ``if
+            # moves_to_write:`` and was skipped whenever every applicable move
+            # re-classified to "exact".
+            #
+            # Compare against the missing-file sentinel ``0`` (the
+            # ``_read_with_mtime`` convention), NOT a bare ``is_file()`` guard:
+            # a concurrent DELETE of the target (mtime → 0) is just as much an
+            # external change as an edit, and on the all-"exact" path a bare
+            # ``is_file()`` check would skip the abort and clean the source
+            # against a target that no longer exists.
+            current_target_mtime_ns = (
+                plan.target_path.stat().st_mtime_ns if plan.target_path.is_file() else 0
+            )
+            if sigs_to_drop and current_target_mtime_ns != target_mtime_ns:
+                result.warnings.append(
+                    f"{plan.target_path} was modified by another process "
+                    f"during apply; nothing was written. {retry_hint}"
+                )
+                return result
+
             if moves_to_write:
-                # mtime recheck (second layer, like generate_all_settings
-                # Step 3): catches a direct disk edit that bypassed the
-                # sidecar lock during classification. Abort the whole apply —
-                # the target was not written, so the source must not be
-                # cleaned either.
-                if (
-                    plan.target_path.is_file()
-                    and plan.target_path.stat().st_mtime_ns != target_mtime_ns
-                ):
-                    result.warnings.append(
-                        f"{plan.target_path} was modified by another process "
-                        f"during apply; nothing was written. {retry_hint}"
-                    )
-                    return result
                 # ``already_at_target`` is forced False so _add_target_rules
                 # appends every move we decided to write — including a
                 # plan-time "already" move that re-classified to "missing"

--- a/packages/memtomem/tests/test_settings_migrate.py
+++ b/packages/memtomem/tests/test_settings_migrate.py
@@ -895,6 +895,83 @@ class TestApplyConcurrencyGuards:
         assert _read_settings(plan.target_path) == concurrent
         assert _read_settings(plan.source_path) == source_before
 
+    def test_all_exact_batch_rechecks_target_before_cleaning_source(self, project_root, fake_home):
+        """All-"exact" two-tier data-loss guard: when every applicable move
+        re-classifies "exact" (target already carries the rule), nothing is
+        written to the target but the source clean-up still runs. The target
+        ``st_mtime_ns`` recheck must therefore fire on this batch too — a
+        concurrent edit that removes the entry from the target between the read
+        and the source write must ABORT, else the entry is dropped from the
+        source while the target no longer holds it: lost from BOTH tiers.
+
+        Pre-fix the recheck lived inside ``if moves_to_write:`` and was skipped
+        whenever ``moves_to_write`` was empty (the all-"exact" batch), so the
+        source was cleaned against a stale target snapshot."""
+        import os
+        import unittest.mock
+
+        from memtomem.context import settings_migrate as migrate_mod
+
+        plan = self._plan(project_root, fake_home)
+        # Drift to all-"exact": the target already carries the canonical rule,
+        # so every applicable move re-classifies exact (moves_to_write empty).
+        _write_settings(plan.target_path, _settings_doc(_bundled_hook()))
+        source_before = _read_settings(plan.source_path)
+
+        # A concurrent process removes the entry from the target after our read.
+        concurrent = {"hooks": {}, "_concurrent": True}
+        orig_read = migrate_mod._read_with_mtime
+
+        def patched_read(path):
+            result = orig_read(path)
+            if path == plan.target_path:
+                _write_settings(plan.target_path, concurrent)
+                st = plan.target_path.stat()
+                os.utime(plan.target_path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+            return result
+
+        with unittest.mock.patch.object(migrate_mod, "_read_with_mtime", patched_read):
+            result = apply_migration(plan)
+
+        assert result.target_written is False
+        # The fix: the source is NOT cleaned, so the entry survives in the
+        # source instead of vanishing from both tiers.
+        assert result.source_written is False
+        assert any("modified by another process" in w for w in result.warnings)
+        assert _read_settings(plan.source_path) == source_before
+        assert _read_settings(plan.target_path) == concurrent
+
+    def test_all_exact_batch_aborts_on_target_deletion(self, project_root, fake_home):
+        """All-"exact" path, target DELETED mid-apply (not merely edited): the
+        recheck compares against the missing-file sentinel ``0`` (not a bare
+        ``is_file()`` guard), so a concurrent delete still aborts and the
+        source is not cleaned against a target that no longer exists — the
+        entry survives in the source instead of vanishing from both tiers."""
+        import unittest.mock
+
+        from memtomem.context import settings_migrate as migrate_mod
+
+        plan = self._plan(project_root, fake_home)
+        _write_settings(plan.target_path, _settings_doc(_bundled_hook()))  # force all-"exact"
+        source_before = _read_settings(plan.source_path)
+
+        orig_read = migrate_mod._read_with_mtime
+
+        def patched_read(path):
+            result = orig_read(path)
+            if path == plan.target_path:
+                plan.target_path.unlink()  # concurrent delete after our read
+            return result
+
+        with unittest.mock.patch.object(migrate_mod, "_read_with_mtime", patched_read):
+            result = apply_migration(plan)
+
+        assert result.target_written is False
+        assert result.source_written is False
+        assert any("modified by another process" in w for w in result.warnings)
+        assert _read_settings(plan.source_path) == source_before
+        assert not plan.target_path.exists()
+
     def test_aborts_on_source_mtime_change_after_target_write(self, project_root, fake_home):
         """Same second layer on the source clean-up: a direct edit during the
         strip computation survives; only the clean-up is refused (the target


### PR DESCRIPTION
## Problem

`apply_migration` (`mm context settings-migrate --apply`) could lose a hook entry from **both** tiers.

Under the pair-lock it re-classifies each move against the live target. The target `st_mtime_ns` recheck — the second layer that catches a non-gateway disk edit bypassing the sidecar lock — lived inside `if moves_to_write:`. But `sigs_to_drop` (which drives the **source clean-up**) is populated for `"exact"` moves too. So when *every* applicable move re-classifies to `"exact"` (the target already carries the rule), `moves_to_write` is empty, the recheck is **skipped**, and the source is still stripped — against a target snapshot taken at the top of the lock.

If an external writer removes the entry from the target between that read and the source write, the source entry is dropped while the target no longer holds it → the entry is **irrecoverably lost from both tiers** (no staging/backup). The missing/mixed batch already enforced this guard; the pure-`"exact"` batch did not.

## Fix

- Lift the target mtime recheck out of `if moves_to_write:` so it runs whenever `sigs_to_drop` is non-empty — i.e. before *any* source mutation.
- Compare against the missing-file sentinel `0` (the `_read_with_mtime` convention) instead of a bare `is_file()` guard, so a concurrent **DELETE** of the target (mtime → 0) aborts too. (A bare `is_file()` check would skip the abort on the all-`"exact"` path and clean the source against a vanished target — caught in review.)
- The fresh-target write path is unchanged: a legitimately-absent target stays `0 == 0`, so no spurious abort.

## Tests

`TestApplyConcurrencyGuards`:
- `test_all_exact_batch_rechecks_target_before_cleaning_source` — target concurrently **edited** to drop the entry → abort, source uncleaned.
- `test_all_exact_batch_aborts_on_target_deletion` — target concurrently **deleted** → abort, source uncleaned.

Both leave the entry intact in the source and both **fail on the pre-fix code**. `ruff` + `mypy` clean; full `test_settings_migrate.py` green (45).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
