### PR TITLE
fix(web): hold the cross-process sidecar lock for the inline settings-rule writes

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -14,6 +14,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from memtomem.config import TargetScope
+from memtomem.context._atomic import _file_lock, _lock_path_for
 from memtomem.context.privacy_scan import (
     PrivacyBlockedError,
     format_scan_block_message,
@@ -21,6 +22,7 @@ from memtomem.context.privacy_scan import (
 )
 from memtomem.context.projects import compute_scope_id
 from memtomem.context.settings import (
+    _SETTINGS_LOCK_BUDGET_S,
     CANONICAL_SETTINGS_FILE,
     resolve_scope_path,
     _rule_content_equal,
@@ -86,6 +88,56 @@ def _rule_hash(rule: dict) -> str:
 def _mtime_ns(path: Path) -> str | None:
     """Return an mtime token safe for JSON clients, or ``None`` if missing."""
     return str(path.stat().st_mtime_ns) if path.is_file() else None
+
+
+def _locked_cas_write(
+    path: Path, expected_mtime_ns: int | None, doc: dict
+) -> tuple[bool, int | None]:
+    """Commit *doc* to *path* under the cross-process sidecar ``_file_lock``,
+    but only if *path*'s ``st_mtime_ns`` still equals *expected_mtime_ns*
+    (captured at the route's unlocked read). Returns ``(wrote, current_mtime)``:
+    ``(False, current)`` when the file changed under us (caller → 409 stale),
+    ``(True, new_mtime)`` after a successful write.
+
+    The inline rule routes (resolve / delete / promote) hold only the
+    in-process ``_gateway_lock``, which serializes web writers but is invisible
+    to a separate-process writer. ``generate_all_settings`` (the CLI/MCP
+    settings sync) and ``apply_hook_copy`` take the per-file sidecar
+    ``_file_lock`` across their read-merge-write of these SAME files; without
+    participating, a lock-free ``os.replace`` here could land between such a
+    writer's read and write (or vice versa) and silently drop one side's hook
+    rule (#1123 B3-3 shape). Holding the lock across the recheck + write makes
+    the mtime compare-and-swap atomic against every lock-respecting writer: a
+    change captured at the unlocked read is detected and refused (no clobber);
+    a change after our locked recheck cannot occur while we hold the lock.
+
+    Run via ``asyncio.to_thread`` so the bounded ``portalocker`` wait never
+    stalls the event loop (the #1145 shape — mirrors ``apply_settings_sync`` /
+    ``copy_hook_to_project``). ``expected_mtime_ns=None`` means the file was
+    absent at read time (a fresh canonical create); a file appearing
+    cross-process between the read and the lock is then also caught.
+    """
+    with _file_lock(_lock_path_for(path), timeout=_SETTINGS_LOCK_BUDGET_S):
+        current = path.stat().st_mtime_ns if path.is_file() else None
+        if current != expected_mtime_ns:
+            return False, current
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _write_json(path, doc)
+        return True, path.stat().st_mtime_ns
+
+
+def _stale_mtime_response(current_mtime_ns: int | None) -> JSONResponse:
+    """409 envelope for a compare-and-swap that lost to a concurrent writer."""
+    return JSONResponse(
+        status_code=409,
+        content={
+            "status": "aborted",
+            "reason": "Target file was modified by another process. Retry.",
+            "mtime_ns": (str(current_mtime_ns) if current_mtime_ns is not None else None),
+            "error_kind": "conflict",
+            "reason_code": "stale_mtime",
+        },
+    )
 
 
 def _serialize_duplicate_tiers(duplicates: list[DuplicateTier]) -> list[dict]:
@@ -658,29 +710,21 @@ async def resolve_conflict(
                     if not replaced:
                         raise _error(404, "missing", f"Rule '{label}' not found in target")
 
-                # mtime check before write — protects against cross-process
-                # writers (CLI, manual edit) that the in-process lock can't see.
-                # Echo the current ``mtime_ns`` on abort so clients can refresh
-                # local state without an extra round-trip — HTTP 409 with the
-                # same body shape as the Skills/Commands/Agents stale-write
-                # envelope (the comment used to CLAIM that parity while the
-                # route returned 200, #1229).
-                current_mtime_ns = target_path.stat().st_mtime_ns
-                if current_mtime_ns != mtime_ns:
-                    return JSONResponse(
-                        status_code=409,
-                        content={
-                            "status": "aborted",
-                            "reason": "Target file was modified by another process. Retry.",
-                            "mtime_ns": str(current_mtime_ns),
-                            "error_kind": "conflict",
-                            "reason_code": "stale_mtime",
-                        },
-                    )
-
                 target_hooks[body.event] = rules
                 target["hooks"] = target_hooks
-                _write_json(target_path, target)
+                # Commit under the cross-process sidecar lock with an mtime
+                # compare-and-swap (``mtime_ns`` captured at the read above).
+                # The in-process ``_gateway_lock`` does not serialize a separate
+                # ``mm context sync`` writing this same file: a cross-process
+                # write landing after our read is detected here and refused
+                # (409) — HTTP 409 with the Skills/Commands/Agents stale-write
+                # envelope shape (#1229). Offloaded so the portalocker wait
+                # never stalls the event loop (#1145).
+                wrote, current_mtime_ns = await asyncio.to_thread(
+                    _locked_cas_write, target_path, mtime_ns, target
+                )
+                if not wrote:
+                    return _stale_mtime_response(current_mtime_ns)
                 return {
                     "status": "ok",
                     "reason": f"Rule '{label}' replaced with memtomem's version",
@@ -827,6 +871,10 @@ async def delete_target_rule(
                 )
                 if stale:
                     return JSONResponse(status_code=409, content=stale)
+                # mtime baseline for the locked compare-and-swap below, captured
+                # at this read (the freshness check above compares the CLIENT's
+                # mtime, not ours).
+                target_mtime_ns = target_path.stat().st_mtime_ns
                 target = _load_settings_record(target_path, label="Target")
                 match = _target_rule_for_action(
                     target,
@@ -844,7 +892,15 @@ async def delete_target_rule(
                 else:
                     target_hooks.pop(body.event, None)
                 target["hooks"] = target_hooks
-                _write_json(target_path, target)
+                # Cross-process sidecar lock + mtime CAS: a concurrent
+                # ``mm context sync`` writing this target between our read and
+                # write must not be silently clobbered (the in-process
+                # ``_gateway_lock`` can't see it).
+                wrote, current_mtime_ns = await asyncio.to_thread(
+                    _locked_cas_write, target_path, target_mtime_ns, target
+                )
+                if not wrote:
+                    return _stale_mtime_response(current_mtime_ns)
                 return _ok_envelope(
                     reason=f"Rule '{_rule_label(body.event, body.matcher)}' deleted from target",
                     target_path=target_path,
@@ -943,6 +999,12 @@ async def promote_target_rule(
                         "canonical_mtime_ns": _mtime_ns(canonical_path),
                     }
 
+                # mtime baseline for the locked compare-and-swap below (``None``
+                # when the canonical does not exist yet — a fresh create the CAS
+                # still guards against a cross-process file appearing).
+                canonical_mtime_ns = (
+                    canonical_path.stat().st_mtime_ns if canonical_path.is_file() else None
+                )
                 if canonical_path.is_file():
                     canonical = _load_settings_record(canonical_path, label="Canonical")
                 else:
@@ -977,8 +1039,17 @@ async def promote_target_rule(
                 event_rules.append(rule)
                 canonical_hooks[body.event] = event_rules
                 canonical["hooks"] = canonical_hooks
-                canonical_path.parent.mkdir(parents=True, exist_ok=True)
-                _write_json(canonical_path, canonical)
+                # Cross-process sidecar lock + mtime CAS on the CANONICAL file:
+                # ``apply_hook_copy`` (a separate-process ``mm context`` hook
+                # copy) does a locked read-merge-write of this same canonical,
+                # so a lock-free write here could drop its appended rule. The
+                # CAS (baseline captured at the canonical read above) refuses
+                # rather than clobber.
+                wrote, current_mtime_ns = await asyncio.to_thread(
+                    _locked_cas_write, canonical_path, canonical_mtime_ns, canonical
+                )
+                if not wrote:
+                    return _stale_mtime_response(current_mtime_ns)
                 return _ok_envelope(
                     reason=f"Rule '{label}' promoted to canonical",
                     target_path=target_path,

--- a/packages/memtomem/tests/test_settings_sync_locked_cas.py
+++ b/packages/memtomem/tests/test_settings_sync_locked_cas.py
@@ -1,0 +1,96 @@
+"""Cross-process locked compare-and-swap for the inline settings-rule routes.
+
+``resolve`` / ``delete`` / ``promote`` hold only the in-process
+``_gateway_lock``, which is invisible to a separate-process writer (a CLI
+``mm context sync`` or ``apply_hook_copy``). Their write now goes through
+:func:`_locked_cas_write`, which takes the per-file sidecar ``_file_lock`` (the
+SAME lock ``generate_all_settings`` / ``apply_hook_copy`` hold across their
+read-merge-write of these files) plus an mtime compare-and-swap, so a
+concurrent cross-process write landing between the route's read and write is
+detected and REFUSED instead of silently clobbered (#1123 B3-3 shape).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from memtomem.context._atomic import _file_lock, _lock_path_for
+from memtomem.web.routes import settings_sync
+from memtomem.web.routes.settings_sync import _locked_cas_write
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_writes_when_mtime_matches(tmp_path: Path) -> None:
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps({"hooks": {}}), encoding="utf-8")
+    expected = path.stat().st_mtime_ns
+
+    wrote, new_mtime = _locked_cas_write(path, expected, {"hooks": {"PostToolUse": []}})
+
+    assert wrote is True
+    assert new_mtime == path.stat().st_mtime_ns
+    assert _read(path) == {"hooks": {"PostToolUse": []}}
+
+
+def test_refuses_and_preserves_bytes_when_mtime_changed(tmp_path: Path) -> None:
+    """A concurrent writer changed the file after the route's read: the CAS
+    refuses (no clobber) and echoes the current mtime for the client refresh."""
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps({"original": True}), encoding="utf-8")
+    # The route captured an mtime that no longer matches the file on disk.
+    stale_expected = path.stat().st_mtime_ns - 1
+
+    wrote, current = _locked_cas_write(path, stale_expected, {"clobber": True})
+
+    assert wrote is False
+    assert current == path.stat().st_mtime_ns
+    assert _read(path) == {"original": True}  # NOT clobbered
+
+
+def test_fresh_create_when_absent(tmp_path: Path) -> None:
+    """``expected=None`` is the absent-at-read case (a fresh canonical create);
+    it writes and makes the parent dir."""
+    path = tmp_path / "sub" / "settings.json"
+
+    wrote, new_mtime = _locked_cas_write(path, None, {"hooks": {}})
+
+    assert wrote is True
+    assert _read(path) == {"hooks": {}}
+    assert new_mtime == path.stat().st_mtime_ns
+
+
+def test_refuses_when_file_appeared_after_absent_read(tmp_path: Path) -> None:
+    """Absent at read (``expected=None``) but a file appeared cross-process
+    before our locked write: caught, not overwritten."""
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps({"appeared": True}), encoding="utf-8")
+
+    wrote, current = _locked_cas_write(path, None, {"clobber": True})
+
+    assert wrote is False
+    assert current == path.stat().st_mtime_ns
+    assert _read(path) == {"appeared": True}
+
+
+def test_participates_in_sidecar_lock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CAS acquires the per-file sidecar ``_file_lock``: while another
+    holder (a separate fd, standing in for the cross-process CLI writer) holds
+    it, the write blocks to the budget and raises ``TimeoutError`` — proving
+    real mutual exclusion, not just the in-process ``_gateway_lock`` check.
+    Nothing is written under contention."""
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps({"hooks": {}}), encoding="utf-8")
+    expected = path.stat().st_mtime_ns
+    monkeypatch.setattr(settings_sync, "_SETTINGS_LOCK_BUDGET_S", 0.2)
+
+    with _file_lock(_lock_path_for(path)):
+        with pytest.raises(TimeoutError):
+            _locked_cas_write(path, expected, {"hooks": {"X": []}})
+
+    assert _read(path) == {"hooks": {}}  # never written while contended


### PR DESCRIPTION
## Problem

The inline settings-rule routes could **silently lose a hook rule** to a concurrent cross-process writer.

`resolve_conflict` (writes the target tier), `delete_target_rule` (target tier), and `promote_target_rule` (canonical `.memtomem/settings.json`) serialized only on the in-process `_gateway_lock`, then did a lock-free full-file `_write_json`. That in-process lock is **invisible to a separate process**: `generate_all_settings` (the CLI/MCP `mm context sync`) and `apply_hook_copy` take the per-file **sidecar `_file_lock`** across their read-merge-write of these *same* files. So a concurrent CLI sync / hook-copy could land a write between a route's read and its `os.replace` (or vice versa) and have its rule dropped — a lost update (#1123 B3-3 shape). `resolve` had only an unlocked `stat→write` recheck; `delete`/`promote` had no in-route mtime recheck at all.

## Fix

Add **`_locked_cas_write(path, expected_mtime_ns, doc)`**: takes `_file_lock(_lock_path_for(path))` and writes only if the file's `st_mtime_ns` still equals the baseline captured at the route's unlocked read — a compare-and-swap that is **atomic against every lock-respecting writer**:
- a change before our locked recheck → refused (409 stale), never clobbered;
- a change after it can't happen while we hold the lock.

It runs via `asyncio.to_thread` so the bounded portalocker wait never stalls the event loop (the #1145 shape, like `apply_settings_sync` / `copy_hook_to_project`).

Wired into all three routes on the **correct path** — target for resolve/delete, canonical for promote — with the baseline captured at each route's own read (`expected=None` for an absent canonical, so a file *appearing* cross-process is also caught). The resolve route's old unlocked recheck is replaced by the CAS.

## Tests

`test_settings_sync_locked_cas.py` — `_locked_cas_write`: writes on match; refuses + preserves bytes on mtime change; fresh-creates when absent; refuses when a file appeared after an absent read; and **blocks + times out under sidecar contention** (proving real cross-process exclusion, not just the in-process check). Existing resolve/delete/promote route tests (happy path + 409 / conflict / needs_confirmation) stay green (778 in the settings/rule/write-guard sweep).

## Notes

- The routes keep `-> dict` because FastAPI reads the return annotation as `response_model` (`-> dict | JSONResponse` breaks registration). The JSONResponse 409 returns therefore keep the **pre-existing advisory** mypy return-type warnings — the established pattern in this file (6 → 8, all identical). `ruff` is clean.
- Scope is intentionally the cross-process **lost-update** close (refuse-on-change, matching the existing resolve 409 semantics). A read-merge retry instead of refuse is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
