### PR TITLE
fix(wiki): roll back a wedged half-wiki when the bootstrap commit fails (#1385)

### DIFF
--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -186,17 +186,39 @@ class WikiStore:
                 f"directory {self.root} is not empty and is not a wiki — refusing to init"
             )
 
+        # The guard above leaves the root either absent or pre-existing-empty;
+        # remember which so rollback never deletes a dir the user already had.
+        root_preexisted = self.root.exists()
         self.root.mkdir(parents=True, exist_ok=True)
-        for asset_type in WIKI_ASSET_TYPES:
-            asset_dir = self.root / asset_type
-            asset_dir.mkdir(exist_ok=True)
-            (asset_dir / ".gitkeep").write_text("", encoding="utf-8")
+        try:
+            for asset_type in WIKI_ASSET_TYPES:
+                asset_dir = self.root / asset_type
+                asset_dir.mkdir(exist_ok=True)
+                (asset_dir / ".gitkeep").write_text("", encoding="utf-8")
 
-        (self.root / "README.md").write_text(_README_TEMPLATE, encoding="utf-8")
+            (self.root / "README.md").write_text(_README_TEMPLATE, encoding="utf-8")
 
-        _git(["init", "-b", "main"], cwd=self.root)
-        _git(["add", "."], cwd=self.root)
-        _git(["commit", "-m", _INITIAL_COMMIT_MESSAGE], cwd=self.root)
+            _git(["init", "-b", "main"], cwd=self.root)
+            _git(["add", "."], cwd=self.root)
+            _git(["commit", "-m", _INITIAL_COMMIT_MESSAGE], cwd=self.root)
+        except RuntimeError:
+            # Bootstrap failed — most plausibly ``git commit`` with no resolvable
+            # user identity (a minimal/rootless container, ``user.useConfigOnly``).
+            # Without rollback, ``.git/`` survives → ``exists()`` returns True, so
+            # re-running ``init`` / ``init_from_url`` is refused AND every read op
+            # (``current_commit``, ``is_dirty``, …) fails on the HEAD-less repo —
+            # manual ``rm -rf`` the only escape. Remove exactly what we created
+            # (never a pre-existing root) and re-raise so the caller still
+            # surfaces the failure. We add no fallback identity: the "memtomem
+            # injects no git identity" invariant is preserved.
+            if root_preexisted:
+                shutil.rmtree(self.root / ".git", ignore_errors=True)
+                for asset_type in WIKI_ASSET_TYPES:
+                    shutil.rmtree(self.root / asset_type, ignore_errors=True)
+                (self.root / "README.md").unlink(missing_ok=True)
+            else:
+                shutil.rmtree(self.root, ignore_errors=True)
+            raise
 
     def init_from_url(self, url: str) -> None:
         """Clone an existing wiki from ``url`` into ``root``."""

--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -12,9 +12,10 @@ import logging
 import os
 import re
 import shutil
+import stat
 import subprocess
 import tempfile
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
@@ -137,6 +138,28 @@ def _git(
         raise RuntimeError(f"git {' '.join(args)} failed: {detail}") from exc
 
 
+def _force_rmtree(path: Path) -> None:
+    """Best-effort recursive remove that survives Windows read-only git files.
+
+    Plain ``shutil.rmtree(ignore_errors=True)`` *silently* leaves files behind
+    on Windows: git marks ``.git`` pack/loose-object files read-only, and
+    Windows refuses to unlink a read-only file. The swallowed error means a
+    failed ``init`` bootstrap leaves a surviving ``.git/`` — ``exists()`` then
+    reports a wedged half-wiki, defeating the rollback. Clear the read-only bit
+    and retry per failed entry; stay best-effort (the caller re-raises the
+    original bootstrap error, so a residual file must not mask it).
+    """
+
+    def _on_error(func: Callable[[str], object], p: str, _exc: BaseException) -> None:
+        try:
+            os.chmod(p, stat.S_IWRITE)
+            func(p)
+        except OSError:
+            pass
+
+    shutil.rmtree(path, onexc=_on_error)
+
+
 def _require_clean_rel(rel: str) -> None:
     """Reject anything that isn't a clean wiki-relative POSIX path.
 
@@ -212,12 +235,12 @@ class WikiStore:
             # surfaces the failure. We add no fallback identity: the "memtomem
             # injects no git identity" invariant is preserved.
             if root_preexisted:
-                shutil.rmtree(self.root / ".git", ignore_errors=True)
+                _force_rmtree(self.root / ".git")
                 for asset_type in WIKI_ASSET_TYPES:
-                    shutil.rmtree(self.root / asset_type, ignore_errors=True)
+                    _force_rmtree(self.root / asset_type)
                 (self.root / "README.md").unlink(missing_ok=True)
             else:
-                shutil.rmtree(self.root, ignore_errors=True)
+                _force_rmtree(self.root)
             raise
 
     def init_from_url(self, url: str) -> None:

--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -82,6 +82,50 @@ class TestInitScratch:
         with pytest.raises(WikiAlreadyExistsError, match="not empty"):
             store.init()
 
+    def test_init_rolls_back_when_commit_has_no_identity(
+        self, wiki_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # #1385 finding 5: a bootstrap ``git commit`` with no resolvable identity
+        # (minimal / rootless container) must NOT leave a wedged half-wiki — a
+        # surviving ``.git/`` makes ``exists()`` return True (re-init refused) and
+        # every read op fail on the HEAD-less repo. init() rolls back exactly what
+        # it created and re-raises; NO fallback identity is injected (invariant).
+        import os
+
+        # Strip every identity source. ``user.useConfigOnly`` defeats git's
+        # auto-derive-from-system fallback, so ``commit`` fails on every git build.
+        for var in (
+            "GIT_AUTHOR_NAME",
+            "GIT_AUTHOR_EMAIL",
+            "GIT_COMMITTER_NAME",
+            "GIT_COMMITTER_EMAIL",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        no_identity = tmp_path / "no-identity.gitconfig"
+        no_identity.write_text("[user]\n\tuseConfigOnly = true\n", encoding="utf-8")
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(no_identity))
+        monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+
+        store = WikiStore.at_default()
+        with pytest.raises(RuntimeError, match="git commit"):
+            store.init()
+
+        # Rollback removed everything init() created — no wedge left behind.
+        assert not store.exists()
+        assert not (wiki_root / ".git").exists()
+        assert not (wiki_root / "README.md").exists()
+        for asset_type in WIKI_ASSET_TYPES:
+            assert not (wiki_root / asset_type).exists()
+
+        # An env identity bypasses ``useConfigOnly``, so a retry now succeeds —
+        # proving the directory was not left wedged.
+        monkeypatch.setenv("GIT_AUTHOR_NAME", "test")
+        monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+        monkeypatch.setenv("GIT_COMMITTER_NAME", "test")
+        monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+        store.init()
+        assert store.exists()
+
 
 class TestInitFromUrl:
     def test_clone_from_local_file_url(


### PR DESCRIPTION
## What

`WikiStore.init()` did `git init` + `add` + `commit` with no rollback. If `git commit` fails — **no resolvable user identity** (a minimal/rootless container, or `user.useConfigOnly` with no name/email) — the partially-created `.git/` survives, so `exists()` returns `True`. That:
- blocks re-running `mm wiki init` / `init_from_url` (both refuse when `exists()`),
- makes every read op (`current_commit`, `is_dirty`, …) fail on the HEAD-less repo,

with a manual `rm -rf` the only escape.

## Fix

Wrap the layout + git bootstrap in `try/except RuntimeError` (the type `_git` raises on a `CalledProcessError`). On failure, remove **exactly what `init()` created** — `.git/`, the asset dirs, `README.md` — then re-raise so the caller still surfaces the failure.

A **pre-existing empty root** (the second guard permits one) is preserved (only its created contents are removed); an `init()`-created root is removed wholesale. **No fallback git identity is injected** — the "memtomem injects no git identity" invariant holds (CLAUDE.md / `packages/memtomem/README.md`).

`init_from_url` is unaffected: `git clone` cleans up its own partial target on failure (different code path, no half-wiki).

## Test

`test_init_rolls_back_when_commit_has_no_identity` forces commit failure via `user.useConfigOnly=true` + stripped `GIT_*` identity env (defeats git's auto-derive-from-system fallback on every build), asserts `init()` raises and leaves **no** `.git/`/layout (`exists()` is `False`), then proves a retry with an env identity succeeds. Verified **failing pre-fix** (the wedged `.git/` survived → `exists()` stayed `True`).

Part of #1385 (finding 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
