### PR TITLE
fix(web): path-free 422 detail for the settings-copy privacy block (#1385)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -63,6 +63,20 @@ router = APIRouter(tags=["settings-sync", "context-gateway"])
 
 _MALFORMED = object()
 
+#: Fixed, path-free 422 detail for a project_shared settings privacy block
+#: (#1385 finding-1 sibling, Codex-scoped). ``PrivacyBlockedError.message`` comes
+#: from ``format_scan_block_message``, which ends with the absolute canonical
+#: settings path (``… remove the secret from {blocked.path} …``) — leaking the
+#: host $HOME over the loopback dashboard, with no product contract requiring it
+#: (unlike the transfer route's deliberate source-path hint). Keeps the
+#: issue-pinned STRING-detail shape; the chained ``exc`` retains the full path
+#: for server logs.
+_PRIVACY_BLOCK_DETAIL = (
+    "Privacy scan blocked this settings copy: a secret was detected in the hook "
+    "bytes. git history is forever — no force bypass for project_shared "
+    "(ADR-0011 §5). Remove the secret and retry."
+)
+
 
 def _claude_target(project_root: Path, scope: str) -> Path:
     """Resolve the Claude Code settings file under *scope* (ADR-0010 §3).
@@ -1203,7 +1217,7 @@ async def copy_hook_to_project(
     try:
         gate_a_scan(plan, "web_context_settings_hook_copy")
     except PrivacyBlockedError as exc:
-        raise HTTPException(422, exc.message) from exc
+        raise HTTPException(422, _PRIVACY_BLOCK_DETAIL) from exc
 
     git_tracked_write = plan.pending_canonical_write or (
         plan.pending_target_write and body.to_target_scope == "project_shared"
@@ -1247,7 +1261,7 @@ async def copy_hook_to_project(
             503, "busy", "Copy timed out — another sync or settings write may be in progress"
         )
     except PrivacyBlockedError as exc:
-        raise HTTPException(422, exc.message) from exc
+        raise HTTPException(422, _PRIVACY_BLOCK_DETAIL) from exc
 
     status = "noop" if plan.is_noop else ("conflicts" if result.warnings else "ok")
     return {"status": status, **_serialize_hook_copy_result(result)}

--- a/packages/memtomem/tests/test_web_routes_settings_copy.py
+++ b/packages/memtomem/tests/test_web_routes_settings_copy.py
@@ -354,4 +354,10 @@ async def test_gate_a_422_string_before_consent(client, tmp_path, cwd_root) -> N
     assert isinstance(detail, str)
     assert "git history is forever" in detail
     assert SECRET not in detail
+    # #1385 finding-1 sibling (Codex rec A): the 422 detail must not echo the
+    # absolute canonical settings path. Pre-fix it ended with "… remove the
+    # secret from {blocked.path} …" under cwd_root (the source canonical).
+    assert str(cwd_root) not in detail
+    assert str(cwd_root.resolve()) not in detail
+    assert str(other) not in detail
     assert not (other / CANONICAL_SETTINGS_FILE).exists()


### PR DESCRIPTION
## What

The settings hook-copy route translated a `project_shared` Gate A privacy block into `HTTPException(422, exc.message)`, where `PrivacyBlockedError.message` comes from `format_scan_block_message` and ends with the absolute canonical settings path (`… remove the secret from {blocked.path} …`). Over the loopback dashboard that leaks the host `$HOME` + OS username — the **same shape as #1385 finding 1**.

## Scope (Codex design review)

A full-tree sweep during finding 1 surfaced this *and* `context_transfer.py:495`. A Codex design review scoped the follow-up to **settings only**:
- **settings** — no product contract requires the path; it's an inconsistent **unintentional** leak → fix.
- **transfer** — the source path is a **deliberate, test-pinned** "Offending file" remediation hint (route docstring + `test_privacy_scan_blocks_with_standard_string_envelope`, ADR-0023/#1276). Making it path-free would silently undo that design → **left as-is**.

## Fix

Raise a fixed, path-free `_PRIVACY_BLOCK_DETAIL` at both `PrivacyBlockedError` handlers (`:1206`, `:1250`), keeping the issue-pinned **string-detail** shape (like the sync/import surfaces) and chaining `exc` so the full path survives in the server-side traceback.

## Test

`test_gate_a_422_string_before_consent` extended to assert the 422 detail contains **no** absolute canonical path (`cwd_root`, both symlink forms, and the destination root) — load-bearing: pre-fix the detail ended with `… remove the secret from {blocked.path} …` under `cwd_root`. Keeps the existing `git history is forever` + secret-absent assertions.

Follow-up to #1385 (Codex-scoped finding 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
