### PR TITLE
fix(web): path-free 422 detail for project_shared privacy blocks (#1385)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/_errors.py
+++ b/packages/memtomem/src/memtomem/web/routes/_errors.py
@@ -47,6 +47,29 @@ _HOME = str(Path.home())
 _ERROR_MESSAGE_LIMIT = 200
 _SECRET_REDACTED_MARKER = "<redacted: secret-shape>"
 
+#: Fixed, path-free 422 details for a ``project_shared`` privacy block (#1385
+#: finding 1). The engine messages embed an absolute, ``.resolve()``'d host
+#: path — the sync remediation ends with ``… remove the secret from
+#: {blocked.path} …`` (``privacy_scan.py``) and the import Gate A block with
+#: ``… remove the secret from {src} …`` (``_gate_a.py``). Over the loopback
+#: dashboard that leaks ``$HOME`` and the OS username. The web cores raise
+#: THESE fixed strings (the privacy 422 keeps a *string* detail, issue-pinned)
+#: and chain the original exception (``raise … from exc``) so the full path
+#: survives only in the server-side traceback. Mirrors the path-free
+#: ``context_mutations._privacy_blocked()`` precedent.
+PRIVACY_BLOCK_DETAIL = (
+    "Privacy scan blocked this sync: a secret was detected in the canonical bytes. "
+    "git history is forever — project_shared has no force bypass (ADR-0011 §5). "
+    "Remove the secret, or migrate the artifact to a writable tier (project_local), "
+    "then re-run sync."
+)
+PRIVACY_BLOCK_IMPORT_DETAIL = (
+    "Privacy scan blocked this import: a secret was detected in the source bytes. "
+    "git history is forever — project_shared has no force bypass (ADR-0011 §5). "
+    "Import into the user or project_local tier instead, or remove the secret "
+    "from the source first."
+)
+
 
 def _classify_exception(exc: BaseException) -> str:
     """Map an exception to one of {parse, permission, missing, internal}.

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -50,7 +50,7 @@ from memtomem.web.routes.context_projects import (
 )
 from memtomem.web.routes.context_versions import include_has, version_summary
 from memtomem.web.routes._confirm import host_write_gate
-from memtomem.web.routes._errors import _error
+from memtomem.web.routes._errors import PRIVACY_BLOCK_DETAIL, PRIVACY_BLOCK_IMPORT_DETAIL, _error
 from memtomem.web.routes._locks import _gateway_lock
 from memtomem.web.routes._sync_phase import SyncPhaseError
 
@@ -786,9 +786,11 @@ async def _sync_agents_core(
         # 422 Unprocessable Entity — request is well-formed but the canonical
         # bytes violate the project_shared privacy gate. ADR-0011 §5: no
         # bypass valve, so the user must remove the secret or migrate the
-        # artifact to a writable tier (the message body explains how).
+        # artifact to a writable tier (the message body explains how). The
+        # detail is fixed/path-free — ``exc.message`` embeds the absolute
+        # canonical path (#1385 finding 1); the chained ``exc`` keeps it for logs.
         raise SyncPhaseError(
-            422, exc.message, error_kind="validation", reason_code="privacy_blocked"
+            422, PRIVACY_BLOCK_DETAIL, error_kind="validation", reason_code="privacy_blocked"
         ) from exc
     except StrictDropError as exc:
         # on_drop="error" aborts mid-Phase-2 with earlier writes persisted
@@ -965,7 +967,7 @@ async def import_agents(
         raise _error(503, "busy", "Agents import timed out — another sync may be in progress")
     except click.ClickException as exc:
         # project_shared Gate A privacy block → 422 (see context_skills.import_skills).
-        raise HTTPException(422, exc.message) from exc
+        raise HTTPException(422, PRIVACY_BLOCK_IMPORT_DETAIL) from exc
     return _import_payload(result, project_root, target_scope, dry_run=dry_run)
 
 
@@ -1031,7 +1033,7 @@ async def import_agent(
         raise _error(503, "busy", "Agent import timed out — another sync may be in progress")
     except click.ClickException as exc:
         # project_shared Gate A privacy block → 422 (see context_skills.import_skills).
-        raise HTTPException(422, exc.message) from exc
+        raise HTTPException(422, PRIVACY_BLOCK_IMPORT_DETAIL) from exc
     if not result.imported and not result.skipped:
         raise _error(404, "missing", f"No runtime agent named {name!r} to import")
     return _import_payload(result, project_root, target_scope, dry_run=None)

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -49,7 +49,7 @@ from memtomem.web.routes.context_projects import (
 )
 from memtomem.web.routes.context_versions import include_has, version_summary
 from memtomem.web.routes._confirm import host_write_gate
-from memtomem.web.routes._errors import _error
+from memtomem.web.routes._errors import PRIVACY_BLOCK_DETAIL, PRIVACY_BLOCK_IMPORT_DETAIL, _error
 from memtomem.web.routes._locks import _gateway_lock
 from memtomem.web.routes._sync_phase import SyncPhaseError
 
@@ -778,8 +778,10 @@ async def _sync_commands_core(
             force_unsafe=force_unsafe,
         )
     except PrivacyScanError as exc:
+        # Path-free detail — ``exc.message`` embeds the absolute canonical path
+        # (#1385 finding 1). The chained ``exc`` keeps the full text for logs.
         raise SyncPhaseError(
-            422, exc.message, error_kind="validation", reason_code="privacy_blocked"
+            422, PRIVACY_BLOCK_DETAIL, error_kind="validation", reason_code="privacy_blocked"
         ) from exc
     except StrictDropError as exc:
         # on_drop="error" aborts mid-Phase-2 with earlier writes persisted
@@ -955,7 +957,7 @@ async def import_commands(
         raise _error(503, "busy", "Commands import timed out — another sync may be in progress")
     except click.ClickException as exc:
         # project_shared Gate A privacy block → 422 (see context_skills.import_skills).
-        raise HTTPException(422, exc.message) from exc
+        raise HTTPException(422, PRIVACY_BLOCK_IMPORT_DETAIL) from exc
     return _import_payload(result, project_root, target_scope, dry_run=dry_run)
 
 
@@ -1021,7 +1023,7 @@ async def import_command(
         raise _error(503, "busy", "Command import timed out — another sync may be in progress")
     except click.ClickException as exc:
         # project_shared Gate A privacy block → 422 (see context_skills.import_skills).
-        raise HTTPException(422, exc.message) from exc
+        raise HTTPException(422, PRIVACY_BLOCK_IMPORT_DETAIL) from exc
     if not result.imported and not result.skipped:
         raise _error(404, "missing", f"No runtime command named {name!r} to import")
     return _import_payload(result, project_root, target_scope, dry_run=None)

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -31,7 +31,7 @@ from memtomem.context.skills import (
 )
 from memtomem.config import TargetScope
 from memtomem.web.routes._confirm import host_write_gate
-from memtomem.web.routes._errors import _error
+from memtomem.web.routes._errors import PRIVACY_BLOCK_DETAIL, PRIVACY_BLOCK_IMPORT_DETAIL, _error
 from memtomem.web.routes._locks import _gateway_lock
 from memtomem.web.routes._sync_phase import SyncPhaseError
 from memtomem.web.routes.context_gateway import delete_skip_entry, sanitize_diff_reason
@@ -674,8 +674,10 @@ async def _sync_skills_core(
             force_unsafe=force_unsafe,
         )
     except PrivacyScanError as exc:
+        # Path-free detail — ``exc.message`` embeds the absolute canonical path
+        # (#1385 finding 1). The chained ``exc`` keeps the full text for logs.
         raise SyncPhaseError(
-            422, exc.message, error_kind="validation", reason_code="privacy_blocked"
+            422, PRIVACY_BLOCK_DETAIL, error_kind="validation", reason_code="privacy_blocked"
         ) from exc
     return {
         "generated": [
@@ -852,7 +854,7 @@ async def import_skills(
         # and the MCP import tool gives this exact exception, rather than letting
         # it fall through to the generic 500 handler (the PrivacyScanError
         # docstring's stated intent: non-CLI surfaces translate, never 500).
-        raise HTTPException(422, exc.message) from exc
+        raise HTTPException(422, PRIVACY_BLOCK_IMPORT_DETAIL) from exc
     return _import_payload(result, project_root, target_scope, dry_run=dry_run)
 
 
@@ -921,7 +923,7 @@ async def import_skill(
         raise _error(503, "busy", "Skill import timed out — another sync may be in progress")
     except click.ClickException as exc:
         # project_shared Gate A privacy block → 422 (see import_skills).
-        raise HTTPException(422, exc.message) from exc
+        raise HTTPException(422, PRIVACY_BLOCK_IMPORT_DETAIL) from exc
     if not result.imported and not result.skipped:
         raise _error(404, "missing", f"No runtime skill named {name!r} to import")
     return _import_payload(result, project_root, target_scope, dry_run=None)
@@ -1004,7 +1006,7 @@ async def import_skill_to_user(
         # Defensive: the user dest is force-bypassable, so Gate A raises a
         # ClickException only on a project_shared dest — which this route never
         # uses. Translate to 422 anyway rather than risk a generic 500 (#1378).
-        raise HTTPException(422, exc.message) from exc
+        raise HTTPException(422, PRIVACY_BLOCK_IMPORT_DETAIL) from exc
     if not result.imported and not result.skipped:
         raise _error(404, "missing", f"No project runtime skill named {name!r} to import")
     return _import_payload(

--- a/packages/memtomem/tests/test_import_privacy_block_surfaces.py
+++ b/packages/memtomem/tests/test_import_privacy_block_surfaces.py
@@ -12,7 +12,9 @@ but the three web import routes caught only ``TimeoutError`` — so a real
 secret inside a skill the user clicked "Import" on fell through to the
 generic ``Exception`` handler and came back as
 ``{"detail": "Internal server error"}`` (HTTP 500). These pin the 422
-translation across all three artifact kinds plus the single-item route.
+translation across all three artifact kinds plus the single-item route, and
+that the absolute source path / offending filename never reach the 422
+envelope — the route raises a fixed, path-free detail (#1385 finding 1).
 """
 
 from __future__ import annotations
@@ -24,10 +26,16 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
-# Echoes the project_shared block wording; never carries the matched bytes
-# (the ``never echo secrets`` contract — only the hit count + file name).
+# The REAL Gate A block message embeds the absolute source path (the
+# ``… remove the secret from {src} …`` clause, ``_gate_a.py``) plus the
+# offending filename. Reproduce both so the assertions pin that NEITHER reaches
+# the 422 envelope (#1385 finding 1) — the route raises a fixed, path-free detail
+# and keeps the full Gate A text only on the chained exception (server logs).
+_LEAKY_PATH = "/tmp/p/.claude/skills/leak/SKILL.md"
 _MSG = (
-    "Gate A: SKILL.md contains 2 privacy pattern hit(s); import to scope='project_shared' rejected."
+    "Gate A: SKILL.md contains 2 privacy pattern hit(s); import to "
+    f"scope='project_shared' rejected. Retry with --scope=user, or remove the "
+    f"secret from {_LEAKY_PATH} first."
 )
 
 
@@ -69,7 +77,10 @@ class TestWebImportTranslatesTo422:
         res = client.post("/context/skills/import", json={})
 
         assert res.status_code == 422, res.text
-        assert _MSG in res.json()["detail"]
+        detail = res.json()["detail"]
+        assert _LEAKY_PATH not in detail  # absolute source path never leaks
+        assert "SKILL.md" not in detail  # nor the offending filename
+        assert "secret was detected" in detail  # fixed, path-free import detail
 
     def test_skills_single_import_returns_422(self, monkeypatch) -> None:
         from memtomem.web.routes import context_skills
@@ -80,7 +91,10 @@ class TestWebImportTranslatesTo422:
         res = client.post("/context/skills/leak/import", json={})
 
         assert res.status_code == 422, res.text
-        assert _MSG in res.json()["detail"]
+        detail = res.json()["detail"]
+        assert _LEAKY_PATH not in detail  # absolute source path never leaks
+        assert "SKILL.md" not in detail  # nor the offending filename
+        assert "secret was detected" in detail  # fixed, path-free import detail
 
     def test_agents_section_import_returns_422(self, monkeypatch) -> None:
         from memtomem.web.routes import context_agents
@@ -91,7 +105,10 @@ class TestWebImportTranslatesTo422:
         res = client.post("/context/agents/import", json={})
 
         assert res.status_code == 422, res.text
-        assert _MSG in res.json()["detail"]
+        detail = res.json()["detail"]
+        assert _LEAKY_PATH not in detail  # absolute source path never leaks
+        assert "SKILL.md" not in detail  # nor the offending filename
+        assert "secret was detected" in detail  # fixed, path-free import detail
 
     def test_agents_single_import_returns_422(self, monkeypatch) -> None:
         from memtomem.web.routes import context_agents
@@ -102,7 +119,10 @@ class TestWebImportTranslatesTo422:
         res = client.post("/context/agents/leak/import", json={})
 
         assert res.status_code == 422, res.text
-        assert _MSG in res.json()["detail"]
+        detail = res.json()["detail"]
+        assert _LEAKY_PATH not in detail  # absolute source path never leaks
+        assert "SKILL.md" not in detail  # nor the offending filename
+        assert "secret was detected" in detail  # fixed, path-free import detail
 
     def test_commands_section_import_returns_422(self, monkeypatch) -> None:
         from memtomem.web.routes import context_commands
@@ -113,7 +133,10 @@ class TestWebImportTranslatesTo422:
         res = client.post("/context/commands/import", json={})
 
         assert res.status_code == 422, res.text
-        assert _MSG in res.json()["detail"]
+        detail = res.json()["detail"]
+        assert _LEAKY_PATH not in detail  # absolute source path never leaks
+        assert "SKILL.md" not in detail  # nor the offending filename
+        assert "secret was detected" in detail  # fixed, path-free import detail
 
     def test_commands_single_import_returns_422(self, monkeypatch) -> None:
         from memtomem.web.routes import context_commands
@@ -124,4 +147,7 @@ class TestWebImportTranslatesTo422:
         res = client.post("/context/commands/leak/import", json={})
 
         assert res.status_code == 422, res.text
-        assert _MSG in res.json()["detail"]
+        detail = res.json()["detail"]
+        assert _LEAKY_PATH not in detail  # absolute source path never leaks
+        assert "SKILL.md" not in detail  # nor the offending filename
+        assert "secret was detected" in detail  # fixed, path-free import detail

--- a/packages/memtomem/tests/test_sync_privacy_block_surfaces.py
+++ b/packages/memtomem/tests/test_sync_privacy_block_surfaces.py
@@ -27,8 +27,16 @@ from fastapi.testclient import TestClient
 from memtomem.context.privacy_scan import FileScan, PrivacyBlockedError
 
 
-_FAKE_BLOCKED = FileScan(Path("/tmp/p/.memtomem/agents/leak.md"), "blocked", 1)
-_FAKE_MSG = "Gate A: leak.md contains 1 privacy pattern hit(s); fan-out rejected."
+_LEAK_PATH = "/tmp/p/.memtomem/agents/leak.md"
+_FAKE_BLOCKED = FileScan(Path(_LEAK_PATH), "blocked", 1)
+# Mirror the real engine remediation, which ends with the absolute canonical
+# path (``privacy_scan.py``). The web 422 must NOT echo it (#1385 finding 1);
+# the MCP tool surface (a different trust boundary — the result goes to the
+# calling agent, not a loopback browser) still round-trips the full message.
+_FAKE_MSG = (
+    "Gate A: leak.md contains 1 privacy pattern hit(s); fan-out rejected. "
+    f"Or remove the secret from {_LEAK_PATH} before re-running sync."
+)
 
 
 def _raise_privacy_block(*args, **kwargs):
@@ -67,9 +75,12 @@ class TestWebSyncTranslatesTo422:
         res = client.post("/context/agents/sync", json={})
 
         assert res.status_code == 422, res.text
-        # FastAPI's default HTTPException renders as ``{"detail": "..."}``;
-        # the formatted message must round-trip so the UI can surface it.
-        assert _FAKE_MSG in res.json()["detail"]
+        # FastAPI's default HTTPException renders as ``{"detail": "..."}``; the
+        # detail is now a fixed, path-free string (the engine message embeds the
+        # absolute canonical path, which must not reach the loopback dashboard).
+        detail = res.json()["detail"]
+        assert _LEAK_PATH not in detail  # #1385 finding 1: host path never leaks
+        assert "secret was detected" in detail  # fixed, path-free PRIVACY_BLOCK_DETAIL
 
     def test_commands_sync_returns_422(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from memtomem.web.routes import context_commands
@@ -80,7 +91,9 @@ class TestWebSyncTranslatesTo422:
         res = client.post("/context/commands/sync", json={})
 
         assert res.status_code == 422, res.text
-        assert _FAKE_MSG in res.json()["detail"]
+        detail = res.json()["detail"]
+        assert _LEAK_PATH not in detail  # #1385 finding 1: host path never leaks
+        assert "secret was detected" in detail  # fixed, path-free PRIVACY_BLOCK_DETAIL
 
     def test_skills_sync_returns_422(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from memtomem.web.routes import context_skills
@@ -91,7 +104,9 @@ class TestWebSyncTranslatesTo422:
         res = client.post("/context/skills/sync")
 
         assert res.status_code == 422, res.text
-        assert _FAKE_MSG in res.json()["detail"]
+        detail = res.json()["detail"]
+        assert _LEAK_PATH not in detail  # #1385 finding 1: host path never leaks
+        assert "secret was detected" in detail  # fixed, path-free PRIVACY_BLOCK_DETAIL
 
 
 class TestMcpContextToolTranslates:

--- a/packages/memtomem/tests/test_web_routes_context_sync_all.py
+++ b/packages/memtomem/tests/test_web_routes_context_sync_all.py
@@ -357,6 +357,32 @@ async def test_mixed_result_failed_phase_does_not_stop_later_phases(client, cwd_
 
 
 @pytest.mark.asyncio
+async def test_privacy_block_422_message_is_path_free(client, cwd_root: Path) -> None:
+    """#1385 finding 1: the privacy-block 422 envelope must not echo the
+    absolute canonical path. The engine's ``PrivacyScanError.message`` ends
+    with ``… remove the secret from {blocked.path} …`` — a ``.resolve()``'d
+    host path under ``$HOME`` (leaking the OS username over loopback). The
+    sync cores must raise a fixed, path-free detail and keep the full message
+    only on the chained exception (server-side traceback)."""
+    _seed_artifacts(cwd_root)
+    (cwd_root / ".memtomem" / "agents" / "leaky.md").write_bytes(_SECRET_AGENT_BODY)
+
+    resp = await client.post("/api/context/sync-all")
+    assert resp.status_code == 200, resp.text
+    error = _phase(resp.json(), "agents")["error"]
+
+    assert error["reason_code"] == "privacy_blocked"
+    assert error["http_status"] == 422
+    assert "privacy" in error["message"].lower()
+    # The fix: the privacy-block detail carries no absolute canonical path
+    # (in either symlink form). (A settings phase's write ``target`` is a
+    # separate, intentional path surface and is out of scope here.)
+    assert str(cwd_root) not in error["message"]
+    assert str(cwd_root.resolve()) not in error["message"]
+    assert "leaky.md" not in error["message"]
+
+
+@pytest.mark.asyncio
 async def test_settings_error_rolls_up_to_failed_phase(client, cwd_root: Path) -> None:
     """Settings failures are in-band result rows, not exceptions: the phase
     status rolls up to ``failed`` with the rows embedded (no ``error`` key),


### PR DESCRIPTION
## What

Both web surfaces that translate a `project_shared` Gate A privacy block into a 422 echoed an absolute, `.resolve()`'d host path in the **string** detail:

- **sync** — the `skills`/`commands`/`agents` cores raised `SyncPhaseError(422, exc.message)` where `PrivacyScanError.message` ends with `… remove the secret from {blocked.path} …` (`privacy_scan.py`). `context_sync_all._phase_error_envelope` renders a string detail verbatim (only the `except Exception` fallback runs `_redact_message`).
- **import** — the same three cores' Gate A `ClickException` handlers raised `HTTPException(422, exc.message)` where `format_project_shared_block_message` embeds `… remove the secret from {src} …` (`_gate_a.py:67`).

Either way the one failure path guaranteed to fire on real user data emitted the host `$HOME` + OS username over the loopback dashboard.

## Fix

Two fixed, path-free detail constants in `_errors.py` (`PRIVACY_BLOCK_DETAIL` for sync, `PRIVACY_BLOCK_IMPORT_DETAIL` for import), raised in place of `exc.message` with `raise … from exc` so the full path survives only in the server-side traceback. Mirrors the path-free `context_mutations._privacy_blocked()` precedent. `mcp-servers` already emits `source_path.name` only (unchanged); the MCP context tool round-trips the full message by design (a different trust surface than loopback HTTP).

## Tests

- `test_privacy_block_422_message_is_path_free` (sync-all envelope) — new, verified failing pre-fix (leaked `/private/var/.../cwd/.memtomem/agents/leaky.md`).
- `test_sync_privacy_block_surfaces.py` / `test_import_privacy_block_surfaces.py` — updated so the raised fakes carry a path, and assert the absolute path + offending filename never reach the 422 detail.

## Scope

Initially scoped to sync; **expanded to the import surface on the Codex review gate** (same bug shape, same files). A full-tree sweep surfaced the *same* leak in two other route files — `context_transfer.py:495` and `settings_sync.py:1206,1250` (pre-existing, different exception types) — tracked as a follow-up on #1385 rather than folded in, to keep this PR to the sync/import cores.

Rebased onto current `main` (picks up #1381–1384, #1386).

Part of #1385 (finding 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
