### PR TITLE
fix(tags): decode non-ASCII tags instead of storing \uXXXX escape text

### DIFF
--- a/packages/memtomem/src/memtomem/chunking/markdown.py
+++ b/packages/memtomem/src/memtomem/chunking/markdown.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -330,6 +331,17 @@ class MarkdownChunker:
         """
         value = value.strip()
         if value.startswith("[") and value.endswith("]"):
+            # Prefer strict JSON: this decodes ``\uXXXX`` escapes (the shape
+            # ``json.dumps(..., ensure_ascii=True)`` produced for older files)
+            # back to their characters and keeps quoted commas intact. Fall
+            # back to the lenient hand-split for non-JSON shapes that we also
+            # accept (single quotes ``['a']``, bare ``[a, b]``).
+            try:
+                parsed = json.loads(value)
+            except (ValueError, TypeError):
+                parsed = None
+            if isinstance(parsed, list):
+                return [str(t).strip() for t in parsed if str(t).strip()]
             return [t.strip().strip("'\"") for t in value[1:-1].split(",") if t.strip()]
         if value:
             return [value.strip("'\"")]

--- a/packages/memtomem/src/memtomem/storage/sqlite_schema.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_schema.py
@@ -25,6 +25,15 @@ _CHUNK_LINKS_BACKFILL_KEY = "chunk_links_backfill_v1"
 
 _SHARED_FROM_TAG_PREFIX = "shared-from="
 
+# One-shot repair key for tags that were stored as their literal ``\uXXXX``
+# escape text instead of the characters they encode (pre ``ensure_ascii=False``
+# memory_writer fix). Bump (``..._v2``) to force a re-run.
+_TAGS_UNICODE_REPAIR_KEY = "tags_unicode_repair_v1"
+
+# Matches a single ``\uXXXX`` BMP escape sequence as literal text (a backslash,
+# a ``u``, then four hex digits) — what a mis-decoded tag still carries.
+_UNICODE_ESCAPE_RE = re.compile(r"\\u[0-9a-fA-F]{4}")
+
 
 def create_tables(
     db: sqlite3.Connection,
@@ -456,6 +465,7 @@ def create_tables(
     )
 
     _backfill_chunk_links(db, meta)
+    _repair_unicode_escaped_tags(db, meta)
 
     # --- Entity extraction table ---
     db.execute("""
@@ -590,6 +600,84 @@ def _backfill_chunk_links(db: sqlite3.Connection, meta: MetaManager) -> int:
 
     meta.set_meta(_CHUNK_LINKS_BACKFILL_KEY, "done")
     return inserted
+
+
+def _decode_unicode_escaped(text: str) -> str:
+    """Decode literal ``\\uXXXX`` escape text, composing surrogate pairs.
+
+    Replacing each ``\\uXXXX`` token independently yields *lone* surrogate
+    code points for non-BMP characters (an emoji is two escapes, e.g.
+    ``\\ud83d\\ude00``). A UTF-16 ``surrogatepass`` round-trip recombines an
+    adjacent high+low pair back into the real code point so the result is a
+    str that SQLite can store. Strings with no escapes return unchanged.
+    """
+    decoded = _UNICODE_ESCAPE_RE.sub(lambda m: chr(int(m.group(0)[2:], 16)), text)
+    if decoded == text:
+        return text
+    try:
+        return decoded.encode("utf-16", "surrogatepass").decode("utf-16")
+    except UnicodeError:
+        # Lone/un-pairable surrogate — hand back the per-escape decode; the
+        # caller test-encodes before writing and skips anything un-encodable.
+        return decoded
+
+
+def _repair_unicode_escaped_tags(db: sqlite3.Connection, meta: MetaManager) -> int:
+    """Decode literal ``\\uXXXX`` escapes left in chunk tags by older ingest.
+
+    Tags written before the ``memory_writer`` ``ensure_ascii=False`` fix were
+    serialized as their JSON escape *text* (e.g. ``\\ucee4\\ub9ac...``) and the
+    markdown parser split the array by hand without JSON-decoding, so the
+    literal escape survived into ``ChunkMetadata.tags`` and the DB. This pass
+    walks the affected rows once, decodes the escapes to their characters,
+    de-duplicates (preserving order), and rewrites the row. It is idempotent —
+    completion is recorded in ``_memtomem_meta`` and clean tags (already
+    Hangul) carry no escape text, so re-runs are no-ops.
+
+    A row whose decoded tags cannot be UTF-8 encoded (un-pairable surrogate
+    junk) is left untouched rather than crash startup.
+
+    Returns the number of rows rewritten on this call (0 once recorded).
+    """
+    if meta.get_meta(_TAGS_UNICODE_REPAIR_KEY) == "done":
+        return 0
+
+    # ``ensure_ascii`` serialization means every non-ASCII tag's column text
+    # contains ``\u`` — clean *and* broken alike — so the LIKE is only a cheap
+    # pre-filter; the json.loads round-trip below is what tells them apart.
+    rows = db.execute("SELECT id, tags FROM chunks WHERE tags LIKE '%\\u%'").fetchall()
+
+    repaired = 0
+    for chunk_id, tags_json in rows:
+        if not tags_json:
+            continue
+        try:
+            tags = json.loads(tags_json)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(tags, list):
+            continue
+        seen: set[str] = set()
+        new_tags: list[str] = []
+        for tag in tags:
+            if isinstance(tag, str):
+                tag = _decode_unicode_escaped(tag)
+            if tag not in seen:
+                seen.add(tag)
+                new_tags.append(tag)
+        if new_tags == tags:
+            continue
+        payload = json.dumps(new_tags, ensure_ascii=False)
+        try:
+            payload.encode("utf-8")
+        except UnicodeEncodeError:
+            # Un-encodable (lone surrogate) — skip rather than fail the write.
+            continue
+        db.execute("UPDATE chunks SET tags=? WHERE id=?", (payload, chunk_id))
+        repaired += 1
+
+    meta.set_meta(_TAGS_UNICODE_REPAIR_KEY, "done")
+    return repaired
 
 
 def _migrate_chunks_uniqueness(db: sqlite3.Connection, *, has_vec_table: bool) -> None:

--- a/packages/memtomem/src/memtomem/storage/sqlite_schema.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_schema.py
@@ -657,14 +657,18 @@ def _repair_unicode_escaped_tags(db: sqlite3.Connection, meta: MetaManager) -> i
             continue
         if not isinstance(tags, list):
             continue
+        # Tags are contractually strings; a non-str element (e.g. a dict) is
+        # malformed and un-hashable for the dedup below — leave such a row
+        # untouched rather than crash startup.
+        if not all(isinstance(tag, str) for tag in tags):
+            continue
         seen: set[str] = set()
         new_tags: list[str] = []
         for tag in tags:
-            if isinstance(tag, str):
-                tag = _decode_unicode_escaped(tag)
-            if tag not in seen:
-                seen.add(tag)
-                new_tags.append(tag)
+            decoded = _decode_unicode_escaped(tag)
+            if decoded not in seen:
+                seen.add(decoded)
+                new_tags.append(decoded)
         if new_tags == tags:
             continue
         payload = json.dumps(new_tags, ensure_ascii=False)

--- a/packages/memtomem/src/memtomem/tools/memory_writer.py
+++ b/packages/memtomem/src/memtomem/tools/memory_writer.py
@@ -26,11 +26,16 @@ def append_entry(
     parses as YAML downstream. The chunker promotes ``> tags:`` into
     ``ChunkMetadata.tags`` and strips the header from chunk content (see
     ``memtomem.chunking.markdown.MarkdownChunker``).
+
+    ``ensure_ascii=False`` keeps non-ASCII tags (e.g. Hangul) as their
+    real characters in the file rather than ``\\uXXXX`` escape text. The
+    parser does not JSON-decode the array element-by-element, so escaped
+    text would otherwise survive verbatim into the stored tag.
     """
     file_path.parent.mkdir(parents=True, exist_ok=True)
 
     now = datetime.now(timezone.utc).isoformat(timespec="seconds")
-    tag_line = f"\n> tags: {json.dumps(list(tags))}" if tags else ""
+    tag_line = f"\n> tags: {json.dumps(list(tags), ensure_ascii=False)}" if tags else ""
 
     # Skip heading if content already starts with one (e.g., from a template)
     stripped = content.strip()

--- a/packages/memtomem/tests/test_chunking_blockquote_tags.py
+++ b/packages/memtomem/tests/test_chunking_blockquote_tags.py
@@ -8,6 +8,7 @@ content so it does not leak into BM25 / embedding inputs. See
 ``planning/mem-add-tags-blockquote-promote-rfc.md``.
 """
 
+import json
 from pathlib import Path
 
 from memtomem.chunking.markdown import MarkdownChunker
@@ -126,6 +127,32 @@ class TestSectionBlockquoteTags:
         chunks_double = _chunk(content_double)
         assert set(chunks_single[0].metadata.tags) == {"x", "y"}
         assert set(chunks_double[0].metadata.tags) == {"x", "y"}
+
+    def test_legacy_unicode_escaped_tags_decode_to_hangul(self):
+        """Pre-fix files wrote ``ensure_ascii`` escape text — decode it on read.
+
+        Older ``memory_writer`` emitted ``> tags: ["\\ucee4..."]`` (the literal
+        JSON escape sequence). The hand-split parser stored that verbatim, so
+        the tag cloud showed ``\\ucee4...`` instead of Hangul. The parser now
+        JSON-decodes the array, recovering the real characters from files
+        already on disk (and thus on re-index).
+        """
+        tags_in = ["커리큘럼설계", "재사용자산"]
+        escaped = json.dumps(tags_in)  # ensure_ascii=True → literal \uXXXX text
+        assert "\\u" in escaped, "test must reproduce the on-disk escaped shape"
+        content = (
+            "## 강의 설계\n"
+            "\n"
+            "> created: 2026-04-24T22:12:30+00:00\n"
+            f"> tags: {escaped}\n"
+            "\n"
+            "본문 텍스트.\n"
+        )
+        chunks = _chunk(content)
+        assert len(chunks) == 1
+        assert set(chunks[0].metadata.tags) == set(tags_in)
+        # The escape text must not survive into the stored tag.
+        assert not any("\\u" in t for t in chunks[0].metadata.tags)
 
     def test_block_list_shape_in_blockquote(self):
         """``> tags:`` followed by ``> - a`` / ``> - b`` block-list lines.

--- a/packages/memtomem/tests/test_memory_writer_tag_format.py
+++ b/packages/memtomem/tests/test_memory_writer_tag_format.py
@@ -61,3 +61,21 @@ class TestAppendEntryTagFormat:
         append_entry(f, "Body.", title="H", tags=["x"])
         text = f.read_text(encoding="utf-8")
         assert "\n> created: " in text
+
+    def test_non_ascii_tags_written_as_characters_not_escapes(self, tmp_path: Path):
+        """Hangul tags land in the file as real characters, not ``\\uXXXX`` text.
+
+        ``ensure_ascii=True`` (the old default) wrote ``["\\ucee4..."]`` — the
+        literal escape sequence — which the hand-split parser then stored
+        verbatim, surfacing ``\\ucee4...`` in the tag cloud.
+        """
+        f = tmp_path / "out.md"
+        tags_in = ["커리큘럼설계", "재사용자산"]
+        append_entry(f, "Body.", title="제목", tags=tags_in)
+        text = f.read_text(encoding="utf-8")
+        assert '> tags: ["커리큘럼설계", "재사용자산"]' in text
+        # No literal backslash-u escape sequence may survive.
+        assert "\\u" not in text
+        # And the line still parses as JSON back to the originals.
+        line = next(line for line in text.splitlines() if line.startswith("> tags: "))
+        assert json.loads(line.split("> tags: ", 1)[1]) == tags_in

--- a/packages/memtomem/tests/test_tags_unicode_repair.py
+++ b/packages/memtomem/tests/test_tags_unicode_repair.py
@@ -1,0 +1,191 @@
+"""One-shot DB repair of unicode-escaped chunk tags.
+
+Tags ingested before the ``memory_writer`` ``ensure_ascii=False`` fix were
+stored as their literal ``\\uXXXX`` escape text instead of the characters they
+encode (a Korean tag surfaced in the tag cloud as ``\\ucee4...``). The
+``_repair_unicode_escaped_tags`` migration in ``create_tables`` decodes those
+rows once per database without forcing a full re-embed re-index.
+
+These mirror the ``chunk_links`` back-fill tests: seed AFTER the first
+``create_tables`` pass, clear the idempotency marker, then re-init so the
+migration runs against the seeded rows.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+
+import sqlite_vec
+
+from memtomem.storage.sqlite_meta import MetaManager
+from memtomem.storage.sqlite_schema import create_tables
+
+_MARKER_KEY = "tags_unicode_repair_v1"
+
+
+def _connect() -> sqlite3.Connection:
+    db = sqlite3.connect(":memory:")
+    db.enable_load_extension(True)
+    sqlite_vec.load(db)
+    db.enable_load_extension(False)
+    db.execute("PRAGMA foreign_keys=ON")
+    return db
+
+
+def _initialize(db: sqlite3.Connection) -> None:
+    meta = MetaManager(lambda: db)
+    create_tables(db, meta, dimension=0, embedding_provider="none", embedding_model="")
+
+
+def _insert_chunk(db: sqlite3.Connection, chunk_id: str, *, tags_json: str) -> None:
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    db.execute(
+        "INSERT INTO chunks (id, content, content_hash, source_file, namespace, "
+        "tags, created_at, updated_at) VALUES (?, '', ?, '', 'default', ?, ?, ?)",
+        (chunk_id, chunk_id, tags_json, now, now),
+    )
+
+
+def _rerun_migration(db: sqlite3.Connection) -> None:
+    db.execute("DELETE FROM _memtomem_meta WHERE key=?", (_MARKER_KEY,))
+    db.commit()
+    _initialize(db)
+
+
+def _escaped_text(hangul: str) -> str:
+    """The literal ``\\uXXXX`` escape *text* an older file stored for *hangul*."""
+    escaped = json.dumps(hangul)[1:-1]  # strip the surrounding quotes
+    assert "\\u" in escaped, "fixture must reproduce the on-disk escaped shape"
+    return escaped
+
+
+def _stored_tags(db: sqlite3.Connection, chunk_id: str) -> list[str]:
+    row = db.execute("SELECT tags FROM chunks WHERE id=?", (chunk_id,)).fetchone()
+    return json.loads(row[0])
+
+
+class TestRepairUnicodeEscapedTags:
+    def test_decodes_escaped_tag_to_hangul(self) -> None:
+        db = _connect()
+        try:
+            _initialize(db)
+            broken = _escaped_text("커리큘럼설계")
+            _insert_chunk(db, "esc-1", tags_json=json.dumps([broken]))
+            _rerun_migration(db)
+            assert _stored_tags(db, "esc-1") == ["커리큘럼설계"]
+        finally:
+            db.close()
+
+    def test_decodes_surrogate_pair_emoji(self) -> None:
+        """Non-BMP tags (emoji = a high+low ``\\uXXXX`` pair) decode atomically.
+
+        Decoding each escape independently would yield two lone surrogates and
+        crash the row's ``UPDATE`` on UTF-8 encode; the UTF-16 recompose fixes
+        it. Regression for the surrogate-pair startup crash.
+        """
+        db = _connect()
+        try:
+            _initialize(db)
+            broken = _escaped_text("😀")  # → literal '😀' text
+            _insert_chunk(db, "emoji-1", tags_json=json.dumps([broken]))
+            _rerun_migration(db)  # must not raise
+            assert _stored_tags(db, "emoji-1") == ["😀"]
+        finally:
+            db.close()
+
+    def test_unpairable_surrogate_left_untouched(self) -> None:
+        """A lone (high-only) surrogate escape can't form valid UTF-8 — the row
+        must be skipped, never crash startup."""
+        db = _connect()
+        try:
+            _initialize(db)
+            # Column text ``["\\ud83d"]`` → json.loads yields the *escape text*
+            # ``\ud83d`` (6 chars), which decodes to an un-encodable surrogate.
+            _insert_chunk(db, "lone-1", tags_json=r'["\\ud83d"]')
+            _rerun_migration(db)  # must not raise
+            assert _stored_tags(db, "lone-1") == [r"\ud83d"]
+        finally:
+            db.close()
+
+    def test_clean_hangul_tag_untouched(self) -> None:
+        """A correctly-stored Hangul tag (ensure_ascii column text) decodes fine
+        and the migration leaves its value intact."""
+        db = _connect()
+        try:
+            _initialize(db)
+            _insert_chunk(db, "clean-1", tags_json=json.dumps(["재사용자산"]))
+            _rerun_migration(db)
+            assert _stored_tags(db, "clean-1") == ["재사용자산"]
+        finally:
+            db.close()
+
+    def test_ascii_tag_untouched(self) -> None:
+        db = _connect()
+        try:
+            _initialize(db)
+            _insert_chunk(db, "ascii-1", tags_json='["FCA", "shared-from=abc"]')
+            _rerun_migration(db)
+            assert _stored_tags(db, "ascii-1") == ["FCA", "shared-from=abc"]
+        finally:
+            db.close()
+
+    def test_decode_collapses_duplicate(self) -> None:
+        """Escaped + already-decoded copies of the same tag de-dup to one."""
+        db = _connect()
+        try:
+            _initialize(db)
+            broken = _escaped_text("커리큘럼설계")
+            _insert_chunk(db, "dup-1", tags_json=json.dumps([broken, "커리큘럼설계"]))
+            _rerun_migration(db)
+            assert _stored_tags(db, "dup-1") == ["커리큘럼설계"]
+        finally:
+            db.close()
+
+    def test_idempotent_marker_short_circuits(self) -> None:
+        """Marker recorded; rows added after the run are not re-scanned."""
+        db = _connect()
+        try:
+            _initialize(db)
+            _insert_chunk(db, "esc-early", tags_json=json.dumps([_escaped_text("초안")]))
+            _rerun_migration(db)
+            assert _stored_tags(db, "esc-early") == ["초안"]
+
+            marker = db.execute(
+                "SELECT value FROM _memtomem_meta WHERE key=?", (_MARKER_KEY,)
+            ).fetchone()
+            assert marker is not None and marker[0] == "done"
+
+            # A new escaped row added AFTER the migration must stay untouched
+            # (later writes go through the fixed writer/parser, not a re-scan).
+            broken_late = _escaped_text("후속")
+            _insert_chunk(db, "esc-late", tags_json=json.dumps([broken_late]))
+            db.commit()
+            _initialize(db)  # marker still "done" → no-op
+            assert _stored_tags(db, "esc-late") == [broken_late]
+        finally:
+            db.close()
+
+    def test_running_twice_is_stable(self) -> None:
+        """Re-running the repair on already-decoded data changes nothing."""
+        db = _connect()
+        try:
+            _initialize(db)
+            _insert_chunk(db, "esc-2", tags_json=json.dumps([_escaped_text("재사용자산")]))
+            _rerun_migration(db)
+            first = _stored_tags(db, "esc-2")
+            _rerun_migration(db)
+            assert _stored_tags(db, "esc-2") == first == ["재사용자산"]
+        finally:
+            db.close()
+
+    def test_corrupt_tags_json_skipped(self) -> None:
+        """Malformed ``tags`` JSON must not crash the migration."""
+        db = _connect()
+        try:
+            _initialize(db)
+            _insert_chunk(db, "bad-1", tags_json="not json \\u0041 at all")
+            _rerun_migration(db)  # must not raise
+        finally:
+            db.close()

--- a/packages/memtomem/tests/test_tags_unicode_repair.py
+++ b/packages/memtomem/tests/test_tags_unicode_repair.py
@@ -189,3 +189,16 @@ class TestRepairUnicodeEscapedTags:
             _rerun_migration(db)  # must not raise
         finally:
             db.close()
+
+    def test_non_string_tag_element_left_untouched(self) -> None:
+        """A valid JSON array whose element is non-str (e.g. a dict) is malformed
+        and un-hashable for dedup — the row must be skipped, never crash."""
+        db = _connect()
+        try:
+            _initialize(db)
+            # ensure_ascii column text carries \u so the LIKE prefilter walks it.
+            _insert_chunk(db, "obj-1", tags_json=json.dumps([{"label": "가"}]))
+            _rerun_migration(db)  # must not raise
+            assert _stored_tags(db, "obj-1") == [{"label": "가"}]
+        finally:
+            db.close()


### PR DESCRIPTION
## What

Non-ASCII tags (Korean, emoji, …) were stored and displayed as their literal
JSON escape text — e.g. the tag cloud showed `커리하럼설계`
instead of `커리큘럼설계`. Only ASCII tags rendered correctly.

Found during a UI/UX audit of the Tags view; the console was clean, so it was a
silent data defect, not a render crash.

## Root cause

A write/read mismatch around the per-entry `> tags:` blockquote line:

- **Write** — `memory_writer.append_entry` serialized with `json.dumps(...)`
  (`ensure_ascii=True`), so the markdown file got `\uXXXX` *escape text*.
- **Read** — `MarkdownChunker._parse_tags_value` split the JSON array by hand
  (`value[1:-1].split(",")` + `strip("'\"")`) and never JSON-decoded, so the
  escape text passed straight through into `ChunkMetadata.tags` and the DB.

The DB round-trip (`json.dumps`/`json.loads`) is self-consistent and was **not**
the culprit — the source string going in was already the literal escape.

## Fix

- **Write**: `json.dumps(list(tags), ensure_ascii=False)` keeps real characters
  in the file.
- **Read**: `_parse_tags_value` now tries strict `json.loads` first (decoding
  `\uXXXX` and preserving quoted commas), falling back to the lenient
  hand-split for the non-JSON shapes we still accept (`['a']`, `[a, b]`). This
  also repairs already-on-disk escaped files on re-index.
- **Migration**: a one-shot, idempotent `_repair_unicode_escaped_tags` in
  `create_tables` decodes already-indexed escaped tags in place, gated by a
  `_memtomem_meta` flag and mirroring the existing `_backfill_chunk_links`
  pattern — so existing DBs are fixed without forcing a full re-embed.
  Surrogate pairs (emoji) are recomposed via UTF-16; rows that still can't be
  UTF-8 encoded are skipped rather than crash startup.

## Tests

- `test_memory_writer_tag_format.py` — Hangul written as characters, not `\u`.
- `test_chunking_blockquote_tags.py` — legacy escaped-file form decodes to Hangul.
- `test_tags_unicode_repair.py` — migration: Hangul repair, emoji surrogate-pair
  round-trip, lone-surrogate skip (no crash), idempotency, dedup, corrupt JSON.

`ruff check` / `ruff format --check` clean; `mypy` clean; 103-test regression
sweep across chunking/storage/tags green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
