### PR TITLE
fix(context): fail closed on an unreadable subtree during the sync Gate A scan (#1385)

### DIFF
--- a/packages/memtomem/src/memtomem/context/privacy_scan.py
+++ b/packages/memtomem/src/memtomem/context/privacy_scan.py
@@ -33,6 +33,7 @@ divergence stabilises (see PR-E3 plan §2d Implementer-side note 9).
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Literal, NamedTuple
 
@@ -133,6 +134,34 @@ class ScanResult(NamedTuple):
     blocked: list[FileScan]
 
 
+def _iter_scannable_artifact_files(root: Path) -> Iterator[Path]:
+    """Yield every regular file under *root*, failing CLOSED on enumeration error.
+
+    Unlike :meth:`Path.rglob`, which SUPPRESSES per-directory ``OSError`` (an
+    unreadable subtree just vanishes from the results — yet the staged tree
+    still carries its bytes to be promoted), this walker lets any ``iterdir``
+    ``OSError`` propagate so :func:`scan_artifact_tree` can raise
+    :class:`PrivacyScanReadError` instead of fanning out an unscanned subtree.
+    This is the directory-axis sibling of #1381's skills-import enumeration
+    guard (:func:`memtomem.context.skills._iter_scannable_skill_files`).
+
+    Symlink handling matches the ``sorted(p for p in src.rglob("*") if
+    p.is_file())`` this replaces — NOT #1381's copier-mirroring walker. A
+    symlinked DIRECTORY is not descended: ``rglob`` never recurses links, and
+    ``scan_artifact_tree`` is not always a fresh ``copy_tree_atomic`` output —
+    transfer/copy and migrate-EXDEV staging preserve symlinks as links
+    (``transfer.py`` / ``migrate.py``), so following one could escape the staged
+    tree (scanning bytes that are NOT being promoted) or loop a symlink cycle.
+    A symlink to a FILE is still yielded — ``is_file()`` follows it, exactly as
+    the old ``p.is_file()`` filter did.
+    """
+    for entry in sorted(root.iterdir()):
+        if entry.is_dir() and not entry.is_symlink():
+            yield from _iter_scannable_artifact_files(entry)
+        elif entry.is_file():
+            yield entry
+
+
 def scan_artifact_tree(
     src: Path,
     *,
@@ -199,7 +228,23 @@ def scan_artifact_tree(
         ``blocked`` convenience subset. Callers branch on
         ``result.blocked`` and ``scope`` to decide raise-vs-skip.
     """
-    files = [src] if src.is_file() else sorted(p for p in src.rglob("*") if p.is_file())
+    try:
+        files = [src] if src.is_file() else sorted(_iter_scannable_artifact_files(src))
+    except OSError as exc:
+        # Enumeration failure (an unreadable directory). ``Path.rglob`` silently
+        # suppresses per-directory ``OSError`` — the unreadable subtree would
+        # vanish from the scan, its files never inspected yet still present in
+        # the staged tree to be promoted (#1385 finding 6 — the directory-axis
+        # sibling of the per-file read guard below). Fail closed identically.
+        bad = Path(exc.filename) if exc.filename else src
+        raise PrivacyScanReadError(
+            f"Gate A: cannot enumerate {bad} (errno={exc.errno}); refusing to "
+            f"fan-out / migrate to scope='{scope}'. An unreadable directory "
+            "cannot be scanned for secrets — fix the permission or remove it "
+            "before re-running.",
+            path=bad,
+            scope=scope,
+        ) from exc
     decisions: list[FileScan] = []
     audit_context_base: dict[str, object] = {"kind": "sync", "scope": scope}
     if project_root is not None:

--- a/packages/memtomem/tests/test_privacy_scan.py
+++ b/packages/memtomem/tests/test_privacy_scan.py
@@ -304,6 +304,61 @@ class TestUnreadableFileFailsClosed:
             )
         assert "leak.sh" in exc_info.value.message
 
+    def test_unreadable_subtree_fails_closed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # #1385 finding 6: an unreadable SUBDIRECTORY (enumeration-level OSError)
+        # must hard-abort the scan. ``Path.rglob`` suppressed the per-directory
+        # OSError, so the subtree's files were never inspected yet still sat in
+        # the staged tree to be promoted; the fail-closed walker propagates the
+        # error to a PrivacyScanReadError. (rglob uses ``os.scandir``, not
+        # ``Path.iterdir`` — so pre-fix this patch is a no-op and the scan
+        # completes silently, which is exactly the hole being closed.)
+        skill_root = _seed_skill(tmp_path / "foo")
+        unreadable = skill_root / "scripts"
+        real_iterdir = Path.iterdir
+
+        def explode(self: Path):
+            if self == unreadable:
+                raise PermissionError(13, "Permission denied", str(self))
+            return real_iterdir(self)
+
+        monkeypatch.setattr(Path, "iterdir", explode)
+
+        with pytest.raises(PrivacyScanReadError) as exc_info:
+            scan_artifact_tree(
+                skill_root,
+                surface="t",
+                scope="project_shared",
+                project_root=tmp_path,
+            )
+        assert "scripts" in exc_info.value.message
+        # The unreadable path is carried on the typed error (caller rollback).
+        assert exc_info.value.path == unreadable
+
+    @pytest.mark.requires_symlinks
+    def test_symlinked_directory_not_descended(self, tmp_path: Path) -> None:
+        # #1385 finding 6 (Codex gate): the fail-closed walker must preserve the
+        # prior ``rglob`` file set — a symlinked DIRECTORY is NOT descended.
+        # ``scan_artifact_tree`` is not always a fresh copy_tree_atomic output:
+        # transfer/migrate staging preserves symlinks as links, so following one
+        # would scan out-of-tree bytes that are NOT being promoted (and could
+        # loop a cycle). The symlink itself is promoted as a link, not its target.
+        skill_root = _seed_skill(tmp_path / "foo")  # all clean
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.md").write_text(f"{SECRET}\n", encoding="utf-8")
+        (skill_root / "linkdir").symlink_to(outside, target_is_directory=True)
+
+        result = scan_artifact_tree(
+            skill_root, surface="t", scope="project_shared", project_root=tmp_path
+        )
+        # The out-of-tree target's secret is neither scanned nor blocked — same
+        # file set as the old ``rglob`` walk (which never recursed links).
+        scanned = {d.path for d in result.decisions}
+        assert (outside / "secret.md") not in scanned
+        assert result.blocked == []
+
 
 class TestRaiseOrCollect:
     def test_project_shared_raises(self) -> None:


### PR DESCRIPTION
## What

`scan_artifact_tree` enumerated the staged tree with `Path.rglob`, which **suppresses per-directory `OSError`** (Python's `glob`): an unreadable subtree silently vanishes from the file list — its files never inspected by Gate A, yet still present in the staging dir to be promoted.

This is the **directory-axis sibling** of the enumeration-suppression hole #1381 closed for the skills-import scanner. The per-file *read* guard already failed closed (`PrivacyScanReadError`); the *enumeration* did not.

## Fix

Replace the `rglob` with a local fail-closed walker `_iter_scannable_artifact_files` that lets `iterdir` `OSError` propagate, and wrap the enumeration so it raises `PrivacyScanReadError` — **identical handling to the per-file read failure**, so the caller's rollback (re-rename / drop staging) still runs.

**Symlink parity (Codex review gate):** the walker checks `is_symlink()` *before* recursing, so a symlinked **directory** is not descended — matching `rglob` (which never recurses links). `scan_artifact_tree` is **not** always a fresh `copy_tree_atomic` output: transfer/copy and migrate-EXDEV staging *preserve symlinks as links* (`transfer.py`/`migrate.py`), so following one could scan out-of-tree bytes that aren't being promoted, or loop a cycle. A symlink to a **file** is still yielded (`is_file()` follows it, as the old `p.is_file()` filter did).

## Tests

- `test_unreadable_subtree_fails_closed` — an unreadable subdirectory raises `PrivacyScanReadError` (load-bearing: `rglob` uses `os.scandir`, so pre-fix the scan completed silently).
- `test_symlinked_directory_not_descended` — a symlinked dir's out-of-tree target is neither scanned nor blocked (preserves the prior `rglob` file set).

Part of #1385 (finding 6, the deferred follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
