### PR TITLE
feat(cli): mm wiki remote/push/pull — wiki backup & cross-device sync (#1416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+- **CLI: `mm wiki remote` / `push` / `pull` — wiki backup & cross-device sync
+  (ADR-0008).** The wiki (`~/.memtomem-wiki`) has always been a normal git repo,
+  but until now the only product affordance was the one-time `mm wiki init --from
+  <url>` clone — backup and sync meant dropping to raw `git`. `mm wiki remote
+  [<url>]` shows or sets the `origin` backup remote; `mm wiki push` and `mm wiki
+  pull` are **thin pass-through** wrappers over `git push`/`git pull origin
+  <branch>`. They surface git's own errors verbatim (non-fast-forward, merge
+  conflict, dirty tree) and own no merge/conflict resolution or fast-forward
+  policy — divergent histories follow your own `git pull` config, exactly like
+  any private repo (no new sync protocol). Credentials embedded in a remote URL
+  are redacted from all displayed output and error messages (they still persist
+  in `.git/config` — prefer SSH keys or a git credential helper). Restoring onto
+  a fresh machine stays `mm wiki init --from <url>`.
+
 - **CLI: `mm wiki {skill,agent,command} commit` (ADR-0027 §3).** The terminal
   parity of the in-browser wiki **Commit** affordance. After editing a canonical
   asset or a vendor override (e.g. with `mm wiki skill override <name> --vendor

--- a/docs/adr/0008-wiki-layer.md
+++ b/docs/adr/0008-wiki-layer.md
@@ -293,7 +293,12 @@ override slots. They can be added in v2 if their runtime surface grows.
   work without a lockfile.
 - **`~/.memtomem-wiki/` is a normal git repo.** Backup, sharing, and
   versioning use git remotes — the same workflow as any private repo.
-  No new sync protocol.
+  `mm wiki remote [<url>]` (show or set `origin`), `mm wiki push`, and
+  `mm wiki pull` are thin pass-through wrappers over `git -C ~/.memtomem-wiki`
+  that make this actionable without a new sync protocol: they surface git's
+  own errors (non-fast-forward, merge conflict, dirty tree) and own no
+  merge/conflict resolution. Restoring onto a fresh machine stays
+  `mm wiki init --from <url>` (clone). No new sync protocol.
 - **Vendor overrides are opt-in.** Default (no overrides directory)
   means existing fan-out behavior is unchanged. Override usage is
   surfaced in `mm context update` log lines (`[override applied:

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -1218,11 +1218,20 @@ mm wiki skill override <name> --vendor claude --editor  # writes overrides/claud
 mm wiki skill diff <name> --vendor claude               # canonical render vs this vendor override (--vendor required)
 mm wiki skill commit <name> --vendor claude             # override-only commit (add --canonical only for a combined commit)
 
+# Back up / sync the wiki across machines (it is a normal git repo — no new sync protocol):
+mm wiki remote git@github.com:you/memtomem-wiki.git    # configure the 'origin' backup remote (no arg = show it)
+mm wiki push                                           # back up: git push origin <branch>
+mm wiki pull                                           # sync down: git pull origin <branch>
+mm wiki init --from <url>                              # restore onto a fresh machine (one-time clone)
+
 # Notes:
 #   - commit only records files that already exist on disk (create canonical / seed override first)
 #   - `mm wiki <type> commit` makes ONE isolated commit of the selected paths; it never
 #     sweeps unrelated staged changes (no `git add . && git commit`)
 #   - agents/commands mirror skill: `mm wiki agent ...`, `mm wiki command ...`
+#   - push/pull are thin git wrappers: they surface git's own errors and own no conflict
+#     resolution — resolve merge conflicts / divergent histories with ordinary git, and avoid
+#     embedding credentials in the remote URL (prefer SSH keys or a git credential helper)
 
 # Agent context sync
 mm context detect                      # find agent config files

--- a/packages/memtomem/src/memtomem/cli/wiki_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/wiki_cmd.py
@@ -36,7 +36,7 @@ from memtomem.wiki.override import (
     canonical_asset_file,
     seed_override,
 )
-from memtomem.wiki.store import WikiHeadMovedError
+from memtomem.wiki.store import WikiHeadMovedError, _redact_url_userinfo
 
 # ``--vendor`` Choices derive from OVERRIDE_FORMATS (the single source of
 # truth) so they never drift from the matrix: kimi is valid for skills/agents
@@ -393,6 +393,95 @@ def list_cmd(asset_type: str | None) -> None:
             click.secho(f"  {asset.type}/", fg="cyan")
             last_type = asset.type
         click.echo(f"    {asset.name}")
+
+
+# ── Remote / backup ─────────────────────────────────────────────────────
+#
+# Thin wrappers over git (ADR-0008: "git remotes — no new sync protocol"): they
+# surface git's own errors and own no merge/conflict resolution. The wiki is a
+# normal git repo, so anything these don't cover is plain `git -C <wiki> ...`.
+
+
+@wiki.command("remote")
+@click.argument("url", required=False, default=None)
+def remote_cmd(url: str | None) -> None:
+    """Show or set the wiki's backup remote ('origin').
+
+    With no argument, prints the configured origin URL (credentials redacted).
+    With a git URL, configures origin so `mm wiki push` / `mm wiki pull` can back
+    up and restore the wiki across machines.
+
+    WARNING: a URL with embedded credentials (https://user:token@host/...) is
+    stored as plaintext in the wiki's .git/config — prefer SSH keys or a git
+    credential helper.
+    """
+    store = WikiStore.at_default()
+    try:
+        if url is None:
+            current = store.remote_url()
+            if current is None:
+                click.secho("No wiki remote configured.", fg="yellow")
+                click.echo("# set one: mm wiki remote <git-url>")
+                return
+            click.echo(f"origin\t{_redact_url_userinfo(current)}")
+            return
+        action = store.set_remote(url)
+        click.secho(
+            f"Set wiki remote 'origin' → {_redact_url_userinfo(url)} ({action})",
+            fg="green",
+        )
+        click.echo("# back up: mm wiki push   # restore elsewhere: mm wiki pull")
+    except WikiNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@wiki.command("push")
+def push_cmd() -> None:
+    """Push the wiki to its backup remote ('origin').
+
+    Thin pass-through to `git push origin <branch>`. memtomem owns no conflict
+    resolution: if git rejects the push (e.g. the remote moved), git's own
+    message — which already tells you to `mm wiki pull` / `git pull` first —
+    is surfaced verbatim. Configure the remote once with `mm wiki remote <url>`.
+    """
+    store = WikiStore.at_default()
+    try:
+        output = store.push()
+    except WikiNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except RuntimeError as exc:
+        # Covers WikiDetachedHeadError, the no-remote precondition, and any git
+        # failure (non-fast-forward, auth, unborn branch). str(exc) is already
+        # credential-redacted at the _git boundary; the local wiki path it may
+        # carry is the user's own (the init/commit CLI convention).
+        raise click.ClickException(str(exc)) from exc
+    if output:
+        click.echo(output)
+    click.secho("Pushed.", fg="green")
+
+
+@wiki.command("pull")
+def pull_cmd() -> None:
+    """Pull the wiki from its backup remote ('origin').
+
+    Thin pass-through to `git pull origin <branch>` (a normal merge). On a merge
+    conflict or dirty working tree git stops and leaves the wiki for you to
+    resolve with ordinary git — memtomem owns no conflict resolution; git's own
+    message is surfaced verbatim. To restore onto a fresh machine instead, clone
+    with `mm wiki init --from <url>`.
+    """
+    store = WikiStore.at_default()
+    try:
+        output = store.pull()
+    except WikiNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if output:
+        click.echo(output)
+    click.secho("Pulled.", fg="green")
 
 
 # ── Skill subgroup ──────────────────────────────────────────────────────

--- a/packages/memtomem/src/memtomem/wiki/__init__.py
+++ b/packages/memtomem/src/memtomem/wiki/__init__.py
@@ -14,6 +14,7 @@ from memtomem.wiki.store import (
     WIKI_ASSET_TYPES,
     WikiAlreadyExistsError,
     WikiAsset,
+    WikiDetachedHeadError,
     WikiNotFoundError,
     WikiStore,
 )
@@ -23,6 +24,7 @@ __all__ = [
     "WIKI_ASSET_TYPES",
     "WikiAlreadyExistsError",
     "WikiAsset",
+    "WikiDetachedHeadError",
     "WikiNotFoundError",
     "WikiStore",
 ]

--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -94,6 +94,17 @@ class WikiNothingToCommitError(RuntimeError):
     """
 
 
+class WikiDetachedHeadError(RuntimeError):
+    """Raised when a branch operation runs on a detached-HEAD wiki.
+
+    ``mm wiki push`` / ``pull`` push or pull a *branch* (``origin <branch>``);
+    a detached HEAD has no branch to name, so :meth:`WikiStore.current_branch`
+    refuses rather than let git emit a cryptic refspec error. The message is
+    deliberately path- and SHA-free so it stays safe if a future web surface
+    ever reuses it (CLI surfaces it as a classified ``ClickException``).
+    """
+
+
 @dataclass(frozen=True)
 class WikiAsset:
     """An entry in the wiki — a skill, agent, or command directory."""
@@ -108,6 +119,38 @@ def _wiki_path_from_env() -> Path:
     if env:
         return Path(env).expanduser()
     return DEFAULT_WIKI_PATH
+
+
+# Match the ``userinfo@`` segment of a ``scheme://userinfo@host`` URL. The
+# authority ends at ``/``, ``?``, or ``#``, so excluding those (and whitespace)
+# keeps the greedy match inside it: it strips up to the LAST ``@`` in the
+# authority (so a password containing ``@`` still goes) without reaching into a
+# path/query/fragment that legitimately contains ``@`` (e.g. ``?email=a@b``).
+_URL_USERINFO_RE = re.compile(r"([a-zA-Z][a-zA-Z0-9+.\-]*://)[^/?#\s]*@")
+
+
+def _redact_url_userinfo(text: str) -> str:
+    """Strip ``userinfo@`` (``user``, ``user:pass``, or a bare token) from any
+    ``scheme://userinfo@host`` URL in *text*.
+
+    Display/diagnostic hygiene for the common case — git remote URLs may embed
+    credentials (``https://user:token@host/repo.git``), and a properly-formed
+    (RFC 3986) credential is kept out of terminals, shell history, and error
+    messages. The real URL stays intact in ``.git/config`` (git's own credential
+    store; memtomem doesn't manage it).
+
+    Best-effort, not a guarantee: a credential containing an unencoded ``/`` or
+    whitespace is not valid URL userinfo (RFC 3986 requires percent-encoding), so
+    it falls outside the authority this matches and may survive — but such a
+    value is already exposed on the command line that set it. The CLI help and
+    docs steer users to SSH keys / credential helpers over inline credentials.
+
+    Applied at the :func:`_git` error boundary so every git-subprocess failure
+    (clone / remote / push / pull) is redacted in one place. scp-like SSH
+    (``git@host:repo``) is left untouched: no scheme, no password syntax — the
+    ``git@`` is a username, not a secret.
+    """
+    return _URL_USERINFO_RE.sub(r"\1", text)
 
 
 def _git(
@@ -135,7 +178,36 @@ def _git(
         )
     except subprocess.CalledProcessError as exc:
         detail = (exc.stderr or exc.stdout or "").strip()
-        raise RuntimeError(f"git {' '.join(args)} failed: {detail}") from exc
+        # Redact the WHOLE message: both the echoed argv (``clone <url>`` /
+        # ``remote add origin <url>`` embed the URL) and git's stderr may carry
+        # credentials. See :func:`_redact_url_userinfo`.
+        raise RuntimeError(_redact_url_userinfo(f"git {' '.join(args)} failed: {detail}")) from exc
+    except OSError as exc:
+        # git binary missing / cwd vanished mid-call. Classify as RuntimeError so
+        # a raw OSError never escapes a caller's (or the CLI's) RuntimeError
+        # handler; redact in case the message carries a URL.
+        raise RuntimeError(_redact_url_userinfo(f"git {' '.join(args)} failed: {exc}")) from exc
+
+
+def _git_query(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run ``git <args>`` allowing a non-zero exit; normalize only ``OSError``.
+
+    Like :func:`_git` but does NOT raise on a non-zero return code — the caller
+    inspects ``returncode`` (e.g. ``git config --get`` exit 1 == key absent).
+    The not-found/IO ``OSError`` (missing git binary, vanished cwd) is still
+    converted to a redacted :class:`RuntimeError` so a raw ``OSError`` never
+    escapes a caller's — or the CLI's — ``except RuntimeError`` handler.
+    """
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as exc:
+        raise RuntimeError(_redact_url_userinfo(f"git {' '.join(args)} failed: {exc}")) from exc
 
 
 def _force_rmtree(path: Path) -> None:
@@ -256,6 +328,121 @@ class WikiStore:
         if self.root.exists():
             self.root.rmdir()
         _git(["clone", url, str(self.root)], cwd=self.root.parent)
+
+    # ── Remote / backup (ADR-0008: "git remotes — no new sync protocol") ─────
+    #
+    # ``remote`` / ``push`` / ``pull`` are deliberately THIN wrappers over git:
+    # they surface git's own errors (non-fast-forward, merge conflict, dirty
+    # tree, auth) and own no merge/conflict resolution and no ff-only policy.
+    # push/pull always pass an explicit ``origin <branch>`` refspec — never
+    # ``-u`` / tracking config — so behavior is predictable and a first pull
+    # works without a tracking branch having been set up.
+    #
+    # No cross-process lock is taken (unlike :meth:`commit_paths`): a concurrent
+    # ``mm web`` / ``mm wiki commit`` advances HEAD under its own ref CAS, which
+    # already fails cleanly if push/pull moves the ref underneath it. push/pull
+    # are foreground user actions; running them alongside a commit is the user's
+    # call, like any git repo.
+
+    def remote_url(self, name: str = "origin") -> str | None:
+        """Return the configured URL of remote *name*, or ``None`` if unset.
+
+        Uses ``git config --get remote.<name>.url`` (stable since git 1.6) rather
+        than ``git remote get-url`` (git 2.7+, rc=2 on a missing remote). Exit 1
+        means the key is absent → ``None`` (the expected "no remote" case); any
+        OTHER non-zero code (e.g. 128 = unparsable ``.git/config``) is a real
+        failure and is surfaced (redacted) rather than masked as an absent remote
+        — otherwise a broken config would read as the friendly push/pull
+        no-remote precondition.
+        """
+        self.require_exists()
+        result = _git_query(["config", "--get", f"remote.{name}.url"], self.root)
+        if result.returncode == 0:
+            url = result.stdout.strip()
+            return url or None
+        if result.returncode == 1:
+            return None
+        detail = (result.stderr or result.stdout or "").strip()
+        raise RuntimeError(
+            _redact_url_userinfo(f"git config --get remote.{name}.url failed: {detail}")
+        )
+
+    def set_remote(self, url: str, name: str = "origin") -> str:
+        """Configure remote *name* to *url*; return ``"added"`` or ``"updated"``.
+
+        ``git remote set-url`` fails if the remote does not exist, so add when
+        absent and set-url otherwise. The URL is written verbatim to
+        ``.git/config`` (git's store) — callers that echo it back must redact
+        credentials first (:func:`_redact_url_userinfo`).
+        """
+        self.require_exists()
+        if self.remote_url(name) is None:
+            _git(["remote", "add", name, url], cwd=self.root)
+            return "added"
+        _git(["remote", "set-url", name, url], cwd=self.root)
+        return "updated"
+
+    def current_branch(self) -> str:
+        """Return the checked-out branch name (e.g. ``"main"``).
+
+        Uses ``git symbolic-ref --short HEAD``, which resolves to the branch
+        name even on an *unborn* branch (a clone of an empty remote) — so push
+        then surfaces git's own "src refspec ... does not match any" rather than
+        this method crashing on ``rev-parse`` of a missing HEAD. A detached HEAD
+        is not a symbolic ref (rc != 0), so we raise
+        :class:`WikiDetachedHeadError`: push/pull operate on a branch, and a
+        detached HEAD has none to name. (Mirrors :meth:`commit_paths`, which
+        also derives the branch via ``symbolic-ref``.)
+        """
+        self.require_exists()
+        result = _git_query(["symbolic-ref", "--short", "HEAD"], self.root)
+        if result.returncode != 0:
+            raise WikiDetachedHeadError(
+                "wiki is in detached HEAD state; check out a branch before push/pull"
+            )
+        branch = result.stdout.strip()
+        if not branch:
+            # symbolic-ref rc 0 with empty output should never happen, but guard
+            # so push/pull never run `git push origin ""`.
+            raise RuntimeError("could not determine the wiki's current branch")
+        return branch
+
+    def push(self, name: str = "origin") -> str:
+        """Push the current branch to remote *name*; return git's output.
+
+        Thin pass-through: ``git push <name> <branch>``. A missing remote is the
+        one memtomem-level precondition (points the user at ``mm wiki remote``);
+        every other failure (non-fast-forward, auth, unborn branch) surfaces
+        git's own message verbatim via :class:`RuntimeError`.
+        """
+        self.require_exists()
+        if self.remote_url(name) is None:
+            raise RuntimeError(
+                f"no remote named {name!r} configured; set one with `mm wiki remote <url>`"
+            )
+        branch = self.current_branch()
+        result = _git(["push", name, branch], cwd=self.root)
+        return _redact_url_userinfo((result.stdout + result.stderr).strip())
+
+    def pull(self, name: str = "origin") -> str:
+        """Pull the current branch from remote *name*; return git's output.
+
+        Thin pass-through: ``git pull <name> <branch>``. Divergent histories
+        follow the user's own git config (``pull.rebase`` / ``pull.ff``); with
+        none set, modern git refuses and says so — that message is surfaced
+        verbatim. On a merge conflict or dirty tree git exits non-zero and
+        leaves the working tree as-is for the user to resolve — memtomem owns no
+        conflict resolution. A missing remote is the one memtomem-level
+        precondition.
+        """
+        self.require_exists()
+        if self.remote_url(name) is None:
+            raise RuntimeError(
+                f"no remote named {name!r} configured; set one with `mm wiki remote <url>`"
+            )
+        branch = self.current_branch()
+        result = _git(["pull", name, branch], cwd=self.root)
+        return _redact_url_userinfo((result.stdout + result.stderr).strip())
 
     def current_commit(self) -> str:
         """Return the wiki HEAD commit SHA as the full 40-character hex string.

--- a/packages/memtomem/tests/test_wiki_cmd_remote.py
+++ b/packages/memtomem/tests/test_wiki_cmd_remote.py
@@ -1,0 +1,190 @@
+"""Tests for the ``mm wiki remote`` / ``push`` / ``pull`` CLI surface (#1416)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from memtomem.cli.wiki_cmd import wiki
+from memtomem.wiki.store import WikiStore
+
+
+def _bare_origin(path: Path) -> Path:
+    subprocess.run(
+        ["git", "init", "--bare", "-b", "main", str(path)],
+        check=True,
+        capture_output=True,
+    )
+    return path
+
+
+def _commit_file(root: Path, rel: str, content: str, msg: str) -> None:
+    target = root / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    subprocess.run(["git", "-C", str(root), "add", rel], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(root), "commit", "-m", msg], check=True, capture_output=True)
+
+
+class TestRemoteCmd:
+    def test_show_when_unset(self, wiki_root: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(wiki, ["init"])
+        result = runner.invoke(wiki, ["remote"])
+        assert result.exit_code == 0, result.output
+        assert "No wiki remote configured" in result.output
+        assert "mm wiki remote" in result.output
+
+    def test_set_added(self, wiki_root: Path, tmp_path: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(wiki, ["init"])
+        origin = _bare_origin(tmp_path / "origin.git")
+        result = runner.invoke(wiki, ["remote", str(origin)])
+        assert result.exit_code == 0, result.output
+        assert "Set wiki remote 'origin'" in result.output
+        assert "(added)" in result.output
+
+    def test_show_after_set(self, wiki_root: Path, tmp_path: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(wiki, ["init"])
+        origin = _bare_origin(tmp_path / "origin.git")
+        runner.invoke(wiki, ["remote", str(origin)])
+        result = runner.invoke(wiki, ["remote"])
+        assert result.exit_code == 0, result.output
+        assert str(origin) in result.output
+
+    def test_set_redacts_credentials(self, wiki_root: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(wiki, ["init"])
+        result = runner.invoke(wiki, ["remote", "https://user:secret@github.com/o/r.git"])
+        assert result.exit_code == 0, result.output
+        assert "secret" not in result.output
+        assert "github.com/o/r.git" in result.output
+
+    def test_show_redacts_credentials(self, wiki_root: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(wiki, ["init"])
+        runner.invoke(wiki, ["remote", "https://user:secret@github.com/o/r.git"])
+        result = runner.invoke(wiki, ["remote"])
+        assert result.exit_code == 0, result.output
+        assert "secret" not in result.output
+        assert "github.com/o/r.git" in result.output
+
+    def test_requires_wiki(self, wiki_root: Path) -> None:
+        runner = CliRunner()  # no init
+        result = runner.invoke(wiki, ["remote"])
+        assert result.exit_code != 0
+        assert "wiki not found" in result.output
+
+
+class TestPushCmd:
+    def test_push_happy(self, wiki_root: Path, tmp_path: Path) -> None:
+        runner = CliRunner()
+        assert runner.invoke(wiki, ["init"]).exit_code == 0
+        origin = _bare_origin(tmp_path / "origin.git")
+        assert runner.invoke(wiki, ["remote", str(origin)]).exit_code == 0
+        result = runner.invoke(wiki, ["push"])
+        assert result.exit_code == 0, result.output
+        assert "Pushed." in result.output
+        # The push actually landed: origin's main matches the local wiki HEAD.
+        remote_head = subprocess.run(
+            ["git", "ls-remote", str(origin), "main"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.split()[0]
+        local_head = WikiStore.at(wiki_root).current_commit()
+        assert remote_head == local_head
+
+    def test_push_detached_head_surfaces_error(self, wiki_root: Path, tmp_path: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(wiki, ["init"])
+        origin = _bare_origin(tmp_path / "origin.git")
+        runner.invoke(wiki, ["remote", str(origin)])
+        head = WikiStore.at(wiki_root).current_commit()
+        subprocess.run(
+            ["git", "-C", str(wiki_root), "checkout", head], check=True, capture_output=True
+        )
+        result = runner.invoke(wiki, ["push"])
+        assert result.exit_code != 0
+        assert "detached HEAD" in result.output
+
+    def test_push_no_remote_is_friendly(self, wiki_root: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(wiki, ["init"])
+        result = runner.invoke(wiki, ["push"])
+        assert result.exit_code != 0
+        assert "mm wiki remote" in result.output
+
+    def test_push_non_fast_forward_shows_git_message(self, wiki_root: Path, tmp_path: Path) -> None:
+        runner = CliRunner()
+        assert runner.invoke(wiki, ["init"]).exit_code == 0
+        origin = _bare_origin(tmp_path / "origin.git")
+        assert runner.invoke(wiki, ["remote", str(origin)]).exit_code == 0
+        assert runner.invoke(wiki, ["push"]).exit_code == 0
+
+        # A second clone advances origin; the local wiki then diverges.
+        other = WikiStore.at(tmp_path / "other")
+        other.init_from_url(str(origin))
+        _commit_file(other.root, "README.md", "from other\n", "other edit")
+        other.push()
+        _commit_file(wiki_root, "README.md", "local\n", "local edit")
+
+        result = runner.invoke(wiki, ["push"])
+        assert result.exit_code != 0
+        lowered = result.output.lower()
+        assert "rejected" in lowered or "fast-forward" in lowered or "fast forward" in lowered
+
+    def test_push_requires_wiki(self, wiki_root: Path) -> None:
+        runner = CliRunner()  # no init
+        result = runner.invoke(wiki, ["push"])
+        assert result.exit_code != 0
+        assert "wiki not found" in result.output
+
+
+class TestPullCmd:
+    def test_pull_happy(self, wiki_root: Path, tmp_path: Path) -> None:
+        runner = CliRunner()
+        assert runner.invoke(wiki, ["init"]).exit_code == 0
+        origin = _bare_origin(tmp_path / "origin.git")
+        assert runner.invoke(wiki, ["remote", str(origin)]).exit_code == 0
+        assert runner.invoke(wiki, ["push"]).exit_code == 0
+
+        # A second clone pushes a new asset; the local wiki pulls it.
+        other = WikiStore.at(tmp_path / "other")
+        other.init_from_url(str(origin))
+        _commit_file(other.root, "skills/x/SKILL.md", "# x\n", "add x")
+        other.push()
+
+        result = runner.invoke(wiki, ["pull"])
+        assert result.exit_code == 0, result.output
+        assert "Pulled." in result.output
+        assert (wiki_root / "skills" / "x" / "SKILL.md").read_text() == "# x\n"
+
+    def test_pull_no_remote_is_friendly(self, wiki_root: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(wiki, ["init"])
+        result = runner.invoke(wiki, ["pull"])
+        assert result.exit_code != 0
+        assert "mm wiki remote" in result.output
+
+    def test_pull_detached_head_surfaces_error(self, wiki_root: Path, tmp_path: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(wiki, ["init"])
+        origin = _bare_origin(tmp_path / "origin.git")
+        runner.invoke(wiki, ["remote", str(origin)])
+        head = WikiStore.at(wiki_root).current_commit()
+        subprocess.run(
+            ["git", "-C", str(wiki_root), "checkout", head], check=True, capture_output=True
+        )
+        result = runner.invoke(wiki, ["pull"])
+        assert result.exit_code != 0
+        assert "detached HEAD" in result.output
+
+    def test_pull_requires_wiki(self, wiki_root: Path) -> None:
+        runner = CliRunner()  # no init
+        result = runner.invoke(wiki, ["pull"])
+        assert result.exit_code != 0
+        assert "wiki not found" in result.output

--- a/packages/memtomem/tests/test_wiki_remote.py
+++ b/packages/memtomem/tests/test_wiki_remote.py
@@ -1,0 +1,357 @@
+"""Tests for the wiki remote/backup verbs — ``WikiStore.remote_url`` /
+``set_remote`` / ``current_branch`` / ``push`` / ``pull`` and the
+credential-redaction helper (ADR-0008 "git remotes", issue #1416).
+
+These are thin git wrappers: the tests assert the round-trip works, that the
+memtomem-level precondition (no remote) is friendly, and that git's own
+errors (non-fast-forward, conflict, dirty tree) surface verbatim while
+memtomem leaves the working tree for the user to resolve.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from memtomem.wiki.store import (
+    WikiDetachedHeadError,
+    WikiNotFoundError,
+    WikiStore,
+    _git,
+    _redact_url_userinfo,
+)
+
+
+def _bare_origin(path: Path) -> Path:
+    """Create a bare git repo to act as ``origin`` (no working tree)."""
+    subprocess.run(
+        ["git", "init", "--bare", "-b", "main", str(path)],
+        check=True,
+        capture_output=True,
+    )
+    return path
+
+
+def _init_wiki(path: Path) -> WikiStore:
+    store = WikiStore.at(path)
+    store.init()
+    return store
+
+
+def _commit_file(root: Path, rel: str, content: str, msg: str) -> None:
+    target = root / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    subprocess.run(["git", "-C", str(root), "add", rel], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(root), "commit", "-m", msg], check=True, capture_output=True)
+
+
+# ── remote_url / set_remote ─────────────────────────────────────────────
+
+
+class TestRemoteUrl:
+    def test_none_before_set(self, tmp_path: Path, git_identity: None) -> None:
+        store = _init_wiki(tmp_path / "wiki")
+        assert store.remote_url() is None
+
+    def test_returns_url_after_set(self, tmp_path: Path, git_identity: None) -> None:
+        store = _init_wiki(tmp_path / "wiki")
+        origin = _bare_origin(tmp_path / "origin.git")
+        store.set_remote(str(origin))
+        assert store.remote_url() == str(origin)
+
+    def test_requires_existing_wiki(self, tmp_path: Path) -> None:
+        store = WikiStore.at(tmp_path / "missing")
+        with pytest.raises(WikiNotFoundError):
+            store.remote_url()
+
+    def test_oserror_normalized_to_runtimeerror(
+        self, tmp_path: Path, git_identity: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A missing git binary (or vanished cwd) must surface as a RuntimeError,
+        # not a raw OSError that escapes the CLI's `except RuntimeError`.
+        import memtomem.wiki.store as store_module
+
+        store = _init_wiki(tmp_path / "wiki")
+
+        def _boom(*_a: object, **_k: object) -> object:
+            raise FileNotFoundError("git")
+
+        monkeypatch.setattr(store_module.subprocess, "run", _boom)
+        with pytest.raises(RuntimeError):
+            store.remote_url()
+
+    def test_corrupt_config_raises_not_none(self, tmp_path: Path, git_identity: None) -> None:
+        # A broken .git/config makes `git config --get` exit 128 — that is a real
+        # failure and must surface, NOT be masked as "no remote configured"
+        # (which only exit 1 == key-absent means).
+        root = tmp_path / "wiki"
+        store = _init_wiki(root)
+        (root / ".git" / "config").write_text("not a valid git config\n", encoding="utf-8")
+        with pytest.raises(RuntimeError):
+            store.remote_url()
+
+
+class TestSetRemote:
+    def test_added_then_updated(self, tmp_path: Path, git_identity: None) -> None:
+        store = _init_wiki(tmp_path / "wiki")
+        first = _bare_origin(tmp_path / "first.git")
+        second = _bare_origin(tmp_path / "second.git")
+        assert store.set_remote(str(first)) == "added"
+        assert store.set_remote(str(second)) == "updated"
+        assert store.remote_url() == str(second)
+
+    def test_requires_existing_wiki(self, tmp_path: Path) -> None:
+        store = WikiStore.at(tmp_path / "missing")
+        with pytest.raises(WikiNotFoundError):
+            store.set_remote("file:///x")
+
+
+# ── current_branch ──────────────────────────────────────────────────────
+
+
+class TestCurrentBranch:
+    def test_returns_main(self, tmp_path: Path, git_identity: None) -> None:
+        store = _init_wiki(tmp_path / "wiki")
+        assert store.current_branch() == "main"
+
+    def test_raises_when_detached(self, tmp_path: Path, git_identity: None) -> None:
+        root = tmp_path / "wiki"
+        store = _init_wiki(root)
+        head = store.current_commit()
+        # Checking out the commit SHA directly detaches HEAD.
+        subprocess.run(["git", "-C", str(root), "checkout", head], check=True, capture_output=True)
+        with pytest.raises(WikiDetachedHeadError, match="detached HEAD"):
+            store.current_branch()
+
+    def test_oserror_normalized_to_runtimeerror(
+        self, tmp_path: Path, git_identity: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import memtomem.wiki.store as store_module
+
+        store = _init_wiki(tmp_path / "wiki")
+
+        def _boom(*_a: object, **_k: object) -> object:
+            raise FileNotFoundError("git")
+
+        monkeypatch.setattr(store_module.subprocess, "run", _boom)
+        with pytest.raises(RuntimeError):
+            store.current_branch()
+
+    def test_unborn_branch_returns_name(self, tmp_path: Path, git_identity: None) -> None:
+        # Cloning an EMPTY remote leaves an unborn HEAD (no commits). The branch
+        # name still resolves (symbolic-ref) — current_branch must NOT crash on
+        # rev-parse of a missing HEAD; push then surfaces git's own refspec error.
+        origin = _bare_origin(tmp_path / "origin.git")
+        store = WikiStore.at(tmp_path / "wiki")
+        store.init_from_url(str(origin))
+        assert store.current_branch() == "main"
+
+
+# ── push / pull round-trip ──────────────────────────────────────────────
+
+
+class TestPushPullRoundTrip:
+    def test_push_creates_branch_on_origin(self, tmp_path: Path, git_identity: None) -> None:
+        store = _init_wiki(tmp_path / "wiki")
+        origin = _bare_origin(tmp_path / "origin.git")
+        store.set_remote(str(origin))
+        store.push()
+        # origin now has main pointing at the wiki HEAD.
+        remote_head = _git(["ls-remote", str(origin), "main"], cwd=store.root).stdout.split()[0]
+        assert remote_head == store.current_commit()
+
+    def test_pull_fast_forwards_a_remote_commit(self, tmp_path: Path, git_identity: None) -> None:
+        # wiki A seeds origin; wiki B clones it, adds a commit, pushes.
+        a = _init_wiki(tmp_path / "a")
+        origin = _bare_origin(tmp_path / "origin.git")
+        a.set_remote(str(origin))
+        a.push()
+
+        b = WikiStore.at(tmp_path / "b")
+        b.init_from_url(str(origin))
+        _commit_file(b.root, "skills/code-review/SKILL.md", "# review\n", "add skill")
+        b.push()
+
+        # A pulls B's commit; the new file fast-forwards into A's tree.
+        out = a.pull()
+        assert (a.root / "skills" / "code-review" / "SKILL.md").read_text() == "# review\n"
+        assert isinstance(out, str)
+
+
+# ── error surfacing (thin pass-through) ─────────────────────────────────
+
+
+class TestPushPullErrors:
+    def test_push_without_remote_is_friendly(self, tmp_path: Path, git_identity: None) -> None:
+        store = _init_wiki(tmp_path / "wiki")
+        with pytest.raises(RuntimeError, match="mm wiki remote"):
+            store.push()
+
+    def test_pull_without_remote_is_friendly(self, tmp_path: Path, git_identity: None) -> None:
+        store = _init_wiki(tmp_path / "wiki")
+        with pytest.raises(RuntimeError, match="mm wiki remote"):
+            store.pull()
+
+    def test_push_non_fast_forward_surfaces_git_message(
+        self, tmp_path: Path, git_identity: None
+    ) -> None:
+        a = _init_wiki(tmp_path / "a")
+        origin = _bare_origin(tmp_path / "origin.git")
+        a.set_remote(str(origin))
+        a.push()
+
+        b = WikiStore.at(tmp_path / "b")
+        b.init_from_url(str(origin))
+        _commit_file(b.root, "README.md", "from B\n", "B edit")
+        b.push()
+
+        # A diverges locally without pulling → its push is rejected by git.
+        _commit_file(a.root, "README.md", "from A\n", "A edit")
+        with pytest.raises(RuntimeError) as exc:
+            a.push()
+        msg = str(exc.value).lower()
+        assert "rejected" in msg or "fast-forward" in msg or "fast forward" in msg
+
+    def test_pull_merge_conflict_left_for_user(self, tmp_path: Path, git_identity: None) -> None:
+        a = _init_wiki(tmp_path / "a")
+        origin = _bare_origin(tmp_path / "origin.git")
+        a.set_remote(str(origin))
+        a.push()
+
+        b = WikiStore.at(tmp_path / "b")
+        b.init_from_url(str(origin))
+        _commit_file(b.root, "README.md", "B line\n", "B edit")
+        b.push()
+
+        # A commits a conflicting change to the same file. Force a merge
+        # strategy so the divergent pull actually merges (modern git otherwise
+        # fatals "need to specify how to reconcile divergent branches" — itself
+        # a faithfully-surfaced thin-pass-through error, just not a conflict).
+        _commit_file(a.root, "README.md", "A line\n", "A edit")
+        subprocess.run(
+            ["git", "-C", str(a.root), "config", "pull.rebase", "false"],
+            check=True,
+            capture_output=True,
+        )
+        with pytest.raises(RuntimeError) as exc:
+            a.pull()
+        msg = str(exc.value).lower()
+        assert "conflict" in msg or "merge" in msg
+        # memtomem owns no resolution: the merge is left in progress for the user.
+        assert a.is_dirty() is True
+
+    def test_pull_dirty_tree_surfaces_git_message(self, tmp_path: Path, git_identity: None) -> None:
+        a = _init_wiki(tmp_path / "a")
+        origin = _bare_origin(tmp_path / "origin.git")
+        a.set_remote(str(origin))
+        a.push()
+
+        b = WikiStore.at(tmp_path / "b")
+        b.init_from_url(str(origin))
+        _commit_file(b.root, "README.md", "from B\n", "B edit")
+        b.push()
+
+        # A has an uncommitted local edit to the same file git wants to update.
+        (a.root / "README.md").write_text("uncommitted local\n", encoding="utf-8")
+        with pytest.raises(RuntimeError):
+            a.pull()
+
+    def test_push_detached_head_raises(self, tmp_path: Path, git_identity: None) -> None:
+        root = tmp_path / "wiki"
+        store = _init_wiki(root)
+        origin = _bare_origin(tmp_path / "origin.git")
+        store.set_remote(str(origin))
+        head = store.current_commit()
+        subprocess.run(["git", "-C", str(root), "checkout", head], check=True, capture_output=True)
+        with pytest.raises(WikiDetachedHeadError):
+            store.push()
+
+    def test_pull_detached_head_raises(self, tmp_path: Path, git_identity: None) -> None:
+        root = tmp_path / "wiki"
+        store = _init_wiki(root)
+        origin = _bare_origin(tmp_path / "origin.git")
+        store.set_remote(str(origin))
+        head = store.current_commit()
+        subprocess.run(["git", "-C", str(root), "checkout", head], check=True, capture_output=True)
+        with pytest.raises(WikiDetachedHeadError):
+            store.pull()
+
+    def test_push_unborn_branch_surfaces_git_message(
+        self, tmp_path: Path, git_identity: None
+    ) -> None:
+        # Clone of an empty remote → unborn HEAD, nothing to push. current_branch
+        # resolves "main"; git push then fails with its own refspec error, which
+        # is surfaced verbatim (thin pass-through) rather than crashing earlier.
+        origin = _bare_origin(tmp_path / "origin.git")
+        store = WikiStore.at(tmp_path / "wiki")
+        store.init_from_url(str(origin))  # clone sets origin
+        with pytest.raises(RuntimeError) as exc:
+            store.push()
+        assert "src refspec" in str(exc.value).lower() or "does not match" in str(exc.value).lower()
+
+    def test_push_requires_existing_wiki(self, tmp_path: Path) -> None:
+        store = WikiStore.at(tmp_path / "missing")
+        with pytest.raises(WikiNotFoundError):
+            store.push()
+
+    def test_pull_requires_existing_wiki(self, tmp_path: Path) -> None:
+        store = WikiStore.at(tmp_path / "missing")
+        with pytest.raises(WikiNotFoundError):
+            store.pull()
+
+
+# ── credential redaction ────────────────────────────────────────────────
+
+
+class TestRedactUrlUserinfo:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("https://user:pass@github.com/o/r.git", "https://github.com/o/r.git"),
+            ("https://ghp_TOKEN@github.com/o/r.git", "https://github.com/o/r.git"),
+            ("ssh://git@host/o/r.git", "ssh://host/o/r.git"),
+            # @ inside the password (greedy strips up to the LAST @ in authority).
+            ("https://us:p@ss@github.com/o/r.git", "https://github.com/o/r.git"),
+            # scp-like SSH has no scheme + no password syntax → untouched.
+            ("git@github.com:o/r.git", "git@github.com:o/r.git"),
+            # no userinfo → untouched.
+            ("https://github.com/o/r.git", "https://github.com/o/r.git"),
+            ("file:///tmp/wiki", "file:///tmp/wiki"),
+            # ``@`` in a query/fragment is NOT userinfo → must stay intact.
+            ("https://example.com/p?email=a@b", "https://example.com/p?email=a@b"),
+            ("https://user@example.com/p?x=a@b", "https://example.com/p?x=a@b"),
+            ("https://us:p@ss@host?q=a@b", "https://host?q=a@b"),
+        ],
+    )
+    def test_redacts(self, raw: str, expected: str) -> None:
+        assert _redact_url_userinfo(raw) == expected
+
+    def test_redacts_within_free_text(self) -> None:
+        text = "fatal: unable to access 'https://tok@github.com/r.git/': Could not resolve host"
+        out = _redact_url_userinfo(text)
+        assert "tok@" not in out
+        assert "https://github.com/r.git" in out
+
+    def test_git_error_redacts_credential_url(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The ``_git`` boundary redacts credentials in BOTH the echoed argv and
+        git's stderr before raising — so no caller can leak them."""
+        import memtomem.wiki.store as store_module
+
+        def _boom(*_args: object, **_kwargs: object) -> object:
+            raise subprocess.CalledProcessError(
+                returncode=128,
+                cmd=["git", "push"],
+                stderr="fatal: Authentication failed for 'https://user:secret@host/r.git'",
+            )
+
+        monkeypatch.setattr(store_module.subprocess, "run", _boom)
+        with pytest.raises(RuntimeError) as exc:
+            _git(["push", "https://user:secret@host/r.git", "main"], cwd=tmp_path)
+        msg = str(exc.value)
+        assert "secret" not in msg
+        assert "host/r.git" in msg


### PR DESCRIPTION
## What & why

Closes #1416.

ADR-0008 says the wiki (`~/.memtomem-wiki`) is a normal git repo whose
backup/sharing/versioning "use git remotes — no new sync protocol", but the only
product affordance was the one-time `mm wiki init --from <url>` clone. There was
no `remote`/`push`/`pull`, so configuring a backup remote and cross-device sync
meant dropping to raw `git` in the wiki directory — the restore story ADR-0008
describes was real but **not actionable** from within memtomem.

## What this adds

Three **thin pass-through** wrappers over `git -C ~/.memtomem-wiki`:

- `mm wiki remote [<url>]` — show or set the `origin` backup remote.
- `mm wiki push` — `git push origin <branch>`.
- `mm wiki pull` — `git pull origin <branch>`.

## Design (maintainer decision on #1416: CLI-only, thin pass-through)

- memtomem owns **no** merge/conflict resolution and **no** fast-forward policy.
  git's own errors (non-fast-forward, merge conflict, dirty tree, divergent
  histories) are surfaced verbatim; divergent pulls follow the user's own
  `git pull` config — exactly like any private repo. No new sync protocol.
- The only memtomem-level precondition is "no remote configured", which points
  the user at `mm wiki remote <url>`.
- push/pull pass an explicit `origin <branch>` refspec (never `-u`/tracking), so
  a first pull works without a tracking branch and behavior is predictable.
- **Credential redaction:** remote URLs may embed credentials
  (`https://user:token@host/...`). A new `_redact_url_userinfo` helper applied at
  the `_git` error boundary keeps RFC-3986-formed credentials out of every
  displayed line and error message — and incidentally closes the same latent leak
  in `mm wiki init --from` clone failures. The raw URL still persists in
  `.git/config` (git's own store), so the help/docs steer users to SSH keys /
  credential helpers. (Redaction is best-effort for malformed URLs — a credential
  with an unencoded `/` or whitespace is not valid userinfo and is already exposed
  on the command line that set it.)
- **No cross-process lock** (unlike `commit_paths`): a concurrent `mm web` /
  `mm wiki commit` advances HEAD under its own ref CAS, which already fails
  cleanly if push/pull moves the ref. push/pull are foreground user actions.

## Robustness (folded from Codex + adversarial review)

- `remote_url` returns `None` only for `git config` exit 1 (key absent); any other
  code (e.g. 128 = unparsable `.git/config`) surfaces redacted, not masked as
  "no remote".
- `current_branch` uses `git symbolic-ref --short HEAD`, so an unborn branch
  (clone of an empty remote) resolves the name and push surfaces git's own refspec
  error; a detached HEAD raises a clear `WikiDetachedHeadError`.
- `_git` classifies `OSError` (missing git binary / vanished cwd) as a
  `RuntimeError` so no raw `OSError` escapes the CLI handler.
- The redaction regex stops at `/`, `?`, and `#`, so an `@` in a path/query
  (e.g. `?email=a@b`) is never mistaken for userinfo.

## Docs

ADR-0008 Consequences names the verbs; `docs/guides/reference.md` wiki quickstart
gains a backup/sync block; CHANGELOG entry. Restoring onto a fresh machine stays
`mm wiki init --from <url>`.

## Testing

`mm wiki` suite: **269 passed** (221 existing + 48 new), `ruff check`/`format`
clean, `mypy` clean. New coverage: store round-trip (push verified via
`ls-remote`, two-clone pull), no-remote friendly error, non-fast-forward, forced
merge-conflict (tree left for the user), dirty-tree, detached-HEAD (push+pull),
unborn-HEAD, corrupt-config, require-exists, and credential-redaction units incl.
query/fragment `@`; CLI parity for every path incl. redaction-in-display,
push-landed verification, and detached HEAD.

## Out of scope (CLI-only per #1416)

- A web "connect remote" affordance and repointing the #1415 wiki nav tooltip
  copy at the new verbs (possible follow-ups).
- This PR makes the ADR-0027 §D-E trigger ("wiki gains a configured push remote")
  reachable via a product verb but does **not** change the editor's soft-warn
  privacy posture — that stays a separate event-driven maintainer call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
