### PR TITLE
docs(adr-0026): record the self-run gauge + P2 create-vs-overwrite constraint

### DIFF
--- a/docs/adr/0026-context-gateway-onboarding-ia.md
+++ b/docs/adr/0026-context-gateway-onboarding-ia.md
@@ -342,6 +342,13 @@ drifted.
   protocols + the seed harness in `memtomem-docs/memtomem/testing/` remain
   ready if P2 is taken up. Use the pass bars defined below verbatim — they are
   the single source of truth; do not re-derive thresholds elsewhere.
+  A facilitator **self-run gauge** (not a naive run) on build `6080fcb7`
+  (2026-06-20) re-verified the seed harness rendering and confirmed the
+  reversible D-F default lands a clean first-run in Simple with no
+  `localStorage` step (harness + default-path only — no comprehension claim);
+  it is recorded on #1353. By the self-run's own validity limit an informed
+  N=1 cannot clear the /6 bars, so it yields harness validation + a friction
+  gauge only — **P2 stays deferred** pending a naive run.
 
 **Companion string issues** #1348 / #1349 / #1350 / #1351 / #1352 — all
 **closed**.
@@ -441,6 +448,15 @@ to the prior open question Q-x.)
     the row badge + per-runtime chips** for detail, and keep the
     create-vs-overwrite cue on list/Sync-All rows *before* the confirm
     modal (do not hide it in the modal).
+  - *Observed 2026-06-20 (author self-run gauge, build `6080fcb7`; string
+    rendering only):* today's four-status model already surfaces this cue
+    explicitly in the Sync confirm modal — `settings.ctx.confirm_sync_impact`
+    ("create {create} missing and overwrite {overwrite} out-of-sync runtime
+    files…") plus `settings.ctx.confirm_sync_overwrite_warning`. A P2
+    status-collapse to ahead/behind/in-sync must therefore preserve an
+    equivalent create-vs-overwrite signal, not regress it — this constraint is
+    the concrete form of the second P2 gate condition (the gate itself stays
+    unmet, pending the naive run).
   - **Alternatives (kept):** collapse to a single ahead/behind/in-sync
     badge with no per-runtime chips (simpler, but loses the mixed-state and
     overwrite-risk signal at a glance); keep today's four-status model


### PR DESCRIPTION
## What

Records the 2026-06-20 **self-run gauge** of the ADR-0026 §Validation first-run
test, run on `main` (`6080fcb7`) via the new `mm context seed-validation` seeder
(#1425) + Playwright. Docs-only — two additions to `docs/adr/0026-…`:

- **§Validation status** — note the self-run as harness validation + a friction
  gauge only (informed N=1, no comprehension claim); **P2 stays deferred**
  pending a naive run.
- **D-C** — anchor the *second P2 gate condition* ("status-collapse must not cost
  power users the create-vs-overwrite distinction") to the concrete current cue:
  `confirm_sync_impact` + `confirm_sync_overwrite_warning` surface
  create-vs-overwrite today, so a P2 status-collapse must preserve it.

## Why

`§5` follow-up to the self-run. The gauge confirmed the harness renders all six
affordances and the reversible D-F Simple-as-default lands a clean first-run —
but, by design, an informed self-run cannot clear the /6 naive bars, so it
changes no gate. The durable, decision-record-worthy output is the
create-vs-overwrite design constraint for whoever takes up P2.

## Honesty / no-preload

No comprehension copy ships here. The spec'd P5 line stays deferred (it would
pre-answer the gated probe); the adjacent `confirm_sync_no_changes` ("Everything
is already in sync.") is the all-in-sync count-state branch, not the mixed-state
P5 cue. Adversarially reviewed (no-preload + honesty + factual lenses) before
commit.

## Test

Docs-only; `test_docs_guards.py` green (12 passed).

Full gauge readout recorded on #1353 (stays open — no auto-close keyword).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
