### PR TITLE
fix(context): keep `mm context status` from crashing on an unreadable installed subtree

### DIFF
--- a/packages/memtomem/src/memtomem/context/_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_atomic.py
@@ -319,6 +319,17 @@ def iter_installed_files(root: Path) -> Iterator[Path]:
     helper), so both consume the exact same set of files —
     ``installed_at`` cannot reference a file the dirty-checker will
     later ignore, and vice versa.
+
+    Enumeration is FAIL-CLOSED by design: an unreadable directory or entry
+    raises ``OSError`` rather than silently shrinking the result. The
+    privacy-gate source scan (``install._gate_a_scan_src_tree``) walks this
+    to decide what to copy, so a silently-dropped file would be copied
+    UNSCANNED — the same fail-open hole the skills-import scanner avoids with
+    its own fail-closed walker. Callers that must instead survive an
+    unreadable subtree (the read-only ``is_asset_dirty`` status walk) wrap the
+    iteration in their own ``try``/``except OSError`` and degrade to "dirty"
+    (cannot prove clean) — they do NOT push that policy down here, because
+    doing so would relax the gate's fail-closed contract too.
     """
     for entry in root.iterdir():
         if entry.name in COPY_SKIP_NAMES:

--- a/packages/memtomem/src/memtomem/context/dirty.py
+++ b/packages/memtomem/src/memtomem/context/dirty.py
@@ -100,6 +100,15 @@ class DirtyReport:
     :func:`memtomem.context.lockfile.manifest_from_entry`) on legacy
     entries that carry one; pre-manifest entries keep deletions
     invisible.
+
+    ``walk_failed`` is set with ``reason="dirty"`` when the dest tree could
+    not be fully enumerated (an unreadable subtree, or a path vanishing
+    mid-walk). The "dirty" verdict is then a FAIL-SAFE ("cannot prove
+    clean"), not an enumerated diff: ``dirty_files`` / ``missing_files`` are
+    incomplete because the at-risk set is unknown. Read-only callers (``mm
+    context status``, the update/install previews) treat it as plain dirty;
+    MUTATION callers must REFUSE on it even with ``--force`` — they cannot
+    back up files they could not enumerate.
     """
 
     reason: DirtyReason
@@ -107,6 +116,7 @@ class DirtyReport:
     dirty_files: tuple[Path, ...]
     checked_files: int
     missing_files: tuple[Path, ...] = ()
+    walk_failed: bool = False
 
     def summary(self) -> str:
         """Human-readable local-edit summary for messages and status rows.
@@ -119,6 +129,8 @@ class DirtyReport:
             parts.append(f"{len(self.dirty_files)} file(s) modified locally")
         if self.missing_files:
             parts.append(f"{len(self.missing_files)} file(s) deleted locally")
+        if self.walk_failed:
+            parts.append("tree could not be fully read (unreadable file or directory)")
         return " and ".join(parts) if parts else "0 file(s) changed"
 
 
@@ -189,62 +201,88 @@ def is_asset_dirty(
     checked = 0
     present_rels: set[str] = set()
     missing: list[Path] = []
+    # An unreadable subtree / entry that aborts the enumeration. The walker is
+    # fail-closed (it raises), which is correct for the privacy-gate source
+    # scan but would crash this read-only status walk over N projects. Catch it
+    # here and degrade to "dirty" — "cannot prove clean" protects, and unlike
+    # `missing` this fires on BOTH branches (a pre-manifest legacy entry has no
+    # recorded set to surface a skipped subtree, so silently skipping would
+    # report clean). Never push the skip down into the walker: that would relax
+    # the gate's fail-closed contract too.
+    walk_failed = False
     digests = digests_from_entry(lock_entry)
-    if digests is not None:
-        # Digest branch (#1247 id 15): byte equality against the SHA-256
-        # recorded for the bytes the install wrote. mtime is deliberately
-        # not consulted — it would re-import touch-only false positives
-        # for zero detection gain. Deltas vs legacy: touch-only edit →
-        # clean, backdated edit/addition → dirty, unreadable → dirty+warn.
-        for file_path in iter_installed_files(dest):
-            checked += 1
-            rel = file_path.relative_to(dest).as_posix()
-            present_rels.add(rel)
-            recorded = digests.get(rel)
-            if recorded is None:
-                dirty.append(file_path)  # local addition — never recorded
-                continue
-            try:
-                blob = file_path.read_bytes()
-            except OSError as exc:
-                # Fail-safe: cannot prove clean. The read error itself
-                # surfaces loudly pre-mutation (Gate A / copy2), not here —
-                # `mm context status` over N projects must stay usable.
-                logger.warning(
-                    "%s/%s: cannot read %s for digest check (%s); classifying dirty",
-                    asset_type,
-                    name,
-                    file_path,
-                    exc,
-                )
-                dirty.append(file_path)
-                continue
-            if hashlib.sha256(blob).hexdigest() != recorded:
-                dirty.append(file_path)
-        # Deletion detection from the digest map's own keys — when digests
-        # validate, `files` was written by the same upsert from the same
-        # set; if a hand-edit makes them diverge, the digest map is the
-        # single record we trust (mirrored on the reconcile side).
-        missing = [dest / rel for rel in sorted(digests.keys() - present_rels)]
-    else:
-        # Legacy branch — pre-digest behavior verbatim.
-        for file_path in iter_installed_files(dest):
-            checked += 1
-            present_rels.add(file_path.relative_to(dest).as_posix())
-            if file_path.stat().st_mtime > installed_at_epoch:
-                dirty.append(file_path)
+    try:
+        if digests is not None:
+            # Digest branch (#1247 id 15): byte equality against the SHA-256
+            # recorded for the bytes the install wrote. mtime is deliberately
+            # not consulted — it would re-import touch-only false positives
+            # for zero detection gain. Deltas vs legacy: touch-only edit →
+            # clean, backdated edit/addition → dirty, unreadable → dirty+warn.
+            for file_path in iter_installed_files(dest):
+                checked += 1
+                rel = file_path.relative_to(dest).as_posix()
+                present_rels.add(rel)
+                recorded = digests.get(rel)
+                if recorded is None:
+                    dirty.append(file_path)  # local addition — never recorded
+                    continue
+                try:
+                    blob = file_path.read_bytes()
+                except OSError as exc:
+                    # Fail-safe: cannot prove clean. The read error itself
+                    # surfaces loudly pre-mutation (Gate A / copy2), not here —
+                    # `mm context status` over N projects must stay usable.
+                    logger.warning(
+                        "%s/%s: cannot read %s for digest check (%s); classifying dirty",
+                        asset_type,
+                        name,
+                        file_path,
+                        exc,
+                    )
+                    dirty.append(file_path)
+                    continue
+                if hashlib.sha256(blob).hexdigest() != recorded:
+                    dirty.append(file_path)
+            # Deletion detection from the digest map's own keys — when digests
+            # validate, `files` was written by the same upsert from the same
+            # set; if a hand-edit makes them diverge, the digest map is the
+            # single record we trust (mirrored on the reconcile side).
+            missing = [dest / rel for rel in sorted(digests.keys() - present_rels)]
+        else:
+            # Legacy branch — pre-digest behavior verbatim.
+            for file_path in iter_installed_files(dest):
+                checked += 1
+                present_rels.add(file_path.relative_to(dest).as_posix())
+                if file_path.stat().st_mtime > installed_at_epoch:
+                    dirty.append(file_path)
 
-        # Deletion detection (#1247): a manifest-recorded file gone from disk
-        # is a local edit. Valid-manifest entries only — legacy/stale/malformed
-        # manifests degrade to the pre-manifest behavior (deletions invisible).
-        manifest = manifest_from_entry(lock_entry)
-        if manifest is not None:
-            missing = [dest / rel for rel in sorted(manifest - present_rels)]
+            # Deletion detection (#1247): a manifest-recorded file gone from
+            # disk is a local edit. Valid-manifest entries only —
+            # legacy/stale/malformed manifests degrade to the pre-manifest
+            # behavior (deletions invisible).
+            manifest = manifest_from_entry(lock_entry)
+            if manifest is not None:
+                missing = [dest / rel for rel in sorted(manifest - present_rels)]
+    except OSError as exc:
+        # An unreadable directory (search bit removed) or a path vanishing
+        # mid-walk aborts the enumeration: we cannot enumerate the installed
+        # tree, so we cannot prove the asset clean. Degrade to dirty instead of
+        # crashing the status walk. Also covers the legacy branch's unguarded
+        # `file_path.stat()` racing-delete.
+        logger.warning(
+            "%s/%s: cannot enumerate %s for dirty check (%s); classifying dirty",
+            asset_type,
+            name,
+            dest,
+            exc,
+        )
+        walk_failed = True
 
     return DirtyReport(
-        reason="dirty" if (dirty or missing) else "clean",
+        reason="dirty" if (dirty or missing or walk_failed) else "clean",
         installed_at=installed_at,
         dirty_files=tuple(dirty),
         checked_files=checked,
         missing_files=tuple(missing),
+        walk_failed=walk_failed,
     )

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -789,6 +789,20 @@ def _apply_update(
     """
     dirty_report = is_asset_dirty(project_root, asset_type, name, lock_entry=lock_entry)
 
+    if dirty_report.walk_failed:
+        # The dest tree could not be fully enumerated (an unreadable subtree).
+        # We cannot identify the at-risk files to back up, so even --force must
+        # NOT proceed: copy + reconcile would mutate the readable files and
+        # only then fail on the unreadable subtree, leaving a partial update
+        # with no .bak. Fail loudly BEFORE any mutation (is_asset_dirty used to
+        # raise straight out here; the status walk no longer crashes, so the
+        # refusal is explicit now).
+        raise StaleInstallError(
+            f"{asset_type}/{name}: {dirty_report.summary()} under "
+            f"{dest} — refusing to update even with --force, because the "
+            f"at-risk files can't be enumerated to back up; fix permissions and retry"
+        )
+
     if dirty_report.reason == "dirty" and not force:
         raise StaleInstallError(
             f"{asset_type}/{name}: {dirty_report.summary()} "
@@ -1386,6 +1400,16 @@ def _apply_pinned_install(
     # classified install/skip and went dirty during the prompt refuses loud
     # here (the CLI loop catches → red row, file intact).
     report = is_asset_dirty(project_root, asset_type, name, lock_entry=classification.lock_entry)
+    if report.walk_failed:
+        # Unenumerable dest tree (unreadable subtree): refuse before any
+        # mutation even with --force — the at-risk files can't be backed up.
+        # Mirrors _apply_update; the --all CLI loop catches → red row, file
+        # intact.
+        raise StaleInstallError(
+            f"{asset_type}/{name}: {report.summary()} under {dest} — refusing to "
+            f"update even with --force, because the at-risk files can't be "
+            f"enumerated to back up; fix permissions and retry"
+        )
     unprovable = report.reason == "never_installed" and dest.is_dir()
     if report.reason == "dirty" and not force:
         raise StaleInstallError(

--- a/packages/memtomem/tests/test_context_atomic.py
+++ b/packages/memtomem/tests/test_context_atomic.py
@@ -248,3 +248,32 @@ class TestIsCopySkippedRel:
         for rel, skipped in verdicts.items():
             assert is_copy_skipped_rel(rel) is skipped
             assert (rel in walked) is (not skipped)
+
+
+class TestIterInstalledFilesFailClosed:
+    """``iter_installed_files`` is FAIL-CLOSED: an unreadable directory or
+    entry raises rather than silently shrinking the result. The privacy-gate
+    source scan (``install._gate_a_scan_src_tree``) walks it to decide what to
+    copy, so a silently-dropped file would be copied UNSCANNED. Callers that
+    must survive an unreadable subtree (the read-only ``is_asset_dirty`` status
+    walk) wrap the iteration themselves and degrade to dirty — they do not push
+    a skip policy down into the walker (see test_dirty_digest)."""
+
+    def test_raises_on_unreadable_subdir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / "asset"
+        (root / "scripts").mkdir(parents=True)
+        (root / "SKILL.md").write_bytes(b"a")
+        (root / "scripts" / "run.sh").write_bytes(b"b")
+
+        orig_iterdir = Path.iterdir
+
+        def failing_iterdir(self: Path):
+            if self.name == "scripts":
+                raise PermissionError(13, "Permission denied", str(self))
+            return orig_iterdir(self)
+
+        monkeypatch.setattr(Path, "iterdir", failing_iterdir)
+        with pytest.raises(OSError):
+            list(iter_installed_files(root))

--- a/packages/memtomem/tests/test_dirty_digest.py
+++ b/packages/memtomem/tests/test_dirty_digest.py
@@ -413,6 +413,65 @@ def test_unreadable_file_classifies_dirty_with_warning(
 
 
 @requires_posix_perms
+def test_unreadable_subdir_classifies_dirty_not_crash(
+    wiki_root: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``is_asset_dirty`` must survive an unreadable SUBDIRECTORY, not just an
+    unreadable file. Removing a subtree's search bit makes ``iterdir`` raise;
+    pre-fix that escaped ``is_asset_dirty`` (no surrounding guard) and 500'd the
+    whole ``mm context status`` table over N projects. The walk now catches the
+    enumeration error and classifies DIRTY — protective ("cannot prove clean"),
+    never a crash, never a silent clean."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n", "scripts/run.sh": b"echo hi\n"})
+    install_skill(tmp_path, "web")
+
+    scripts = tmp_path / ".memtomem" / "skills" / "web" / "scripts"
+    scripts.chmod(0o000)
+    try:
+        with caplog.at_level(logging.WARNING, logger="memtomem.context.dirty"):
+            report = is_asset_dirty(tmp_path, "skills", "web")
+    finally:
+        scripts.chmod(0o755)
+
+    assert report.reason == "dirty"
+    assert any("cannot enumerate" in r.message for r in caplog.records)
+
+
+@requires_posix_perms
+def test_unreadable_subdir_pre_manifest_legacy_classifies_dirty(
+    wiki_root: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The crash-guard must also fail-CLOSED on a PRE-MANIFEST legacy entry
+    (no digests, no ``files`` manifest): there is no recorded set to surface a
+    skipped subtree as ``missing``, so a walker that silently skipped would
+    report CLEAN — vouching for bytes it could not read. Catching the
+    enumeration error and classifying dirty closes that on both branches."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n", "scripts/run.sh": b"echo hi\n"})
+    install_skill(tmp_path, "web")
+
+    # Strip the entry down to a pre-#1247 legacy shape: keep only wiki_commit +
+    # installed_at, drop the digests/files manifest entirely (the legacy
+    # branch with manifest_from_entry() == None).
+    lock = Lockfile.at(tmp_path)
+    entry = lock.read_entry("skills", "web")
+    assert entry is not None
+    legacy_entry = {"wiki_commit": entry["wiki_commit"], "installed_at": entry["installed_at"]}
+
+    scripts = tmp_path / ".memtomem" / "skills" / "web" / "scripts"
+    scripts.chmod(0o000)
+    try:
+        with caplog.at_level(logging.WARNING, logger="memtomem.context.dirty"):
+            report = is_asset_dirty(tmp_path, "skills", "web", lock_entry=legacy_entry)
+    finally:
+        scripts.chmod(0o755)
+
+    assert report.reason == "dirty"  # not a silent clean
+    assert any("cannot enumerate" in r.message for r in caplog.records)
+
+
+@requires_posix_perms
 def test_unreadable_file_force_update_fails_loudly_before_any_mutation(
     wiki_root: Path, tmp_path: Path
 ) -> None:
@@ -435,6 +494,37 @@ def test_unreadable_file_force_update_fails_loudly_before_any_mutation(
             update_skill(tmp_path, "web", force=True)
     finally:
         locked.chmod(0o644)
+
+    assert not list(dest.rglob("*.bak"))
+    assert (dest / "SKILL.md").read_bytes() == b"# web\n"  # v2 never landed
+    assert _entry(tmp_path) == entry_before
+
+
+@requires_posix_perms
+def test_unreadable_subdir_force_update_refuses_before_any_mutation(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """Mutation half of the subtree case: when the dest tree can't be fully
+    enumerated (unreadable SUBDIRECTORY), ``is_asset_dirty`` reports
+    ``walk_failed`` and ``update --force`` must REFUSE before any mutation —
+    the at-risk files can't be enumerated to ``.bak``, so proceeding would
+    copy/reconcile the readable files and only then fail on the subtree,
+    leaving a partial update with no backups. No ``.bak``, dest bytes
+    untouched, no lockfile drift."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web\n", "scripts/run.sh": b"echo hi\n"})
+    install_skill(tmp_path, "web")
+    entry_before = _entry(tmp_path)
+
+    _modify_wiki_skill(wiki_root, "web", {"SKILL.md": b"# web v2\n"})
+    dest = tmp_path / ".memtomem" / "skills" / "web"
+    scripts = dest / "scripts"
+    scripts.chmod(0o000)
+    try:
+        with pytest.raises(StaleInstallError, match="can't be enumerated"):
+            update_skill(tmp_path, "web", force=True)
+    finally:
+        scripts.chmod(0o755)
 
     assert not list(dest.rglob("*.bak"))
     assert (dest / "SKILL.md").read_bytes() == b"# web\n"  # v2 never landed


### PR DESCRIPTION
## Problem

`mm context status` could crash (500 the whole table over N projects) on a single unreadable installed subtree.

`is_asset_dirty` walks the dest tree via `iter_installed_files`, whose recursive `iterdir()` is unguarded. An unreadable subdirectory (search/exec bit removed, or a path vanishing mid-walk) raised straight out of `is_asset_dirty`, and the status table (`status.py`) and the update/install `--all` previews call it with no surrounding guard. The existing `test_unreadable_file_classifies_dirty_with_warning` only pinned the per-**file** read path; the directory-**enumeration** axis was uncovered.

## Fix

The walker has two incompatible caller classes, so the fix splits by caller rather than relaxing the walker:

- **`iter_installed_files` stays FAIL-CLOSED (raises).** The privacy-gate source scan (`install._gate_a_scan_src_tree`) and the pre-mutation `files_to_bak` / `installed_at` / provenance-rehash callers depend on the raise — a silently dropped file would be copied **unscanned**, the same fail-open the skills-import scanner avoids with its own fail-closed walker. (An earlier attempt that made the walker itself resilient reopened that hole — reverted.)
- **`is_asset_dirty` wraps its digest+legacy walk in `try/except OSError`** → logs, sets the new `DirtyReport.walk_failed`, and classifies the asset **dirty**. It never crashes the status walk and never silently passes — the fail-safe fires on **both** branches, including a pre-manifest legacy entry that has no recorded set to surface a skipped subtree as `missing`.
- **Both update mutation paths** (`_apply_update`, the `--all` apply) now **refuse** with `StaleInstallError` on `report.walk_failed` **before any `.bak`/copy, even with `--force`**: an unenumerable tree means the at-risk files can't be backed up, so proceeding would mutate the readable files and only then fail on the subtree — a partial update with no backups. (Pre-fix the raise gave this for free; with the status walk no longer crashing, the refusal is explicit.)

## Tests

- `status` classifies **dirty** (not crash) on an unreadable subtree — incl. the **pre-manifest legacy** entry (no recorded set), which would otherwise report a silent clean.
- `update --force` **refuses before any mutation** on an unreadable subtree: no `.bak`, dest bytes untouched, no lockfile drift.
- `iter_installed_files`' fail-closed contract is pinned (raises on an unreadable subtree).

The status/force tests **fail on the pre-fix code**. `ruff` + `mypy` clean; broad install/update/status/transfer/provenance suite green.

## Review

Hardened across four adversarial review passes — the cascading edges caught and closed: Gate A source-scan enumeration fail-open, the pre-manifest legacy silent-clean, and the `--force` partial-mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
