### PR TITLE
fix(web): hold _gateway_lock for the wiki override-seed write (#1385)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/wiki_mutations.py
+++ b/packages/memtomem/src/memtomem/web/routes/wiki_mutations.py
@@ -119,7 +119,21 @@ async def seed_wiki_override(asset_type: AssetType, name: str, body: OverrideSee
         return result, store.is_dirty()
 
     try:
-        result, wiki_dirty = await asyncio.to_thread(_seed)
+        # Force-seed mutates ``overrides/<vendor>.<ext>`` (and a ``.bak`` on
+        # re-seed); hold ``_gateway_lock`` under the same 60s budget as the
+        # other three mutators (PUT override/canonical, POST commit) so a seed
+        # concurrent with an editor PUT to the same file serialises instead of
+        # last-writer-wins (#1385 finding 2). ``_seed`` runs SYNCHRONOUSLY
+        # inside the lock — the ``_locks.py`` convention the editor writers
+        # follow. A ``to_thread`` offload would reintroduce an await inside the
+        # lock: on an ``asyncio.timeout`` the await is cancelled and the lock
+        # released, yet the worker thread keeps writing past it, so a second
+        # mutator could acquire the lock and race the still-running seed (Codex
+        # review gate). With no await between acquire and release, the timeout
+        # can only fire while CONTENDING for the lock — never mid-write.
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                result, wiki_dirty = _seed()
     except WikiNotFoundError as exc:
         raise _wiki_absent(exc) from exc
     except OverrideExistsError as exc:
@@ -139,6 +153,10 @@ async def seed_wiki_override(asset_type: AssetType, name: str, body: OverrideSee
             "missing",
             f"{asset_type}/{name} has no canonical to seed from",
             reason_code="canonical_absent",
+        ) from exc
+    except TimeoutError as exc:
+        raise _error(
+            503, "busy", "wiki override seed timed out — another sync may be in progress"
         ) from exc
     return {
         "seeded": True,

--- a/packages/memtomem/tests/test_web_routes_wiki_mutations.py
+++ b/packages/memtomem/tests/test_web_routes_wiki_mutations.py
@@ -203,6 +203,59 @@ async def test_seed_wiki_absent_is_404(dev_client, wiki_root: Path) -> None:  # 
     assert str(wiki_root) not in resp.text
 
 
+@pytest.mark.asyncio
+async def test_seed_timeout_is_503(dev_client, seeded_wiki: Path, monkeypatch) -> None:
+    # #1385 finding 2: the seed mutator now takes _gateway_lock under a 60s
+    # budget like the other three wiki mutators, so a lock-acquire timeout maps
+    # to 503 busy instead of running lock-free (last-writer-wins vs a concurrent
+    # editor PUT). Pre-fix the route never entered asyncio.timeout, so the
+    # patched boom had no effect and the seed returned 200.
+    from memtomem.web.routes import wiki_mutations as wm
+
+    class _BoomTimeout:
+        def __init__(self, *a, **k) -> None: ...
+
+        async def __aenter__(self):
+            raise TimeoutError
+
+        async def __aexit__(self, *a) -> bool:
+            return False
+
+    monkeypatch.setattr(wm.asyncio, "timeout", lambda *a, **k: _BoomTimeout())
+    resp = await dev_client.post("/api/wiki/skills/alpha/override", json={"vendor": "claude"})
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["error_kind"] == "busy"
+
+
+@pytest.mark.asyncio
+async def test_seed_runs_synchronously_inside_lock(
+    dev_client, seeded_wiki: Path, monkeypatch
+) -> None:
+    # #1385 finding 2 (Codex gate): the seed write must run SYNCHRONOUSLY inside
+    # _gateway_lock, mirroring edit_wiki_override — NOT via asyncio.to_thread. A
+    # to_thread offload would, on an asyncio.timeout, release the lock while the
+    # worker thread kept writing the override past it, letting a second mutator
+    # race the still-running seed. Pinned deterministically by the executing
+    # thread (no fragile timing): a to_thread offload runs on a pool worker,
+    # the synchronous call runs on the event loop's (main) thread.
+    import threading
+
+    from memtomem.web.routes import wiki_mutations as wm
+
+    real_seed = wm.seed_override
+    ran_on_main: dict[str, bool] = {}
+
+    def _record_thread(*args, **kwargs):
+        ran_on_main["value"] = threading.current_thread() is threading.main_thread()
+        return real_seed(*args, **kwargs)
+
+    monkeypatch.setattr(wm, "seed_override", _record_thread)
+    resp = await dev_client.post("/api/wiki/skills/alpha/override", json={"vendor": "claude"})
+
+    assert resp.status_code == 200, resp.text
+    assert ran_on_main.get("value") is True  # synchronous, inside the lock
+
+
 # ── tier gating ────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What

`seed_wiki_override` (`POST /api/wiki/{type}/{name}/override`) ran its `seed_override` write via `asyncio.to_thread` **without** acquiring `_gateway_lock` — the only one of the four wiki mutators that wrote the single-curator, host-global wiki store lock-free (PUT override, PUT canonical, POST commit all hold it).

A force-seed concurrent with an editor PUT to the same `overrides/<vendor>.<ext>` was last-writer-wins with no 409 — a saved edit silently dropped (and the `.bak` rename races too).

## Fix

Wrap the seed in `async with asyncio.timeout(60): async with _gateway_lock:` and map `TimeoutError → 503 busy`.

Run `_seed` **synchronously** inside the lock (the `_locks.py` convention the editor writers follow), **not** via `to_thread`. A `to_thread` offload reintroduces an `await` inside the lock: on `asyncio.timeout` the await is cancelled and the lock released, yet the worker thread keeps writing the override past it — a second mutator could then acquire the lock and race the still-running seed (**Codex review gate**). With no await between acquire and release, the timeout can only fire while *contending* for the lock, never mid-write.

## Tests

- `test_seed_timeout_is_503` — a lock-acquire timeout maps to 503 `busy` (mirrors `test_edit_timeout_is_503`).
- `test_seed_runs_synchronously_inside_lock` — pins that `seed_override` runs on the event loop's main thread (synchronous, inside the lock), not a `to_thread` pool worker. Deterministic (no fragile timing); fails pre-fix (worker thread).

Part of #1385 (finding 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
