### PR TITLE
fix(web): map engine FileNotFoundError to a 404 envelope on install/update (#1385)

### DIFF
--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -75,6 +75,20 @@ __all__ = [
 ]
 
 
+class ProjectRootMissingError(FileNotFoundError):
+    """Raised by ``_install_asset`` / ``_update_asset`` when the destination
+    project root does not exist (the ``project_root.is_dir()`` guard).
+
+    Subclasses ``FileNotFoundError`` (not ``RuntimeError`` like its siblings) so
+    every existing ``except FileNotFoundError`` caller — the CLI verbs, any
+    ``str(exc)`` consumer — keeps working byte-for-byte. The distinct type lets
+    the web route map ONLY this guard to a fixed 404 ``project_root_missing``
+    envelope; a bare ``FileNotFoundError`` from a later source-walk / copy race
+    (``iter_installed_files``, ``copy_tree_atomic``, ``installed_at_from_dest``)
+    must NOT be mislabeled as a missing destination project (#1385 finding 4).
+    """
+
+
 class AssetNotFoundError(RuntimeError):
     """Raised when the requested asset directory does not exist in the wiki."""
 
@@ -523,7 +537,7 @@ def _install_asset(
     validated = validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
     project_root = Path(project_root).expanduser()
     if not project_root.is_dir():
-        raise FileNotFoundError(f"project root does not exist: {project_root}")
+        raise ProjectRootMissingError(f"project root does not exist: {project_root}")
 
     wiki = wiki if wiki is not None else WikiStore.at_default()
     wiki.require_exists()
@@ -687,7 +701,7 @@ def _update_asset(
     validated = validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
     project_root = Path(project_root).expanduser()
     if not project_root.is_dir():
-        raise FileNotFoundError(f"project root does not exist: {project_root}")
+        raise ProjectRootMissingError(f"project root does not exist: {project_root}")
 
     wiki = wiki if wiki is not None else WikiStore.at_default()
     wiki.require_exists()

--- a/packages/memtomem/src/memtomem/web/routes/context_mutations.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mutations.py
@@ -32,6 +32,7 @@ from memtomem.context.install import (
     AssetNotFoundError,
     InstallResult,
     NotInstalledError,
+    ProjectRootMissingError,
     StaleInstallError,
     UpdateResult,
     install_agent,
@@ -151,6 +152,21 @@ async def install_asset(
         raise _error(
             409, "conflict", "project lock.json is unreadable", reason_code="lockfile_corrupt"
         ) from exc
+    except ProjectRootMissingError as exc:
+        # Narrow TOCTOU: the project root was deleted between dependency
+        # resolution and the ``to_thread`` engine call (the engine's is_dir
+        # guard). A DEDICATED exception — never a bare ``FileNotFoundError`` —
+        # so a later source-walk / copy race (iter_installed_files /
+        # copy_tree_atomic) is not mislabeled as a missing destination project.
+        # Fixed message — no ``str(exc)`` (it embeds the absolute project path)
+        # — so the router's fixed-envelope contract holds, not a default 500
+        # (#1385 finding 4).
+        raise _error(
+            404,
+            "missing",
+            f"{asset_type}/{name}: destination project no longer exists",
+            reason_code="project_root_missing",
+        ) from exc
     return {
         "installed": True,
         "asset_type": result.asset_type,
@@ -222,6 +238,20 @@ async def update_asset(
     except LockfileError as exc:
         raise _error(
             409, "conflict", "project lock.json is unreadable", reason_code="lockfile_corrupt"
+        ) from exc
+    except ProjectRootMissingError as exc:
+        # Narrow TOCTOU: the project root was deleted between dependency
+        # resolution and the ``to_thread`` engine call (the engine's is_dir
+        # guard). A DEDICATED exception — never a bare ``FileNotFoundError`` —
+        # so a later source-walk / copy race is not mislabeled as a missing
+        # destination project. Fixed message — no ``str(exc)`` (absolute path)
+        # — so the router's fixed-envelope contract holds, not a default 500
+        # (#1385 finding 4).
+        raise _error(
+            404,
+            "missing",
+            f"{asset_type}/{name}: destination project no longer exists",
+            reason_code="project_root_missing",
         ) from exc
     return {
         "updated": True,

--- a/packages/memtomem/tests/test_web_routes_context_mutations.py
+++ b/packages/memtomem/tests/test_web_routes_context_mutations.py
@@ -163,6 +163,93 @@ async def test_install_agent_and_command(client, seeded_wiki, project_root: Path
     assert _lock_entry(project_root, "commands", "gamma") is not None
 
 
+@pytest.mark.asyncio
+async def test_install_project_root_deleted_is_404(
+    client, seeded_wiki, project_root: Path, monkeypatch
+) -> None:
+    # #1385 finding 4: the project root is deleted in the TOCTOU window between
+    # dependency resolution and the to_thread engine call, so the engine's
+    # ``is_dir()`` guard raises a BARE FileNotFoundError. The handler must map
+    # it to the fixed 404 envelope (no FastAPI default 500), with no absolute
+    # project path in the body.
+    import shutil
+
+    import memtomem.web.routes.context_mutations as cm
+
+    original = cm._INSTALLERS["skills"]
+
+    def _delete_then_install(*args, **kwargs):
+        shutil.rmtree(project_root, ignore_errors=True)
+        return original(*args, **kwargs)
+
+    monkeypatch.setitem(cm._INSTALLERS, "skills", _delete_then_install)
+    resp = await client.post("/api/context/skills/alpha/install")
+
+    assert resp.status_code == 404, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error_kind"] == "missing"
+    assert detail["reason_code"] == "project_root_missing"
+    assert detail["message"] == "skills/alpha: destination project no longer exists"
+    # Fixed message — neither the absolute project path nor the raw engine
+    # ``str(exc)`` ("project root does not exist: ...") reaches the envelope.
+    assert str(project_root) not in resp.text
+    assert "project root does not exist" not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_update_project_root_deleted_is_404(
+    client, seeded_wiki, project_root: Path, monkeypatch
+) -> None:
+    # Same TOCTOU on the update path: the ``is_dir()`` guard fires before the
+    # not-installed check, so no prior install is needed to reach it.
+    import shutil
+
+    import memtomem.web.routes.context_mutations as cm
+
+    original = cm._UPDATERS["skills"]
+
+    def _delete_then_update(*args, **kwargs):
+        shutil.rmtree(project_root, ignore_errors=True)
+        return original(*args, **kwargs)
+
+    monkeypatch.setitem(cm._UPDATERS, "skills", _delete_then_update)
+    resp = await client.post("/api/context/skills/alpha/update")
+
+    assert resp.status_code == 404, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error_kind"] == "missing"
+    assert detail["reason_code"] == "project_root_missing"
+    assert detail["message"] == "skills/alpha: destination project no longer exists"
+    assert str(project_root) not in resp.text
+    assert "project root does not exist" not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_non_guard_filenotfound_is_not_project_root_missing(
+    client, seeded_wiki, project_root: Path, monkeypatch
+) -> None:
+    # #1385 finding 4 (Codex gate): ONLY the engine's project-root is_dir guard
+    # (ProjectRootMissingError) maps to 404 project_root_missing. A BARE
+    # FileNotFoundError from a later source-walk / copy race (iter_installed_files,
+    # copy_tree_atomic, installed_at_from_dest) must NOT be mislabeled — it falls
+    # through to the generic 500, not a clean "destination project no longer
+    # exists" 404. Pins the fix away from the original broad ``except
+    # FileNotFoundError``, which WOULD have caught this and mislabeled it.
+    import memtomem.web.routes.context_mutations as cm
+
+    def _raise_plain_fnf(*args, **kwargs):
+        raise FileNotFoundError("wiki source file vanished mid-copy")
+
+    monkeypatch.setitem(cm._INSTALLERS, "skills", _raise_plain_fnf)
+    # The plain FNF is not ProjectRootMissingError, so the route does NOT catch
+    # it — it propagates (a generic 500 in production) rather than being
+    # mislabeled as a clean 404 project_root_missing. The original broad
+    # ``except FileNotFoundError`` WOULD have caught and mislabeled it, so this
+    # ``raises`` (the FNF reaches the test transport) would fail pre-fix.
+    with pytest.raises(FileNotFoundError, match="vanished mid-copy"):
+        await client.post("/api/context/skills/alpha/install")
+
+
 # ── update lifecycle ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What

`install_asset` / `update_asset` resolve the project root via a FastAPI dependency, then run the engine in a worker thread. If the project root is deleted in that TOCTOU window, the engine's `project_root.is_dir()` guard fires, which fell through to FastAPI's default **500** — breaking the router's "every handler maps to a fixed-message envelope" contract.

## Fix

The guard raised a **bare `FileNotFoundError`**, but `_install_asset` / `_update_asset` can *also* raise raw `FileNotFoundError` later — `iter_installed_files` (source walk), `copy_tree_atomic` (`src.iterdir()` / `read_bytes()`), `installed_at_from_dest` (dest `stat()` race). A broad `except FileNotFoundError` would mislabel any of those as `project_root_missing` (**caught on the Codex review gate**).

So:
- New `ProjectRootMissingError(FileNotFoundError)` in `context/install.py`, raised **only** at the two `is_dir()` guards. Subclassing `FileNotFoundError` keeps every existing `except FileNotFoundError` CLI/engine caller byte-compatible.
- Both web handlers catch **that specific type** → 404 `missing`, `reason_code="project_root_missing"`, fixed message (no `str(exc)` path leak).
- A later non-guard `FileNotFoundError` is *not* caught → stays an internal 500 (correct: a genuine I/O race, not a missing destination project).

## Tests

- `test_install_project_root_deleted_is_404` / `test_update_project_root_deleted_is_404` — delete the root mid-flight → `ProjectRootMissingError` → 404 envelope, no path leak.
- `test_non_guard_filenotfound_is_not_project_root_missing` — a plain `FileNotFoundError` from the installer is **not** mapped to `project_root_missing` (propagates / 500), pinning the fix away from the original broad catch.

Part of #1385 (finding 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
