### PR TITLE
fix(web): localize the sync / Sync-All privacy 422 toast via reason_code (#1409)

### DIFF
--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -51,6 +51,7 @@ from memtomem.web.routes import (
     wiki,
     wiki_mutations,
 )
+from memtomem.web.routes._sync_phase import register_sync_phase_error_handler
 
 logger = logging.getLogger(__name__)
 
@@ -246,6 +247,11 @@ def create_app(lifespan=None, mode: WebMode = "prod") -> FastAPI:
     if mode == "dev":
         for router_mod in _DEV_ONLY_ROUTERS:
             app.include_router(router_mod.router, prefix="/api")
+
+    # Surface a per-type sync ``SyncPhaseError``'s ``reason_code`` to the client
+    # (#1409) — FastAPI's default HTTPException handler would drop it. Path-free
+    # string details stay byte-identical; see ``_sync_phase_error_handler``.
+    register_sync_phase_error_handler(app)
 
     @app.exception_handler(ValueError)
     async def value_error_handler(request: Request, exc: ValueError) -> JSONResponse:

--- a/packages/memtomem/src/memtomem/web/routes/_sync_phase.py
+++ b/packages/memtomem/src/memtomem/web/routes/_sync_phase.py
@@ -28,7 +28,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
 
 
 class SyncPhaseError(HTTPException):
@@ -50,3 +51,51 @@ class SyncPhaseError(HTTPException):
         super().__init__(status_code=status_code, detail=detail)
         self.error_kind = error_kind
         self.reason_code = reason_code
+
+
+async def _sync_phase_error_handler(request: Request, exc: SyncPhaseError) -> JSONResponse:
+    """Render a standalone-route ``SyncPhaseError`` with its ``reason_code`` (#1409).
+
+    The standalone per-type sync routes raise ``SyncPhaseError`` and let it
+    propagate — ``context_sync_all`` catches it FIRST (``_run_phase`` ``except
+    HTTPException``) to build its own per-phase envelope, so this handler only
+    ever sees the standalone routes, never the sync-all aggregation.
+
+    FastAPI's built-in ``HTTPException`` handler would emit ``{"detail": …}``
+    and DROP the ``reason_code`` the core attached. The privacy 422 keeps a
+    deliberately path-free *string* ``detail`` (#1385/#1387 issue-pinned), and
+    the per-type sync route has OTHER 422 causes (``parse``, ``strict_drop``),
+    so the client cannot tell a privacy block from a parse error by status code
+    alone — it falls back to rendering the raw English ``PRIVACY_BLOCK_DETAIL``
+    in the localized UI. Hoisting ``reason_code`` to a top-level sibling lets
+    the client disambiguate and localize.
+
+    We hoist ONLY for *string* details: the privacy 422 (and any future
+    string-detail reason_code) gains a sibling ``reason_code`` while its detail
+    stays byte-identical. Anything structured — today the ``agents``/``commands``
+    ``strict_drop`` *dict* (``{reason_code, message, generated}``) which already
+    embeds its ``reason_code`` for the client to read THERE, and any future
+    non-string detail — keeps its bare ``{"detail": …}`` wire shape untouched,
+    so this change cannot perturb the strict-drop contract or silently broaden a
+    yet-unwritten structured detail. The ``isinstance(str)`` test (not merely
+    ``not dict``) is deliberate: a string detail is the only shape that can't
+    carry its own ``reason_code``, so it's the only one that needs the hoist.
+    """
+    content: dict[str, Any] = {"detail": exc.detail}
+    if exc.reason_code is not None and isinstance(exc.detail, str):
+        content["reason_code"] = exc.reason_code
+    return JSONResponse(status_code=exc.status_code, content=content, headers=exc.headers or None)
+
+
+def register_sync_phase_error_handler(app: FastAPI) -> None:
+    """Install :func:`_sync_phase_error_handler` for ``SyncPhaseError``.
+
+    A single registrar shared by the production factory (``web.app.create_app``)
+    and the route tests, so the path-free + ``reason_code`` regression exercises
+    the SAME handler the app ships (no hand-rolled test double to drift).
+    """
+    # Starlette types the handler's exception param as the base ``Exception``
+    # (handlers are looked up by the class key, then invoked with the concrete
+    # instance), so a precise ``SyncPhaseError`` annotation is contravariant
+    # against the stub — the standard typed-FastAPI exception-handler idiom.
+    app.add_exception_handler(SyncPhaseError, _sync_phase_error_handler)  # type: ignore[arg-type]

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -419,6 +419,14 @@ async function _ctxErrorMessageFromResponse(resp, fallback) {
   const contentType = resp.headers.get('content-type') || '';
   if (contentType.includes('application/json')) {
     const err = await resp.json().catch(() => ({}));
+    // #1409: the per-type sync privacy 422 hoists ``reason_code`` to a top-level
+    // sibling of its path-free string ``detail``. Map it to the localized sync
+    // hint here so the Sync All per-phase summary localizes the block the same
+    // way the per-row Sync button does (``_ctxSyncErrToast``), instead of
+    // surfacing the raw locale-unaware English ``detail``.
+    if (err && err.reason_code === 'privacy_blocked') {
+      return t('settings.ctx.privacy_blocked_shared_sync_hint');
+    }
     const detail = err.detail;
     // Defensive branch for structured payloads shaped like `{detail: "..."}`
     // (ProjectTierBlocked / redaction) — a different shape than #1210's 409, so
@@ -1458,6 +1466,22 @@ async function _ctxMaybeForceUnsafeImport(data, reimport) {
 function _ctxImportErrToast(status, detail) {
   if (status === 422) return t('settings.ctx.privacy_blocked_shared_hint');
   return _ctxErrDetail(detail, t('toast.request_failed'));
+}
+
+// Sync error toast text. Unlike import — whose ONLY 422 is the privacy block,
+// so it keys on ``status`` (#1398 item 1) — the per-type sync route has OTHER
+// 422 causes (parse_error, strict_drop), so the privacy block can't be inferred
+// from the status alone. It's disambiguated by the top-level ``reason_code`` the
+// server now hoists alongside the path-free string ``detail`` (#1409). On
+// ``privacy_blocked`` we surface the fully-localized sync hint (the English
+// server detail is locale-unaware AND issue-pinned path-free, so it's shown to
+// nobody); every other error falls back to the shared detail renderer unchanged.
+// ``err`` is the parsed response body (``{detail, reason_code?}``).
+function _ctxSyncErrToast(err) {
+  if (err && err.reason_code === 'privacy_blocked') {
+    return t('settings.ctx.privacy_blocked_shared_sync_hint');
+  }
+  return _ctxErrDetail(err && err.detail, t('toast.request_failed'));
 }
 
 // ``_ctxMaybeForceUnsafeSync`` is the fan-out (sync) mirror of
@@ -6297,7 +6321,7 @@ async function _ctxRunSync(type, { btn, canonicalCount, noFanout, onComplete }) 
       let r = await syncOnce(null);
       if (!r.ok) {
         const err = await r.json().catch(() => ({}));
-        showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
+        showToast(_ctxSyncErrToast(err), 'error');
         return;
       }
       let data = await r.json();
@@ -6308,7 +6332,7 @@ async function _ctxRunSync(type, { btn, canonicalCount, noFanout, onComplete }) 
         if (!r) return;
         if (!r.ok) {
           const err = await r.json().catch(() => ({}));
-          showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
+          showToast(_ctxSyncErrToast(err), 'error');
           return;
         }
         data = await r.json();

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1603,7 +1603,7 @@
   <script src="/settings-harness.js?v=4"></script>
   <script src="/settings-hooks-watchdog.js?v=21"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=95"></script>
+  <script src="/context-gateway.js?v=96"></script>
   <script src="/context-portal.js?v=7"></script>
   <script src="/wiki.js?v=6"></script>
   <script src="/path-picker.js?v=4"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -679,6 +679,7 @@
   "settings.ctx.force_unsafe_sync_message": "{count} file(s) look like they may contain a secret (e.g. an API key). If you've reviewed them and they're safe — for example a type annotation like 'api_key: str' — you can sync them to your runtimes anyway:",
   "settings.ctx.force_unsafe_sync_btn": "Sync anyway",
   "settings.ctx.privacy_blocked_shared_hint": "Shared (project) imports can't override a flagged secret — git history is permanent. Open the skill and use 'Import to user library' instead, or remove the flagged line.",
+  "settings.ctx.privacy_blocked_shared_sync_hint": "Shared (project) sync can't override a flagged secret — git history is permanent. Remove the flagged line, then re-run sync.",
   "settings.ctx.import_to_user": "Import to user library",
   "settings.ctx.import_to_user_success": "Imported into your user library (~/.memtomem)",
   "settings.ctx.runtime_only_detail_hint": "Runtime preview — not yet in .memtomem/.",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -679,6 +679,7 @@
   "settings.ctx.force_unsafe_sync_message": "{count}개 파일이 시크릿(예: API 키)을 포함한 것처럼 보입니다. 검토 결과 안전하다면 — 예를 들어 'api_key: str' 같은 타입 어노테이션 — 런타임으로 그대로 동기화할 수 있습니다:",
   "settings.ctx.force_unsafe_sync_btn": "그대로 동기화",
   "settings.ctx.privacy_blocked_shared_hint": "공유(프로젝트) 가져오기는 표시된 시크릿을 우회할 수 없습니다 — git 기록은 영구적입니다. 스킬을 열어 '사용자 라이브러리로 가져오기'를 쓰거나, 표시된 줄을 제거하세요.",
+  "settings.ctx.privacy_blocked_shared_sync_hint": "공유(프로젝트) 동기화는 표시된 시크릿을 우회할 수 없습니다 — git 기록은 영구적입니다. 표시된 줄을 제거한 뒤 다시 동기화하세요.",
   "settings.ctx.import_to_user": "사용자 라이브러리로 가져오기",
   "settings.ctx.import_to_user_success": "사용자 라이브러리(~/.memtomem)로 가져왔습니다",
   "settings.ctx.runtime_only_detail_hint": "런타임 미리보기 — 아직 .memtomem/ 에 없습니다.",

--- a/packages/memtomem/tests-js/ctx-sync-privacy-localize.test.mjs
+++ b/packages/memtomem/tests-js/ctx-sync-privacy-localize.test.mjs
@@ -1,0 +1,107 @@
+/* Localized sync / Sync-All privacy-block toast (#1409).
+ *
+ * The per-type sync privacy 422 keeps a deliberately path-free ENGLISH string
+ * ``detail`` (#1385/#1387, issue-pinned) and now rides a top-level
+ * ``reason_code: "privacy_blocked"`` sibling. Unlike the import surface — whose
+ * ONLY 422 is the privacy block, so it keys on ``status`` (#1398 item 1) — the
+ * sync route has other 422 causes (parse_error, strict_drop), so the privacy
+ * block is disambiguated by ``reason_code``, not the status code.
+ *
+ * These pin:
+ *   - ``_ctxSyncErrToast`` (per-row / per-section Sync button error path):
+ *     ``reason_code === 'privacy_blocked'`` → the localized SYNC hint, every
+ *     other error → the shared detail renderer.
+ *   - ``_ctxErrorMessageFromResponse`` (Sync-All per-phase summary): the same
+ *     ``reason_code`` → the same localized SYNC hint, so the aggregate toast
+ *     localizes the block exactly like the per-row button does.
+ *   - the SYNC hint is its own key, distinct from the IMPORT hint (the import
+ *     wording — "Import to user library" — is wrong for the fan-out direction).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+async function boot() {
+  const dom = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+  const { window } = dom;
+  await window.I18N.init();
+  return window;
+}
+
+// A minimal ``Response`` double for ``_ctxErrorMessageFromResponse``: a
+// content-type header lookup + an async JSON body.
+const jsonResp = (body) => ({
+  headers: { get: () => 'application/json' },
+  json: async () => body,
+  text: async () => '',
+});
+
+describe('localized sync privacy-block toast (#1409)', () => {
+  it('_ctxSyncErrToast maps reason_code privacy_blocked → the localized SYNC hint', async () => {
+    const window = await boot();
+    const { I18N } = window;
+    const out = window._ctxSyncErrToast({
+      detail: 'Privacy scan blocked this sync: a secret was detected …',
+      reason_code: 'privacy_blocked',
+    });
+    expect(out).toBe(I18N.t('settings.ctx.privacy_blocked_shared_sync_hint'));
+    // NOT the raw English server detail (the whole point — locale-unaware).
+    expect(out).not.toContain('Privacy scan blocked this sync');
+  });
+
+  it('_ctxSyncErrToast uses the SYNC hint, distinct from the IMPORT hint', async () => {
+    const window = await boot();
+    const { I18N } = window;
+    const syncHint = I18N.t('settings.ctx.privacy_blocked_shared_sync_hint');
+    const importHint = I18N.t('settings.ctx.privacy_blocked_shared_hint');
+    // The two hints exist and differ — the import wording ("Import to user
+    // library") would be wrong for the fan-out direction.
+    expect(syncHint).not.toBe(importHint);
+    expect(window._ctxSyncErrToast({ reason_code: 'privacy_blocked' })).toBe(syncHint);
+  });
+
+  it('_ctxSyncErrToast falls back to the detail renderer for non-privacy errors', async () => {
+    const window = await boot();
+    // A string detail is rendered verbatim (parse_error / generic 422).
+    expect(window._ctxSyncErrToast({ detail: 'boom', reason_code: 'parse_error' }))
+      .toBe('boom');
+    // A strict_drop object detail still renders its message via _ctxErrDetail,
+    // and is NOT hijacked by the privacy mapping.
+    const out = window._ctxSyncErrToast({
+      detail: { error_kind: 'validation', message: 'partial fan-out', reason_code: 'strict_drop' },
+      reason_code: 'strict_drop',
+    });
+    expect(out).toContain('partial fan-out');
+    expect(out).not.toBe(window.I18N.t('settings.ctx.privacy_blocked_shared_sync_hint'));
+  });
+
+  it('_ctxSyncErrToast tolerates an empty / missing error body', async () => {
+    const window = await boot();
+    const { I18N } = window;
+    expect(window._ctxSyncErrToast({})).toBe(I18N.t('toast.request_failed'));
+    expect(window._ctxSyncErrToast(null)).toBe(I18N.t('toast.request_failed'));
+  });
+
+  it('_ctxErrorMessageFromResponse localizes the Sync-All privacy phase', async () => {
+    const window = await boot();
+    const { I18N } = window;
+    const reason = await window._ctxErrorMessageFromResponse(
+      jsonResp({
+        detail: 'Privacy scan blocked this sync: a secret was detected …',
+        reason_code: 'privacy_blocked',
+      }),
+      'fallback',
+    );
+    expect(reason).toBe(I18N.t('settings.ctx.privacy_blocked_shared_sync_hint'));
+  });
+
+  it('_ctxErrorMessageFromResponse leaves other phase errors untouched', async () => {
+    const window = await boot();
+    // A non-privacy structured error still renders its server detail string.
+    const reason = await window._ctxErrorMessageFromResponse(
+      jsonResp({ detail: 'parse failed at line 3' }),
+      'fallback',
+    );
+    expect(reason).toBe('parse failed at line 3');
+  });
+});

--- a/packages/memtomem/tests/test_sync_privacy_block_surfaces.py
+++ b/packages/memtomem/tests/test_sync_privacy_block_surfaces.py
@@ -18,6 +18,7 @@ These tests pin:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -56,13 +57,42 @@ def _build_app_with(router) -> FastAPI:
     factory pulls in storage/embedder which the sync route does not
     actually need. The dependency override is enough to satisfy
     ``project_root`` injection without touching the file system.
+
+    Registers the REAL ``SyncPhaseError`` handler the app ships
+    (#1409) via the shared registrar — not a hand-rolled double — so
+    the ``reason_code`` hoisting these tests pin can't drift from
+    production. FastAPI's built-in ``HTTPException`` handler (which a
+    bare app would use) drops ``reason_code``; the registrar installs
+    the handler that surfaces it alongside the path-free string detail.
     """
     from memtomem.web.deps import get_project_root
+    from memtomem.web.routes._sync_phase import register_sync_phase_error_handler
 
     app = FastAPI()
     app.include_router(router)
+    register_sync_phase_error_handler(app)
     app.dependency_overrides[get_project_root] = lambda: Path("/tmp/p")
     return app
+
+
+def _assert_path_free_privacy_422(res, *, detail_contains: str) -> None:
+    """Shared assertions for a per-type sync privacy block (#1385/#1409).
+
+    The wire shape is the path-free *string* ``detail`` (#1385 finding 1 —
+    the engine message embeds the absolute canonical path, which must never
+    reach the loopback dashboard) PLUS the top-level ``reason_code`` sibling
+    (#1409) the client maps to a localized hint. ``reason_code`` itself is a
+    fixed token, so it cannot leak — but assert the WHOLE body is path-free
+    so a future shape change (e.g. echoing the path under a new key) is caught.
+    """
+    assert res.status_code == 422, res.text
+    body = res.json()
+    detail = body["detail"]
+    assert isinstance(detail, str), body  # detail stays a STRING, not an envelope
+    assert _LEAK_PATH not in detail  # #1385 finding 1: host path never leaks
+    assert detail_contains in detail
+    assert body.get("reason_code") == "privacy_blocked", body  # #1409 wire field
+    assert _LEAK_PATH not in json.dumps(body)  # whole body path-free (reason_code too)
 
 
 class TestWebSyncTranslatesTo422:
@@ -74,13 +104,10 @@ class TestWebSyncTranslatesTo422:
 
         res = client.post("/context/agents/sync", json={})
 
-        assert res.status_code == 422, res.text
-        # FastAPI's default HTTPException renders as ``{"detail": "..."}``; the
-        # detail is now a fixed, path-free string (the engine message embeds the
-        # absolute canonical path, which must not reach the loopback dashboard).
-        detail = res.json()["detail"]
-        assert _LEAK_PATH not in detail  # #1385 finding 1: host path never leaks
-        assert "secret was detected" in detail  # fixed, path-free PRIVACY_BLOCK_DETAIL
+        # The detail is a fixed, path-free string (the engine message embeds the
+        # absolute canonical path, which must not reach the loopback dashboard);
+        # ``reason_code`` rides alongside it as a top-level sibling (#1409).
+        _assert_path_free_privacy_422(res, detail_contains="secret was detected")
 
     def test_commands_sync_returns_422(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from memtomem.web.routes import context_commands
@@ -90,10 +117,7 @@ class TestWebSyncTranslatesTo422:
 
         res = client.post("/context/commands/sync", json={})
 
-        assert res.status_code == 422, res.text
-        detail = res.json()["detail"]
-        assert _LEAK_PATH not in detail  # #1385 finding 1: host path never leaks
-        assert "secret was detected" in detail  # fixed, path-free PRIVACY_BLOCK_DETAIL
+        _assert_path_free_privacy_422(res, detail_contains="secret was detected")
 
     def test_skills_sync_returns_422(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from memtomem.web.routes import context_skills
@@ -103,10 +127,88 @@ class TestWebSyncTranslatesTo422:
 
         res = client.post("/context/skills/sync")
 
+        _assert_path_free_privacy_422(res, detail_contains="secret was detected")
+
+    def test_mcp_servers_sync_returns_422(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # MCP servers differ from skills/agents/commands: the PRIVACY 422
+        # surfaces the engine message verbatim (``str(exc)``) rather than the
+        # fixed ``PRIVACY_BLOCK_DETAIL`` constant. For the privacy error that
+        # message is path-free by the ENGINE's construction —
+        # ``McpServerPrivacyError`` names only ``source_path.name`` (the
+        # basename), never the resolved host path (``mcp_servers.py``). This test
+        # pins both halves of the #1409 contract for the PRIVACY branch —
+        # ``reason_code`` on the wire AND a path-free body.
+        #
+        # Scope note: this covers the privacy branch only. The route's OTHER 422
+        # branch (``McpServerParseError`` → ``str(exc)`` with ``error_kind=
+        # "parse"``, no reason_code) embeds the full canonical path and is a
+        # SEPARATE, pre-existing $HOME-leak concern (#1385-class, on the parse
+        # path) that predates and is untouched by #1409 — tracked on its own.
+        from memtomem.context.mcp_servers import McpServerPrivacyError
+        from memtomem.web.routes import context_mcp_servers
+
+        def _raise_mcp_block(*args, **kwargs):
+            raise McpServerPrivacyError(
+                "Gate A: leak.mcp.json contains 1 privacy pattern hit(s); "
+                "MCP server fan-out to project .mcp.json rejected."
+            )
+
+        monkeypatch.setattr(context_mcp_servers, "generate_all_mcp_servers", _raise_mcp_block)
+        client = TestClient(_build_app_with(context_mcp_servers.router))
+
+        res = client.post("/context/mcp-servers/sync")
+
+        _assert_path_free_privacy_422(res, detail_contains="MCP server fan-out")
+
+
+class TestSyncPhaseErrorHandlerContract:
+    """The #1409 handler hoists ``reason_code`` to a top-level sibling ONLY for
+    *string* details. A string is the one detail shape that cannot carry its own
+    ``reason_code``, so it is the only one that needs the hoist; everything
+    structured keeps its bare ``{"detail": …}`` wire shape. These pin all four
+    branches so the boundary can't silently widen (Codex review)."""
+
+    @staticmethod
+    def _client(detail, reason_code) -> TestClient:
+        from memtomem.web.routes._sync_phase import (
+            SyncPhaseError,
+            register_sync_phase_error_handler,
+        )
+
+        app = FastAPI()
+
+        @app.post("/boom")
+        async def _boom() -> None:
+            raise SyncPhaseError(422, detail, error_kind="validation", reason_code=reason_code)
+
+        register_sync_phase_error_handler(app)
+        return TestClient(app)
+
+    def test_string_detail_hoists_reason_code(self) -> None:
+        res = self._client("blocked", "privacy_blocked").post("/boom")
         assert res.status_code == 422, res.text
-        detail = res.json()["detail"]
-        assert _LEAK_PATH not in detail  # #1385 finding 1: host path never leaks
-        assert "secret was detected" in detail  # fixed, path-free PRIVACY_BLOCK_DETAIL
+        assert res.json() == {"detail": "blocked", "reason_code": "privacy_blocked"}
+
+    def test_dict_detail_keeps_reason_code_inside(self) -> None:
+        # strict_drop shape: ``reason_code`` lives INSIDE the detail dict; the
+        # wire stays a bare ``{"detail": {...}}`` with NO top-level sibling so
+        # the strict-drop contract is byte-identical.
+        detail = {"reason_code": "strict_drop", "message": "partial", "generated": []}
+        res = self._client(detail, "strict_drop").post("/boom")
+        assert res.json() == {"detail": detail}
+
+    def test_non_string_non_dict_detail_is_not_hoisted(self) -> None:
+        # A future structured (non-string, non-dict) detail must NOT gain a
+        # top-level reason_code — only string details, which can't carry their
+        # own, are hoisted. ``isinstance(str)`` (not ``not dict``) enforces this.
+        res = self._client(["a", "b"], "privacy_blocked").post("/boom")
+        assert res.json() == {"detail": ["a", "b"]}
+
+    def test_no_reason_code_stays_bare(self) -> None:
+        # A string-detail SyncPhaseError with ``reason_code=None`` (e.g. an mcp
+        # parse error) keeps the historical bare ``{"detail": …}`` shape.
+        res = self._client("parse failed", None).post("/boom")
+        assert res.json() == {"detail": "parse failed"}
 
 
 class TestMcpContextToolTranslates:

--- a/packages/memtomem/tests/web/test_context_gateway_sync_all.py
+++ b/packages/memtomem/tests/web/test_context_gateway_sync_all.py
@@ -50,6 +50,16 @@ SYNC_FAILED_TEMPLATE = "Sync failed: {error}"  # toast.sync_failed
 SYNC_PARTIAL_FAILED_TEMPLATE = (
     "{succeeded} synced — {failed_phase} failed: {reason}"  # toast.sync_partial_failed
 )
+# en.json source of truth — the SYNC privacy-block hint (#1409),
+# ``settings.ctx.privacy_blocked_shared_sync_hint``. A per-type sync privacy
+# 422 now carries ``reason_code: "privacy_blocked"`` on the wire, so the client
+# surfaces THIS localized hint instead of the raw English server ``detail``.
+# Distinct from the IMPORT hint (whose "Import to user library" remedy is wrong
+# for the fan-out direction).
+PRIVACY_BLOCKED_SHARED_SYNC_HINT = (
+    "Shared (project) sync can't override a flagged secret — git history is "
+    "permanent. Remove the flagged line, then re-run sync."
+)
 
 
 _HEALTHY_OVERVIEW = {
@@ -271,27 +281,36 @@ def test_sync_all_happy_path_emits_success_toast(page, mm_web_url: str) -> None:
     ("content_type", "body", "expected_error"),
     [
         (
+            # A 422 WITHOUT reason_code (e.g. a parse error) surfaces its detail
+            # string verbatim — the helper's default path.
             "application/json",
-            json.dumps(
-                {
-                    "detail": (
-                        "Privacy scan blocked project_shared skill sync. Remove the "
-                        "secret or migrate the artifact to a writable tier."
-                    )
-                }
-            ),
-            (
-                "Privacy scan blocked project_shared skill sync. Remove the "
-                "secret or migrate the artifact to a writable tier."
-            ),
+            json.dumps({"detail": "Failed to parse skill front-matter at line 3"}),
+            "Failed to parse skill front-matter at line 3",
         ),
         (
             "text/plain",
             "Plain-text artifact sync failure",
             "Plain-text artifact sync failure",
         ),
+        (
+            # A privacy block now carries reason_code on the wire (#1409): the
+            # client localizes it instead of surfacing the path-free English
+            # server detail. End-to-end proof that the Sync-All partial toast
+            # renders the localized SYNC hint, not the raw PRIVACY_BLOCK_DETAIL.
+            "application/json",
+            json.dumps(
+                {
+                    "detail": (
+                        "Privacy scan blocked this sync: a secret was detected in "
+                        "the canonical bytes. git history is forever …"
+                    ),
+                    "reason_code": "privacy_blocked",
+                }
+            ),
+            PRIVACY_BLOCKED_SHARED_SYNC_HINT,
+        ),
     ],
-    ids=["json-detail", "text-body"],
+    ids=["json-detail", "text-body", "json-reason-code-privacy"],
 )
 def test_sync_all_artifact_422_surfaces_backend_error(
     page,


### PR DESCRIPTION
## What

Localize the `project_shared` **Sync** and **Sync All** privacy-block toast by propagating the server's `reason_code` on the wire for the per-type sync 422.

Closes #1409.

## Why

The per-type sync routes raise `SyncPhaseError` and let it propagate. FastAPI's built-in `HTTPException` handler renders `{"detail": <string>}` and **drops** the `reason_code` the core already attached (`context_skills.py:679-681` etc.). The privacy 422 keeps a deliberately **path-free string detail** (#1385/#1387 — the engine message embeds a `.resolve()`'d `$HOME` canonical path that must never reach the loopback dashboard), and the sync route has **other** 422 causes (`parse`, `strict_drop`), so the client could not tell a privacy block from a parse error by status alone — it surfaced the raw English `PRIVACY_BLOCK_DETAIL` inside the Korean dashboard.

Import could key off `status === 422` (its only 422 is the privacy block, #1398); sync cannot.

## How

**Server** (`_sync_phase.py` + `app.py`): a `SyncPhaseError` exception handler that hoists `reason_code` to a top-level sibling **only for string details**. The privacy 422 gains `{detail, reason_code}` while its detail stays byte-identical; `strict_drop`'s **dict** detail (which already embeds `reason_code`) is left untouched. A shared registrar wires the handler into both `create_app()` and the route tests, so the path-free + `reason_code` regression exercises the **shipped** handler (no test-double drift).

**Client** (`context-gateway.js`): `_ctxSyncErrToast` (per-row / per-section Sync) and `_ctxErrorMessageFromResponse` (Sync-All per-phase summary) map `reason_code === 'privacy_blocked'` → a **new** localized hint `settings.ctx.privacy_blocked_shared_sync_hint`. This is a dedicated key, **not** the import hint — the import wording ("Import to user library") is wrong for the fan-out direction. The new key is jargon-free (no `project_local` / `canonical`) per the ADR-0026 §Validation guard.

Sync-all's 200-report path is unaffected: `_run_phase` catches `SyncPhaseError` (`except HTTPException`) before it reaches the handler, so this only changes the standalone per-type routes.

## Security review (path-free contract preserved)

- The change is **path-safe**: every `reason_code`-bearing string-detail `SyncPhaseError` carries a path-free detail (skills/agents/commands use the fixed `PRIVACY_BLOCK_DETAIL`; mcp-servers' privacy message names only `source_path.name`), and `reason_code` values are fixed tokens — never a path.
- `strict_drop` dict-detail wire shape is **byte-identical** (verified: `test_web_sync_on_drop.py`).
- `settings_sync` privacy 422 does **not** route through this handler (it raises plain `HTTPException`, and its constant is path-free anyway).
- New regression: whole-body path-free assertion + the `string-only hoist` boundary (string→hoist, dict/list/None→bare).

## Tests

- `test_sync_privacy_block_surfaces.py`: extended to assert `reason_code` + whole-body path-free for agents/commands/skills, **added mcp-servers** coverage, and a new `TestSyncPhaseErrorHandlerContract` pinning the string-only hoist boundary (4 branches).
- `ctx-sync-privacy-localize.test.mjs`: `_ctxSyncErrToast` + `_ctxErrorMessageFromResponse` map `reason_code` → the localized hint; non-privacy errors render verbatim; the sync hint is distinct from the import hint.
- `test_context_gateway_sync_all.py`: a new end-to-end parametrize case proving the Sync-All partial toast renders the **localized** hint for a `reason_code` privacy 422.

Gates run green: full vitest (330), `test_sync_privacy_block_surfaces` (10), `test_web_sync_on_drop` / `test_web_routes_context_sync_all`, `test_web_invariants_registry` (CSRF-AST), `test_i18n` (jargon guard + parity), `test_context_gateway_sync_all` (Playwright), `ruff check`/`format`, `mypy` (clean). `context-gateway.js` cache-bust `?v=95 → 96`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
