### PR TITLE
fix(web): Context Gateway Sync All — isolate per-phase failures (don't abort siblings) (#1396)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -3112,18 +3112,12 @@ document.getElementById('ctx-sync-all-btn')?.addEventListener('click', async () 
         break;
       }
       if (!resp.ok) {
-        // A per-phase HTTP error response (e.g. a project_shared privacy-block
-        // 422, or a transient 5xx) is recoverable for the RUN: the server is up
-        // and the OTHER artifact types have no issue, so they must still sync.
-        // Mirror the backend ``/sync-all`` per-phase isolation ("Per-phase
-        // report, NOT cross-type all-or-nothing") instead of the all-or-nothing
-        // this client loop used to do — a single secret-bearing skill no longer
-        // strands every later type as ``not_run`` (#1396). Record the failed
-        // phase and CONTINUE; only a transport failure (``fetch`` threw, above)
-        // aborts, since a dead connection would just fail the siblings too.
-        // ``failed`` holds the FIRST failure — its reason drives the toast and
-        // gates the settings phase; the per-phase summary shows every ``failed``
-        // row, so the toast's failed-phase list is derived from ``phaseStates``.
+        // A per-phase HTTP error (e.g. a project_shared privacy-block 422) is
+        // recoverable for the run: the other types must still sync, so mirror
+        // the backend ``/sync-all`` per-phase isolation — CONTINUE rather than
+        // abort the whole fan-out (only a transport failure, above, aborts). The
+        // FIRST failure drives the toast reason + gates settings; the failed
+        // list comes from ``phaseStates`` (#1396).
         const reason = await _ctxErrorMessageFromResponse(resp, `Sync ${typ} failed`);
         if (!failed) failed = { phase: typ, reason };
         setPhase(typ, 'failed');
@@ -3185,13 +3179,22 @@ document.getElementById('ctx-sync-all-btn')?.addEventListener('click', async () 
       setPhase('settings', 'syncing');
       let settingsResp;
       try {
+        // Inline the CSRF headers at the call site (rather than the shared
+        // run-level ``headers`` var): this phase's fetch sits beyond the
+        // invariant guard's binding-lookback window, so thread the token here.
+        // ``csrf`` is the run-level token bound above.
         settingsResp = await fetch(
           _ctxWithTargetScope('/api/context/settings/sync', {
             scopeId: syncAllScopeId,
             scopeResolved: true,
             targetScope: syncAllTier,
           }),
-          { method: 'POST', headers },
+          {
+            method: 'POST',
+            headers: csrf
+              ? { 'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf }
+              : { 'Content-Type': 'application/json' },
+          },
         );
       } catch (err) {
         failed = { phase: 'settings', reason: err.message };

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -2449,6 +2449,9 @@ async function _ctxSyncProjectScope(scopeId, btn) {
 
   const succeeded = [];
   let failed = null;
+  // Every failed phase (this card fan-out no longer aborts on the first
+  // per-phase HTTP error — #1396), so the partial toast can name them all.
+  const failedPhases = [];
   let settingsSeverity = null;
   let settingsReason = '';
   let anyPhaseStarted = false;
@@ -2472,15 +2475,20 @@ async function _ctxSyncProjectScope(scopeId, btn) {
           { method: 'POST', headers }
         );
       } catch (err) {
-        failed = { phase: typ, reason: err.message };
+        if (!failed) failed = { phase: typ, reason: err.message };
+        failedPhases.push(typ);
         break;
       }
       if (!resp.ok) {
-        failed = {
-          phase: typ,
-          reason: await _ctxErrorMessageFromResponse(resp, `Sync ${typ} failed`),
-        };
-        break;
+        // Recoverable per-phase HTTP error (e.g. a project_shared privacy-block
+        // 422): the server is up and the other types have no issue, so keep
+        // going — mirror the backend ``/sync-all`` per-phase isolation (#1396).
+        // Only a transport failure (above) aborts the run. ``failed`` keeps the
+        // FIRST failure (drives the toast reason + gates the settings phase).
+        const reason = await _ctxErrorMessageFromResponse(resp, `Sync ${typ} failed`);
+        if (!failed) failed = { phase: typ, reason };
+        failedPhases.push(typ);
+        continue;
       }
       succeeded.push(typ);
       const body = await resp.json().catch(() => ({}));
@@ -2502,6 +2510,7 @@ async function _ctxSyncProjectScope(scopeId, btn) {
             phase: 'settings',
             reason: await _ctxErrorMessageFromResponse(settingsResp, 'Settings sync failed'),
           };
+          failedPhases.push('settings');
         } else {
           const settingsData = await settingsResp.json().catch(() => ({}));
           const settingsResults = settingsData.results || [];
@@ -2522,6 +2531,7 @@ async function _ctxSyncProjectScope(scopeId, btn) {
         }
       } catch (err) {
         failed = { phase: 'settings', reason: err.message };
+        failedPhases.push('settings');
       }
     }
 
@@ -2530,10 +2540,12 @@ async function _ctxSyncProjectScope(scopeId, btn) {
       if (succeeded.length === 0) {
         showToast(t('toast.sync_failed', { error: failed.reason }), 'error');
       } else {
+        // Name EVERY failed phase — the loop no longer aborts on the first
+        // per-phase HTTP error (#1396); ``failed.reason`` stays the first one.
         showToast(
           t('toast.sync_partial_failed', {
             succeeded: succeeded.map(phaseLabel).join(', '),
-            failed_phase: phaseLabel(failed.phase),
+            failed_phase: failedPhases.map(phaseLabel).join(', '),
             reason: failed.reason,
           }),
           'error'
@@ -3100,12 +3112,22 @@ document.getElementById('ctx-sync-all-btn')?.addEventListener('click', async () 
         break;
       }
       if (!resp.ok) {
-        failed = {
-          phase: typ,
-          reason: await _ctxErrorMessageFromResponse(resp, `Sync ${typ} failed`),
-        };
+        // A per-phase HTTP error response (e.g. a project_shared privacy-block
+        // 422, or a transient 5xx) is recoverable for the RUN: the server is up
+        // and the OTHER artifact types have no issue, so they must still sync.
+        // Mirror the backend ``/sync-all`` per-phase isolation ("Per-phase
+        // report, NOT cross-type all-or-nothing") instead of the all-or-nothing
+        // this client loop used to do — a single secret-bearing skill no longer
+        // strands every later type as ``not_run`` (#1396). Record the failed
+        // phase and CONTINUE; only a transport failure (``fetch`` threw, above)
+        // aborts, since a dead connection would just fail the siblings too.
+        // ``failed`` holds the FIRST failure — its reason drives the toast and
+        // gates the settings phase; the per-phase summary shows every ``failed``
+        // row, so the toast's failed-phase list is derived from ``phaseStates``.
+        const reason = await _ctxErrorMessageFromResponse(resp, `Sync ${typ} failed`);
+        if (!failed) failed = { phase: typ, reason };
         setPhase(typ, 'failed');
-        break;
+        continue;
       }
       // Parse the body for the per-type result counts (generated/dropped/
       // skipped). Tolerates an empty/non-JSON body — a bare ``{}`` yields all
@@ -3231,10 +3253,17 @@ document.getElementById('ctx-sync-all-btn')?.addEventListener('click', async () 
       if (succeeded.length === 0) {
         showToast(t('toast.sync_failed', { error: failed.reason }), 'error');
       } else {
+        // The loop no longer aborts on the first per-phase HTTP error (#1396),
+        // so name EVERY failed phase — derived from the authoritative per-phase
+        // status so the toast stays in lockstep with the summary rows. The
+        // reason stays the FIRST failure's (the summary carries the rest).
+        const failedPhaseLabels = _CTX_SYNC_PHASES
+          .filter((p) => phaseStates[p].state === 'failed')
+          .map(_ctxSyncPhaseLabel);
         showToast(
           t('toast.sync_partial_failed', {
             succeeded: succeeded.map(_ctxSyncPhaseLabel).join(', '),
-            failed_phase: _ctxSyncPhaseLabel(failed.phase),
+            failed_phase: failedPhaseLabels.join(', '),
             reason: failed.reason,
           }),
           'error',

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1600,7 +1600,7 @@
   <script src="/settings-harness.js?v=4"></script>
   <script src="/settings-hooks-watchdog.js?v=21"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=93"></script>
+  <script src="/context-gateway.js?v=94"></script>
   <script src="/context-portal.js?v=7"></script>
   <script src="/wiki.js?v=6"></script>
   <script src="/path-picker.js?v=4"></script>

--- a/packages/memtomem/tests-js/ctx-sync-all-progress.test.mjs
+++ b/packages/memtomem/tests-js/ctx-sync-all-progress.test.mjs
@@ -194,13 +194,17 @@ describe('Sync All — per-phase progress + result summary', () => {
     expect(window.document.querySelector('#toast-container .toast-success')).toBeNull();
   });
 
-  it('marks phases after a mid-run failure as not_run, not a frozen spinner', async () => {
+  it('isolates a failed artifact phase — later types still sync, no frozen spinner (#1396)', async () => {
+    // A per-phase HTTP error (here agents → 422) must NOT abort the run: the
+    // LATER artifact type (mcp-servers) still syncs (``done``) instead of being
+    // stranded ``not_run``, mirroring the backend per-phase isolation. Settings
+    // is still skipped after an artifact failure (its own deliberate gate) →
+    // ``not_run``. The frozen-spinner guard (#1074) is retained.
     const window = await bootSyncAll({
       skills: { body: { generated: [{ runtime: 'claude' }], skipped: [] } },
       commands: { body: { generated: [{ runtime: 'claude' }], skipped: [] } },
-      // agents fails → loop breaks; mcp-servers + settings never fire.
       agents: { ok: false, status: 422, body: { detail: 'Agents target is read-only' } },
-      'mcp-servers': { body: { generated: [] } },
+      'mcp-servers': { body: { generated: [{ runtime: 'claude' }] } },
       settings: { body: { results: [{ name: 'claude', status: 'ok' }] } },
     });
     const { I18N } = window;
@@ -211,11 +215,12 @@ describe('Sync All — per-phase progress + result summary', () => {
     const region = window.document.getElementById('ctx-sync-status');
     expect(region.hidden).toBe(false);
 
-    // skills + commands done; agents failed; mcp-servers + settings not_run.
-    expect(region.querySelectorAll('.ctx-sync-phase--done').length).toBe(2);
+    // skills + commands + mcp-servers done (mcp-servers ran AFTER the agents
+    // failure — the isolation fix); agents failed; settings not_run.
+    expect(region.querySelectorAll('.ctx-sync-phase--done').length).toBe(3);
     expect(region.querySelectorAll('.ctx-sync-phase--failed').length).toBe(1);
-    expect(region.querySelectorAll('.ctx-sync-phase--not_run').length).toBe(2);
-    // No phase left mid-flight (a frozen spinner is the bug this guards).
+    expect(region.querySelectorAll('.ctx-sync-phase--not_run').length).toBe(1);
+    // No phase left mid-flight (a frozen spinner is the bug this also guards).
     expect(region.querySelectorAll('.ctx-sync-phase--syncing').length).toBe(0);
     expect(region.querySelector('.ctx-sync-spinner')).toBeNull();
 
@@ -223,10 +228,62 @@ describe('Sync All — per-phase progress + result summary', () => {
     expect(failedRow.textContent).toContain(I18N.t('settings.ctx.agents_phase_title'));
     expect(failedRow.textContent).toContain(I18N.t('settings.ctx.sync_state_failed'));
 
-    // Partial-failure toast names what landed + the failed phase (#1074).
+    // Partial-failure toast names what landed (incl. mcp-servers, which ran
+    // after the failure) + the failed phase (#1074 / #1396).
     const toast = window.document.querySelector('#toast-container .toast-error .toast-msg');
     expect(toast).not.toBeNull();
     expect(toast.textContent).toContain(I18N.t('settings.ctx.agents_phase_title'));
+    expect(toast.textContent).toContain(I18N.t('settings.ctx.mcp_servers_phase_title'));
+  });
+
+  it('continues past a first-phase privacy block so clean types still sync (#1396)', async () => {
+    // The reported bug: a project_shared privacy block is a hard 422 from the
+    // FIRST phase (skills). The loop used to ``break`` → every later type
+    // ``not_run`` and zero partial progress. Now skills reads ``failed`` while
+    // commands / agents / mcp-servers all sync.
+    const calls = [];
+    const window = await bootSyncAll({
+      skills: {
+        ok: false,
+        status: 422,
+        body: { detail: 'A value here looks like a secret; remove it and retry.' },
+      },
+      commands: { body: { generated: [{ runtime: 'claude' }], skipped: [] } },
+      agents: { body: { generated: [{ runtime: 'claude' }], skipped: [] } },
+      'mcp-servers': { body: { generated: [{ runtime: 'claude' }], skipped: [] } },
+      settings: { body: { results: [{ name: 'claude', status: 'ok' }] } },
+    });
+    const { I18N } = window;
+    // Record which /sync endpoints actually fire — proves the loop did not abort
+    // at the skills 422.
+    const upstream = window.fetch;
+    window.fetch = async (input, opts) => {
+      const url = typeof input === 'string' ? input : input?.url || '';
+      const m = url.split('?')[0].match(/\/api\/context\/([^/]+)\/sync$/);
+      if (m) calls.push(m[1]);
+      return upstream(input, opts);
+    };
+
+    window.document.getElementById('ctx-sync-all-btn').click();
+    await flush(window);
+
+    // All three clean artifact types were POSTed AFTER the skills 422.
+    expect(calls).toContain('commands');
+    expect(calls).toContain('agents');
+    expect(calls).toContain('mcp-servers');
+
+    const region = window.document.getElementById('ctx-sync-status');
+    // skills failed; the three clean types done; settings skipped (not_run).
+    expect(region.querySelectorAll('.ctx-sync-phase--failed').length).toBe(1);
+    expect(region.querySelectorAll('.ctx-sync-phase--done').length).toBe(3);
+    const failedRow = region.querySelector('.ctx-sync-phase--failed');
+    expect(failedRow.textContent).toContain(I18N.t('settings.ctx.skills_phase_title'));
+
+    // Partial-failure toast: skills failed, the clean phases landed.
+    const toast = window.document.querySelector('#toast-container .toast-error .toast-msg');
+    expect(toast).not.toBeNull();
+    expect(toast.textContent).toContain(I18N.t('settings.ctx.skills_phase_title'));
+    expect(toast.textContent).toContain(I18N.t('settings.ctx.commands_phase_title'));
   });
 
   it('renders the settings phase as attention (not done) on needs_confirmation', async () => {

--- a/packages/memtomem/tests/web/test_context_gateway_sync_all.py
+++ b/packages/memtomem/tests/web/test_context_gateway_sync_all.py
@@ -300,12 +300,14 @@ def test_sync_all_artifact_422_surfaces_backend_error(
     body: str,
     expected_error: str,
 ) -> None:
-    """S1-b.1: artifact sync HTTP 422 must preserve the backend error body.
+    """S1-b.1: a blocked artifact sync (HTTP 422) must surface the backend error
+    body AND not abort the run (#1396).
 
-    Privacy blocks include remediation guidance in ``detail``. Sync All used
-    to discard that body and throw ``Sync <type> failed``, leaving users with
-    no way to resolve the blocked fan-out from the toast. Plain-text bodies
-    cover the helper's non-JSON fallback path.
+    Privacy blocks include remediation guidance in ``detail``. Sync All used to
+    discard that body and throw ``Sync <type> failed`` AND ``break`` the whole
+    fan-out. Now the reason is preserved in the partial-failure toast and the
+    later artifact phases still sync. Plain-text bodies cover the helper's
+    non-JSON fallback path.
     """
     install_default_stubs(page)
     _stub_overview_with_counter(page, [_HEALTHY_OVERVIEW])
@@ -320,13 +322,13 @@ def test_sync_all_artifact_422_surfaces_backend_error(
             body=body,
         )
 
-    def _unexpected_sync(route):
+    def _record_sync(route):
         sync_calls.append(route.request.url)
         route.fulfill(status=200, content_type="application/json", body="{}")
 
     page.route("**/api/context/skills/sync", _skills_privacy_block)
-    page.route("**/api/context/agents/sync", _unexpected_sync)
-    page.route("**/api/context/settings/sync", _unexpected_sync)
+    page.route("**/api/context/agents/sync", _record_sync)
+    page.route("**/api/context/settings/sync", _record_sync)
 
     page.goto(mm_web_url)
     _open_context_gateway(page)
@@ -346,34 +348,49 @@ def test_sync_all_artifact_422_surfaces_backend_error(
     toast_text = (
         page.locator("#toast-container .toast.toast-error .toast-msg").text_content() or ""
     ).strip()
-    expected = SYNC_FAILED_TEMPLATE.format(error=expected_error)
+    # skills is blocked first, but commands/agents/mcp-servers (all 200) still
+    # sync; the backend detail is carried as the partial toast's reason.
+    expected = SYNC_PARTIAL_FAILED_TEMPLATE.format(
+        succeeded="Commands, Subagents, MCP Servers",
+        failed_phase="Skills",
+        reason=expected_error,
+    )
     assert toast_text == expected, (
-        f"Artifact privacy block toast must surface backend detail {expected!r}, got {toast_text!r}"
+        f"Blocked artifact must surface its backend detail in the partial toast "
+        f"({expected!r}), got {toast_text!r}"
     )
 
     sync_paths = [u.split("/api/")[-1] for u in sync_calls]
-    assert sync_paths == ["context/skills/sync"], (
-        f"Sync All must stop after the blocked artifact sync, got {sync_paths!r}"
+    # The loop no longer aborts at the blocked artifact: agents (a later phase)
+    # still fired. Settings stays gated behind a clean artifact run, so it does
+    # NOT fire after a failure.
+    assert "context/agents/sync" in sync_paths, (
+        f"Sync All must continue past the blocked artifact, got {sync_paths!r}"
+    )
+    assert "context/settings/sync" not in sync_paths, (
+        f"Settings must stay skipped after an artifact failure, got {sync_paths!r}"
     )
 
 
 def test_sync_all_mid_run_failure_refreshes_overview_with_partial_toast(
     page, mm_web_url: str
 ) -> None:
-    """S1-b.2 (#1074): skills succeed → agents fails → settings is skipped,
-    but the overview is still refreshed and the toast names what landed.
+    """S1-b.2 (#1074 / #1396): skills + commands succeed → agents fails →
+    mcp-servers STILL syncs (the failed phase is isolated, not abort-the-run);
+    settings is skipped, but the overview is still refreshed and the toast names
+    what landed.
 
-    Pre-fix the handler ``throw``-ed on the first non-OK response and the
-    ``catch`` branch fell straight through to ``btnLoading(btn, false)``
-    without re-fetching the overview. Disk had changed (skills already
-    wrote) but the dashboard kept showing the pre-sync counts — a stale
-    diff target that made retries confusing.
+    Pre-fix the handler ``break``-ed on the first non-OK response, stranding
+    every later type, and the ``catch`` branch fell straight through to
+    ``btnLoading(btn, false)`` without re-fetching the overview. Disk had
+    changed (skills already wrote) but the dashboard kept showing the pre-sync
+    counts — a stale diff target that made retries confusing.
 
     Symmetric pin (``feedback_pin_invert_symmetric_assertion.md``):
-    positive on the partial toast text + overview reload counter, negative
-    on the settings sync POST not firing (we stop on first failure to
-    avoid cascading noise; settings often shares root cause with
-    artifact failures).
+    positive on the partial toast text + the later mcp-servers POST firing +
+    overview reload counter; negative on the settings sync POST not firing
+    (settings stays gated behind a clean artifact run — it often shares root
+    cause with artifact failures).
     """
     install_default_stubs(page)
     overview_state = _stub_overview_with_counter(page, [_HEALTHY_OVERVIEW])
@@ -401,6 +418,7 @@ def test_sync_all_mid_run_failure_refreshes_overview_with_partial_toast(
     page.route("**/api/context/skills/sync", _record_ok)
     page.route("**/api/context/commands/sync", _record_ok)
     page.route("**/api/context/agents/sync", _agents_fail)
+    page.route("**/api/context/mcp-servers/sync", _record_ok)
     page.route("**/api/context/settings/sync", _unexpected_settings)
 
     page.goto(mm_web_url)
@@ -424,7 +442,7 @@ def test_sync_all_mid_run_failure_refreshes_overview_with_partial_toast(
         page.locator("#toast-container .toast.toast-error .toast-msg").text_content() or ""
     ).strip()
     expected = SYNC_PARTIAL_FAILED_TEMPLATE.format(
-        succeeded="Skills, Commands",
+        succeeded="Skills, Commands, MCP Servers",
         failed_phase="Subagents",
         reason=agents_reason,
     )
@@ -444,13 +462,19 @@ def test_sync_all_mid_run_failure_refreshes_overview_with_partial_toast(
         f"Partial failure must not render the bare {sync_failed_only!r} toast; saw {error_toasts!r}"
     )
 
-    # Settings POST must not have fired — we stop on first failure.
+    # mcp-servers (a later phase) still fired after the agents failure — the run
+    # isolates the failed phase instead of aborting. Settings stays gated behind
+    # a clean artifact run, so it does NOT fire.
     sync_paths = [u.split("/api/")[-1] for u in sync_calls]
     assert sync_paths == [
         "context/skills/sync",
         "context/commands/sync",
         "context/agents/sync",
-    ], f"Sync All must stop at the failed phase, got {sync_paths!r}"
+        "context/mcp-servers/sync",
+    ], f"Sync All must isolate the failed phase and run the rest, got {sync_paths!r}"
+    assert "context/settings/sync" not in sync_paths, (
+        f"Settings must stay skipped after an artifact failure, got {sync_paths!r}"
+    )
 
     # Load-bearing assertion for #1074: overview reloaded even though the
     # run failed mid-way. Without this the dashboard would show the

--- a/packages/memtomem/tests/web/test_context_portal_card_sync.py
+++ b/packages/memtomem/tests/web/test_context_portal_card_sync.py
@@ -197,6 +197,55 @@ def test_portal_sync_fires_scoped_posts_for_enrolled_scope(page, mm_web_url: str
     assert state["projects"] > projects_before, "portal did not refresh after sync"
 
 
+def test_portal_sync_isolates_a_blocked_artifact_phase(page, mm_web_url: str) -> None:
+    """#1396: a per-phase privacy-block 422 on the card fan-out must NOT abort
+    the run — the other artifact types still sync. Mirrors the Overview Sync All
+    isolation fix on the toast-only portal-card path.
+
+    skills → 422 (privacy block); commands/agents/mcp-servers still POST.
+    Settings stays gated behind a clean artifact run (no POST after a failure).
+    """
+    state = _stub_portal_sync(page)
+
+    # Re-route skills to a privacy-block 422 AFTER the default recording stub
+    # (last-route-wins); still record the URL so the ordering assertion holds.
+    def _skills_block(route):
+        state["sync"].append(route.request.url)
+        route.fulfill(
+            status=422,
+            content_type="application/json",
+            body=json.dumps({"detail": "A value looks like a secret; remove it and retry."}),
+        )
+
+    page.route("**/api/context/skills/sync**", _skills_block)
+
+    _open_portal(page, mm_web_url)
+    _click_sync_and_confirm(page, "scope-on")
+
+    # 4 artifact POSTs fire (skills failed, but commands/agents/mcp-servers still
+    # ran); settings is gated behind a clean artifact run, so it does NOT fire.
+    deadline = time.monotonic() + 4.0
+    while len(state["sync"]) < 4 and time.monotonic() < deadline:
+        page.wait_for_timeout(50)
+    synced = [u.split("/api/")[-1].split("?")[0] for u in state["sync"]]
+    assert "context/commands/sync" in synced, synced
+    assert "context/agents/sync" in synced, synced
+    assert "context/mcp-servers/sync" in synced, synced
+    assert "context/settings/sync" not in synced, (
+        f"settings must stay skipped after an artifact failure, got {synced}"
+    )
+
+    # Partial-failure toast (real partial progress, not a hard abort): names a
+    # landed phase + the blocked one, rather than the bare "Sync failed".
+    page.wait_for_selector("#toast-container .toast.toast-error", timeout=4_000)
+    toast_text = (
+        page.locator("#toast-container .toast.toast-error .toast-msg").text_content() or ""
+    ).strip()
+    assert "Commands" in toast_text and "Skills" in toast_text, (
+        f"expected a partial-failure toast naming landed + blocked phases, got {toast_text!r}"
+    )
+
+
 def test_portal_sync_server_cwd_empty_scope_id(page, mm_web_url: str) -> None:
     """Server CWD's effective scope_id collapses to '' — its Sync fans out with
     no scope_id param (blocking parity with the removed matrix path)."""


### PR DESCRIPTION
## Summary

The Context Gateway **"Sync All"** fan-outs aborted every remaining artifact type as soon as one earlier phase hit a recoverable per-phase HTTP error (e.g. a `project_shared` privacy-block **422**). Because `skills` runs first, a single secret-bearing skill left the whole project unsynced with **zero partial progress**.

Both "Sync All" surfaces are client-side sequential loops over the per-type `POST /api/context/<type>/sync` routes, and both `break` on the first non-OK response:
- **Overview** Advanced "Sync All" (`context-gateway.js` ~L3102) — the repro in #1396.
- **Projects-card** "Sync All" (`context-gateway.js` ~L2478) — the same latent bug in the same feature; fixed here for parity.

## Fix

Mirror the backend `POST /api/context/sync-all` contract — *"Per-phase report, NOT cross-type all-or-nothing"*:

- On a per-phase **HTTP error response**, mark the phase `failed` and **continue** to the next type.
- Only a **transport failure** (`fetch` threw — the server is unreachable, so siblings would fail too) still aborts.
- The partial-failure toast now names **every** failed phase — derived from `phaseStates` (overview) / a `failedPhases` array (card). The reason stays the first failure's; the per-phase summary carries the rest.
- **Settings** stays gated behind a clean artifact run (unchanged — it often shares a root cause with artifact failures).

Why isolate *all* per-phase HTTP errors rather than just privacy blocks: the per-type 422 body is a string-only `{detail: ...}` (`SyncPhaseError`'s `reason_code` is consumed only by the server-side sync-all envelope, never serialized), so the client can't sniff "privacy block" from the wire. Isolating every per-phase HTTP error is both correct and the only robust option.

## Tests

- `tests-js/ctx-sync-all-progress.test.mjs`: new **first-phase privacy-block** case (asserts commands/agents/mcp-servers all POST after the skills 422); the mid-run-failure test now asserts the later type still syncs (`done`, not `not_run`).
- `tests/web/test_context_gateway_sync_all.py`: the two failure tests now assert siblings still fire + settings stays skipped.
- `tests/web/test_context_portal_card_sync.py`: new card-path isolation test.
- Cache-bust `context-gateway.js?v=93→94`.

Full vitest suite (317), the affected Playwright files (24), `test_i18n.py` (79), and `ruff` are green. Codex-reviewed → SHIP.

Closes #1396

🤖 Generated with [Claude Code](https://claude.com/claude-code)
