### PR TITLE
fix(context): typed TransferCollisionError on promote-time dst collision (#1385)

### DIFF
--- a/packages/memtomem/src/memtomem/context/transfer.py
+++ b/packages/memtomem/src/memtomem/context/transfer.py
@@ -908,7 +908,19 @@ def transfer_artifact(
                                 scan.blocked[0].path, staging, src_path
                             ),
                         )
-                _promote_move(staging, dst_path)
+                try:
+                    _promote_move(staging, dst_path)
+                except FileExistsError as exc:
+                    # TOCTOU: an external writer (one not holding our sidecar
+                    # lock) created dst between the in-lock ``dst_path.exists()``
+                    # check and the promote. Surface the typed collision (web
+                    # 409 / CLI ``ClickException``) instead of a bare
+                    # ``FileExistsError`` the engine never declares (#1385
+                    # finding 3). Nested inside the outer ``try`` so the staging
+                    # cleanup below still runs.
+                    raise TransferCollisionError(
+                        f"destination appeared during promote: {dst_path}."
+                    ) from exc
             except BaseException:
                 # Copy staging never consumed the source — the source
                 # bytes are intact at src_path by construction, so
@@ -947,7 +959,15 @@ def transfer_artifact(
                             ),
                         )
 
-                _promote_move(staging, dst_path)
+                try:
+                    _promote_move(staging, dst_path)
+                except FileExistsError as exc:
+                    # Same promote-window TOCTOU as the copy branch — typed
+                    # collision so the move rollback below runs and the caller
+                    # sees a 409 / clean CLI error (#1385 finding 3).
+                    raise TransferCollisionError(
+                        f"destination appeared during promote: {dst_path}."
+                    ) from exc
             except BaseException:
                 # Roll back: put bytes back at src so the caller can retry
                 # without manual cleanup.

--- a/packages/memtomem/tests/test_context_transfer.py
+++ b/packages/memtomem/tests/test_context_transfer.py
@@ -775,6 +775,64 @@ def test_destination_appeared_during_lock(two_projects, monkeypatch):
     assert not list(dst_dir.parent.glob(".migrate-*"))
 
 
+def _racing_scan_creating_dst(transfer_mod, dst_dir: Path):
+    """A ``scan_artifact_tree`` wrapper that creates *dst_dir* as a side effect.
+
+    The scan runs between the in-lock ``dst_path.exists()`` check and
+    ``_promote_move`` — so this reproduces the TOCTOU where an external writer
+    (one not holding our sidecar lock) creates the destination in that window
+    (#1385 finding 3). Delegates to the real scan so a clean staging tree still
+    reports no privacy block.
+    """
+    real_scan = transfer_mod.scan_artifact_tree
+
+    def racing_scan(staging, **kwargs):
+        result = real_scan(staging, **kwargs)
+        if not dst_dir.exists():
+            dst_dir.mkdir(parents=True)
+            (dst_dir / "agent.md").write_text("---\nname: foo\n---\n\nracer\n", encoding="utf-8")
+        return result
+
+    return racing_scan
+
+
+@pytest.mark.parametrize("mode", ["copy", "move"])
+def test_destination_appeared_during_promote(two_projects, monkeypatch, mode):
+    """dst created in the window between the in-lock check and the promote →
+    typed ``TransferCollisionError`` (web 409 / clean CLI ``ClickException``),
+    NOT a bare ``FileExistsError`` that ``_classify_exception`` maps to a 500 /
+    the CLI dumps as a traceback. #1385 finding 3 — pins BOTH promote call
+    sites (copy at transfer.py:911, move at :950)."""
+    import memtomem.context.transfer as transfer_mod
+    from memtomem.context.transfer import TransferCollisionError
+
+    src_manifest = _write_canonical(
+        two_projects, "agents", "project_shared", "a", "foo", _AGENT_BODY_CLEAN
+    )
+    dst_dir = _canonical_root(two_projects, "agents", "project_shared", "b") / "foo"
+    monkeypatch.setattr(
+        transfer_mod, "scan_artifact_tree", _racing_scan_creating_dst(transfer_mod, dst_dir)
+    )
+
+    with pytest.raises(TransferCollisionError, match="appeared during promote"):
+        transfer_artifact(
+            "agents",
+            "foo",
+            src_project_root=two_projects["a"],
+            from_scope="project_shared",
+            dst_project_root=two_projects["b"],
+            to_scope="project_shared",
+            mode=mode,
+            apply_=True,
+        )
+
+    # Rollback ran (it lives in the outer ``except BaseException``): the racer's
+    # dst is intact, the source bytes are recovered, and no staging residue.
+    assert src_manifest.read_text(encoding="utf-8") == _AGENT_BODY_CLEAN
+    assert "racer" in (dst_dir / "agent.md").read_text(encoding="utf-8")
+    assert not list(dst_dir.parent.glob(".migrate-*"))
+
+
 def test_exdev_fallback_cross_project_move(two_projects, monkeypatch):
     """EXDEV on the staging rename falls back to copy; move still completes."""
     import os as os_mod


### PR DESCRIPTION
## What

`transfer_artifact` re-checks the destination inside the pair-lock (`transfer.py:873`, raising the typed `TransferCollisionError`), but the final `_promote_move` has a real TOCTOU window: staging + the Gate A scan run between that check and the `os.replace`, so an external writer **not holding our sidecar lock** can create `dst` in that window.

`migrate._promote_move`'s own guard then raises a **bare `FileExistsError`** (`migrate.py:844`), bypassing the engine's typed-collision contract:
- web transfer route → `_classify_exception` → **500** (internal), instead of **409** `destination_exists`;
- CLI → full traceback, instead of a clean `ClickException`.

## Fix

Wrap each `_promote_move` call (copy at `:911`, move at `:950`) in a nested `try` that re-raises `FileExistsError` as `TransferCollisionError("destination appeared during promote: {dst}.")` — mirroring the in-lock guard's wording. The nesting sits **inside** the existing outer `except BaseException`, so the copy/move rollback (drop staging / rename src back) still runs before the typed error propagates.

## Test

`test_destination_appeared_during_promote[copy|move]` injects the racer via a `scan_artifact_tree` wrapper (it runs in exactly the TOCTOU window) and asserts `TransferCollisionError` (not bare `FileExistsError`) plus correct rollback (src recovered, racer's dst intact, no staging residue). Verified **failing pre-fix** (bare `FileExistsError` escaped).

Part of #1385 (finding 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
