### PR TITLE
fix(web): Context Gateway force-unsafe sync confirm counts unique files (#1397)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -1490,10 +1490,17 @@ async function _ctxMaybeForceUnsafeSync(data, resync) {
   );
   if (!blocked.length) return null;
   const names = blocked.map(s => s.runtime || s.name).filter(Boolean);
+  // The sync skip tuple serializes one entry PER RUNTIME for the same artifact,
+  // so ``blocked.length`` is the runtime fan-out count, not the file count. The
+  // count and the warning list must agree on UNIQUE files — a security-sensitive
+  // "override secret detection" dialog overstating the affected-file count by
+  // the fan-out factor (e.g. "4 files" for 1 file × 4 runtimes) is misleading
+  // (#1397). Derive both from one de-duped list.
+  const uniqueNames = [...new Set(names)];
   const ok = await showConfirm({
     title: t('settings.ctx.force_unsafe_sync_title'),
-    message: t('settings.ctx.force_unsafe_sync_message', { count: blocked.length }),
-    warningText: [...new Set(names)].join('\n') || '—',
+    message: t('settings.ctx.force_unsafe_sync_message', { count: uniqueNames.length }),
+    warningText: uniqueNames.join('\n') || '—',
     confirmText: t('settings.ctx.force_unsafe_sync_btn'),
     // Overriding a secret-shape detection is the one sync action that warrants
     // the red button.

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1600,7 +1600,7 @@
   <script src="/settings-harness.js?v=4"></script>
   <script src="/settings-hooks-watchdog.js?v=21"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=94"></script>
+  <script src="/context-gateway.js?v=95"></script>
   <script src="/context-portal.js?v=7"></script>
   <script src="/wiki.js?v=6"></script>
   <script src="/path-picker.js?v=4"></script>

--- a/packages/memtomem/tests-js/ctx-sync-force-unsafe.test.mjs
+++ b/packages/memtomem/tests-js/ctx-sync-force-unsafe.test.mjs
@@ -74,6 +74,41 @@ describe('_ctxMaybeForceUnsafeSync (reviewed Gate A bypass on fan-out)', () => {
     expect(out).toEqual({ generated: [{ runtime: 'claude' }], skipped: [] });
   });
 
+  it('counts UNIQUE files, not per-runtime skip tuples (#1397)', async () => {
+    // The engine emits one privacy_blocked skip PER RUNTIME for the same
+    // artifact. The red confirm's count must match the de-duped file list it
+    // shows (1 file), not the runtime fan-out (4 tuples) — overstating the
+    // affected-file count in a "bypass secret detection" dialog is misleading.
+    const window = await boot();
+    const confirms = [];
+    window.showConfirm = async (opts) => { confirms.push(opts); return true; };
+    window.showToast = () => {};
+    const { I18N } = window;
+
+    const fourRuntimesOneFile = {
+      generated: [],
+      skipped: [
+        { runtime: 'user-secret', reason: 'privacy blocked', reason_code: 'privacy_blocked' },
+        { runtime: 'user-secret', reason: 'privacy blocked', reason_code: 'privacy_blocked' },
+        { runtime: 'user-secret', reason: 'privacy blocked', reason_code: 'privacy_blocked' },
+        { runtime: 'user-secret', reason: 'privacy blocked', reason_code: 'privacy_blocked' },
+      ],
+    };
+    const resync = resyncSpy([okResp({ generated: [{ runtime: 'claude' }], skipped: [] })]);
+    await window._ctxMaybeForceUnsafeSync(fourRuntimesOneFile, resync);
+
+    expect(confirms.length).toBe(1);
+    // Count matches the 1 unique file, NOT the 4 runtime tuples (the bug).
+    expect(confirms[0].message).toBe(
+      I18N.t('settings.ctx.force_unsafe_sync_message', { count: 1 }),
+    );
+    expect(confirms[0].message).not.toBe(
+      I18N.t('settings.ctx.force_unsafe_sync_message', { count: 4 }),
+    );
+    // The warning list shows the single file once (de-duped, same source).
+    expect(confirms[0].warningText).toBe('user-secret');
+  });
+
   it('returns null and re-syncs nothing when the override is declined', async () => {
     const window = await boot();
     window.showConfirm = async () => false;


### PR DESCRIPTION
## Summary

The Context Gateway **force-unsafe sync** confirm ("시크릿일 수 있는데도 동기화할까요?" / "… appear to contain secrets") **overstated the affected-file count**: it showed "**4 files**" while the warning list below listed only **1** unique file.

The engine emits one `privacy_blocked` skip tuple **per runtime** for the same artifact (the artifact name is serialized under the `runtime` key). `_ctxMaybeForceUnsafeSync` used `blocked.length` (the runtime fan-out count) for the message `{count}`, but de-duped the warning list with `new Set(...)` — so the count and the list disagreed by the fan-out factor (4× for a skill with 4 runtimes).

A security-sensitive "override secret detection" dialog overstating the affected-file count is misleading — a reviewer is told "4 files" when exactly 1 file is affected.

## Fix

Derive **both** the count and the warning list from one de-duped list:

```js
const uniqueNames = [...new Set(names)];
// message: { count: uniqueNames.length }
// warningText: uniqueNames.join('\n')
```

The **import** sibling (`_ctxMaybeForceUnsafeImport`) is intentionally left unchanged — import skips key on the file `name` with no per-runtime fan-out, so its `blocked.length` already equals the unique-file count (Codex confirmed).

## Tests

- `tests-js/ctx-sync-force-unsafe.test.mjs`: new case feeds 4 per-runtime tuples for **one** file and asserts the confirm reports `count: 1` (not `4`) with a single de-duped warning line.
- Full vitest suite (317), `test_i18n.py` (79) green. Codex-reviewed → SHIP.
- Cache-bust `context-gateway.js?v=93→95` (94 is reserved for the sibling Sync All isolation PR #1399).

Closes #1397

🤖 Generated with [Claude Code](https://claude.com/claude-code)
