### PR TITLE
feat(cli): ship ADR-0026 validation seeder as `mm context seed-validation` (#1353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   memtomem uses DOMPurify with the default config (no `setConfig()` attribute
   hooks), so exposure was low, but this clears the `vendored-assets` OSV gate.
 
+- **CLI: `mm context seed-validation <dir>` — hidden first-run seeder
+  (ADR-0026 §Validation).** A hidden QA helper that seeds a fresh project with
+  the six Context Gateway first-run affordances (out-of-sync, not-imported,
+  empty, MCP orphan, MCP parse-error, in-sync) so the onboarding user test is
+  reproducible from an installed wheel — previously the seeder lived in
+  `tests/fixtures/` and was unreachable by anyone who only `pip install`-ed
+  memtomem (the prerequisite for an unmoderated async run). The seeder logic
+  moved to `memtomem.context._validation_seed` (shipped under `src/`); the
+  command refuses a non-empty target directory unless `--force`, so it can never
+  overwrite a real project. No change to any user-facing behavior — the command
+  is hidden and writes only into the directory you point it at.
+
 - **Web UI: wiki "uncommitted changes" badge at the nav/glance level
   (ADR-0008).** A saved-but-not-committed wiki edit is invisible to `mm context
   install`, which installs committed git objects only — yet from the Context

--- a/docs/adr/0026-context-gateway-onboarding-ia.md
+++ b/docs/adr/0026-context-gateway-onboarding-ia.md
@@ -378,16 +378,20 @@ power users the create-vs-overwrite distinction.
 
 ### Reproducing the first-run state
 
-`seed_adr0026_validation_states`
-(`packages/memtomem/tests/fixtures/ctx_validation_states.py`) seeds the six
-probe affordances above into one project — out-of-sync, not-yet-imported, empty
-type, MCP orphan, MCP parse-error, and an in-sync baseline — so every
-participant sees the same Overview. `test_ctx_validation_harness.py` pins the
-seed against the real diff engine, including the easy-to-invert Store-vs-runtime
+`mm context seed-validation <dir>` (a hidden CLI helper backed by
+`seed_adr0026_validation_states` in `memtomem.context._validation_seed`) seeds
+the six probe affordances above into one project — out-of-sync, not-yet-imported,
+empty type, MCP orphan, MCP parse-error, and an in-sync baseline — so every
+participant sees the same Overview. The seeder ships in the wheel (it lives under
+`src/`, not the unpackaged `tests/`), so a participant who only `pip install`-ed
+memtomem can reproduce the state without a source checkout — the prerequisite for
+an unmoderated async run. The command refuses a non-empty target directory
+unless `--force`, so it cannot silently overwrite a real project (the Gateway
+follows the server's working dir). `test_ctx_validation_harness.py` pins the seed
+against the real diff engine, including the easy-to-invert Store-vs-runtime
 direction (a runtime-only artifact reads as "Not yet imported", never "Out of
-sync"), so it cannot silently rot. It is version-controlled (not the gitignored
-`scripts/` tree) so it stays in lockstep with the moderated facilitator protocol
-that consumes it.
+sync"), so it cannot silently rot, and stays in lockstep with the moderated
+facilitator protocol that consumes it.
 
 ## Provisional decisions
 

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -5219,3 +5219,73 @@ def projects_pause_cmd(selector: str) -> None:
 def projects_resume_cmd(selector: str) -> None:
     """Resume sync enrollment for a paused project."""
     _projects_set_enabled(selector, enabled=True, verb="resume")
+
+
+# ── seed-validation (hidden QA helper) ──────────────────────────────────────
+
+
+@context.command("seed-validation", hidden=True)
+@click.argument(
+    "directory",
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Re-seed even if DIRECTORY already contains a .memtomem/ Store.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Print the seed manifest as JSON (for scripting the facilitator setup).",
+)
+def seed_validation_cmd(directory: Path, force: bool, as_json: bool) -> None:
+    """Seed the ADR-0026 §Validation first-run demo project into DIRECTORY.
+
+    Hidden QA helper. Writes the six Context Gateway first-run affordances
+    (out-of-sync / not-imported / empty / mcp-orphan / parse-error / in-sync)
+    into a fresh project so a moderator — or an async user-test participant who
+    only ``pip install``-ed memtomem — can reproduce the exact state ADR-0026
+    §Validation measures. The recipe lives in the seeder docstring
+    (``memtomem.context._validation_seed``); ``test_ctx_validation_harness``
+    pins it against the real diff engine.
+
+    Refuses a non-empty target directory unless ``--force`` so it can never
+    silently overwrite a real project — the seeder writes ``.memtomem/`` *and*
+    runtime trees (``.claude/`` …), ``.mcp.json``, and ``pyproject.toml``, any
+    of which a real repo may already have, and the Gateway shows the server-cwd
+    project, so launching ``mm web`` from a real repo would otherwise mix the
+    seed into live data.
+    """
+    from memtomem.context._validation_seed import seed_adr0026_validation_states
+
+    if directory.exists() and any(directory.iterdir()) and not force:
+        raise click.ClickException(
+            f"{directory} is not empty — refusing to seed so a real project is never "
+            "overwritten. Pass a fresh/empty directory, or --force to seed in place."
+        )
+
+    manifest = seed_adr0026_validation_states(directory)
+
+    if as_json:
+        click.echo(json.dumps(manifest, indent=2))
+        return
+
+    root = manifest["project_root"]
+    click.secho(f"Seeded ADR-0026 §Validation first-run state at {root}", fg="green")
+    click.echo("\nSix Context Gateway affordances seeded:")
+    for state in manifest["states"].values():
+        name = state.get("name", "—")
+        status = state.get("diff_status") or "empty"
+        click.echo(f"  {state['tile']:12s} {name:16s} {status}")
+    click.echo(
+        "\nNext — launch the Gateway against this project:\n"
+        f"  cd {root}\n"
+        "  mm web\n"
+        "  # open the Gateway tab — the Simple view is the default (ADR-0026 D-F).\n"
+        "  # the Project path shown must match the directory above (the Gateway\n"
+        "  # follows the server's working dir)."
+    )

--- a/packages/memtomem/src/memtomem/context/_validation_seed.py
+++ b/packages/memtomem/src/memtomem/context/_validation_seed.py
@@ -1,9 +1,16 @@
-"""First-run validation harness for ADR-0026 §Validation.
+"""First-run validation seeder for ADR-0026 §Validation.
 
 Seeds a project on disk so the Context Gateway Overview surfaces all six
 user-test affordances at once, giving a moderator a reproducible first-run
 state to drive the lightweight 5-6 participant test described in ADR-0026
 §Validation.
+
+This module ships in the wheel (it lives under ``src/`` rather than
+``tests/fixtures/``) so a naive participant who only ``pip install``-ed
+memtomem can reproduce the state with one command: ``mm context
+seed-validation <dir>`` (a hidden QA helper in ``cli/context_cmd.py``). The
+guard test ``tests/test_ctx_validation_harness.py`` imports this same function,
+so the seeder and its rot-guard stay in lockstep.
 
 The six affordances (one per §Validation probe family):
 
@@ -29,10 +36,6 @@ imported" (pull into the Store); a Store artifact with a stale/missing runtime
 copy reads as "Out of sync" (push to the runtime). ``test_ctx_validation_harness``
 pins both directions against the real diff engine so a future edit cannot
 silently swap them.
-
-This module lives under version control (``tests/fixtures/``) on purpose — the
-gitignored ``scripts/`` tree cannot hold the harness the runbook depends on, and
-keeping the seeder beside its guard test keeps the two in lockstep.
 """
 
 from __future__ import annotations
@@ -41,8 +44,11 @@ import json
 from pathlib import Path
 from typing import Any
 
+from memtomem.config import TargetScope
+from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
 from memtomem.context._runtime_targets import runtime_fanout_root
 from memtomem.context.mcp_servers import CANONICAL_MCP_SERVER_ROOT, PROJECT_MCP_CONFIG
+from memtomem.context.scope_resolver import ArtifactKind
 from memtomem.context.skills import CANONICAL_SKILL_ROOT, SKILL_GENERATORS, SKILL_MANIFEST
 
 # Names chosen to read naturally under the §Validation framing task
@@ -57,7 +63,7 @@ MCP_PARSE_ERROR = "broken-server"
 # root from the production table (rather than hard-coding ".claude/skills")
 # means the seeder follows any future relocation of the runtime layout.
 _RUNTIME = "claude"
-_SCOPE = "project_shared"
+_SCOPE: TargetScope = "project_shared"
 
 
 def _write_lf(path: Path, content: str) -> None:
@@ -65,13 +71,16 @@ def _write_lf(path: Path, content: str) -> None:
 
     Byte-for-byte LF (never CRLF) so the in-sync baseline compares equal to its
     runtime copy on Windows too — mirrors ``_write_text_lf`` in the web route
-    tests.
+    tests. Routed through ``atomic_write_bytes`` (not a bare ``write_bytes``)
+    because this module lives under ``context/``, the gateway atomic-write
+    surface (``test_no_bare_writes_on_gateway_surfaces``); the helper also
+    creates parent dirs. ``0o644`` matches the runtime-readable convention of
+    ``copy_tree_atomic``.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(content.encode("utf-8"))
+    atomic_write_bytes(path, content.encode("utf-8"), mode=0o644)
 
 
-def _runtime_root(artifact: str, project_root: Path) -> Path:
+def _runtime_root(artifact: ArtifactKind, project_root: Path) -> Path:
     root = runtime_fanout_root(artifact, _RUNTIME, _SCOPE, project_root)
     if root is None:  # pragma: no cover - claude has a project_shared fan-out
         raise RuntimeError(
@@ -112,9 +121,10 @@ def seed_adr0026_validation_states(project_root: Path) -> dict[str, Any]:
     # directory as a project (cheapest marker, mirrors the CLI e2e seeder).
     pyproject = project_root / "pyproject.toml"
     if not pyproject.exists():
-        pyproject.write_text(
+        atomic_write_text(
+            pyproject,
             '[project]\nname = "adr0026-firstrun-fixture"\nversion = "0.0.0"\n',
-            encoding="utf-8",
+            mode=0o644,
         )
 
     skill_canon = project_root / CANONICAL_SKILL_ROOT

--- a/packages/memtomem/tests/test_context_seed_validation_cmd.py
+++ b/packages/memtomem/tests/test_context_seed_validation_cmd.py
@@ -1,0 +1,121 @@
+"""Tests for ``mm context seed-validation`` — the shipped ADR-0026 §Validation seeder.
+
+The seeder logic itself (six distinct diff states) is pinned against the real
+diff engine in ``test_ctx_validation_harness``. These tests own the *CLI
+surface* that exposes it from the installed wheel: wiring to the seeder, the
+overwrite guard, the ``--json`` manifest, and that it stays a hidden helper.
+
+That CLI surface is the whole point of the command existing — a naive async
+user-test participant who only ``pip install``-ed memtomem cannot import
+``tests/fixtures``; the command is the supported way to reproduce the first-run
+state.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+
+from .helpers import set_home
+
+
+@pytest.fixture
+def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliRunner:
+    # Isolate HOME so nothing the CLI group touches reaches the real user home.
+    set_home(monkeypatch, tmp_path / "home")
+    return CliRunner()
+
+
+def test_seed_validation_writes_store_and_runtime(runner: CliRunner, tmp_path: Path) -> None:
+    demo = tmp_path / "demo"
+    result = runner.invoke(cli, ["context", "seed-validation", str(demo)])
+
+    assert result.exit_code == 0, result.output
+    # Store side (.memtomem/) and runtime side (.claude/) both seeded.
+    assert (demo / ".memtomem").is_dir()
+    assert (demo / ".claude").is_dir()
+    # The dir becomes a project root so `mm web` from here shows the seed.
+    assert (demo / "pyproject.toml").is_file()
+    # Human output names the seeded artifacts + the next-step launch.
+    assert "Seeded ADR-0026" in result.output
+    assert "code-review" in result.output
+    assert "mm web" in result.output
+
+
+def test_seed_validation_creates_missing_directory(runner: CliRunner, tmp_path: Path) -> None:
+    demo = tmp_path / "nested" / "demo"  # parent does not exist yet
+    result = runner.invoke(cli, ["context", "seed-validation", str(demo)])
+
+    assert result.exit_code == 0, result.output
+    assert (demo / ".memtomem").is_dir()
+
+
+def test_seed_validation_json_manifest(runner: CliRunner, tmp_path: Path) -> None:
+    demo = tmp_path / "demo"
+    result = runner.invoke(cli, ["context", "seed-validation", "--json", str(demo)])
+
+    assert result.exit_code == 0, result.output
+    manifest = json.loads(result.output)
+    # All six §Validation affordances present, and project_root points at DIRECTORY.
+    assert set(manifest["states"]) == {
+        "out_of_sync",
+        "not_yet_imported",
+        "empty_type",
+        "mcp_orphan",
+        "parse_error",
+        "in_sync",
+    }
+    assert Path(manifest["project_root"]) == demo
+
+
+@pytest.mark.parametrize(
+    "make_existing",
+    [
+        pytest.param(lambda d: (d / ".memtomem").mkdir(), id="memtomem-store"),
+        pytest.param(lambda d: (d / ".mcp.json").write_text("{}\n"), id="mcp-json-only"),
+        pytest.param(lambda d: (d / ".claude" / "skills").mkdir(parents=True), id="claude-only"),
+        pytest.param(lambda d: (d / "README.md").write_text("real repo\n"), id="unrelated-file"),
+    ],
+)
+def test_seed_validation_refuses_nonempty_dir(
+    runner: CliRunner, tmp_path: Path, make_existing
+) -> None:
+    """Never overwrite a real project: ANY non-empty target is refused without --force.
+
+    The seeder writes ``.memtomem/`` *and* runtime trees (``.claude/`` …),
+    ``.mcp.json`` and ``pyproject.toml``; a guard that only checked ``.memtomem/``
+    would silently clobber a repo that has ``.claude/`` or ``.mcp.json`` but has
+    not adopted memtomem yet.
+    """
+    demo = tmp_path / "real-project"
+    demo.mkdir()
+    make_existing(demo)
+
+    result = runner.invoke(cli, ["context", "seed-validation", str(demo)])
+    assert result.exit_code != 0
+    assert "is not empty" in result.output
+
+    # --force overrides the guard (idempotent re-seed in place).
+    forced = runner.invoke(cli, ["context", "seed-validation", "--force", str(demo)])
+    assert forced.exit_code == 0, forced.output
+    assert (demo / ".claude").is_dir()
+
+
+def test_seed_validation_seeds_into_existing_empty_dir(runner: CliRunner, tmp_path: Path) -> None:
+    demo = tmp_path / "empty"
+    demo.mkdir()  # exists but empty — proceeds without --force
+    result = runner.invoke(cli, ["context", "seed-validation", str(demo)])
+    assert result.exit_code == 0, result.output
+    assert (demo / ".memtomem").is_dir()
+
+
+def test_seed_validation_is_hidden(runner: CliRunner) -> None:
+    # Hidden QA helper — must not surface in the user-facing group help.
+    result = runner.invoke(cli, ["context", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "seed-validation" not in result.output

--- a/packages/memtomem/tests/test_ctx_validation_harness.py
+++ b/packages/memtomem/tests/test_ctx_validation_harness.py
@@ -1,8 +1,9 @@
 """Guard the ADR-0026 §Validation first-run harness against silent rot.
 
 These are pure-Python tests against the *real* diff engine — no browser. They
-exist so the seeder in ``fixtures/ctx_validation_states.py`` keeps producing the
-six distinct user-test affordances, and in particular so the Store-vs-runtime
+exist so the seeder in ``memtomem.context._validation_seed`` (shipped in the
+wheel, exposed as ``mm context seed-validation``) keeps producing the six
+distinct user-test affordances, and in particular so the Store-vs-runtime
 direction (the bug class called out in the seeder docstring) can never silently
 invert: "Not yet imported" must stay a runtime-only / ``missing canonical`` row,
 not a ``missing target`` row.
@@ -20,7 +21,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from fixtures.ctx_validation_states import seed_adr0026_validation_states
+from memtomem.context._validation_seed import seed_adr0026_validation_states
 
 from memtomem.context.agents import canonical_agent_name, diff_agents, list_canonical_agents
 from memtomem.context.commands import (


### PR DESCRIPTION
## Summary

The ADR-0026 §Validation first-run user test — the only remaining gate on **P2**
of the Context Gateway onboarding campaign (#1353) — needs a participant to
reproduce the six Gateway affordances on their own machine. The seeder that
produces them lived in `tests/fixtures/ctx_validation_states.py`, which the wheel
does not package (`packages = ["src/memtomem"]`), so anyone who only
`pip install`-ed memtomem could not run it. That **build-delivery gap** was the
one open blocker for an unmoderated async run.

This ships the seeder as a CLI command:

- **Move** the seeder to `memtomem.context._validation_seed` (now under `src/`, so
  it ships in the wheel). The guard test imports the same function, keeping the
  seeder and its rot-guard in lockstep — `git` records the move as a 92% rename.
- **Expose** it as a hidden `mm context seed-validation <dir>` helper (matching
  the `mm agent debug-resolve` hidden-helper precedent). It prints the six seeded
  states and the next-step launch.
- **Guard**: refuses a non-empty target directory unless `--force`, so it can
  never overwrite a real project — the seeder writes `.memtomem/` **and** runtime
  trees (`.claude/` …), `.mcp.json`, and `pyproject.toml`, and the Gateway follows
  the server's working dir.

Since D-F flipped Simple to the default (#1424), the bootstrap no longer needs
the prior `localStorage memtomem_ctx_simple_mode='1'` step.

This does **not** pursue P2 itself (still gated on the naive evidence the test
will collect); it only unblocks running that test from an installed wheel.

## Test plan

- `test_context_seed_validation_cmd.py` (new): wiring, `--json` manifest, hidden
  in `--help`, missing-dir, empty-dir-proceeds, and the overwrite guard
  parametrized over `.memtomem` / `.mcp.json` / `.claude` / unrelated-file.
- `test_ctx_validation_harness.py`: unchanged assertions, now importing the
  seeder from its shipped location.
- End-to-end: `mm context seed-validation /tmp/demo` produces the correct Store
  vs runtime layout (out-of-sync Store=v2 / runtime=v1; `summarize` runtime-only
  → Import; MCP orphan + malformed canonical; agents empty).
- `ruff check` + `format --check` clean (src + tests); `mypy` clean on the new
  module; full suite collects (7308 tests) with no fixture-deletion fallout.

Refs #1353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
