### PR TITLE
Separate global Wiki in Context Gateway nav

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1436,8 +1436,8 @@ const LEGACY_SECTION_MAP = { 'harness-watchdog': 'harness-health' };
 // per-call-site updates.
 const GATEWAY_SECTIONS = new Set([
   'ctx-overview', 'ctx-projects', 'ctx-skills', 'ctx-commands', 'ctx-agents', 'ctx-mcp-servers',
-  'ctx-wiki',
   'hooks-sync',
+  'ctx-wiki',
 ]);
 
 function loadNavCollapseState() {
@@ -1467,6 +1467,9 @@ function applyNavCollapseState() {
     const groupId = btn.dataset.group;
     if (groupId === 'danger') return;
     btn.classList.toggle('collapsed-member', !!state[groupId]);
+  });
+  document.querySelectorAll('.settings-nav-divider[data-group]').forEach(divider => {
+    divider.classList.toggle('collapsed-member', !!state[divider.dataset.group]);
   });
 }
 

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -537,18 +537,19 @@
             <span class="nav-sub" data-i18n="settings.nav.ctx_mcp_servers_sub">Project tool servers</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-wiki" data-group="integrations" data-i18n-title="settings.nav.ctx_wiki_tip" title="Canonical = the one authoritative copy of each skill, subagent, and command that every runtime renders from.">
-          <span class="nav-icon" aria-hidden="true">📚</span>
-          <span class="nav-labels">
-            <span class="nav-label" data-i18n="settings.nav.ctx_wiki">Wiki</span>
-            <span class="nav-sub" data-i18n="settings.nav.ctx_wiki_sub">Global canonical library</span>
-          </span>
-        </button>
         <button class="settings-nav-btn" data-ui-tier="prod" data-section="hooks-sync" data-group="integrations">
           <span class="nav-icon" aria-hidden="true">📎</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.hooks_sync">Hooks</span>
             <span class="nav-sub" data-i18n="settings.nav.hooks_sync_sub">Lifecycle hooks</span>
+          </span>
+        </button>
+        <div class="settings-nav-divider" data-group="integrations" aria-hidden="true"></div>
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-wiki" data-group="integrations" data-i18n-title="settings.nav.ctx_wiki_tip" title="Canonical = the one authoritative copy of each skill, subagent, and command that every runtime renders from.">
+          <span class="nav-icon" aria-hidden="true">📚</span>
+          <span class="nav-labels">
+            <span class="nav-label" data-i18n="settings.nav.ctx_wiki">Wiki</span>
+            <span class="nav-sub" data-i18n="settings.nav.ctx_wiki_sub">Global canonical library</span>
           </span>
         </button>
       </nav>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=117" />
+  <link rel="stylesheet" href="/style.css?v=118" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -1595,7 +1595,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=5"></script>
-  <script src="/app.js?v=129"></script>
+  <script src="/app.js?v=130"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=11"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -240,6 +240,13 @@ header h1 { font-size: 1.2rem; font-weight: 700; color: var(--accent); letter-sp
 .settings-nav-btn .nav-sub { font-size: 0.68rem; color: var(--muted); line-height: 1.2; }
 .settings-nav-btn.active .nav-sub { color: var(--accent); opacity: 0.75; }
 .settings-nav-btn.collapsed-member { display: none; }
+.settings-nav-divider {
+  height: 1px;
+  margin: 8px 14px;
+  background: var(--border);
+  opacity: 0.85;
+}
+.settings-nav-divider.collapsed-member { display: none; }
 .settings-nav-group {
   display: flex; align-items: center; gap: 6px;
   width: 100%; text-align: left;

--- a/packages/memtomem/tests-js/ctx-wiki-nav-separation.test.mjs
+++ b/packages/memtomem/tests-js/ctx-wiki-nav-separation.test.mjs
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+const SCRIPTS = ['i18n.js', 'app.js', 'context-gateway.js'];
+
+describe('Context Gateway Wiki nav placement', () => {
+  it('keeps the host-global Wiki entry separated at the end of the Gateway nav', async () => {
+    const { window } = await bootApp({ scripts: SCRIPTS });
+    const nav = window.document.querySelector('#tab-context-gateway .settings-nav');
+    const buttons = [...nav.querySelectorAll('.settings-nav-btn[data-section]')];
+    const sections = buttons.map((btn) => btn.dataset.section);
+
+    expect(sections.at(-2)).toBe('hooks-sync');
+    expect(sections.at(-1)).toBe('ctx-wiki');
+
+    const wikiBtn = nav.querySelector('.settings-nav-btn[data-section="ctx-wiki"]');
+    const divider = wikiBtn.previousElementSibling;
+    expect(divider.classList.contains('settings-nav-divider')).toBe(true);
+    expect(divider.dataset.group).toBe('integrations');
+    expect(divider.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('hides the Wiki separator when the Gateway nav group is collapsed', async () => {
+    const { window } = await bootApp({ scripts: SCRIPTS });
+    const group = window.document.querySelector(
+      '#tab-context-gateway .settings-nav-group[data-group="integrations"]',
+    );
+    const divider = window.document.querySelector(
+      '#tab-context-gateway .settings-nav-divider[data-group="integrations"]',
+    );
+
+    group.click();
+
+    expect(group.getAttribute('aria-expanded')).toBe('false');
+    expect(divider.classList.contains('collapsed-member')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- move the host-global Wiki entry to the end of the Context Gateway nav
- add a visual separator before Wiki to distinguish it from project-scoped gateway surfaces
- hide the separator when the Gateway nav group is collapsed

## Tests
- npm test -- ctx-wiki-nav-separation.test.mjs context-toolbar.test.mjs