### PR TITLE
fix(web): render path-free detail for mcp-servers parse-error 422s (#1412)

### DIFF
--- a/packages/memtomem/src/memtomem/context/mcp_servers.py
+++ b/packages/memtomem/src/memtomem/context/mcp_servers.py
@@ -36,7 +36,22 @@ MCP_RUNTIME = "project_mcp"
 
 
 class McpServerParseError(ValueError):
-    """Raised when a canonical MCP server definition cannot be parsed."""
+    """Raised when a canonical MCP server definition cannot be parsed.
+
+    ``safe_message`` is a path-free rendering of the failure for the web
+    trust boundary (#1412). The JSON-decode raise embeds the absolute,
+    ``.resolve()``'d source ``Path`` in the default message — useful on the
+    CLI / MCP surfaces, but a ``$HOME``/username disclosure over the loopback
+    dashboard (the #1385 finding-1 class, on the parse branch). Web catch
+    sites render ``exc.safe_message`` (basename + the JSON problem, no host
+    path); CLI / MCP keep ``str(exc)`` with the full path. The validation-shape
+    raises already name only the server (``'{name}'``), never a path, so
+    ``safe_message`` defaults to the full message.
+    """
+
+    def __init__(self, message: str, *, safe_message: str | None = None) -> None:
+        super().__init__(message)
+        self.safe_message = message if safe_message is None else safe_message
 
 
 class McpServerPrivacyError(ValueError):
@@ -116,7 +131,14 @@ def parse_mcp_server_text(text: str, *, name: str, source: Path) -> McpServerDef
     try:
         data = json.loads(text)
     except json.JSONDecodeError as exc:
-        raise McpServerParseError(f"invalid JSON in {source}: {exc.msg}") from exc
+        raise McpServerParseError(
+            f"invalid JSON in {source}: {exc.msg}",
+            # Path-free twin for the loopback web boundary (#1412): the default
+            # message embeds the resolved source path ($HOME/username leak over
+            # the dashboard), so web catch sites render this basename form. The
+            # JSON-decode ``exc.msg`` ("Expecting ...") never carries the path.
+            safe_message=f"invalid JSON in {source.name}: {exc.msg}",
+        ) from exc
     return McpServerDefinition(
         name=validate_name(name, kind="MCP server"),
         definition=validate_mcp_server_definition(data, name=name),

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -51,11 +51,26 @@ def sanitize_diff_reason(message: str | None, project_root: Path) -> str | None:
     the overview ``error_message`` field. Shared by every context_* list
     and per-name diff route so the sanitization boundary cannot drift
     per kind.
+
+    Strip BOTH the given root and its ``.resolve()``'d form (#1412): engine
+    paths are resolved (``canonical_mcp_server_root`` etc.), but the route may
+    receive an unresolved/symlinked ``project_root`` (macOS ``/tmp``→
+    ``/private/tmp``, a symlinked home, a case-variant mount). Stripping only
+    one form leaves the absolute resolved path in the reason — the same
+    canonical-path disclosure #1412 closes on the parse-error 422s, here on the
+    list/diff ``reason`` surface. Longest-first so a root that contains the
+    other as a prefix can't be half-stripped.
     """
     if not message:
         return None
-    root = str(project_root)
-    cleaned = message.replace(root + os.sep, "").replace(root, ".")
+    roots = {str(project_root)}
+    try:
+        roots.add(str(project_root.resolve()))
+    except (AttributeError, OSError):
+        pass  # PurePath input / unresolvable root — the bare form still strips
+    cleaned = message
+    for root in sorted(roots, key=len, reverse=True):
+        cleaned = cleaned.replace(root + os.sep, "").replace(root, ".")
     return _redact_message(cleaned)
 
 

--- a/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
@@ -50,11 +50,29 @@ def _safe_rel(p: Path, project_root: Path) -> str:
     ``project_root``. Parity with ``context_agents`` / ``context_commands``
     (#1264); this route was never covered by #1256's diff tests, so the
     ``str()`` form lingered latent (#1325).
+
+    ``p`` is a ``.resolve()``'d canonical/runtime path, but the route may receive
+    an unresolved/symlinked ``project_root`` (macOS ``/tmp``→``/private/tmp``),
+    so ``relative_to`` against the bare root raises ``ValueError`` and the
+    fallback would emit the ABSOLUTE resolved path to the loopback dashboard
+    (#1412, the same disclosure as the parse-error reason). Try the resolved
+    root too before falling back. ``resolve()`` lives only on concrete ``Path``
+    objects — the cross-platform ``PureWindowsPath`` tests (#1325) drive this
+    with a pure path, so the resolved attempt is guarded and skipped there.
     """
+    roots = [project_root]
     try:
-        return p.relative_to(project_root).as_posix()
-    except ValueError:
-        return p.as_posix()
+        resolved_root = project_root.resolve()
+    except (AttributeError, OSError):
+        resolved_root = project_root
+    if resolved_root != project_root:
+        roots.append(resolved_root)
+    for root in roots:
+        try:
+            return p.relative_to(root).as_posix()
+        except ValueError:
+            continue
+    return p.as_posix()
 
 
 def _reject_non_shared_write(target_scope: TargetScope, action: str) -> None:
@@ -220,7 +238,10 @@ async def create_mcp_server(
     except TimeoutError:
         raise _error(503, "busy", "MCP server create timed out — another sync may be in progress")
     except McpServerParseError as exc:
-        raise _error(422, "parse", str(exc)) from exc
+        # Path-free detail at the loopback boundary (#1412): a syntax error
+        # embeds the resolved canonical path in ``str(exc)``. ``raise … from``
+        # keeps the full message in the server log.
+        raise _error(422, "parse", exc.safe_message) from exc
     except McpServerPrivacyError as exc:
         raise HTTPException(422, str(exc)) from exc
     return {"name": name, "canonical_path": _safe_rel(path, project_root)}
@@ -285,7 +306,8 @@ async def _update_mcp_server_impl(
     except TimeoutError:
         raise _error(503, "busy", "MCP server update timed out — another sync may be in progress")
     except McpServerParseError as exc:
-        raise _error(422, "parse", str(exc)) from exc
+        # Path-free detail at the loopback boundary (#1412); see create route.
+        raise _error(422, "parse", exc.safe_message) from exc
     except McpServerPrivacyError as exc:
         raise HTTPException(422, str(exc)) from exc
     return JSONResponse(content={"name": name, "mtime_ns": str(new_mtime_ns)})
@@ -398,8 +420,12 @@ async def diff_mcp_server(
                 ).definition
             except McpServerParseError as exc:
                 # Canonical-side parse failure — the reason names the
-                # canonical file (#1229 U7; previously discarded).
-                reason = sanitize_diff_reason(str(exc), project_root)
+                # canonical file (#1229 U7; previously discarded). Use the
+                # path-free twin (#1412): ``sanitize_diff_reason`` strips the
+                # project root, but only when it prefix-matches the resolved
+                # canonical path (macOS ``/tmp``→``/private/tmp`` defeats it);
+                # ``safe_message`` is path-free at the source regardless.
+                reason = sanitize_diff_reason(exc.safe_message, project_root)
 
     # Runtime side is read INDEPENDENTLY of canonical health (#1247 id 31):
     # the runtime-only detail pane fetches this route, and a server that
@@ -472,7 +498,12 @@ async def _sync_mcp_servers_core(project_root: Path) -> dict:
     try:
         result = generate_all_mcp_servers(project_root, surface="web_context_mcp_servers_sync")
     except McpServerParseError as exc:
-        raise SyncPhaseError(422, str(exc), error_kind="parse") from exc
+        # Path-free detail at the loopback boundary (#1412): the engine message
+        # embeds the resolved canonical path. This single point covers BOTH the
+        # standalone sync route (``_sync_phase_error_handler`` renders
+        # ``exc.detail``) and the Sync-All aggregation (``_phase_error_envelope``
+        # does ``str(detail)`` with no redaction). CLI / MCP keep the full path.
+        raise SyncPhaseError(422, exc.safe_message, error_kind="parse") from exc
     except McpServerPrivacyError as exc:
         raise SyncPhaseError(
             422, str(exc), error_kind="validation", reason_code="privacy_blocked"

--- a/packages/memtomem/src/memtomem/web/routes/context_transfer.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_transfer.py
@@ -513,8 +513,10 @@ async def transfer_context_artifact(
         # mcp-servers copy refuses to propagate a definition the
         # destination's sync would choke its whole mcp phase on (A-12);
         # same 422 status the mcp CRUD routes use for this error, in this
-        # route's object envelope.
-        raise _error(422, "parse", str(exc)) from exc
+        # route's object envelope. Path-free detail at the loopback boundary
+        # (#1412): a syntax error embeds the resolved SOURCE path in
+        # ``str(exc)``; ``raise … from`` keeps it in the server log.
+        raise _error(422, "parse", exc.safe_message) from exc
     except InvalidNameError as exc:
         raise _error(400, "validation", str(exc)) from exc
     except click.ClickException as exc:

--- a/packages/memtomem/tests/test_sync_privacy_block_surfaces.py
+++ b/packages/memtomem/tests/test_sync_privacy_block_surfaces.py
@@ -140,10 +140,11 @@ class TestWebSyncTranslatesTo422:
         # ``reason_code`` on the wire AND a path-free body.
         #
         # Scope note: this covers the privacy branch only. The route's OTHER 422
-        # branch (``McpServerParseError`` → ``str(exc)`` with ``error_kind=
-        # "parse"``, no reason_code) embeds the full canonical path and is a
-        # SEPARATE, pre-existing $HOME-leak concern (#1385-class, on the parse
-        # path) that predates and is untouched by #1409 — tracked on its own.
+        # branch (``McpServerParseError`` → ``error_kind="parse"``, no
+        # reason_code) embedded the full canonical path until #1412, which routes
+        # the parse detail through ``exc.safe_message`` (basename only) at every
+        # web catch site — see ``TestMcpServersParseBranchPathFree`` below, which
+        # exercises the REAL parse path (a genuinely malformed canonical file).
         from memtomem.context.mcp_servers import McpServerPrivacyError
         from memtomem.web.routes import context_mcp_servers
 
@@ -159,6 +160,182 @@ class TestWebSyncTranslatesTo422:
         res = client.post("/context/mcp-servers/sync")
 
         _assert_path_free_privacy_422(res, detail_contains="MCP server fan-out")
+
+
+class TestMcpServersParseBranchPathFree:
+    """#1412 — the mcp-servers parse-error 422 must be path-free at every web
+    (loopback) catch site, the #1385 finding-1 invariant extended from the
+    privacy branch to the parse branch.
+
+    Unlike the privacy tests above (which monkeypatch the generator to raise a
+    crafted error), these drive the REAL parse path: a genuinely malformed
+    canonical ``.mcp.json`` reaches ``parse_mcp_server_text``, whose JSON-decode
+    raise embeds the resolved canonical ``Path``. The fix renders
+    ``exc.safe_message`` (basename + the JSON problem) instead of ``str(exc)``,
+    so the resolved host path never reaches the dashboard while the CLI / MCP
+    surfaces keep the full path.
+    """
+
+    # A trailing comma → ``json.JSONDecodeError`` ("Expecting property name
+    # enclosed in double quotes"), the issue's reproduction. No secret shape, so
+    # the sync route's Gate-A scan (which runs BEFORE the parser) passes and the
+    # parse branch is actually reached.
+    _MALFORMED = '{\n  "command": "echo",\n}\n'
+
+    @staticmethod
+    def _build_app(project_root: Path) -> TestClient:
+        from memtomem.web.routes import context_mcp_servers
+        from memtomem.web.routes._sync_phase import register_sync_phase_error_handler
+        from memtomem.web.routes.context_projects import (
+            resolve_scope_root,
+            resolve_writable_scope_root,
+        )
+
+        app = FastAPI()
+        app.include_router(context_mcp_servers.router)
+        register_sync_phase_error_handler(app)
+        # Override BOTH resolvers (reads use ``resolve_scope_root``, sync uses
+        # the writable variant) so the routes run against a real project root
+        # without the eligibility / selector machinery.
+        app.dependency_overrides[resolve_scope_root] = lambda: project_root
+        app.dependency_overrides[resolve_writable_scope_root] = lambda: project_root
+        return TestClient(app)
+
+    @staticmethod
+    def _assert_path_free(body: dict, project_root: Path, *, basename: str) -> None:
+        """Whole-body path-free assertions (no assumption about the body shape).
+
+        Asserts the resolved canonical absolute path (and its parent dir) and
+        the resolved project root never appear ANYWHERE in the body — not just
+        in the message field, so a future shape change that echoes the path
+        under a new key is caught (mirrors the privacy-branch whole-body check).
+        The basename alone is not an absolute path, so it may (and should)
+        survive; each test asserts its own actionable field separately.
+        """
+        from memtomem.context.mcp_servers import canonical_mcp_server_root
+
+        resolved = canonical_mcp_server_root(project_root) / basename
+        blob = json.dumps(body)
+        assert str(resolved) not in blob, body  # full canonical path never leaks
+        assert str(resolved.parent) not in blob, body  # nor its directory
+        assert str(project_root.resolve()) not in blob, body  # nor the project root
+        assert str(Path.home()) not in blob, body  # #1385 literal: no $HOME / username
+
+    def _seed(self, tmp_path: Path) -> Path:
+        from memtomem.context.mcp_servers import CANONICAL_MCP_SERVER_ROOT
+
+        project_root = tmp_path / "proj"
+        canon = project_root / CANONICAL_MCP_SERVER_ROOT
+        canon.mkdir(parents=True)
+        (canon / "broken.json").write_text(self._MALFORMED, encoding="utf-8")
+        return project_root
+
+    def test_sync_real_malformed_canonical_is_path_free(self, tmp_path: Path) -> None:
+        # The route the issue found: SyncPhaseError(error_kind="parse") → string
+        # ``detail``. One fix point covers both this standalone route and the
+        # Sync-All aggregation (``_phase_error_envelope`` does ``str(detail)``).
+        project_root = self._seed(tmp_path)
+        res = self._build_app(project_root).post("/context/mcp-servers/sync")
+
+        assert res.status_code == 422, res.text
+        body = res.json()
+        assert isinstance(body["detail"], str), body  # parse 422 keeps a string detail
+        self._assert_path_free(body, project_root, basename="broken.json")
+        message = body["detail"]
+        assert "broken.json" in message, message  # names the artifact
+        assert "invalid JSON" in message, message  # names the problem
+
+    def test_create_real_malformed_content_is_path_free(self, tmp_path: Path) -> None:
+        # create renders the object envelope (``_error`` → ``detail`` is a dict);
+        # the path-free message lives at ``detail.message``.
+        project_root = self._seed(tmp_path)
+        res = self._build_app(project_root).post(
+            "/context/mcp-servers",
+            json={"name": "broken", "content": self._MALFORMED},
+        )
+
+        assert res.status_code == 422, res.text
+        body = res.json()
+        assert body["detail"]["error_kind"] == "parse", body
+        self._assert_path_free(body, project_root, basename="broken.json")
+        message = body["detail"]["message"]
+        assert "broken.json" in message, message
+        assert "invalid JSON" in message, message
+
+    def test_update_real_malformed_content_is_path_free(self, tmp_path: Path) -> None:
+        # update renders the object envelope like create. The seeded canonical
+        # already exists (``is_file`` passes); the malformed *body* content hits
+        # the parser before the mtime/lock dance, so any integer ``mtime_ns``
+        # reaches the parse 422.
+        project_root = self._seed(tmp_path)
+        res = self._build_app(project_root).put(
+            "/context/mcp-servers/broken",
+            json={"content": self._MALFORMED, "mtime_ns": "0", "force": False},
+        )
+
+        assert res.status_code == 422, res.text
+        body = res.json()
+        assert body["detail"]["error_kind"] == "parse", body
+        self._assert_path_free(body, project_root, basename="broken.json")
+        message = body["detail"]["message"]
+        assert "broken.json" in message, message
+        assert "invalid JSON" in message, message
+
+    def test_diff_real_malformed_canonical_is_path_free(self, tmp_path: Path) -> None:
+        # The diff route routes the reason through ``sanitize_diff_reason``, but
+        # that only strips a prefix-matching project root; ``safe_message`` is
+        # path-free at the source regardless (macOS ``/tmp``→``/private/tmp``).
+        project_root = self._seed(tmp_path)
+        res = self._build_app(project_root).get("/context/mcp-servers/broken/diff")
+
+        assert res.status_code == 200, res.text  # diff diagnoses, never 422s
+        body = res.json()
+        reason = body["runtimes"][0].get("reason", "")
+        assert body["runtimes"][0]["status"] == "parse error", body
+        self._assert_path_free(body, project_root, basename="broken.json")
+        assert "broken.json" in reason, reason
+
+    def test_list_symlinked_root_is_path_free(self, tmp_path: Path) -> None:
+        # Codex #1412-review repro: under a symlinked / case-variant project
+        # root the canonical path is ``.resolve()``'d but the route's
+        # ``project_root`` is not, so the single-form strips left the absolute
+        # resolved path in BOTH ``canonical_path`` (``_safe_rel`` fallback) and
+        # the diff-row ``reason`` (``sanitize_diff_reason``). Pin both path-free.
+        from memtomem.context.mcp_servers import CANONICAL_MCP_SERVER_ROOT
+
+        real = (tmp_path / "real").resolve()
+        canon = real / CANONICAL_MCP_SERVER_ROOT
+        canon.mkdir(parents=True)
+        (canon / "broken.json").write_text(self._MALFORMED, encoding="utf-8")
+        link = tmp_path / "link"
+        link.symlink_to(real)
+
+        # The route receives the UNRESOLVED symlink as project_root.
+        res = self._build_app(link).get("/context/mcp-servers")
+
+        assert res.status_code == 200, res.text
+        body = res.json()
+        self._assert_path_free(body, link, basename="broken.json")  # resolves link→real
+        server = body["mcp-servers"][0]
+        assert server["canonical_path"] == ".memtomem/mcp-servers/broken.json", server
+        assert server["runtimes"][0]["status"] == "parse error", server
+        assert "broken.json" in server["runtimes"][0]["reason"], server
+
+    def test_safe_message_is_basename_only(self) -> None:
+        # The core contract every web catch site relies on: ``safe_message``
+        # names only the basename while ``str(exc)`` keeps the full path the CLI
+        # / MCP surfaces want. Driven through the real parser (no hand-built
+        # exception) so the raise site and the twin stay in lockstep.
+        from memtomem.context.mcp_servers import McpServerParseError, parse_mcp_server_text
+
+        src = Path("/abs/home-username/proj/.memtomem/mcp-servers/x.json")
+        with pytest.raises(McpServerParseError) as ei:
+            parse_mcp_server_text(self._MALFORMED, name="x", source=src)
+        exc = ei.value
+        assert str(src) in str(exc)  # CLI / MCP keep the full path
+        assert str(src) not in exc.safe_message  # web boundary stays path-free
+        assert str(src.parent) not in exc.safe_message
+        assert exc.safe_message.startswith("invalid JSON in x.json:")  # names the artifact
 
 
 class TestSyncPhaseErrorHandlerContract:

--- a/packages/memtomem/tests/test_web_routes_context_transfer.py
+++ b/packages/memtomem/tests/test_web_routes_context_transfer.py
@@ -724,6 +724,38 @@ async def test_mcp_copy_ok(client, cwd_root: Path, tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_mcp_copy_malformed_source_is_path_free(
+    client, cwd_root: Path, tmp_path: Path
+) -> None:
+    # Real parse path for the transfer-copy catch site (#1412): a malformed
+    # SOURCE canonical makes the copy adapter's parser embed the resolved
+    # source path in ``str(exc)``; the web boundary must render the path-free
+    # ``exc.safe_message`` (basename + the JSON problem) instead. A trailing
+    # comma is invalid JSON but secret-free, so Gate A passes and the parse
+    # branch is the one that fires.
+    store = cwd_root / ".memtomem" / "mcp-servers"
+    store.mkdir(parents=True, exist_ok=True)
+    src = store / "pg.json"
+    src.write_text('{\n  "command": "echo",\n}\n', encoding="utf-8")
+    other = _other_project(tmp_path)
+    scope_b = await _register(client, other)
+
+    resp = await client.post("/api/context/mcp-servers/pg/transfer", json=_mcp_copy_body(scope_b))
+
+    assert resp.status_code == 422, resp.text
+    body = resp.json()
+    assert body["detail"]["error_kind"] == "parse", body
+    message = body["detail"]["message"]
+    assert "pg.json" in message, message  # names the artifact
+    assert "invalid JSON" in message, message  # names the problem
+    blob = json.dumps(body)
+    assert str(src.resolve()) not in blob, body  # full source path never leaks
+    assert str(src.resolve().parent) not in blob, body
+    assert str(cwd_root.resolve()) not in blob, body
+    assert str(Path.home()) not in blob, body  # #1385 literal: no $HOME / username
+
+
+@pytest.mark.asyncio
 async def test_mcp_needs_confirmation_round_trip(client, cwd_root: Path, tmp_path: Path) -> None:
     _write_mcp_server(cwd_root)
     other = _other_project(tmp_path)


### PR DESCRIPTION
## What & why

Closes #1412.

A malformed canonical `.mcp.json` makes `generate_all_mcp_servers` (and the create/update/diff parsers) raise `McpServerParseError` whose message embeds the absolute, `.resolve()`'d source `Path`. Every web/loopback catch site surfaced it verbatim, so a `POST /api/context/mcp-servers/sync` against a broken canonical returned:

```
422 {"detail": "invalid JSON in /Users/<username>/.../.memtomem/mcp-servers/broken.json: ..."}
```

That leaks `$HOME` + the OS username to the loopback dashboard — the **#1385 finding-1 disclosure class, on the parse branch** instead of the privacy branch. Pre-existing; not introduced by #1409/#1411 (surfaced during that adversarial audit, where the mcp-servers regression test deliberately scoped its path-free claim to the privacy branch and flagged this as a separate concern).

## Fix

- **`McpServerParseError` gains a path-free `safe_message` twin**, set only at the JSON-decode raise — the sole site that embeds the full `Path`; the validation-shape raises already name only `'{name}'`. `safe_message` defaults to the full message everywhere else.
- **The five web catch sites render `exc.safe_message`** (basename + the JSON problem): create, update, diff, standalone sync, and the transfer-copy site in `context_transfer.py` (a sibling the issue didn't enumerate). **CLI / MCP keep `str(exc)`** with the full path — useful there, not a loopback leak. The single sync fix covers both the standalone route and the **Sync-All** aggregation (`_phase_error_envelope` renders `str(detail)` with no redaction).
- **basename-only, not the `$HOME → ~` redactor**, is deliberate: a project rooted outside `$HOME` would still leak its absolute path through a prefix collapse. The basename form is path-free regardless of where the project lives.

### Found in review (same disclosure class)

The **list route** (`GET /context/mcp-servers`) leaked the same path under a **symlinked / case-variant root** (e.g. macOS `/tmp`→`/private/tmp`): the canonical path is `.resolve()`'d but the route receives an unresolved `project_root`, so `_safe_rel` fell back to the absolute path and `sanitize_diff_reason` stripped only the unresolved root — both `canonical_path` **and** the diff-row `reason` leaked. Both now try the resolved root too (guarded for `PurePath` / `OSError`; `sanitize_diff_reason` is shared, so this hardens every context_* list/diff route).

## Acceptance (from the issue)

- ✅ A malformed canonical `.mcp.json` sync renders a 422 whose body contains **no** `$HOME` / username / absolute path.
- ✅ The parse error stays actionable (names the artifact basename + the JSON problem) without the host path.
- ✅ CLI / MCP parse messages are unchanged.

## Tests

- `TestMcpServersParseBranchPathFree` drives a **real malformed canonical** (not a monkeypatched generator) through sync, create, update, diff, and the symlinked-root list path, plus a `safe_message` engine-contract test — each asserts the whole 422/200 body carries no absolute path, `$HOME`, or username.
- A real malformed-source **transfer-copy** test in the route-level harness.
- **Mutation-validated**: neutering `safe_message` reds the sync/create tests; reverting `_safe_rel` + `sanitize_diff_reason` reds the symlinked-root test — all four fixes are load-bearing.

## Validation

`ruff check` + `ruff format --check` clean, `mypy` clean. Focused + broad suites green (the only full-suite reds are local-env `wiki_absent` tests — my machine has a real `~/.memtomem-wiki`; they pass with an isolated HOME — and order-dependent `session_tracing` config tests that pass in isolation; none touch the changed files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
