### PR TITLE
feat(web): surface uncommitted wiki changes at the nav/glance level (#1417)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+- **Web UI: wiki "uncommitted changes" badge at the nav/glance level
+  (ADR-0008).** A saved-but-not-committed wiki edit is invisible to `mm context
+  install`, which installs committed git objects only — yet from the Context
+  Gateway sidebar there was no signal that the wiki had edits that won't reach
+  projects yet (the in-section `#wiki-head` badge only shows once you open the
+  **Wiki** section). The Wiki nav entry now carries a small dirty dot driven by
+  the same `is_dirty` state, kept live by the existing save/seed/commit
+  responses and refreshed by a lightweight `GET /api/wiki/status` probe on
+  Context Gateway open (HEAD + `git status` only — so a cold reload with a
+  wiki left dirty in a prior session flags it without first opening the
+  section). Legibility only — no change to install/sync behavior. The dot is a
+  screen-reader-labelled indicator with no live region (it is never announced as
+  it appears).
+
 - **CLI: `mm wiki remote` / `push` / `pull` — wiki backup & cross-device sync
   (ADR-0008).** The wiki (`~/.memtomem-wiki`) has always been a normal git repo,
   but until now the only product affordance was the one-time `mm wiki init --from

--- a/packages/memtomem/src/memtomem/web/routes/wiki.py
+++ b/packages/memtomem/src/memtomem/web/routes/wiki.py
@@ -74,6 +74,36 @@ async def list_wiki() -> dict:
         raise _wiki_absent(exc) from exc
 
 
+@router.get("/status")
+async def wiki_status() -> dict:
+    """Lightweight wiki HEAD + dirty probe for the nav-level glance badge (#1417).
+
+    Unlike :func:`list_wiki` this lists NO assets — it is a single HEAD read
+    plus ``git status``, cheap enough to fire on every Context Gateway open so
+    the sidebar can flag a wiki whose uncommitted edits ``mm context install``
+    would not yet reach (``install`` reads committed git objects only). Declared
+    before the ``/{asset_type}/...`` routes so the literal ``/status`` path can
+    never be captured as an asset type.
+
+    A missing wiki is the common onboarding state, not an error here: it returns
+    ``present=False`` (the nav badge simply stays hidden) rather than the 404 the
+    asset-listing routes raise, so the probe never surfaces an error toast.
+    """
+    store = WikiStore.at_default()
+
+    def _probe() -> dict:
+        return {
+            "present": True,
+            "wiki_head": store.current_commit(),
+            "is_dirty": store.is_dirty(),
+        }
+
+    try:
+        return await asyncio.to_thread(_probe)
+    except WikiNotFoundError:
+        return {"present": False, "wiki_head": None, "is_dirty": False}
+
+
 @router.get("/{asset_type}/{name}/diff")
 async def wiki_diff(asset_type: AssetType, name: str, vendor: str = Query(...)) -> dict:
     """Diff a committed override against the freshly rendered canonical baseline."""

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1411,6 +1411,12 @@ function activateTab(tabName, opts = {}) {
     // still resume their last-viewed section via the localStorage branch above.
     if (!GATEWAY_SECTIONS.has(start)) start = 'ctx-overview';
     switchSettingsSection(start);
+    // #1417: refresh the Wiki nav dirty dot whenever the gateway opens, so a
+    // cold reload landing on any section (not just ctx-wiki) still flags a wiki
+    // left with uncommitted edits. Cheap + best-effort — wiki.js no-ops on an
+    // absent wiki or fetch error. Guarded for script-load order (wiki.js loads
+    // after app.js).
+    if (typeof _probeWikiNavStatus === 'function') _probeWikiNavStatus();
   }
   if (['search', 'timeline'].includes(tabName)) loadNamespaceDropdowns();
 }

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=118" />
+  <link rel="stylesheet" href="/style.css?v=119" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -551,6 +551,19 @@
             <span class="nav-label" data-i18n="settings.nav.ctx_wiki">Wiki</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_wiki_sub">Reuse across your own projects</span>
           </span>
+          <!-- #1417: nav/glance dirty dot. The wiki section body shows the same
+               state in #wiki-head, but from any OTHER gateway section the sidebar
+               gave no signal that the wiki has uncommitted edits `mm context
+               install` won't reach yet. Hidden until wiki.js (_renderWikiNavBadge)
+               or the eager /api/wiki/status probe flips it on. role=img + an
+               aria-label folds the meaning into the button's accessible name; no
+               aria-live (ctx a11y convention — a glance dot, never announced as
+               it appears). -->
+          <span class="wiki-nav-dirty" role="img" hidden
+                data-i18n-title="settings.nav.ctx_wiki_dirty_tip"
+                title="Uncommitted wiki edits — not yet reachable by `mm context install`"
+                data-i18n-aria-label="settings.nav.ctx_wiki_dirty_tip"
+                aria-label="Uncommitted wiki edits — not yet reachable by `mm context install`"></span>
         </button>
       </nav>
       <div class="settings-content">
@@ -1595,7 +1608,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=5"></script>
-  <script src="/app.js?v=130"></script>
+  <script src="/app.js?v=131"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=11"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>
@@ -1606,7 +1619,7 @@
   <script src="/timeline.js?v=3"></script>
   <script src="/context-gateway.js?v=97"></script>
   <script src="/context-portal.js?v=7"></script>
-  <script src="/wiki.js?v=6"></script>
+  <script src="/wiki.js?v=7"></script>
   <script src="/path-picker.js?v=4"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -347,6 +347,7 @@
   "settings.nav.ctx_wiki": "Wiki",
   "settings.nav.ctx_wiki_sub": "Reuse across your own projects",
   "settings.nav.ctx_wiki_tip": "Your personal git library of canonical skills, subagents, and commands — canonical = the one authoritative copy each project pulls a pinned snapshot from via `mm context install` (it never renders into a project on its own). It lives at ~/.memtomem-wiki; to move it to another machine, push and pull it yourself with ordinary git. The wiki is optional — your projects keep working without it.",
+  "settings.nav.ctx_wiki_dirty_tip": "Uncommitted wiki edits — not yet reachable by `mm context install` (it installs committed git objects only). Commit them in the Wiki section to let projects pull them.",
   "settings.nav.dedup": "Deduplicate",
   "settings.nav.dedup_sub": "Remove near-duplicates",
   "settings.nav.decay": "Age-out",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -347,6 +347,7 @@
   "settings.nav.ctx_wiki": "위키",
   "settings.nav.ctx_wiki_sub": "내 여러 프로젝트에서 재사용",
   "settings.nav.ctx_wiki_tip": "내 canonical skill·subagent·command 를 모아 둔 개인 git 라이브러리 — Canonical = 각 프로젝트가 `mm context install` 로 고정된 스냅샷을 가져오는 단일 권위 사본(위키가 프로젝트로 직접 렌더링하지는 않음). ~/.memtomem-wiki 에 있으며, 다른 컴퓨터로 옮기려면 일반 git 으로 직접 push/pull 하세요. 위키는 선택 사항이라 없어도 프로젝트는 그대로 동작합니다.",
+  "settings.nav.ctx_wiki_dirty_tip": "커밋되지 않은 위키 변경 — 아직 `mm context install` 로 전달되지 않습니다(install 은 커밋된 git 객체만 가져옴). 위키 섹션에서 커밋하면 프로젝트가 가져갈 수 있습니다.",
   "settings.nav.dedup": "중복 정리",
   "settings.nav.dedup_sub": "유사 청크 제거",
   "settings.nav.decay": "오래된 기억 만료",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -240,6 +240,21 @@ header h1 { font-size: 1.2rem; font-weight: 700; color: var(--accent); letter-sp
 .settings-nav-btn .nav-sub { font-size: 0.68rem; color: var(--muted); line-height: 1.2; }
 .settings-nav-btn.active .nav-sub { color: var(--accent); opacity: 0.75; }
 .settings-nav-btn.collapsed-member { display: none; }
+/* #1417: glance-level wiki-dirty dot. `display:block` so the empty span sizes
+   (an inline span ignores width/height); `margin-left:auto` parks it at the
+   button's trailing edge. The `hidden` toggle is handled by the global
+   `[hidden] { display:none !important }` (top of this file), which outranks this
+   non-important `display:block` — no local override needed. */
+.settings-nav-btn .wiki-nav-dirty {
+  display: block;
+  margin-left: auto;
+  align-self: center;
+  flex-shrink: 0;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--yellow);
+}
 .settings-nav-divider {
   height: 1px;
   margin: 8px 14px;

--- a/packages/memtomem/src/memtomem/web/static/wiki.js
+++ b/packages/memtomem/src/memtomem/web/static/wiki.js
@@ -90,6 +90,38 @@ function _renderWikiAbsent() {
       t('settings.ctx.wiki_empty_hint'),
     );
   }
+  // No wiki on disk → nothing to commit → clear any stale nav dot (#1417).
+  _renderWikiNavBadge(false);
+}
+
+// Nav/glance dirty badge (#1417). The section body already shows the dirty
+// state in #wiki-head, but from any OTHER Context Gateway section the sidebar
+// gave no signal that the wiki has uncommitted edits `mm context install` won't
+// reach yet. This toggles a small dot on the Wiki nav button, driven by the
+// SAME is_dirty the section tracks: every dirty-state repaint flows through
+// _renderWikiHead / _renderWikiAbsent, so both call here. a11y: just toggle the
+// element's `hidden` (no aria-live) — the dot's aria-label is read when a SR
+// reaches the nav button, but its appearance is never announced (no spam, per
+// the ctx dashboard conventions).
+function _renderWikiNavBadge(isDirty) {
+  const badge = document.querySelector(
+    '.settings-nav-btn[data-section="ctx-wiki"] .wiki-nav-dirty',
+  );
+  if (badge) badge.hidden = !isDirty;
+}
+
+// Eager probe so the nav badge is correct on a cold gateway open, before the
+// Wiki section has been visited (a wiki left dirty in a prior session). Cheap —
+// HEAD + `git status` only, no asset list. Best-effort: a missing wiki
+// (present:false) or any fetch failure leaves the dot hidden rather than
+// surfacing an error. Called from app.js on Context Gateway activation.
+async function _probeWikiNavStatus() {
+  try {
+    const res = await fetch('/api/wiki/status');
+    if (!res.ok) return;
+    const data = await res.json();
+    _renderWikiNavBadge(!!data.is_dirty);
+  } catch { /* glance signal only — never block the gateway on it */ }
 }
 
 function _renderWikiHead() {
@@ -115,6 +147,11 @@ function _renderWikiHead() {
   headEl.innerHTML = html;
   const commitBtn = qs('wiki-commit-btn');
   if (commitBtn) commitBtn.addEventListener('click', () => { _openWikiCommitModal(); });
+  // Mirror the dirty state onto the nav/glance dot (#1417). Every site that
+  // flips _wikiData.is_dirty (load + the Save/seed/commit responses) repaints
+  // the head, so this single hook keeps the sidebar in sync without touching
+  // each call site.
+  _renderWikiNavBadge(!!_wikiData.is_dirty);
 }
 
 // --- Commit affordance (ADR-0027 §3, dev tier only) -------------------------

--- a/packages/memtomem/tests-js/wiki.test.mjs
+++ b/packages/memtomem/tests-js/wiki.test.mjs
@@ -797,3 +797,64 @@ describe('wiki.js commit affordance (ADR-0027 §3, dev tier)', () => {
     expect(window.document.getElementById('wiki-commit-btn')).toBeNull();
   });
 });
+
+describe('wiki.js nav/glance dirty badge (#1417)', () => {
+  const WIKI_LIST_DIRTY = { ...WIKI_LIST, is_dirty: true };
+  const navDot = (window) =>
+    window.document.querySelector('.settings-nav-btn[data-section="ctx-wiki"] .wiki-nav-dirty');
+
+  it('starts hidden in the shipped markup', async () => {
+    const { window } = await boot();
+    expect(navDot(window)).not.toBeNull();
+    expect(navDot(window).hidden).toBe(true);
+  });
+
+  it('reveals the dot after loading a dirty wiki and hides it for a clean one', async () => {
+    const dirty = await boot({ '/api/wiki': WIKI_LIST_DIRTY });
+    await dirty.window.loadWiki();
+    expect(navDot(dirty.window).hidden).toBe(false);
+
+    const clean = await boot({ '/api/wiki': WIKI_LIST }); // is_dirty: false
+    await clean.window.loadWiki();
+    expect(navDot(clean.window).hidden).toBe(true);
+  });
+
+  it('clears the dot when the wiki is absent (404)', async () => {
+    const { window } = await boot();
+    window._renderWikiNavBadge(true); // pretend a prior dirty state lit it
+    expect(navDot(window).hidden).toBe(false);
+    window.fetch = async (input) => {
+      const url = typeof input === 'string' ? input : input?.url;
+      if (url && url.includes('/api/wiki')) {
+        return {
+          ok: false,
+          status: 404,
+          json: async () => ({ detail: { reason_code: 'wiki_absent' } }),
+          text: async () => '',
+        };
+      }
+      return { ok: true, status: 200, json: async () => ({}), text: async () => '{}' };
+    };
+    await window.loadWiki();
+    expect(navDot(window).hidden).toBe(true);
+  });
+
+  it('eager probe lights the dot from /api/wiki/status before the section is opened', async () => {
+    const { window } = await boot({ '/api/wiki/status': { present: true, is_dirty: true } });
+    expect(navDot(window).hidden).toBe(true); // not opened yet
+    await window._probeWikiNavStatus();
+    expect(navDot(window).hidden).toBe(false);
+  });
+
+  it('eager probe leaves the dot hidden for an absent/clean wiki and never throws', async () => {
+    const absent = await boot({ '/api/wiki/status': { present: false, is_dirty: false } });
+    await absent.window._probeWikiNavStatus();
+    expect(navDot(absent.window).hidden).toBe(true);
+
+    // A failed probe must not surface — the dot just stays as-is.
+    const broken = await boot();
+    broken.window.fetch = async () => { throw new Error('network'); };
+    await broken.window._probeWikiNavStatus();
+    expect(navDot(broken.window).hidden).toBe(true);
+  });
+});

--- a/packages/memtomem/tests/test_web_routes_wiki.py
+++ b/packages/memtomem/tests/test_web_routes_wiki.py
@@ -113,6 +113,47 @@ async def test_list_wiki_absent_is_404_not_500(client, wiki_root: Path) -> None:
     assert str(wiki_root) not in resp.text
 
 
+# ── GET /api/wiki/status ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wiki_status_clean(client, seeded_wiki: Path) -> None:
+    resp = await client.get("/api/wiki/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["present"] is True
+    assert data["is_dirty"] is False
+    assert len(data["wiki_head"]) == 40  # full SHA
+
+
+@pytest.mark.asyncio
+async def test_wiki_status_dirty(client, seeded_wiki: Path) -> None:
+    # An uncommitted working-tree edit (the exact state `install` cannot reach).
+    (seeded_wiki / "skills" / "alpha" / "SKILL.md").write_bytes(b"# Alpha EDITED\n")
+    resp = await client.get("/api/wiki/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["present"] is True
+    assert data["is_dirty"] is True
+
+
+@pytest.mark.asyncio
+async def test_wiki_status_absent_is_present_false_not_404(
+    client,
+    wiki_root: Path,  # noqa: F811
+) -> None:
+    # Unlike the asset-listing routes, the nav probe must not 404 on an absent
+    # wiki — it fires on every gateway open, so it degrades to a hidden badge.
+    resp = await client.get("/api/wiki/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["present"] is False
+    assert data["is_dirty"] is False
+    assert data["wiki_head"] is None
+    # The /status literal must not be parsed as an {asset_type} (would 422).
+    assert str(wiki_root) not in resp.text
+
+
 # ── GET /api/wiki/{type}/{name}/diff ──────────────────────────────────────
 
 


### PR DESCRIPTION
## What & why

A **saved-but-not-committed** wiki edit does not propagate to projects:
`mm context install` reads committed git objects only (`git show
<commit>:<path>`), so the working tree — including uncommitted edits visible in
the editor and in `diff`/`lint` — is invisible to `install` until committed.

The CLI already warns about this (`_WIKI_DIRTY_WARN`) and the wiki section body
has a `#wiki-head` dirty badge, but there was **no nav/glance-level signal**:
from the Context Gateway sidebar (while on any *other* section) a user couldn't
tell that their wiki had edits that won't reach projects yet.

This adds a small **dirty dot on the Wiki nav entry**, driven by the existing
`is_dirty` state. Legibility only — **no change to install/sync behavior**.

Closes #1417.

## Design decisions

- **Placement: the nav button**, not the "Global wiki" scope chip — the chip
  sits next to the existing `#wiki-head` badge in the section body, so a badge
  there would be redundant and only visible once you're already in the section.
- **Data flow: eager probe.** A new `GET /api/wiki/status` returns just `wiki_head`
  + `is_dirty` (no asset listing — a single `git status`), fired once on Context
  Gateway open. This closes the *cold-reload* case the issue describes — a wiki
  left dirty in a prior session is flagged from the sidebar **without** first
  opening the Wiki section. The dot also stays live in-session via the existing
  save/seed/commit responses (all of which already return `wiki_dirty`).

## Implementation

| File | Change |
|---|---|
| `web/routes/wiki.py` | `GET /api/wiki/status` — HEAD + `is_dirty` only. Absent wiki → `present:false` (not 404), so the probe never surfaces an error. Declared before `/{asset_type}/...` so `/status` can't be parsed as an asset type. |
| `static/wiki.js` | `_renderWikiNavBadge` + `_probeWikiNavStatus`; a single dirty source threaded through `_renderWikiHead` / `_renderWikiAbsent`, so every existing dirty repaint keeps the dot in sync without touching each call site. |
| `static/app.js` | Probe on Context Gateway activation (best-effort; no-ops on absent wiki / fetch error; guarded for script-load order). |
| `static/index.html` | Dot span in the Wiki nav button (`role=img` + i18n `aria-label`/`title`, `hidden`); `?v=` bumps for `style.css`/`app.js`/`wiki.js`. |
| `static/style.css` | `.wiki-nav-dirty` (7px amber dot; the global `[hidden]{display:none !important}` owns the toggle). |
| `locales/en.json`, `ko.json` | `settings.nav.ctx_wiki_dirty_tip`. |
| `tests-js/wiki.test.mjs` (+5), `tests/test_web_routes_wiki.py` (+3) | Coverage. |

## a11y

Follows the ctx dashboard conventions: the dot is a `role=img` + `aria-label`
indicator folded into the nav button's accessible name, with **no live region**
— it is never announced as it appears (no spam), and it is read when a screen
reader reaches the nav button.

## Testing

- `npx vitest run` (from `tests-js`) — **336 pass** (incl. 5 new nav-badge tests)
- `pytest test_web_routes_wiki.py test_i18n.py` — **96 pass** (incl. 3 new status-route tests)
- `pytest -k "web_invariants or routes_wiki"` + `test_web_a11y` + `test_wiki_gateway` — green
- `ruff check` + `ruff format --check` — clean
- Codex review — **SHIP, no findings**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
