### PR TITLE
test(i18n): align jargon-guard docstring with the exact wiki_ prefix

### DIFF
--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -878,9 +878,10 @@ class TestNoHardcodedStrings:
         denylist over ``settings.ctx.*`` would false-positive — so two
         legitimate-use classes are allowlisted, and only for ``canonical``:
 
-        * **Wiki surface** (``"wiki" in key``) — "canonical" is the real product
-          term for the wiki's canonical/override model; the nav glossary even
-          *requires* it be defined (``test_ctx_nav_sub_glossary_consistency``).
+        * **Wiki surface** (exact ``settings.ctx.wiki_`` key prefix) —
+          "canonical" is the real product term for the wiki's canonical/override
+          model; the nav glossary even *requires* it be defined
+          (``test_ctx_nav_sub_glossary_consistency``).
         * **Path placeholder** ``{canonical}`` — the empty-state hints render the
           on-disk store path through this i18n placeholder, not as bare prose.
 


### PR DESCRIPTION
## What

`test_ctx_settings_namespace_no_raw_jargon` (the namespace-wide jargon guard
added in #1404) had a docstring that described its Wiki-surface allowlist as
`"wiki" in key`, while the actual predicate is the stricter exact prefix
`settings.ctx.wiki_` (test_i18n.py:915). The test's *own* inline comment
already calls this out:

> The wiki predicate is an exact prefix — not `"wiki" in key` — so a future
> non-wiki key that merely contains the substring can't silently earn the
> exemption.

So the docstring bullet contradicted both the code and the comment two lines
below it. This aligns the docstring with the implementation.

## Why it matters

The exact-prefix choice is load-bearing: it prevents a future
non-`settings.ctx.wiki_` key that happens to contain "wiki" from silently
inheriting the `canonical` allowlist exemption. The stale docstring made the
guard look looser (and self-inconsistent) than it is. Surfaced while
reconciling the #1353 onboarding tracker against the merged guard.

## Scope

Docstring-only; no behavior change. `test_i18n.py` stays green (81 passed),
ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
