### PR TITLE
feat(web): ADR-0026 first-run validation harness + staged D-F Simple-as-default switch point

### DIFF
--- a/docs/adr/0026-context-gateway-onboarding-ia.md
+++ b/docs/adr/0026-context-gateway-onboarding-ia.md
@@ -309,7 +309,7 @@ drifted.
 | P0-4 confirm/glossary de-jargon — `move_copy_shared_confirm_message` rewritten (now "…into the project's shared store — committed to git…", no raw `canonical`/`project_shared`); scope-ID tooltips; nav glossary *defines* "canonical" | **Shipped** | #1356 (confirm rewrite); de-jargon companion PRs #1368 / #1375 (under issue #1352) |
 | **P1a — Simple-mode scaffold** — Simple/Advanced `localStorage` toggle, read-only, **Advanced default** (D-F staged opt-in) | **Shipped** | #1358 |
 | **P1b — Simple-mode inline actions** — per-type Sync/Import rows, cross-tier empty-state summary (D-D lean iii), 3-state Simple labels | **Shipped** | #1360 |
-| **P1 — Simple-as-default flip** (D-F) | **Deferred** — gated on the §Validation user test | — |
+| **P1 — Simple-as-default flip** (D-F) | **Staged** — the switch point (`context-gateway.js` `_CTX_SIMPLE_DEFAULT`) and the §Validation harness are in place; the live default **stays Advanced** (`_CTX_SIMPLE_DEFAULT = false`) until the §Validation user test clears probes 1–3. The flip itself = set the constant `true`, then a follow-up PR (deep-link scoping tighten + reference.md copy) flips this row to Shipped. Still gated on the user test. | staged (switch point + harness) |
 | **P2 — Bold** — Push/Pull verb rename, status collapse to ahead/behind/in-sync (D-B / D-C) | **Deferred** — gated on the §Validation user test | — |
 
 **§Validation status:**

--- a/docs/adr/0026-context-gateway-onboarding-ia.md
+++ b/docs/adr/0026-context-gateway-onboarding-ia.md
@@ -364,6 +364,19 @@ probes 1–3 succeed for ≥4/6 without docs; P2 is gated on probe 5
 succeeding for ≥5/6 and the status-merge not costing power users the
 create-vs-overwrite distinction.
 
+### Reproducing the first-run state
+
+`seed_adr0026_validation_states`
+(`packages/memtomem/tests/fixtures/ctx_validation_states.py`) seeds the six
+probe affordances above into one project — out-of-sync, not-yet-imported, empty
+type, MCP orphan, MCP parse-error, and an in-sync baseline — so every
+participant sees the same Overview. `test_ctx_validation_harness.py` pins the
+seed against the real diff engine, including the easy-to-invert Store-vs-runtime
+direction (a runtime-only artifact reads as "Not yet imported", never "Out of
+sync"), so it cannot silently rot. It is version-controlled (not the gitignored
+`scripts/` tree) so it stays in lockstep with the moderated facilitator protocol
+that consumes it.
+
 ## Provisional decisions
 
 These are the author's **recommended leans**, filled in so the ADR reads

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -530,11 +530,20 @@ try {
 // default off so power users are unaffected until the post-validation
 // default-flip lands.
 const _CTX_SIMPLE_MODE_KEY = 'memtomem_ctx_simple_mode';
-let _ctxSimpleMode = false;
+// D-F staged flip switch point (ADR-0026 §"Implementation status"). This is the
+// default used WHEN NO value is stored. It stays ``false`` (Advanced default)
+// until the §Validation first-run user test clears probes 1-3; flipping it to
+// ``true`` makes Simple the default-when-unset and is the entire mechanical flip
+// (see the ADR-0026 §Validation runbook). While it is ``false`` the explicit
+// read below is byte-identical to the old ``=== '1'`` form, so this refactor
+// changes nothing today — it only isolates the one line the live flip will edit.
+const _CTX_SIMPLE_DEFAULT = false;
+let _ctxSimpleMode = _CTX_SIMPLE_DEFAULT;
 try {
-  _ctxSimpleMode = localStorage.getItem(_CTX_SIMPLE_MODE_KEY) === '1';
+  const stored = localStorage.getItem(_CTX_SIMPLE_MODE_KEY);
+  _ctxSimpleMode = stored !== null ? stored === '1' : _CTX_SIMPLE_DEFAULT;
 } catch {
-  _ctxSimpleMode = false;
+  _ctxSimpleMode = _CTX_SIMPLE_DEFAULT;
 }
 
 // Toggle the ``.ctx-simple`` class on the gateway tab (CSS hides the nav +

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1603,7 +1603,7 @@
   <script src="/settings-harness.js?v=4"></script>
   <script src="/settings-hooks-watchdog.js?v=21"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=96"></script>
+  <script src="/context-gateway.js?v=97"></script>
   <script src="/context-portal.js?v=7"></script>
   <script src="/wiki.js?v=6"></script>
   <script src="/path-picker.js?v=4"></script>

--- a/packages/memtomem/tests/fixtures/ctx_validation_states.py
+++ b/packages/memtomem/tests/fixtures/ctx_validation_states.py
@@ -1,0 +1,207 @@
+"""First-run validation harness for ADR-0026 §Validation.
+
+Seeds a project on disk so the Context Gateway Overview surfaces all six
+user-test affordances at once, giving a moderator a reproducible first-run
+state to drive the lightweight 5-6 participant test described in ADR-0026
+§Validation.
+
+The six affordances (one per §Validation probe family):
+
+============  ===================================================  ============
+affordance    on-disk recipe                                       Overview tile
+============  ===================================================  ============
+out of sync   canonical in every runtime; only Claude differs      skills
+not imported  runtime-only artifact, no canonical                  commands
+empty type    nothing seeded for the type                          agents
+mcp orphan    ``.mcp.json`` entry with no canonical definition     mcp_servers
+parse error   malformed *canonical* mcp-server json (valid         mcp_servers
+              ``.mcp.json``)
+in sync       canonical byte-identical in every runtime            skills
+============  ===================================================  ============
+
+The two skills are seeded into *every* skill runtime (not just Claude) so the
+only drift rows are the intended ones — a Claude-only seed would emit a spurious
+``missing target`` row per skill per other runtime and bury the signal.
+
+Direction matters and is easy to invert: the **Store** is ``.memtomem/`` and
+**runtimes** are ``.claude/`` etc. A runtime-only artifact reads as "Not yet
+imported" (pull into the Store); a Store artifact with a stale/missing runtime
+copy reads as "Out of sync" (push to the runtime). ``test_ctx_validation_harness``
+pins both directions against the real diff engine so a future edit cannot
+silently swap them.
+
+This module lives under version control (``tests/fixtures/``) on purpose — the
+gitignored ``scripts/`` tree cannot hold the harness the runbook depends on, and
+keeping the seeder beside its guard test keeps the two in lockstep.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from memtomem.context._runtime_targets import runtime_fanout_root
+from memtomem.context.mcp_servers import CANONICAL_MCP_SERVER_ROOT, PROJECT_MCP_CONFIG
+from memtomem.context.skills import CANONICAL_SKILL_ROOT, SKILL_GENERATORS, SKILL_MANIFEST
+
+# Names chosen to read naturally under the §Validation framing task
+# ("get this project's skills into Claude Code").
+SKILL_OUT_OF_SYNC = "code-review"
+SKILL_IN_SYNC = "commit-helper"
+COMMAND_NOT_IMPORTED = "summarize"
+MCP_ORPHAN = "orphan-server"
+MCP_PARSE_ERROR = "broken-server"
+
+# The Claude runtime is the one named in the framing task; deriving its fan-out
+# root from the production table (rather than hard-coding ".claude/skills")
+# means the seeder follows any future relocation of the runtime layout.
+_RUNTIME = "claude"
+_SCOPE = "project_shared"
+
+
+def _write_lf(path: Path, content: str) -> None:
+    """Write fixtures with sync-style LF bytes on every platform.
+
+    Byte-for-byte LF (never CRLF) so the in-sync baseline compares equal to its
+    runtime copy on Windows too — mirrors ``_write_text_lf`` in the web route
+    tests.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content.encode("utf-8"))
+
+
+def _runtime_root(artifact: str, project_root: Path) -> Path:
+    root = runtime_fanout_root(artifact, _RUNTIME, _SCOPE, project_root)
+    if root is None:  # pragma: no cover - claude has a project_shared fan-out
+        raise RuntimeError(
+            f"no {_RUNTIME} fan-out root for {artifact!r}; the runtime table changed"
+        )
+    return root
+
+
+def _skill_runtime_roots(project_root: Path) -> dict[str, Path]:
+    """Every runtime ``diff_skills`` fans skills out to, keyed by runtime name.
+
+    Seeding a canonical skill into *all* of these (not just Claude) is what
+    keeps the diff to a single intended row: a Claude-only copy would leave the
+    other runtimes empty and emit a spurious ``missing target`` row per skill
+    per runtime, drowning the out-of-sync / in-sync signal the probes rely on.
+    Derived from ``SKILL_GENERATORS`` so it tracks ``diff_skills`` exactly.
+    """
+    roots: dict[str, Path] = {}
+    for gen_name in SKILL_GENERATORS:
+        runtime = gen_name.split("_", 1)[0]
+        root = runtime_fanout_root("skills", runtime, _SCOPE, project_root)
+        if root is not None:
+            roots[runtime] = root
+    return roots
+
+
+def seed_adr0026_validation_states(project_root: Path) -> dict[str, Any]:
+    """Seed the six ADR-0026 §Validation affordances under ``project_root``.
+
+    Idempotent (overwrites in place). Returns a manifest describing what was
+    written and the per-tile Overview verdict each state should produce, so the
+    guard test and the moderator runbook can assert against a single source.
+    """
+    project_root = Path(project_root)
+    project_root.mkdir(parents=True, exist_ok=True)
+
+    # A project-root marker so ``mm`` / ``_find_project_root`` treat the seeded
+    # directory as a project (cheapest marker, mirrors the CLI e2e seeder).
+    pyproject = project_root / "pyproject.toml"
+    if not pyproject.exists():
+        pyproject.write_text(
+            '[project]\nname = "adr0026-firstrun-fixture"\nversion = "0.0.0"\n',
+            encoding="utf-8",
+        )
+
+    skill_canon = project_root / CANONICAL_SKILL_ROOT
+    mcp_canon = project_root / CANONICAL_MCP_SERVER_ROOT
+    skill_runtimes = _skill_runtime_roots(project_root)
+    cmd_runtime = _runtime_root("commands", project_root)
+
+    # (a) OUT OF SYNC — the canonical exists in EVERY skill runtime, but only the
+    # Claude copy diverges. Seeding all runtimes (not just Claude) keeps the diff
+    # to a single "out of sync" row instead of one spurious "missing target" row
+    # per skill per other runtime, which would otherwise dominate the tile.
+    review_canonical = (
+        f"# {SKILL_OUT_OF_SYNC}\n\nStore version (v2): reviews diffs for correctness.\n"
+    )
+    review_claude_stale = f"# {SKILL_OUT_OF_SYNC}\n\nRuntime version (v1): older copy in Claude.\n"
+    _write_lf(skill_canon / SKILL_OUT_OF_SYNC / SKILL_MANIFEST, review_canonical)
+    for runtime, root in skill_runtimes.items():
+        body = review_claude_stale if runtime == _RUNTIME else review_canonical
+        _write_lf(root / SKILL_OUT_OF_SYNC / SKILL_MANIFEST, body)
+
+    # (f) IN SYNC — canonical byte-identical in every skill runtime (baseline +
+    # the P5 "already synced, what does Sync do to it?" item).
+    in_sync_body = f"# {SKILL_IN_SYNC}\n\nWrites Conventional Commit messages.\n"
+    _write_lf(skill_canon / SKILL_IN_SYNC / SKILL_MANIFEST, in_sync_body)
+    for root in skill_runtimes.values():
+        _write_lf(root / SKILL_IN_SYNC / SKILL_MANIFEST, in_sync_body)
+
+    # (b) NOT YET IMPORTED — runtime-only command, no canonical in the Store.
+    _write_lf(
+        cmd_runtime / f"{COMMAND_NOT_IMPORTED}.md",
+        f"# {COMMAND_NOT_IMPORTED}\n\nRuntime-only command not yet in the Store.\n",
+    )
+
+    # (c) EMPTY TYPE — agents: seed nothing. (left intentionally empty)
+
+    # (d) MCP ORPHAN + (e) PARSE ERROR both live on the mcp_servers tile.
+    # The .mcp.json itself MUST stay valid JSON: a broken .mcp.json poisons
+    # EVERY canonical mcp row as "parse error" and would destroy the orphan.
+    # The parse error is a malformed *canonical* definition instead.
+    _write_lf(
+        project_root / PROJECT_MCP_CONFIG,
+        json.dumps(
+            {"mcpServers": {MCP_ORPHAN: {"command": "python", "args": ["-m", "orphan"]}}},
+            indent=2,
+        )
+        + "\n",
+    )
+    # Malformed canonical JSON (truncated object) -> McpServerParseError.
+    _write_lf(mcp_canon / f"{MCP_PARSE_ERROR}.json", '{"command": ')
+
+    return {
+        "project_root": str(project_root),
+        "runtime": _RUNTIME,
+        "framing_task": "get this project's skills into Claude Code",
+        "states": {
+            "out_of_sync": {
+                "tile": "skills",
+                "name": SKILL_OUT_OF_SYNC,
+                "diff_status": "out of sync",
+                "verdict": "needs_sync",
+                "action": "Sync",
+            },
+            "not_yet_imported": {
+                "tile": "commands",
+                "name": COMMAND_NOT_IMPORTED,
+                "diff_status": "missing canonical",
+                "verdict": "not_saved",
+                "action": "Import",
+            },
+            "empty_type": {"tile": "agents", "diff_status": None, "verdict": "empty"},
+            "mcp_orphan": {
+                "tile": "mcp_servers",
+                "name": MCP_ORPHAN,
+                "diff_status": "missing canonical",
+                "action": "Manage",
+            },
+            "parse_error": {
+                "tile": "mcp_servers",
+                "name": MCP_PARSE_ERROR,
+                "diff_status": "parse error",
+                "verdict": "attention",
+                "action": "Manage",
+            },
+            "in_sync": {
+                "tile": "skills",
+                "name": SKILL_IN_SYNC,
+                "diff_status": "in sync",
+            },
+        },
+    }

--- a/packages/memtomem/tests/test_ctx_validation_harness.py
+++ b/packages/memtomem/tests/test_ctx_validation_harness.py
@@ -1,0 +1,135 @@
+"""Guard the ADR-0026 §Validation first-run harness against silent rot.
+
+These are pure-Python tests against the *real* diff engine — no browser. They
+exist so the seeder in ``fixtures/ctx_validation_states.py`` keeps producing the
+six distinct user-test affordances, and in particular so the Store-vs-runtime
+direction (the bug class called out in the seeder docstring) can never silently
+invert: "Not yet imported" must stay a runtime-only / ``missing canonical`` row,
+not a ``missing target`` row.
+
+There is deliberately no committed Playwright test here: how each diff status
+renders as a tile verdict/button is already covered by
+``tests/web/test_context_gateway_overview.py`` and
+``tests/web/test_context_gateway_simple_mode.py``. The risk this module owns is
+the *seed* (pure data), so it asserts the engine output the Overview is built
+from. The live-UI check is the moderator's manual dry-run, documented in the
+ADR-0026 §Validation runbook.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fixtures.ctx_validation_states import seed_adr0026_validation_states
+
+from memtomem.context.agents import canonical_agent_name, diff_agents, list_canonical_agents
+from memtomem.context.commands import (
+    canonical_command_name,
+    diff_commands,
+    list_canonical_commands,
+)
+from memtomem.context.mcp_servers import diff_mcp_servers, list_canonical_mcp_servers
+from memtomem.context.skills import diff_skills, list_canonical_skills
+from memtomem.context.status import summarize_diff_with_canonical
+
+_SCOPE = "project_shared"
+
+
+def _triples(rows) -> list[tuple[str, str, str]]:
+    # DiffRow iterates as the historical 3-tuple; normalise for membership.
+    return [tuple(r)[:3] for r in rows]
+
+
+def test_seed_produces_six_distinct_diff_states(tmp_path: Path) -> None:
+    manifest = seed_adr0026_validation_states(tmp_path)
+    runtime = manifest["runtime"]
+
+    # (a) out of sync + (f) in sync — both Store-side artifacts the runtime has.
+    skills = _triples(diff_skills(tmp_path, scope=_SCOPE))
+    assert (f"{runtime}_skills", "code-review", "out of sync") in skills
+    assert (f"{runtime}_skills", "commit-helper", "in sync") in skills
+
+    # (b) not yet imported — DIRECTION GUARD. A runtime-only artifact must read
+    # as "missing canonical" (pull into the Store / Import), NEVER "missing
+    # target" (which would mean the seed wrote the Store side by mistake).
+    commands = _triples(diff_commands(tmp_path, scope=_SCOPE))
+    assert (f"{runtime}_commands", "summarize", "missing canonical") in commands
+    assert all(status != "missing target" for _rt, _name, status in commands), (
+        "command seed inverted: a 'missing target' row means the runtime-only "
+        "artifact was written to the Store, breaking the Import affordance"
+    )
+
+    # (c) empty type — agents seeded with nothing.
+    assert _triples(diff_agents(tmp_path, scope=_SCOPE)) == []
+
+    # (d) mcp orphan + (e) parse error — both independently visible. A broken
+    # .mcp.json would collapse BOTH into parse_error, so assert orphan survives.
+    mcp = _triples(diff_mcp_servers(tmp_path))
+    assert ("project_mcp", "orphan-server", "missing canonical") in mcp
+    assert ("project_mcp", "broken-server", "parse error") in mcp
+
+    # The manifest the runbook quotes stays honest about what the engine emits.
+    for state in manifest["states"].values():
+        expected = state.get("diff_status")
+        if expected is None:
+            continue
+        all_rows = skills + commands + mcp
+        assert any(row[1] == state.get("name") and row[2] == expected for row in all_rows), (
+            f"manifest claims {state} but the engine did not emit it"
+        )
+
+
+def test_seed_overview_summary_verdicts(tmp_path: Path) -> None:
+    """The per-tile summaries (exactly what ``/context/overview`` builds) must
+    roll up to the intended Simple-mode verdicts."""
+    seed_adr0026_validation_states(tmp_path)
+
+    skills = summarize_diff_with_canonical(
+        diff_skills(tmp_path, scope=_SCOPE),
+        {p.name for p in list_canonical_skills(tmp_path, scope=_SCOPE)},
+    )
+    # out_of_sync -> _ctxSimpleVerdict needs_sync (Sync). The seed populates
+    # EVERY skill runtime, so there must be NO spurious "missing target" rows
+    # (a Claude-only seed would emit one per skill per other runtime and drown
+    # the intended out-of-sync signal — see the docstring of _skill_runtime_roots).
+    assert skills.get("out_of_sync", 0) == 1
+    assert skills.get("in_sync", 0) >= 1
+    assert skills.get("missing_target", 0) == 0
+
+    commands = summarize_diff_with_canonical(
+        diff_commands(tmp_path, scope=_SCOPE),
+        {
+            canonical_command_name(p, layout)
+            for p, layout in list_canonical_commands(tmp_path, scope=_SCOPE)
+        },
+    )
+    # missing_canonical with no needs_sync signal -> not_saved (Import).
+    assert commands.get("missing_canonical", 0) == 1
+    assert commands.get("out_of_sync", 0) == 0
+    assert commands.get("missing_target", 0) == 0
+
+    agents = summarize_diff_with_canonical(
+        diff_agents(tmp_path, scope=_SCOPE),
+        {
+            canonical_agent_name(p, layout)
+            for p, layout in list_canonical_agents(tmp_path, scope=_SCOPE)
+        },
+    )
+    assert agents.get("total", -1) == 0  # -> empty-state CTA
+
+    mcp = summarize_diff_with_canonical(
+        diff_mcp_servers(tmp_path),
+        {p.stem for p in list_canonical_mcp_servers(tmp_path)},
+    )
+    # parse_error outranks missing_canonical in _ctxSimpleVerdict -> attention;
+    # both rows remain individually visible in the default Advanced view.
+    assert mcp.get("parse_error", 0) == 1
+    assert mcp.get("missing_canonical", 0) == 1
+
+
+def test_seed_is_idempotent(tmp_path: Path) -> None:
+    first = seed_adr0026_validation_states(tmp_path)
+    second = seed_adr0026_validation_states(tmp_path)
+    assert first == second
+    # Re-seeding does not multiply rows.
+    assert len(_triples(diff_mcp_servers(tmp_path))) == 2


### PR DESCRIPTION
## What & why

The ADR-0026 §Validation first-run user test gates the Simple-as-default flip
(D-F) and all of P2, but it had **no reproducible setup** and the flip had no
isolated switch point. This PR closes both gaps without changing any live
behaviour — the default **stays Advanced**.

Two focused commits under one purpose ("prepare the D-F flip for the validation
gate"):

### 1. First-run validation harness (`test`)
- `packages/memtomem/tests/fixtures/ctx_validation_states.py` —
  `seed_adr0026_validation_states()` writes the six §Validation affordances into
  one project: **out-of-sync**, **not-yet-imported**, **empty type**, **MCP
  orphan**, **MCP parse-error**, and an **in-sync** baseline. Version-controlled
  (not the gitignored `scripts/` tree) so it stays in lockstep with the runbook
  and its guard test; runtime paths come from `runtime_fanout_root(...)` so they
  can't drift.
- `test_ctx_validation_harness.py` pins the seed against the **real diff engine**
  — including the easy-to-invert direction (runtime-only ⇒ `missing canonical` /
  Import, never `missing target` / Sync) and the per-tile Overview summaries.
- ADR-0026 §Validation gains a **moderator runbook** (isolated HOME → seed →
  register → `mm web`, with an affordance→probe map), cross-referencing the
  existing pass bars rather than restating thresholds.

### 2. Stage the D-F flip (`feat`)
- `context-gateway.js`: the Simple-mode default-when-unset is now a single named
  constant `_CTX_SIMPLE_DEFAULT` (= `false` = Advanced). While `false`, the
  explicit localStorage read is byte-identical to the old `=== '1'` form — **the
  live flip is just `_CTX_SIMPLE_DEFAULT = true`**.
- ADR-0026 §"Implementation status" D-F row: `Deferred` → **`Staged`** (switch
  point + harness in place; default stays Advanced until probes 1–3 pass).
- `index.html` cache-bust `?v=95` → `?v=96`.

**Deliberately NOT here** (they belong to the future, user-test-gated live flip):
flipping the constant; the `.ctx-simple .ctx-overview-grid` deep-link-scoping
tighten (harmless while Advanced is the default); the reference.md "Simple is the
default" copy; and any Simple-default-only first-run i18n hint.

## Verification
- New harness tests (3), `test_i18n.py` (80), `test_web_invariants_registry.py`
  (4), and `ctx-simple-mode.test.mjs` vitest (11, incl. *"defaults to
  Advanced"*) — all green; `ruff check` + `format --check` clean.
- **Live end-to-end dry-run** of the runbook: seeded an isolated HOME, ran
  `mm web`, and confirmed in a real browser that all six affordances render in
  the Overview **and** that Advanced is still the default (`.ctx-simple` absent,
  toggle `aria-pressed=false`, localStorage unset).

## Follow-up (separate, gated on the user test)
Run the §Validation test with the new runbook; if probes 1–3 pass ≥4/6, a small
follow-up PR sets the constant `true`, tightens the Simple CSS scoping, and
updates the reference.md copy.

Refs #1353

🤖 Generated with [Claude Code](https://claude.com/claude-code)
