### PR TITLE
fix(cli): point `mm wiki override` and help text at the isolated commit, not raw git

### DIFF
--- a/packages/memtomem/src/memtomem/cli/wiki_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/wiki_cmd.py
@@ -49,7 +49,12 @@ _COMMAND_VENDORS = override_vendors("commands")
 
 @click.group("wiki")
 def wiki() -> None:
-    """Manage the local memtomem wiki (skills/agents/commands library)."""
+    """Manage the host-global wiki (~/.memtomem-wiki) of canonical skills, agents, and commands.
+
+    These commands edit, check, and commit the host-global wiki itself. Use
+    mm context install / mm context update to copy committed wiki artifacts into
+    a project's .memtomem/ directory.
+    """
 
 
 def _run_seed_override(
@@ -92,13 +97,17 @@ def _run_seed_override(
     # No is_relative_to fallback — a violation is a real bug worth
     # surfacing as ValueError, not a silent path mismatch to mask.
     rel = result.path.relative_to(store.root)
-    ext = result.path.suffix.lstrip(".")
-    # ``as_posix()`` matches the hardcoded ``/`` in the ``git add`` hint below.
+    # ``as_posix()`` keeps the displayed relative path forward-slashed on Windows.
     click.secho(f"Seeded {rel.as_posix()}", fg="green")
     click.echo(str(result.path))
+    # Steer to the target-isolated commit, not a raw ``git add``/``git commit``
+    # (which would sweep unrelated staged changes). ``override`` only seeds the
+    # vendor file, so the hint points at ``--vendor`` — never ``--canonical``.
+    singular = asset_type[:-1]  # "skills" -> "skill": the per-type CLI verb is singular
+    click.echo(f"# next: mm wiki {singular} commit {name} --vendor {vendor}")
     click.echo(
-        f"# next: cd {store.root} && "
-        f"git add {asset_type}/{name}/overrides/{vendor}.{ext} && git commit"
+        f"# then: cd <project> && mm context install {singular} {name}"
+        "   # or update an installed copy"
     )
 
     if result.dropped:
@@ -337,7 +346,7 @@ def _run_commit(
     help="Clone the wiki from a git URL instead of initializing from scratch.",
 )
 def init_cmd(from_url: str | None) -> None:
-    """Create or clone the wiki at ``~/.memtomem-wiki/``."""
+    """Create or clone the wiki at ~/.memtomem-wiki/."""
     store = WikiStore.at_default()
     try:
         if from_url:
@@ -391,7 +400,10 @@ def list_cmd(asset_type: str | None) -> None:
 
 @wiki.group("skill")
 def skill_group() -> None:
-    """Per-skill operations on the wiki (override seeding, ...)."""
+    """Manage wiki skills.
+
+    Seed vendor overrides, then diff, lint, and commit selected paths.
+    """
 
 
 @skill_group.command("override")
@@ -421,8 +433,10 @@ def skill_override_cmd(name: str, vendor: str, force: bool, editor: bool) -> Non
     ``mm wiki skill override <name> --vendor <claude|gemini|codex|kimi>`` writes
     ``<wiki>/skills/<name>/overrides/<vendor>.md`` using the canonical
     ``SKILL.md`` as the working baseline. Edit the file (``--editor`` opens
-    ``$EDITOR``) and commit it inside the wiki repo so that future
-    ``mm context install`` snapshots pick it up.
+    ``$EDITOR``), then record it with
+    ``mm wiki skill commit <name> --vendor <vendor>`` (or the in-browser Commit
+    button) so a later ``mm context install`` can snapshot it — no raw ``git``
+    needed.
     """
     _run_seed_override("skills", name, vendor, force=force, editor=editor)
 
@@ -507,7 +521,10 @@ def skill_commit_cmd(
 
 @wiki.group("agent")
 def agent_group() -> None:
-    """Per-agent operations on the wiki (override seeding, ...)."""
+    """Manage wiki agents.
+
+    Seed vendor overrides, then diff, lint, and commit selected paths.
+    """
 
 
 @agent_group.command("override")
@@ -540,7 +557,9 @@ def agent_override_cmd(name: str, vendor: str, force: bool, editor: bool) -> Non
     matches what the runtime would produce. Fields the vendor format
     cannot represent (e.g. gemini agents drop ``skills`` / ``isolation``)
     are surfaced via a stderr warning so the editor knows what the
-    runtime won't see.
+    runtime won't see. Record the seeded override with
+    ``mm wiki agent commit <name> --vendor <vendor>`` so a later
+    ``mm context install`` can snapshot it.
     """
     _run_seed_override("agents", name, vendor, force=force, editor=editor)
 
@@ -625,7 +644,10 @@ def agent_commit_cmd(
 
 @wiki.group("command")
 def command_group() -> None:
-    """Per-command operations on the wiki (override seeding, ...)."""
+    """Manage wiki commands.
+
+    Seed vendor overrides, then diff, lint, and commit selected paths.
+    """
 
 
 @command_group.command("override")
@@ -658,7 +680,9 @@ def command_override_cmd(name: str, vendor: str, force: bool, editor: bool) -> N
     command surfaces a classified error rather than silently failing.
     Fields the vendor format cannot represent (e.g. gemini commands drop
     ``argument-hint`` / ``allowed-tools`` / ``model``) are surfaced via a
-    stderr warning so the editor knows what the runtime won't see.
+    stderr warning so the editor knows what the runtime won't see. Record the
+    seeded override with ``mm wiki command commit <name> --vendor <vendor>`` so
+    a later ``mm context install`` can snapshot it.
     """
     _run_seed_override("commands", name, vendor, force=force, editor=editor)
 

--- a/packages/memtomem/tests/test_wiki_cmd_override.py
+++ b/packages/memtomem/tests/test_wiki_cmd_override.py
@@ -296,9 +296,13 @@ def test_wiki_skill_override_stdout_contract(wiki_root: Path) -> None:
     # Bare absolute path on its own line for shell capture.
     target_path = wiki_root / "skills" / "hello" / "overrides" / "codex.md"
     assert target_path.as_posix() in out
-    # Commit hint mentioning git commit.
-    assert "git commit" in out
-    assert "git add skills/hello/overrides/codex.md" in out
+    # Isolated-commit-first hint: points at ``mm wiki skill commit ... --vendor``
+    # (override only seeds the vendor file), then the project install step — never
+    # a raw ``git add``/``git commit`` that would sweep unrelated staged changes.
+    assert "mm wiki skill commit hello --vendor codex" in out
+    assert "mm context install skill hello" in out
+    assert "git add" not in out
+    assert "git commit" not in out
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -480,8 +484,10 @@ def test_wiki_agent_override_stdout_contract(wiki_root: Path) -> None:
     assert "Seeded agents/demo/overrides/codex.toml" in out
     target_path = wiki_root / "agents" / "demo" / "overrides" / "codex.toml"
     assert target_path.as_posix() in out
-    assert "git commit" in out
-    assert "git add agents/demo/overrides/codex.toml" in out
+    assert "mm wiki agent commit demo --vendor codex" in out
+    assert "mm context install agent demo" in out
+    assert "git add" not in out
+    assert "git commit" not in out
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -671,8 +677,10 @@ def test_wiki_command_override_stdout_contract(wiki_root: Path) -> None:
     assert "Seeded commands/demo/overrides/gemini.toml" in out
     target_path = wiki_root / "commands" / "demo" / "overrides" / "gemini.toml"
     assert target_path.as_posix() in out
-    assert "git commit" in out
-    assert "git add commands/demo/overrides/gemini.toml" in out
+    assert "mm wiki command commit demo --vendor gemini" in out
+    assert "mm context install command demo" in out
+    assert "git add" not in out
+    assert "git commit" not in out
 
 
 # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Corrects the `mm wiki` CLI to steer users to the **target-isolated commit**
flow instead of raw git, and tightens the wiki help text (plan: "CLI help and
post-override hint").

### Post-`override` hint

After `mm wiki {skill,agent,command} override`, the hint printed a raw
`cd <wiki> && git add <path> && git commit` — which bypasses the
`mm wiki <type> commit` engine that commits only resolved target paths
(protecting unrelated staged changes). It now prints:

```
# next: mm wiki <type> commit <name> --vendor <vendor>
# then: cd <project> && mm context install <type> <name>   # or update an installed copy
```

`override` seeds only the vendor file, so the hint uses `--vendor` (never
`--canonical`). The singular CLI verb is derived from the plural asset dir
(`asset_type[:-1]`); the now-unused `ext` local is removed with the old hint.

### Help text

- top-level `mm wiki` docstring states the mental model: the wiki is
  host-global; `mm context install/update` projects committed artifacts into a
  project;
- the skill/agent/command subgroup docstrings drop the `(override seeding, ...)`
  ellipsis — a short first line keeps `mm wiki --help` untruncated while the
  body enumerates the full command set;
- the three override-command docstrings repoint off "commit it inside the wiki
  repo" to `mm wiki <type> commit <name> --vendor <vendor>`;
- the `init` short summary drops literal RST double-backticks so `--help`
  reads cleanly.

### Tests

The three override stdout-contract tests now **positively** pin the new
`mm wiki <type> commit … --vendor` + `mm context install` hint and
**negatively** assert no raw `git add`/`git commit` survives.

## Verification

- `ruff check` + `ruff format --check` — clean; `mypy` (advisory) — clean.
- `pytest test_wiki_cmd{,_override,_diff_lint,_commit}.py` — 87 passed.
- `mm wiki --help` + subgroup `--help` render cleanly; `mm` ≡ `memtomem` alias
  parity intact.
- Widened raw-git stale-string sweep over `src` + `docs` is clean (the safe
  "never a bare `git add . && git commit`" framing on the commit commands is
  deliberately retained).
- 5-agent adversarial verification + Codex review (SHIP after folding in the
  subgroup help-list fix).

## Out of scope (noted)

Individual `override`/`diff`/`lint`/`commit` command summaries still truncate
with Click's auto-`…` in subgroup `--help` lists — this is pre-existing,
CLI-wide behavior (any long first line), not specific to this change. A
repo-wide `short_help=` pass would be a separate cosmetic PR.

Refs #1353

🤖 Generated with [Claude Code](https://claude.com/claude-code)
