### PR TITLE
fix(config): correct stale "removal in 0.3" wording for rerank.top_k

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -495,7 +495,7 @@ class RerankConfig(BaseSettings):
     # Deprecated: superseded by oversample/min_pool/max_pool. Kept as a
     # field so legacy config.json and MEMTOMEM_RERANK__TOP_K env vars
     # still load without errors; ``_migrate_legacy_top_k`` rewrites it
-    # to ``min_pool`` during validation. Slated for removal in 0.3.
+    # to ``min_pool`` during validation. Slated for removal in a future release.
     top_k: int = 20
 
     @model_validator(mode="before")
@@ -509,7 +509,7 @@ class RerankConfig(BaseSettings):
             warnings.warn(
                 "rerank.top_k is deprecated and is ignored when rerank.min_pool "
                 "is set. Remove rerank.top_k from your config. "
-                "(Slated for removal in memtomem 0.3.)",
+                "(Slated for removal in a future release.)",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -519,7 +519,7 @@ class RerankConfig(BaseSettings):
                 "rerank.top_k is deprecated; migrating to rerank.min_pool. "
                 "Use rerank.oversample + rerank.min_pool + rerank.max_pool to "
                 "scale the reranker candidate pool with the request top_k. "
-                "(Slated for removal in memtomem 0.3.)",
+                "(Slated for removal in a future release.)",
                 DeprecationWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
## Summary

Follow-up to #1429 (docs freshness). The `rerank.top_k` deprecation notice in source still predicted removal **"in 0.3" / "in memtomem 0.3"**, but 0.3.0 shipped with the field still present (it migrates to `min_pool` with a `DeprecationWarning`). Reworded to **"a future release"** so the notice stays accurate past 0.3.x.

## Changes (`packages/memtomem/src/memtomem/config.py`)

- field comment (line ~498): `Slated for removal in 0.3.` → `... in a future release.`
- both `DeprecationWarning` messages (`_migrate_legacy_top_k`): `(Slated for removal in memtomem 0.3.)` → `(Slated for removal in a future release.)`

No behavior change — the warnings still contain `rerank.top_k` / `ignored`, so the existing `test_pipeline` deprecation assertions are unaffected.

## Verification

- `ruff check` + `ruff format --check` on `packages/memtomem/src`: clean
- `pytest test_pipeline.py -k "legacy_top_k or deprecat"`: **2 passed**
- residual grep for `removal in 0.3` / `in memtomem 0.3` across src: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
