### PR TITLE
feat(web): flip Context Gateway Simple-as-default (ADR-0026 D-F), reversibly

### DIFF
--- a/docs/adr/0026-context-gateway-onboarding-ia.md
+++ b/docs/adr/0026-context-gateway-onboarding-ia.md
@@ -1,15 +1,19 @@
 # ADR-0026: Context Gateway first-time-user onboarding & comprehension layer
 
-**Status:** Accepted & partially shipped — P0 and P1a/P1b are merged; the
-P1 Simple-as-default flip and all of P2 remain deferred pending the
-§Validation first-run user test. See §"Implementation status (as of
-2026-06-17)". D-F (staged rollout, Advanced default first) is followed.
+**Status:** Accepted & partially shipped — P0, P1a/P1b, and the P1
+Simple-as-default flip (D-F) are merged; all of P2 remains deferred. See
+§"Implementation status (as of 2026-06-18)". **D-F shipped 2026-06-18 as a
+reversible experiment** (Simple is now the default) rather than gated on the
+§Validation user test — 6 naive participants proved impractical, and the
+Advanced toggle (per-user) plus the one-line constant (global) are the
+rollback. The §Validation test + kit remain available if P2 (irreversible)
+ever needs naive evidence.
 **D-A is now decided (2026-06-17):** the Web display uses friendly tier
 labels ("User" / "Project (shared)" / "Project (local)") + a "Stored in"
 axis — a narrow supersession of ADR-0016 §7 for Web display copy only, with
 the CLI / request identifiers unchanged. The remaining provisional decisions
 (D-B / D-C) stay open, gated on the §Validation user test.
-**Date:** 2026-06-14 (status updated 2026-06-17)
+**Date:** 2026-06-14 (status updated 2026-06-18)
 **Context:** A first-time-user end-to-end smoke test of the Context Gateway
 web UI (driven through Playwright against an isolated, seeded HOME) found
 that the dashboard is *functionally* complete but *conceptually* opaque to
@@ -230,9 +234,10 @@ Each item: **what** · **where** · **acceptance criterion**.
 
 1. **Simple/Advanced toggle** (`localStorage` flag) shows/hides
    `#ctx-control-bar` and the Projects/Wiki/Hooks nav. Simple is the
-   *target* default — but per D-F the rollout is staged (ship with
-   **Advanced default first**, flip to Simple after the §Validation user
-   test). Advanced restores today's UI verbatim; `#ctx-control-bar` stays
+   *target* default — and per D-F it shipped: Simple is the default since
+   2026-06-18 (a reversible flip; the §Validation test was skipped as
+   impractical, the toggle is the rollback). Advanced restores today's UI
+   verbatim; `#ctx-control-bar` stays
    in the DOM (hidden) so the existing hoist guard stays green.
 2. **One-line verdict + per-type inline actions** — each surfaced problem
    carries its resolving verb button on its own row; Sync vs Import is
@@ -242,8 +247,8 @@ Each item: **what** · **where** · **acceptance criterion**.
    untouched.
 4. **Default-flip fan-out** — Simple-as-default ships with its
    onboarding-docs fan-out in the same change (per the repo's
-   default-change discipline); consider a staged opt-in (Advanced default,
-   flip after the user test) — see D-F.
+   default-change discipline) — shipped 2026-06-18 as a reversible flip (the
+   staged opt-in was skipped as impractical; the toggle is the rollback) — see D-F.
 
 **Simple default mode (P1) — low-fi mockup:**
 
@@ -283,9 +288,10 @@ Backend `reason_code`s and request vocabulary (ADR-0015) are unchanged.
 - The glossary (§2) becomes the term set #1351's ko.json pass localizes
   against; #1351 and this ADR must agree on terms before either lands
   user-facing strings, to avoid double-churn.
-- No behavioural, route, schema, or gate change in P0/P1. P2 changes only
-  display copy + status presentation, never `reason_code`s or request
-  params (ADR-0015 preserved).
+- No route, schema, or gate change in P0/P1. P1's Simple-as-default flip
+  changes first-run *presentation* only and stays reversible (Advanced toggle /
+  one-line constant). P2 changes only display copy + status presentation, never
+  `reason_code`s or request params (ADR-0015 preserved).
 - P0 item 4 overlaps #1348's confirm-copy edit at `en.json:415`;
   sequencing must be coordinated (D-E) so the two do not collide.
 - The tier display-term decision (D-A) is **taken** (2026-06-17): the Web
@@ -293,7 +299,7 @@ Backend `reason_code`s and request vocabulary (ADR-0015) are unchanged.
   supersession, Web display only) without colliding with ADR-0015 or
   pre-empting #922 — request identifiers (`target_scope`) are unchanged.
 
-## Implementation status (as of 2026-06-17)
+## Implementation status (as of 2026-06-18)
 
 Shipped-state companion to the phased plan in §3. #1353 remains the home
 for the remaining work; this table is the source of truth for *what has
@@ -307,9 +313,9 @@ drifted.
 | **P0 — Minimal** — Overview primer, Store→Runtimes flow diagram, always-visible status legend, glossary tooltips, `(current folder)` naming, i18n/a11y hygiene (D-G) | **Shipped** | #1356 |
 | P0-3 status-legend help-tip a11y — static aria-label | **Shipped** (follow-up) | #1377 |
 | P0-4 confirm/glossary de-jargon — `move_copy_shared_confirm_message` rewritten (now "…into the project's shared store — committed to git…", no raw `canonical`/`project_shared`); scope-ID tooltips; nav glossary *defines* "canonical" | **Shipped** | #1356 (confirm rewrite); de-jargon companion PRs #1368 / #1375 (under issue #1352) |
-| **P1a — Simple-mode scaffold** — Simple/Advanced `localStorage` toggle, read-only, **Advanced default** (D-F staged opt-in) | **Shipped** | #1358 |
+| **P1a — Simple-mode scaffold** — Simple/Advanced `localStorage` toggle, read-only (default later flipped to Simple — see the D-F row) | **Shipped** | #1358 |
 | **P1b — Simple-mode inline actions** — per-type Sync/Import rows, cross-tier empty-state summary (D-D lean iii), 3-state Simple labels | **Shipped** | #1360 |
-| **P1 — Simple-as-default flip** (D-F) | **Staged** — the switch point (`context-gateway.js` `_CTX_SIMPLE_DEFAULT`) and the §Validation harness are in place; the live default **stays Advanced** (`_CTX_SIMPLE_DEFAULT = false`) until the §Validation user test clears probes 1–3. The flip itself = set the constant `true`, then a follow-up PR (deep-link scoping tighten + reference.md copy) flips this row to Shipped. Still gated on the user test. | staged (switch point + harness) |
+| **P1 — Simple-as-default flip** (D-F) | **Shipped (reversible)** — `_CTX_SIMPLE_DEFAULT = true` (`context-gateway.js`); Simple is the default-when-unset. Shipped 2026-06-18 as a reversible experiment instead of gating on the §Validation test (6 naive participants impractical): the Advanced toggle (per-user, persisted) + reverting the constant (global) are the rollback. Onboarding-docs fan-out shipped same-PR (the `context-gateway.md` guide). The "scoping tighten" the staged plan anticipated is a no-op — the nav/control-bar deep-link trap was already `:has`-guarded in P1a and the tile grid lives only in the Overview, so it cannot strand a user. | 2026-06-18 |
 | **P2 — Bold** — Push/Pull verb rename, status collapse to ahead/behind/in-sync (D-B / D-C) | **Deferred** — gated on the §Validation user test | — |
 
 **§Validation status:**
@@ -328,10 +334,14 @@ drifted.
   placeholder in empty-state hints,
   so a namespace-wide grep would false-positive. Extending the per-key
   guard as new user-facing keys are added remains open work under #1353.
-- *First-run user test (5–6 naive participants).* **Not yet run.** It gates
-  the P1 default flip and all of P2. Use the pass bars defined below
-  verbatim — they are the single source of truth; do not re-derive
-  thresholds elsewhere.
+- *First-run user test (5–6 naive participants).* **Not run — and no longer
+  gating P1.** Recruiting 6 naive participants proved impractical, so the P1
+  Simple-as-default flip (D-F) shipped 2026-06-18 as a reversible experiment
+  instead (the Advanced toggle is the rollback). The test now gates only **P2**
+  (the irreversible Push/Pull re-frame); the moderated + Option-A async
+  protocols + the seed harness in `memtomem-docs/memtomem/testing/` remain
+  ready if P2 is taken up. Use the pass bars defined below verbatim — they are
+  the single source of truth; do not re-derive thresholds elsewhere.
 
 **Companion string issues** #1348 / #1349 / #1350 / #1351 / #1352 — all
 **closed**.
@@ -359,10 +369,12 @@ master copy, what does Sync do?"; (3) identity — "how many projects, which
 are you in?"; (4) scope — "you want your teammate to get this skill —
 which tier?"; (5) **safety (P2 gate)** — "what will Push do to the Claude
 copy that's ahead?" (must predict "overwrite"); (6) recovery — seed a
-parse-error item, "what's wrong, how fix?". **Pass bars:** P0 ships if
-probes 1–3 succeed for ≥4/6 without docs; P2 is gated on probe 5
-succeeding for ≥5/6 and the status-merge not costing power users the
-create-vs-overwrite distinction.
+parse-error item, "what's wrong, how fix?". **Pass bars:** probes 1–3
+(≥4/6 without docs) were the original P0/P1 comprehension gate — now
+**diagnostic/historical**, since P0/P1 (incl. the reversible
+Simple-as-default flip) shipped without the study. The live gate is **P2
+only**: probe 5 succeeding for ≥5/6 **and** the status-merge not costing
+power users the create-vs-overwrite distinction.
 
 ### Reproducing the first-run state
 
@@ -448,15 +460,18 @@ to the prior open question Q-x.)
   - **Alternatives (kept):** let #1351 land first and have this ADR conform
     to whatever terms emerge; or run them fully in parallel with a
     post-hoc reconciliation pass (higher churn risk).
-- **D-F. Default-flip blast radius.**
-  - **Lean:** **staged opt-in first** — ship Simple mode with **Advanced as
-    the default**, gather the §Validation user-test signal, then flip the
-    default in a follow-up (with the onboarding-docs fan-out in the same
-    change), per the repo's default-change discipline. Keep the toggle
-    visible (not buried) as the rollback signal.
-  - **Alternatives (kept):** flip Simple-as-default immediately (with
-    same-change docs fan-out) — faster comprehension win, larger blast
-    radius and weaker rollback signal.
+- **D-F. Default-flip blast radius. DECIDED 2026-06-18 — flip now, reversibly.**
+  - **Decision:** shipped Simple-as-default immediately (`_CTX_SIMPLE_DEFAULT =
+    true`) with the onboarding-docs fan-out in the same change, keeping the
+    Advanced toggle visible (not buried) as the rollback signal. The
+    §Validation signal the original lean waited for was skipped as impractical
+    (6 naive participants out of reach); the bet is acceptable because the
+    change is reversible — per-user via the toggle, globally via the one-line
+    constant — and is watched by real-world feedback rather than a pre-ship study.
+  - **Original lean (not taken):** staged opt-in first — ship with Advanced as
+    the default, gather the §Validation signal, then flip. Rejected on the
+    recruiting cost alone; revisit if real-world feedback shows the flip hurt
+    naive first-runs.
 - **D-G. Accessibility & localization of the new visual onboarding.**
   - **Lean:** make a11y a **P0 gate** (not deferred): the Store→Runtimes
     diagram must carry an equivalent text alternative (it is never the only

--- a/docs/guides/context-gateway.md
+++ b/docs/guides/context-gateway.md
@@ -83,10 +83,11 @@ equivalent paths.
 mm web      # http://127.0.0.1:8080
 ```
 
-Open **Settings → Context Gateway**, find the **Skills** section, and look at the
-status of the skill:
+Open **Settings → Context Gateway**. The default **Simple view** shows one row
+per artifact type — find the **Skills** row:
 
-- If it shows **Out of sync** or **Not in runtime**, click **Sync** on that row.
+- If the skill isn't in your tools yet the row reads **Needs sync** and offers a
+  **Sync** button. Click it.
 - A confirmation appears first — it tells you exactly what will change, e.g.
   *"This will create N missing and overwrite M out-of-sync runtime files in:
   …"*. Read it, then confirm.
@@ -118,8 +119,9 @@ mm context sync --include=skills --scope user
 
 ## Sync vs Import — reading the status
 
-The Web UI shows one of these statuses per artifact. Map the status to the action
-that resolves it:
+The **Advanced** view labels each artifact with one of these precise statuses
+(the default Simple view collapses them into a single per-row verdict + fix
+button). Map the status to the action that resolves it:
 
 | Status | What it means | Action |
 |---|---|---|
@@ -141,14 +143,15 @@ export-only and are never read back.
 
 The Context Gateway tab has two views, toggled by the **Simple view** switch:
 
-- **Advanced** (the current default) — per-type sections (Skills, Subagents,
-  Custom Commands, MCP servers, settings/hooks), each with a status badge and per
-  row Sync/Import buttons, plus a control bar to filter by artifact type, the
-  **Stored in** tier, project, and sync state. **Sync All** pushes everything in
-  the current Store at once (with the same create/overwrite confirmation).
-- **Simple view** — a one-line overview per type with a single fix button on each
-  row, and a **Manage** link that drops you into Advanced for anything without a
-  one-click fix.
+- **Simple view** (the default) — a one-line overview per type with a single fix
+  button on each row, and a **Manage** link that drops you into Advanced for
+  anything without a one-click fix.
+- **Advanced** — per-type sections (Skills, Subagents, Custom Commands, MCP
+  servers, settings/hooks), each with a status badge and per-row Sync/Import
+  buttons, plus a control bar to filter by artifact type, the **Stored in** tier,
+  project, and sync state. **Sync All** pushes everything in the current Store at
+  once (with the same create/overwrite confirmation). The **Simple view** toggle
+  switches back; your choice persists.
 
 The **Projects** portal lists the project roots memtomem knows about: the folder
 the server is running in (marked *current folder*), any roots you registered, and

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -525,19 +525,19 @@ try {
 // section nav and renders the Overview as a one-line verdict + per-type rows.
 // P1b: each fixable row runs Sync/Import inline (same confirm flow as Advanced);
 // clean rows show a check, and rows with no safe one-click fix keep the Manage
-// deep-link into Advanced. Advanced — the default per ADR-0026 D-F's staged
-// rollout — restores today's UI verbatim. Persisted like the active-scope flag;
-// default off so power users are unaffected until the post-validation
-// default-flip lands.
+// deep-link into Advanced. Advanced — reachable via the toggle (the reversible
+// rollback) — restores today's UI verbatim. Persisted like the active-scope
+// flag; Simple is the default-when-unset since the D-F flip, so power users who
+// prefer Advanced toggle once and stay there.
 const _CTX_SIMPLE_MODE_KEY = 'memtomem_ctx_simple_mode';
-// D-F staged flip switch point (ADR-0026 §"Implementation status"). This is the
-// default used WHEN NO value is stored. It stays ``false`` (Advanced default)
-// until the §Validation first-run user test clears probes 1-3; flipping it to
-// ``true`` makes Simple the default-when-unset and is the entire mechanical flip
-// (see the ADR-0026 §Validation runbook). While it is ``false`` the explicit
-// read below is byte-identical to the old ``=== '1'`` form, so this refactor
-// changes nothing today — it only isolates the one line the live flip will edit.
-const _CTX_SIMPLE_DEFAULT = false;
+// D-F flip switch point (ADR-0026 §"Implementation status"). This is the default
+// used WHEN NO value is stored. Flipped to ``true`` 2026-06-18 — Simple is the
+// default-when-unset — as a REVERSIBLE experiment: the §Validation naive user
+// test was skipped as impractical (6 naive participants out of reach), so the
+// rollback is the safety net — the Advanced toggle (per-user, persisted) and
+// setting this back to ``false`` (global). P2 (the irreversible Push/Pull
+// re-frame) stays deferred and still needs genuine naive evidence.
+const _CTX_SIMPLE_DEFAULT = true;
 let _ctxSimpleMode = _CTX_SIMPLE_DEFAULT;
 try {
   const stored = localStorage.getItem(_CTX_SIMPLE_MODE_KEY);

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1617,7 +1617,7 @@
   <script src="/settings-harness.js?v=4"></script>
   <script src="/settings-hooks-watchdog.js?v=21"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=97"></script>
+  <script src="/context-gateway.js?v=98"></script>
   <script src="/context-portal.js?v=7"></script>
   <script src="/wiki.js?v=7"></script>
   <script src="/path-picker.js?v=4"></script>

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -4020,10 +4020,11 @@ body.help-hidden #help-toggle { opacity: 0.5; }
 .ctx-overview-pointer:hover { background: rgba(108, 143, 255, 0.08); color: var(--text); border-color: var(--border); }
 .ctx-overview-pointer:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 
-/* ADR-0026 P1a (#1353): Context Gateway Simple mode. The ``.ctx-simple`` class
-   on ``#tab-context-gateway`` swaps the four-axis tile grid for a one-line
-   verdict + a read-only per-type row list on the Overview. Advanced (the
-   default) is unchanged.
+/* ADR-0026 P1a/P1b (#1353): Context Gateway Simple mode — the default since the
+   D-F flip (2026-06-18, reversible). The ``.ctx-simple`` class on
+   ``#tab-context-gateway`` swaps the four-axis tile grid for a one-line verdict
+   + a per-type row list (each row may carry an inline Sync/Import action) on the
+   Overview. Advanced, one toggle away, is unchanged.
    The section nav + hoisted control bar are hidden ONLY while the Overview is
    the active section (``:has``) — otherwise a persisted Simple flag plus a deep
    link to a non-Overview leaf (e.g. ``?section=ctx-skills``) would strip the

--- a/packages/memtomem/tests-js/ctx-simple-mode.test.mjs
+++ b/packages/memtomem/tests-js/ctx-simple-mode.test.mjs
@@ -1,12 +1,12 @@
 /* ADR-0026 P1a/P1b (#1353) — Context Gateway Simple mode.
  *
  * Simple mode is a progressive-disclosure layer over the Overview: a
- * localStorage flag (default OFF = Advanced, per ADR-0026 D-F's staged rollout)
- * that toggles a ``.ctx-simple`` class on the gateway tab and swaps the
- * four-axis tile grid for a one-line verdict + a per-type row list (3-state
- * display remap). P1a guards:
- *   (1) default is Advanced — the grid renders, no ``.ctx-simple`` class, no
- *       Simple body (today's UI verbatim);
+ * localStorage flag (default ON = Simple since the D-F flip 2026-06-18, a
+ * reversible experiment; Advanced via the toggle) that toggles a ``.ctx-simple``
+ * class on the gateway tab and swaps the four-axis tile grid for a one-line
+ * verdict + a per-type row list (3-state display remap). P1a guards:
+ *   (1) default is Simple — the ``.ctx-simple`` class is on and the verdict +
+ *       per-type rows render (Advanced is one toggle click away);
  *   (2) the toggle flips the class + aria-pressed + persists the flag, and the
  *       Overview re-renders into the verdict + per-type rows (hooks excluded);
  *   (3) the 3-state remap maps each type's raw counts to the right Simple state
@@ -142,31 +142,42 @@ async function boot(overview = OVERVIEW) {
 }
 
 describe('ADR-0026 P1a — Context Gateway Simple mode', () => {
-  it('defaults to Advanced: tile grid renders, no .ctx-simple class, no Simple body', async () => {
+  it('defaults to Simple: .ctx-simple class on, verdict + per-type rows render, toggle pressed', async () => {
     const window = await boot();
     await window.loadCtxOverview();
     await flush(window);
 
     const tab = window.document.getElementById('tab-context-gateway');
-    expect(tab.classList.contains('ctx-simple')).toBe(false);
-    expect(window.document.querySelector('.ctx-overview-grid')).not.toBeNull();
-    expect(window.document.querySelector('.ctx-overview-simple')).toBeNull();
-    // The toggle is present and reports the un-pressed (Advanced) state.
+    expect(tab.classList.contains('ctx-simple')).toBe(true);
+    // Simple body renders by default; the Advanced grid stays in the DOM
+    // (CSS-hidden — visibility is the Playwright spec's job, not jsdom's).
+    expect(window.document.querySelector('.ctx-overview-simple')).not.toBeNull();
+    // The toggle is present and reports the pressed (Simple) state.
     const toggle = window.document.getElementById('ctx-mode-toggle');
     expect(toggle).not.toBeNull();
-    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
   });
 
-  it('toggle flips the class + aria-pressed + persists, and renders verdict + per-type rows', async () => {
+  it('toggle flips the class + aria-pressed + persists, and re-renders the Overview', async () => {
     const window = await boot();
     await window.loadCtxOverview();
     await flush(window);
 
     const tab = window.document.getElementById('tab-context-gateway');
     const toggle = window.document.getElementById('ctx-mode-toggle');
+
+    // Default is Simple; the first click flips to Advanced (class off, flag '0',
+    // Simple body gone).
     toggle.click();
     await flush(window);
+    expect(tab.classList.contains('ctx-simple')).toBe(false);
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    expect(window.localStorage.getItem('memtomem_ctx_simple_mode')).toBe('0');
+    expect(window.document.querySelector('.ctx-overview-simple')).toBeNull();
 
+    // Flip back to Simple: class on, flag '1', verdict + per-type rows render.
+    toggle.click();
+    await flush(window);
     expect(tab.classList.contains('ctx-simple')).toBe(true);
     expect(toggle.getAttribute('aria-pressed')).toBe('true');
     expect(window.localStorage.getItem('memtomem_ctx_simple_mode')).toBe('1');
@@ -181,13 +192,6 @@ describe('ADR-0026 P1a — Context Gateway Simple mode', () => {
     rows.forEach((r) => {
       expect(r.querySelector('.ctx-simple-status-text').textContent.trim().length).toBeGreaterThan(0);
     });
-
-    // Flip back: class off, flag persisted as '0'.
-    toggle.click();
-    await flush(window);
-    expect(tab.classList.contains('ctx-simple')).toBe(false);
-    expect(toggle.getAttribute('aria-pressed')).toBe('false');
-    expect(window.localStorage.getItem('memtomem_ctx_simple_mode')).toBe('0');
   });
 
   it('3-state remap maps raw counts to the right Simple state per type', async () => {

--- a/packages/memtomem/tests/test_ctx_validation_harness.py
+++ b/packages/memtomem/tests/test_ctx_validation_harness.py
@@ -122,7 +122,7 @@ def test_seed_overview_summary_verdicts(tmp_path: Path) -> None:
         {p.stem for p in list_canonical_mcp_servers(tmp_path)},
     )
     # parse_error outranks missing_canonical in _ctxSimpleVerdict -> attention;
-    # both rows remain individually visible in the default Advanced view.
+    # both rows remain individually visible in the Advanced view (one toggle away).
     assert mcp.get("parse_error", 0) == 1
     assert mcp.get("missing_canonical", 0) == 1
 

--- a/packages/memtomem/tests/web/test_context_gateway_mobile_layout.py
+++ b/packages/memtomem/tests/web/test_context_gateway_mobile_layout.py
@@ -63,6 +63,7 @@ def test_gateway_mobile_390px_no_overflow(page, mm_web_url) -> None:
     )
     # The Gateway now lands on Projects by default; this test pins the
     # Overview section's mobile layout, so switch to Overview explicitly.
+    page.evaluate("() => _ctxSetSimpleMode(false)")  # ADR-0026 D-F: Advanced for the grid layout
     page.evaluate("() => switchSettingsSection('ctx-overview')")
     page.wait_for_selector("#ctx-sync-all-btn", timeout=4_000)
 
@@ -141,6 +142,7 @@ def test_gateway_overview_grid_single_column_at_480px(page, mm_web_url) -> None:
     )
     # The Gateway now lands on Projects by default; this test pins the
     # Overview grid's column count, so switch to Overview explicitly.
+    page.evaluate("() => _ctxSetSimpleMode(false)")  # ADR-0026 D-F: Advanced for the grid layout
     page.evaluate("() => switchSettingsSection('ctx-overview')")
     page.wait_for_selector("#tab-context-gateway .ctx-overview-grid", timeout=4_000)
 

--- a/packages/memtomem/tests/web/test_context_gateway_overview.py
+++ b/packages/memtomem/tests/web/test_context_gateway_overview.py
@@ -52,6 +52,9 @@ def _open_context_gateway(page) -> None:
     check is what the assertions actually depend on.
     """
     page.evaluate("() => activateTab('settings')")
+    # ADR-0026 D-F flip: Simple is the production default — switch to Advanced
+    # (the tile-grid surface these specs assert), as a user would via the toggle.
+    page.evaluate("() => _ctxSetSimpleMode(false)")
     page.evaluate("() => switchSettingsSection('ctx-overview')")
     page.wait_for_function(
         "() => {"

--- a/packages/memtomem/tests/web/test_context_gateway_rank10_confirm.py
+++ b/packages/memtomem/tests/web/test_context_gateway_rank10_confirm.py
@@ -304,6 +304,9 @@ def test_portal_sync_confirm_names_project(page, mm_web_url: str) -> None:
     )
     page.goto(mm_web_url)
     page.locator("#tabbtn-context-gateway").click()
+    # ADR-0026 D-F flip: Simple is the default and hides the section nav on the
+    # Overview — switch to Advanced so the Projects nav button is clickable.
+    page.evaluate("() => _ctxSetSimpleMode(false)")
     page.locator(".settings-nav-btn[data-section='ctx-projects']").click()
     page.wait_for_selector(".ctx-portal-row", timeout=3_000)
 

--- a/packages/memtomem/tests/web/test_context_gateway_simple_mode.py
+++ b/packages/memtomem/tests/web/test_context_gateway_simple_mode.py
@@ -1,12 +1,13 @@
 """Browser tests for the Context Gateway Simple mode (ADR-0026 P1a/P1b, #1353).
 
 Simple mode is a progressive-disclosure layer over the Overview: a
-``localStorage`` flag (default OFF = Advanced, per ADR-0026 D-F's staged
-rollout) that toggles a ``.ctx-simple`` class on ``#tab-context-gateway``.
-``.ctx-simple`` hides the section nav, the hoisted control bar, and the tile
-grid (CSS) while the Overview renders a one-line verdict + a per-type row list
-(3-state display remap). P1b adds one inline control per row (Sync / Import / a
-check / Manage) and a counted cross-tier summary on an empty active tier (D-D).
+``localStorage`` flag (default ON = Simple since the D-F flip 2026-06-18, a
+reversible experiment; Advanced via the toggle) that toggles a ``.ctx-simple``
+class on ``#tab-context-gateway``. ``.ctx-simple`` hides the section nav, the
+hoisted control bar, and the tile grid (CSS) while the Overview renders a
+one-line verdict + a per-type row list (3-state display remap). P1b adds one
+inline control per row (Sync / Import / a check / Manage) and a counted
+cross-tier summary on an empty active tier (D-D).
 
 These specs cover what the jsdom unit suite
 (``tests-js/ctx-simple-mode.test.mjs``) cannot — real-browser CSS visibility
@@ -108,32 +109,14 @@ def _switch_tier(page, scope: str) -> None:
     )
 
 
-def test_default_is_advanced_grid_and_nav_visible(page, mm_web_url: str) -> None:
-    """Default (no flag) is Advanced — today's UI verbatim: the tile grid + the
-    section nav render, no ``.ctx-simple`` class, no Simple body, and the toggle
-    reports its un-pressed state."""
+def test_default_is_simple_verdict_and_rows_visible(page, mm_web_url: str) -> None:
+    """Default (no flag) is Simple (ADR-0026 D-F flipped 2026-06-18, reversible):
+    the ``.ctx-simple`` class is on, the Simple verdict + per-type rows render,
+    the Advanced nav / control bar / tile grid are CSS-hidden, and the toggle
+    reports its pressed state (Advanced stays one click away as the rollback)."""
     _stub_overview(page)
     page.goto(mm_web_url)
     _open_context_gateway(page)
-
-    tab = page.locator("#tab-context-gateway")
-    assert "ctx-simple" not in (tab.get_attribute("class") or "")
-    assert page.locator("#ctx-overview-content .ctx-overview-grid").is_visible()
-    assert page.locator("#tab-context-gateway .settings-nav").is_visible()
-    assert page.locator(".ctx-overview-simple").count() == 0
-    assert page.locator("#ctx-mode-toggle").get_attribute("aria-pressed") == "false"
-
-
-def test_toggle_enters_simple_hides_nav_control_bar_grid(page, mm_web_url: str) -> None:
-    """Toggling Simple flips the class + aria-pressed and, via the linked CSS,
-    hides the nav, the hoisted control bar, and the tile grid — while the Simple
-    verdict + per-type rows become visible with text-bearing status (never
-    color-only, ADR-0026 D-G)."""
-    _stub_overview(page)
-    page.goto(mm_web_url)
-    _open_context_gateway(page)
-
-    page.locator("#ctx-mode-toggle").click()
     page.locator(".ctx-overview-simple").wait_for(timeout=3_000)
 
     tab = page.locator("#tab-context-gateway")
@@ -160,11 +143,46 @@ def test_toggle_enters_simple_hides_nav_control_bar_grid(page, mm_web_url: str) 
     )
 
 
+def test_toggle_exits_to_advanced_then_back(page, mm_web_url: str) -> None:
+    """From the default Simple view, the toggle flips to Advanced (nav + control
+    bar + tile grid restored, no Simple body) and back to Simple — Advanced is
+    the reversible rollback (ADR-0026 D-F)."""
+    _stub_overview(page)
+    page.goto(mm_web_url)
+    _open_context_gateway(page)
+    page.locator(".ctx-overview-simple").wait_for(timeout=3_000)
+
+    # Default Simple → click exits to Advanced: nav / control bar / grid restored.
+    page.locator("#ctx-mode-toggle").click()
+    page.wait_for_function(
+        "() => !document.getElementById('tab-context-gateway').classList.contains('ctx-simple')",
+        timeout=3_000,
+    )
+    assert page.locator("#ctx-mode-toggle").get_attribute("aria-pressed") == "false"
+    # The toggle re-renders the Overview async (loadCtxOverview), so wait for the
+    # Advanced grid to come back rather than asserting before the render lands.
+    page.locator("#ctx-overview-content .ctx-overview-grid").wait_for(
+        state="visible", timeout=3_000
+    )
+    assert page.locator("#tab-context-gateway .settings-nav").is_visible()
+    assert page.locator(".ctx-overview-simple").count() == 0
+
+    # Click again → back to Simple: class on, verdict + rows return.
+    page.locator("#ctx-mode-toggle").click()
+    page.locator(".ctx-overview-simple").wait_for(timeout=3_000)
+    assert "ctx-simple" in (page.locator("#tab-context-gateway").get_attribute("class") or "")
+    assert page.locator("#ctx-mode-toggle").get_attribute("aria-pressed") == "true"
+    assert page.locator(".ctx-simple-row").count() == 4
+
+
 def test_toggle_is_keyboard_focusable(page, mm_web_url: str) -> None:
     """D-G: the toggle is a real, keyboard-reachable button — focusing it lands
     the document focus on it (so its focus-visible ring + Enter/Space activation
     come for free)."""
     _stub_overview(page)
+    page.goto(mm_web_url)
+    # Start from Advanced (the non-default now) so the Enter press enters Simple.
+    page.evaluate("() => localStorage.setItem('memtomem_ctx_simple_mode', '0')")
     page.goto(mm_web_url)
     _open_context_gateway(page)
 
@@ -187,7 +205,7 @@ def test_mcp_not_saved_falls_back_to_manage_and_navigates(page, mm_web_url: str)
     page.goto(mm_web_url)
     _open_context_gateway(page)
 
-    page.locator("#ctx-mode-toggle").click()
+    # Simple is the default — land straight on the verdict + rows, no toggle.
     page.locator(".ctx-overview-simple").wait_for(timeout=3_000)
 
     row = page.locator(".ctx-simple-row[data-section='ctx-mcp-servers']")
@@ -216,7 +234,7 @@ def test_inline_sync_button_focusable_and_opens_confirm(page, mm_web_url: str) -
     page.goto(mm_web_url)
     _open_context_gateway(page)
 
-    page.locator("#ctx-mode-toggle").click()
+    # Simple is the default — land straight on the verdict + rows, no toggle.
     page.locator(".ctx-overview-simple").wait_for(timeout=3_000)
 
     sync = page.locator(".ctx-simple-row[data-section='ctx-skills'] [data-ctx-action='sync']")
@@ -259,7 +277,7 @@ def test_empty_tier_names_items_in_another_tier(page, mm_web_url: str) -> None:
     page.goto(mm_web_url)
     _open_context_gateway(page)
 
-    page.locator("#ctx-mode-toggle").click()
+    # Simple is the default — land straight on the verdict + rows, no toggle.
     page.locator(".ctx-overview-simple").wait_for(timeout=3_000)
 
     # The generic hint is patched with the cross-tier summary once the fan-out
@@ -280,7 +298,7 @@ def test_empty_state_shows_hint_and_open_advanced_cta(page, mm_web_url: str) -> 
     page.goto(mm_web_url)
     _open_context_gateway(page)
 
-    page.locator("#ctx-mode-toggle").click()
+    # Simple is the default — land straight on the empty-state hint, no toggle.
     page.locator(".ctx-overview-simple").wait_for(timeout=3_000)
 
     assert page.locator(".ctx-simple-empty-hint").is_visible()
@@ -297,24 +315,29 @@ def test_empty_state_shows_hint_and_open_advanced_cta(page, mm_web_url: str) -> 
     )
 
 
-def test_simple_mode_persists_across_reload(page, mm_web_url: str) -> None:
-    """The flag is persisted (localStorage), so a reload re-enters Simple mode
-    without the user re-toggling — the Advanced toggle stays the visible
-    rollback signal (ADR-0026 D-F)."""
+def test_advanced_choice_persists_across_reload(page, mm_web_url: str) -> None:
+    """The flag is persisted (localStorage), so a user's explicit switch to
+    Advanced survives a reload (it does not snap back to the Simple default) —
+    the toggle is a durable per-user rollback (ADR-0026 D-F)."""
     _stub_overview(page)
     page.goto(mm_web_url)
     _open_context_gateway(page)
-
-    page.locator("#ctx-mode-toggle").click()
     page.locator(".ctx-overview-simple").wait_for(timeout=3_000)
-    assert page.evaluate("() => localStorage.getItem('memtomem_ctx_simple_mode')") == "1"
+
+    # Default is Simple; switch to Advanced and confirm the flag persists as '0'.
+    page.locator("#ctx-mode-toggle").click()
+    page.wait_for_function(
+        "() => !document.getElementById('tab-context-gateway').classList.contains('ctx-simple')",
+        timeout=3_000,
+    )
+    assert page.evaluate("() => localStorage.getItem('memtomem_ctx_simple_mode')") == "0"
 
     page.goto(mm_web_url)
     _open_context_gateway(page)
-    # Re-entered Simple mode on its own: class applied + Simple body present.
-    assert "ctx-simple" in (page.locator("#tab-context-gateway").get_attribute("class") or "")
-    page.locator(".ctx-overview-simple").wait_for(timeout=3_000)
-    assert page.locator(".ctx-simple-row").count() == 4
+    # Stayed Advanced on its own: no .ctx-simple class, the tile grid is visible.
+    assert "ctx-simple" not in (page.locator("#tab-context-gateway").get_attribute("class") or "")
+    assert page.locator("#ctx-overview-content .ctx-overview-grid").is_visible()
+    assert page.locator(".ctx-overview-simple").count() == 0
 
 
 def test_persisted_simple_on_non_overview_section_keeps_nav_visible(page, mm_web_url: str) -> None:
@@ -367,6 +390,10 @@ def test_project_local_inline_sync_is_write_blocked(page, mm_web_url: str) -> No
         route.fulfill(status=200, content_type="application/json", body="{}")
 
     page.route("**/api/context/skills/sync**", _record_sync)
+    page.goto(mm_web_url)
+    # Start from Advanced so the control bar (Simple-hidden) is reachable to
+    # switch tiers; then toggle into Simple to observe the inline write-block.
+    page.evaluate("() => localStorage.setItem('memtomem_ctx_simple_mode', '0')")
     page.goto(mm_web_url)
     _open_context_gateway(page)
     _switch_tier(page, "project_local")

--- a/packages/memtomem/tests/web/test_context_gateway_sync_all.py
+++ b/packages/memtomem/tests/web/test_context_gateway_sync_all.py
@@ -87,6 +87,9 @@ def _open_context_gateway(page) -> None:
     twice (#813 / #816) and a click-based path keeps re-breaking.
     """
     page.evaluate("() => activateTab('settings')")
+    # ADR-0026 D-F flip: Simple is the production default — switch to Advanced
+    # (the control bar + Sync All these specs assert), as a user would.
+    page.evaluate("() => _ctxSetSimpleMode(false)")
     page.evaluate("() => switchSettingsSection('ctx-overview')")
     page.wait_for_function(
         "() => {"

--- a/packages/memtomem/tests/web/test_context_portal.py
+++ b/packages/memtomem/tests/web/test_context_portal.py
@@ -103,6 +103,9 @@ def _stub_portal(page, captured=None):
 def _open_portal(page, mm_web_url: str) -> None:
     page.goto(mm_web_url)
     page.locator("#tabbtn-context-gateway").click()
+    # ADR-0026 D-F flip: Simple is the default and hides the section nav while the
+    # Overview is active — switch to Advanced so the Projects nav button is shown.
+    page.evaluate("() => _ctxSetSimpleMode(false)")
     page.locator(".settings-nav-btn[data-section='ctx-projects']").click()
     page.wait_for_selector(".ctx-portal-row", timeout=3_000)
 

--- a/packages/memtomem/tests/web/test_context_portal_card_sync.py
+++ b/packages/memtomem/tests/web/test_context_portal_card_sync.py
@@ -165,6 +165,9 @@ def _stub_portal_sync(page) -> dict:
 def _open_portal(page, mm_web_url: str) -> None:
     page.goto(mm_web_url)
     page.locator("#tabbtn-context-gateway").click()
+    # ADR-0026 D-F flip: Simple is the default and hides the section nav on the
+    # Overview — switch to Advanced so the Projects nav button is clickable.
+    page.evaluate("() => _ctxSetSimpleMode(false)")
     page.locator(".settings-nav-btn[data-section='ctx-projects']").click()
     page.wait_for_selector(".ctx-portal-row", timeout=3_000)
 

--- a/packages/memtomem/tests/web/test_context_portal_runtimes.py
+++ b/packages/memtomem/tests/web/test_context_portal_runtimes.py
@@ -151,6 +151,9 @@ def _stub_portal(page):
 def _open_portal(page, mm_web_url: str) -> None:
     page.goto(mm_web_url)
     page.locator("#tabbtn-context-gateway").click()
+    # ADR-0026 D-F flip: Simple is the default and hides the section nav on the
+    # Overview — switch to Advanced so the Projects nav button is clickable.
+    page.evaluate("() => _ctxSetSimpleMode(false)")
     page.locator(".settings-nav-btn[data-section='ctx-projects']").click()
     page.wait_for_selector(".ctx-portal-row", timeout=3_000)
     # Heading chips render before the rows in loadCtxProjects, so once a row is
@@ -253,6 +256,9 @@ def test_runtime_deeplink_applies_filter_on_mount(page, mm_web_url: str) -> None
     # Land directly on a ``?runtime=claude`` URL — the filter applies on mount.
     page.goto(f"{mm_web_url}/?runtime=claude")
     page.locator("#tabbtn-context-gateway").click()
+    # ADR-0026 D-F flip: Simple is the default and hides the section nav on the
+    # Overview — switch to Advanced so the Projects nav button is clickable.
+    page.evaluate("() => _ctxSetSimpleMode(false)")
     page.locator(".settings-nav-btn[data-section='ctx-projects']").click()
     page.wait_for_selector(".ctx-portal-row", timeout=3_000)
 

--- a/packages/memtomem/tests/web/test_ui_smoke_matrix.py
+++ b/packages/memtomem/tests/web/test_ui_smoke_matrix.py
@@ -353,6 +353,10 @@ def test_ui_smoke_matrix(page, mode: str, viewport: tuple[int, int]) -> None:
                 assert tab.get_attribute("aria-selected") == "true"
 
         page.locator('.tab-btn[data-tab="context-gateway"]').click()
+        # ADR-0026 D-F flip: Simple is the production default and hides the gateway
+        # section nav on the Overview — switch to Advanced so the nested-nav walk
+        # below reaches each section (as a user would via the toggle).
+        page.evaluate("() => _ctxSetSimpleMode(false)")
         gateway_sections = [
             "ctx-overview",
             "ctx-skills",


### PR DESCRIPTION
## What

Flips the Context Gateway default to **Simple** (`_CTX_SIMPLE_DEFAULT = true`):
a first-time user lands in the Simple Overview (one-line verdict + per-type rows)
instead of the four-axis Advanced grid. **ADR-0026 D-F.**

Shipped as a **reversible experiment** rather than gated on the §Validation naive
user test — recruiting 6 naive participants proved impractical, and the change is
reversible: the Advanced toggle is the per-user rollback (persisted), and
reverting the one constant is the global rollback. **P2** (the irreversible
Push/Pull re-frame) stays deferred and still needs genuine naive evidence.

> **Stacked on #1423** (the Context Gateway walkthrough guide) — this PR's base is
> that branch, so the diff is just the flip. After #1423 merges I'll rebase onto
> main and retarget.

## Changes

- `context-gateway.js` — `_CTX_SIMPLE_DEFAULT` `false → true` (+ comment); cache-bust `?v=97→98`.
- Docs fan-out (same change, per the default-change discipline): `docs/guides/context-gateway.md` leads with the Simple default and frames the precise four-status table as the Advanced view; ADR-0026 D-F → **Shipped (reversible)**, §Validation now gates only P2.
- Tests: the two default-assertion specs now assert Simple; specs that exercise Advanced (the tier control bar, the keyboard-enter-Simple path) start from an explicit Advanced flag; the persistence spec pins that an explicit **Advanced** choice survives reload.

## Verification

- vitest `ctx-simple-mode` 11/11 · Playwright `test_context_gateway_simple_mode` 10/10 · harness + doc-guards 15/15 · ruff clean.
- `style.css` unchanged: the "scoping tighten" the staged plan anticipated is a no-op — the nav/control-bar deep-link trap was already `:has`-guarded in P1a and the tile grid lives only in the Overview (it cannot strand a user).

Refs #1353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
