### PR TITLE
feat(web): add a "Global wiki" scope chip to the Context Gateway Wiki pane

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=116" />
+  <link rel="stylesheet" href="/style.css?v=117" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -679,7 +679,10 @@
         <div class="settings-section" id="settings-ctx-wiki">
           <p class="settings-section-desc" data-i18n="settings.ctx.wiki_desc">Browse the global wiki (~/.memtomem-wiki) of canonical skills, subagents, and commands. Read-only in prod; in dev mode you can seed vendor overrides, edit canonical and override files, and commit — all in the browser.</p>
           <div class="ctx-header">
-            <h2 data-i18n="settings.ctx.wiki_title">Wiki</h2>
+            <div class="ctx-header-title">
+              <h2 data-i18n="settings.ctx.wiki_title">Wiki</h2>
+              <span class="badge wiki-scope-chip" data-i18n="settings.ctx.wiki_scope_chip">Global wiki</span>
+            </div>
             <div id="wiki-head" class="wiki-head"></div>
           </div>
           <div id="wiki-status"></div>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -430,6 +430,7 @@
   "settings.ctx.agents_title": "Subagents",
   "settings.ctx.mcp_servers_title": "MCP Servers",
   "settings.ctx.wiki_title": "Wiki",
+  "settings.ctx.wiki_scope_chip": "Global wiki",
   "settings.ctx.wiki_desc": "Browse the global wiki (~/.memtomem-wiki) of canonical skills, subagents, and commands. Read-only in prod; in dev mode you can seed vendor overrides, edit canonical and override files, and commit — all in the browser.",
   "settings.ctx.wiki_empty": "No wiki found",
   "settings.ctx.wiki_empty_hint": "Run `mm wiki init` to create ~/.memtomem-wiki, then reload.",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -430,6 +430,7 @@
   "settings.ctx.agents_title": "서브에이전트",
   "settings.ctx.mcp_servers_title": "MCP 서버",
   "settings.ctx.wiki_title": "위키",
+  "settings.ctx.wiki_scope_chip": "전역 위키",
   "settings.ctx.wiki_desc": "전역 위키(~/.memtomem-wiki)의 캐노니컬 스킬·서브에이전트·커맨드를 둘러봅니다. prod 에서는 읽기 전용, dev 모드에서는 벤더 오버라이드 시드, 캐노니컬·오버라이드 편집, 커밋까지 모두 브라우저에서 할 수 있습니다.",
   "settings.ctx.wiki_empty": "위키를 찾을 수 없음",
   "settings.ctx.wiki_empty_hint": "`mm wiki init` 으로 ~/.memtomem-wiki 를 만든 뒤 새로고침하세요.",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -4785,6 +4785,11 @@ button.ctx-runtime-chip--greyed:focus-visible {
 /* ── Wiki browser (ADR-0008 PR-E, ctx-wiki) ─────────────────────────────── */
 .wiki-head { display: flex; align-items: center; gap: 8px; font-size: 0.8rem; color: var(--muted); }
 .wiki-head-sha code { font-family: var(--mono); color: var(--text); }
+/* Always-on scope cue beside the Wiki heading: the wiki is host-global (one
+   ~/.memtomem-wiki shared by every project), unlike the project-scoped Context
+   Gateway artifacts. Passive/idle styling (var(--muted)) — it states scope, it
+   doesn't signal state, so it carries no role/aria. */
+.wiki-scope-chip { background: rgba(123, 127, 150, 0.12); color: var(--muted); border: 1px solid var(--border); font-weight: 500; }
 .wiki-group { margin-bottom: 16px; }
 .wiki-group-title { font-size: 0.9rem; margin: 0 0 6px; display: flex; align-items: center; gap: 6px; }
 .wiki-group-count { font-size: 0.72rem; color: var(--muted); background: rgba(123, 127, 150, 0.15); border-radius: 10px; padding: 1px 7px; }

--- a/packages/memtomem/tests/web/test_wiki_gateway.py
+++ b/packages/memtomem/tests/web/test_wiki_gateway.py
@@ -600,3 +600,44 @@ def test_wiki_commit_stale_head_refreshes(page, mm_web_url: str) -> None:
         timeout=5_000,
     )
     assert page.locator("#wiki-commit-btn").count() == 0
+
+
+def test_wiki_scope_chip_renders_and_localizes(page, mm_web_url: str) -> None:
+    """PR-1b scope chip (ADR-0008 / plan #1353): the Wiki pane carries an
+    always-on "Global wiki" scope chip beside the heading so even a read-only
+    (prod) browser sees the host-global scope without entering dev mode. Pin the
+    three properties only a real browser exercises:
+
+    * it renders inside the Wiki section host (``#settings-ctx-wiki``) and is the
+      sole chip — NOT injected into the Projects-owned
+      ``#ctx-portal-heading-chips`` (a different DOM host);
+    * it resolves through the ``settings.ctx.wiki_scope_chip`` i18n key, so a
+      mid-view language switch repaints it (static ``data-i18n`` → applyDOM);
+    * the English default reads "Global wiki" and Korean "전역 위키"."""
+    install_default_stubs(page)
+    _stub_wiki(page)
+    page.goto(mm_web_url)
+    _open_wiki(page)
+
+    chip = page.locator("#settings-ctx-wiki .wiki-scope-chip")
+    chip.wait_for(state="visible", timeout=5_000)
+    assert chip.inner_text().strip() == "Global wiki"
+
+    # Exactly one chip, and it never lives in the Projects heading-chips host.
+    assert page.locator(".wiki-scope-chip").count() == 1
+    assert page.locator("#ctx-portal-heading-chips .wiki-scope-chip").count() == 0
+    # Pin the exact placement contract: it sits in the heading-title wrapper and
+    # never inside the langchange-repainted #wiki-head row — a future JS-rendered
+    # chip in #wiki-head (the inject-clobber host this design avoids) must fail.
+    assert page.locator("#settings-ctx-wiki .ctx-header-title > .wiki-scope-chip").count() == 1
+    assert page.locator("#wiki-head .wiki-scope-chip").count() == 0
+
+    # langchange repaints the static data-i18n chip via applyDOM (ko locale).
+    page.evaluate("async () => { await I18N.setLang('ko'); }")
+    page.wait_for_function(
+        "() => {"
+        "  const el = document.querySelector('#settings-ctx-wiki .wiki-scope-chip');"
+        "  return el && el.textContent.trim() === '전역 위키';"
+        "}",
+        timeout=5_000,
+    )


### PR DESCRIPTION
## What

Adds an always-on **"Global wiki"** scope chip beside the heading of the Context
Gateway → Wiki pane.

The Wiki pane manages a **host-global** artifact library (`~/.memtomem-wiki`, one
copy shared by every project), but nothing on the pane stated that scope. A
read-only (prod) browser only saw the bare "Wiki" heading, with no cue that
edits here differ from the project-scoped Context Gateway artifacts. This is the
prod-visible half of the scope signal called for in the wiki usability plan
(P1, "Clarify Wiki's global placement in Context Gateway"); the dev-tier
Install/Update copy carries the global→project transition separately.

## Why static markup (not a JS-injected node)

The chip is static markup carrying a `data-i18n` key, **not** injected by
`_renderWikiHead`, because:

- it must be visible to **every** user, including the prod read-only browser
  (which never enters the dev render paths);
- `applyDOM` localizes it on `langchange` with no manual wiring;
- it lives in the wiki section host (`#settings-ctx-wiki`, inside a
  `.ctx-header-title` wrapper) — never the Projects-owned
  `#ctx-portal-heading-chips`, and never inside the langchange-repainted
  `#wiki-head` row, so there is no inject-clobber.

It is a passive scope badge (muted styling, no `role`/`aria`): it states scope,
it does not signal state — matching the repo's a11y convention for static
badges.

## Changes

- `index.html` — wrap the Wiki `<h2>` in `.ctx-header-title` and add the chip
  span; bump `style.css?v=116 → 117`.
- `style.css` — new `.wiki-scope-chip` rule (passive `var(--muted)` badge).
- `en.json` / `ko.json` — new `settings.ctx.wiki_scope_chip`
  ("Global wiki" / "전역 위키"); `wiki.js` / `app.js` deliberately **not** bumped
  (no JS change).
- `test_wiki_gateway.py` — Playwright regression test: the chip renders in the
  Wiki pane, is the sole `.wiki-scope-chip`, sits in `.ctx-header-title`, stays
  out of both `#ctx-portal-heading-chips` and `#wiki-head`, and localizes
  en→ko on `langchange`.

## Verification (full web/static four-gate)

- `test_i18n.py` + `test_web_invariants_registry.py` — 84 passed (clears the
  #1404 namespace jargon guard, key/placeholder parity, glossary).
- Playwright `test_wiki_gateway.py` — 12 passed (incl. the new chip test).
- vitest `wiki` + `ctx-a11y` — 44 passed.
- `ruff check` + `ruff format --check` — clean.
- Stale-string sweep: no new raw-git phrasing introduced (the pre-existing
  `wiki_cmd.py` override hint is PR-2's scope, untouched here).

Codex review: **SHIP** (no blockers/majors; the one nit — pinning the exact
`.ctx-header-title` / not-`#wiki-head` placement — is folded into the test).

Refs #1353

🤖 Generated with [Claude Code](https://claude.com/claude-code)
