### PR TITLE
docs(adr-0026): track the deferred P2 (D-B/D-C) in TRACKER.md

### DIFF
--- a/docs/adr/TRACKER.md
+++ b/docs/adr/TRACKER.md
@@ -32,6 +32,7 @@ pointer so a maintainer can scan due dates without opening each ADR.
 | 0022 §"Open questions" §1 | Skills versioning — directory-tree snapshot model (`versions/v1/<SKILL.md + assets>`) with the same label layer (v1 covers agents + commands only) | A concrete need to freeze/rollback a skill OR user-reported parity-gap pain vs agents/commands versioning (criteria in ADR §"Open questions") | (none — tracked in ADR) | (event-driven) |
 | 0027 §"Provisional decisions" D-A | in-browser wiki editor save→commit model | first dev-tier dogfooding of the now-shipped commit affordance; criteria in ADR-0027 §"Provisional decisions" | (none — tracked in ADR) | (event-driven) |
 | 0027 §"Provisional decisions" D-E | wiki editor privacy posture (soft-warn vs hard-gate) | wiki gains a configured push remote; criteria in ADR-0027 §D-E | (none — tracked in ADR) | (event-driven) |
+| 0026 §"Provisional decisions" D-B / D-C | P2 "Bold" re-frame — directional verb rename (D-B: Sync→Push↑ / Import→Pull↓) and status-merge to ahead/behind/in-sync (D-C) | The §Validation first-run user test clears the P2 gate: probe 5 overwrite-prediction ≥5/6 AND the status-merge keeps the create-vs-overwrite distinction (criteria in ADR-0026 §Validation) | [#1353](https://github.com/memtomem/memtomem/issues/1353) | (event-driven) |
 
 ## Adding a row
 


### PR DESCRIPTION
## Why

ADR-0026 §"Provisional decisions" closing line calls for a TRACKER.md row
once the ADR is **accepted with P2 deferred** — which became the case in
#1402, where the ADR status moved to "Accepted & partially shipped" with P2
left gated on the §Validation user test. That row was the one remaining
"due now" item on the #1353 checklist; this adds it.

## What (docs-only)

One row in `docs/adr/TRACKER.md` for the deferred P2 "Bold" re-frame:

- **Deferred question:** D-B (directional verb rename Sync→Push↑ /
  Import→Pull↓) + D-C (status-merge to ahead/behind/in-sync).
- **Trigger:** the §Validation first-run user test clears the P2 gate —
  probe 5 overwrite-prediction ≥5/6 AND the status-merge keeps the
  create-vs-overwrite distinction (criteria live in ADR-0026 §Validation,
  not duplicated here, per the tracker authoring rules).
- **Tracking issue:** #1353. **Next review:** event-driven.

D-B and D-C share the single §Validation trigger, so per the authoring
rules they get one combined row (ADR closing line: "a TRACKER.md row for
D-B/D-C").

Refs #1353
