### PR TITLE
feat(web): de-jargon the search detail panel for first-time users (S1.2, S1.4)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -2730,6 +2730,26 @@ function _scoreViewForResult(r) {
   };
 }
 
+// Localized "Relevance" label, with an English fallback for the pre-i18n /
+// failed-locale path (mirrors the inline pattern used elsewhere on this surface).
+function _relevanceLabel() {
+  if (typeof t === 'function') {
+    const tr = t('search.relevance_label');
+    if (tr !== 'search.relevance_label') return tr;
+  }
+  return 'Relevance';
+}
+
+// First-time-friendly tooltip for the score bar; the raw retrieval math is
+// gated behind the Advanced-details reveal (see showDetail / style.css).
+function _relevanceTooltip() {
+  if (typeof t === 'function') {
+    const tr = t('search.relevance_tooltip');
+    if (tr !== 'search.relevance_tooltip') return tr;
+  }
+  return 'How closely this result matches your query.';
+}
+
 function _buildResultItem(r) {
   const list = qs('results-list');
   const item = document.createElement('div');
@@ -2775,11 +2795,7 @@ function _buildResultItem(r) {
   const scoreView = _scoreViewForResult(r);
   const scorePct = scoreView.percent;
   const barColor = scorePct > 70 ? 'var(--green)' : scorePct > 40 ? 'var(--accent)' : 'var(--muted)';
-  let relevanceLabel = 'Relevance';
-  if (typeof t === 'function') {
-    const translated = t('search.relevance_label');
-    relevanceLabel = translated === 'search.relevance_label' ? relevanceLabel : translated;
-  }
+  const relevanceLabel = _relevanceLabel();
 
   const body = document.createElement('div');
   body.className = 'result-body';
@@ -3039,6 +3055,19 @@ function renderResults(results, retrievalStats) {
   updateBulkToolbar(0);
   list.innerHTML = summaryHtml;
   list.classList.toggle('list-view', STATE.viewMode === 'list');
+  // "Advanced details" doubles as the retrieval-internals reveal: opening it
+  // sets body.show-retrieval-debug, surfacing the raw per-result source badge
+  // and the detail-panel score/source/RRF math (hidden by default). The
+  // <details> is rebuilt on every render, so restore + rebind each time.
+  const debugDetails = list.querySelector('.results-debug-details');
+  if (debugDetails) {
+    debugDetails.open = !!STATE.showRetrievalDebug;
+    debugDetails.addEventListener('toggle', () => {
+      STATE.showRetrievalDebug = debugDetails.open;
+      document.body.classList.toggle('show-retrieval-debug', debugDetails.open);
+    });
+  }
+  document.body.classList.toggle('show-retrieval-debug', !!STATE.showRetrievalDebug);
 
   if (STATE.groupMode) {
     const groups = {};
@@ -3103,7 +3132,8 @@ function showDetail(r) {
   }
   const srcEl = qs('d-source');
   srcEl.textContent = r.source;
-  srcEl.className = `badge badge-retrieval badge-retrieval--${r.source}`;
+  // Keep result-debug-meta so this raw retrieval-source badge stays gated.
+  srcEl.className = `badge badge-retrieval badge-retrieval--${r.source} result-debug-meta`;
 
   // Score detail row: rank + normalized display bar + raw diagnostic score.
   const rrfK = (STATE.serverConfig && STATE.serverConfig.search && STATE.serverConfig.search.rrf_k) || 60;
@@ -3115,7 +3145,11 @@ function showDetail(r) {
   qs('d-score-bar').style.width = `${pct.toFixed(1)}%`;
   qs('d-score-pct').textContent = `${pct.toFixed(0)}%`;
   const scoreDetailRow = qs('d-score-detail');
-  scoreDetailRow.dataset.tooltip = scoreView.isReranked
+  // Default hover tooltip is plain-language; the raw retrieval math lives in
+  // data-tooltip-debug and only renders under body.show-retrieval-debug
+  // (the Advanced-details reveal), so first-time users never meet RRF/k.
+  scoreDetailRow.dataset.tooltip = _relevanceTooltip();
+  scoreDetailRow.dataset.tooltipDebug = scoreView.isReranked
     ? `Reranker percentile ${pct.toFixed(0)}%; raw score ${r.score.toFixed(6)}`
     : `RRF ${r.score.toFixed(6)} / max ${maxRrf.toFixed(6)} (k=${rrfK}, ${nSources} sources)`;
   show(scoreDetailRow);

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -2200,7 +2200,11 @@ function _renderChunkDist(distribution) {
 }
 
 // G. Namespace Summary
-function _formatHomeNsLabel(nsName) {
+// Shared friendly-label formatter for long namespace ids (Home chart, search
+// result badge, detail panel). Short ids (≤28 chars) pass through unchanged;
+// long auto-namespaces collapse to "provider: .../tail". The full id is always
+// preserved by callers in title/aria-label. Filter dropdowns keep full names.
+function formatNsLabel(nsName) {
   const raw = String(nsName || '');
   if (raw.length <= 28) return raw;
 
@@ -2252,7 +2256,7 @@ function _renderNsChart(namespaces) {
     const color = ns.color || palette[i % palette.length];
     const nsName = String(ns.namespace || '');
     const fullNs = escapeHtml(nsName);
-    const shortNs = escapeHtml(_formatHomeNsLabel(nsName));
+    const shortNs = escapeHtml(formatNsLabel(nsName));
     const nsAttr = escapeAttr(nsName);
     const actionLabel = escapeAttr(_homeNsActionLabel(nsName, ns.chunk_count));
     return `<div class="home-bar-row home-ns-row">
@@ -2784,7 +2788,7 @@ function _buildResultItem(r) {
   const ariaParts = [fname, lineRange, nsLabel, age].filter(Boolean);
   item.setAttribute('aria-label', ariaParts.join(', '));
   const nsBadge = r.chunk.namespace && r.chunk.namespace !== 'default'
-    ? ` <span class="badge badge-ns">${escapeHtml(r.chunk.namespace)}</span>` : '';
+    ? ` <span class="badge badge-ns" title="${escapeAttr(r.chunk.namespace)}">${escapeHtml(formatNsLabel(r.chunk.namespace))}</span>` : '';
   // ADR-0016 §7 canonical-residency tier badge. Default-omit for the
   // user tier so the common case stays visually quiet — only the
   // non-default tiers (project_shared / project_local) earn pixels.
@@ -3125,9 +3129,14 @@ function showDetail(r) {
   qs('d-type').textContent = r.chunk.chunk_type.replace('_', ' ');
   const nsEl = qs('d-namespace');
   if (r.chunk.namespace && r.chunk.namespace !== 'default') {
-    nsEl.textContent = r.chunk.namespace;
+    // Friendly label; full id preserved in title + aria-label.
+    nsEl.textContent = formatNsLabel(r.chunk.namespace);
+    nsEl.title = r.chunk.namespace;
+    nsEl.setAttribute('aria-label', `namespace ${r.chunk.namespace}`);
     show(nsEl);
   } else {
+    nsEl.removeAttribute('title');
+    nsEl.removeAttribute('aria-label');
     hide(nsEl);
   }
   const srcEl = qs('d-source');

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -2800,6 +2800,11 @@ function _buildResultItem(r) {
   const scorePct = scoreView.percent;
   const barColor = scorePct > 70 ? 'var(--green)' : scorePct > 40 ? 'var(--accent)' : 'var(--muted)';
   const relevanceLabel = _relevanceLabel();
+  // The score badge is always visible and communicates relevance, so its hover
+  // title stays plain-language in every mode (no stale render-time state). The
+  // raw per-result retrieval score lives in the detail panel's #d-score, which
+  // the Advanced-details reveal un-hides. (aria-label is already friendly.)
+  const scoreTitle = _relevanceTooltip();
 
   const body = document.createElement('div');
   body.className = 'result-body';
@@ -2807,7 +2812,7 @@ function _buildResultItem(r) {
     <div class="result-item-row1">
       <span class="result-type-dot" style="background:${fileTypeColor(r.chunk.source_file || '')}"></span>
       <span class="result-filename">${escapeHtml(fname)}</span>
-      <span class="score-badge" title="${escapeAttr(scoreView.tooltip)}" aria-label="${escapeAttr(relevanceLabel)} ${escapeAttr(scoreView.label)}">${escapeHtml(relevanceLabel)} ${escapeHtml(scoreView.label)}</span>
+      <span class="score-badge" title="${escapeAttr(scoreTitle)}" aria-label="${escapeAttr(relevanceLabel)} ${escapeAttr(scoreView.label)}">${escapeHtml(relevanceLabel)} ${escapeHtml(scoreView.label)}</span>
       <span class="badge badge-retrieval badge-retrieval--${escapeAttr(r.source)} result-debug-meta">${escapeHtml(r.source)}</span>
       ${nsBadge}${tierBadge}${validityBadge}
     </div>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1608,12 +1608,12 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=5"></script>
-  <script src="/app.js?v=132"></script>
+  <script src="/app.js?v=133"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=12"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>
   <script src="/settings-maintenance.js?v=5"></script>
-  <script src="/settings-namespaces.js?v=10"></script>
+  <script src="/settings-namespaces.js?v=11"></script>
   <script src="/settings-harness.js?v=4"></script>
   <script src="/settings-hooks-watchdog.js?v=21"></script>
   <script src="/timeline.js?v=3"></script>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=119" />
+  <link rel="stylesheet" href="/style.css?v=120" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -310,10 +310,10 @@
         <div id="detail-view" hidden>
           <div class="detail-header">
             <div class="detail-meta-row">
-              <span id="d-score" class="badge badge-blue"></span>
+              <span id="d-score" class="badge badge-blue result-debug-meta"></span>
               <span id="d-type" class="badge badge-gray"></span>
               <span id="d-namespace" class="badge badge-ns"></span>
-              <span id="d-source" class="badge badge-source badge-retrieval"></span>
+              <span id="d-source" class="badge badge-source badge-retrieval result-debug-meta"></span>
               <span id="d-created" class="badge badge-gray"></span>
               <span id="d-validity" class="badge badge-validity" hidden></span>
             </div>
@@ -1608,7 +1608,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=5"></script>
-  <script src="/app.js?v=131"></script>
+  <script src="/app.js?v=132"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=12"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1608,7 +1608,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=5"></script>
-  <script src="/app.js?v=133"></script>
+  <script src="/app.js?v=135"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=12"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -129,6 +129,7 @@
   "search.tag_filter_title": "Comma-separated tags to include in results",
   "search.min_relevance_aria": "Minimum relevance score",
   "search.relevance_label": "Relevance",
+  "search.relevance_tooltip": "How closely this result matches your query.",
   "search.advanced_details": "Advanced details",
   "search.ns_all": "All Namespaces",
   "search.ns_filter_title": "Limit search to a specific namespace",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -129,6 +129,7 @@
   "search.tag_filter_title": "결과에 포함할 태그 (쉼표로 구분)",
   "search.min_relevance_aria": "최소 관련성 점수",
   "search.relevance_label": "관련도",
+  "search.relevance_tooltip": "이 결과가 검색어와 얼마나 일치하는지 나타냅니다.",
   "search.advanced_details": "고급 세부정보",
   "search.ns_all": "전체 네임스페이스",
   "search.ns_filter_title": "특정 네임스페이스로 제한",

--- a/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
@@ -586,7 +586,7 @@ _renderNsChart = function(namespaces) {
     const c = ns.color || palette[i % palette.length];
     const nsName = String(ns.namespace || '');
     const nsAttr = escapeAttr(nsName);
-    const label = escapeHtml(_formatHomeNsLabel(nsName));
+    const label = escapeHtml(formatNsLabel(nsName));
     const actionLabel = escapeAttr(_homeNsActionLabel(nsName, ns.chunk_count));
     return `<div class="ns-legend-item">
       <button class="ns-legend-action" type="button" data-home-ns="${nsAttr}" aria-label="${actionLabel}">

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -2574,6 +2574,14 @@ select:focus-visible {
 .results-summary-total { font-size: 0.72rem; color: var(--muted); margin-right: 2px; }
 .results-summary-pipeline { font-size: 0.68rem; color: var(--muted); font-family: var(--mono); margin-left: auto; opacity: 0.7; }
 .result-debug-meta { display: none !important; }
+/* Retrieval internals (raw score, fused/bm25 source badge, RRF math) stay
+   hidden for first-time users. Expanding "Advanced details" sets
+   body.show-retrieval-debug, which reveals them list-wide + in the detail
+   panel and swaps the friendly score tooltip for the raw retrieval math. */
+body.show-retrieval-debug .result-debug-meta { display: inline-block !important; }
+body.show-retrieval-debug .score-detail-row[data-tooltip-debug]:hover::after {
+  content: attr(data-tooltip-debug);
+}
 .results-debug-details {
   margin-left: auto;
   font-size: 0.68rem;

--- a/packages/memtomem/tests-js/search-filter-ux.test.mjs
+++ b/packages/memtomem/tests-js/search-filter-ux.test.mjs
@@ -197,6 +197,32 @@ describe('Search filters - add/remove UX', () => {
     expect(window.STATE.showRetrievalDebug).toBe(false);
     expect(document.body.classList.contains('show-retrieval-debug')).toBe(false);
   });
+
+  it('shows a friendly namespace label while keeping the full id reachable (S1.4)', () => {
+    const longNs = 'claude:-Users-pdstudio-Work-agent-harness-memtomem';
+    window.renderResults([{
+      chunk: {
+        id: 'ns1', content: 'content', source_file: '/repo/notes.md',
+        chunk_type: 'paragraph', start_line: 1, end_line: 3,
+        heading_hierarchy: [], tags: [], namespace: longNs,
+        created_at: '2026-05-13T00:00:00Z', updated_at: '2026-05-13T00:00:00Z',
+        target_scope: 'user',
+      },
+      score: 0.03, rank: 1, source: 'fused',
+    }], { bm25_candidates: 1, dense_candidates: 1, fused_total: 1, final_total: 1 });
+
+    // List badge: truncated label, full id in title (not the raw 50-char id).
+    const listBadge = document.querySelector('.result-item .badge-ns');
+    expect(listBadge.textContent).toBe('claude: .../harness/memtomem');
+    expect(listBadge.getAttribute('title')).toBe(longNs);
+
+    // Detail panel: same friendly label, full id in title + aria-label.
+    const nsEl = document.getElementById('d-namespace');
+    expect(nsEl.hidden).toBe(false);
+    expect(nsEl.textContent).toBe('claude: .../harness/memtomem');
+    expect(nsEl.getAttribute('title')).toBe(longNs);
+    expect(nsEl.getAttribute('aria-label')).toBe(`namespace ${longNs}`);
+  });
 });
 
 describe('Search config hint stays jargon-free', () => {

--- a/packages/memtomem/tests-js/search-filter-ux.test.mjs
+++ b/packages/memtomem/tests-js/search-filter-ux.test.mjs
@@ -145,7 +145,57 @@ describe('Search filters - add/remove UX', () => {
     expect(badges).toEqual(['Relevance 100%', 'Relevance 1%']);
     expect(badges.join(' ')).not.toContain('-');
     expect(document.getElementById('d-score').textContent).toBe('rank #1 · 100%');
-    expect(document.getElementById('d-score-detail').dataset.tooltip).toContain('raw score -0.420000');
+
+    // S1.2: raw score + retrieval source are debug-only (hidden by default via
+    // .result-debug-meta), and the score-bar tooltip is plain-language. The raw
+    // retrieval math moves to data-tooltip-debug, surfaced only in debug mode.
+    expect(document.getElementById('d-score').classList.contains('result-debug-meta')).toBe(true);
+    expect(document.getElementById('d-source').classList.contains('result-debug-meta')).toBe(true);
+    const detailRow = document.getElementById('d-score-detail');
+    expect(detailRow.dataset.tooltip).toBe('How closely this result matches your query.');
+    expect(detailRow.dataset.tooltip).not.toMatch(/RRF|raw score|percentile/);
+    expect(detailRow.dataset.tooltipDebug).toContain('raw score -0.420000');
+  });
+
+  it('keeps retrieval internals hidden until Advanced details is expanded', () => {
+    const mkResult = (id, score, rank, source) => ({
+      chunk: {
+        id, content: `content ${id}`, source_file: `/repo/${id}.md`,
+        chunk_type: 'paragraph', start_line: 1, end_line: 3,
+        heading_hierarchy: [], tags: [], namespace: 'default',
+        created_at: '2026-05-13T00:00:00Z', updated_at: '2026-05-13T00:00:00Z',
+        target_scope: 'user',
+      },
+      score, rank, source,
+    });
+
+    expect(document.body.classList.contains('show-retrieval-debug')).toBe(false);
+
+    window.renderResults(
+      [mkResult('a', 0.03, 1, 'fused'), mkResult('b', 0.02, 2, 'bm25')],
+      { bm25_candidates: 2, dense_candidates: 2, fused_total: 2, final_total: 2 },
+    );
+
+    // Default render: debug class absent, raw per-result source badge carries
+    // the hide hook.
+    expect(document.body.classList.contains('show-retrieval-debug')).toBe(false);
+    expect(document.querySelector('.result-item .badge-retrieval').classList
+      .contains('result-debug-meta')).toBe(true);
+
+    // Expanding "Advanced details" flips the app-wide reveal.
+    const details = document.querySelector('.results-debug-details');
+    expect(details).not.toBeNull();
+    expect(details.open).toBe(false);
+    details.open = true;
+    details.dispatchEvent(new window.Event('toggle'));
+    expect(window.STATE.showRetrievalDebug).toBe(true);
+    expect(document.body.classList.contains('show-retrieval-debug')).toBe(true);
+
+    // Collapsing it hides them again.
+    details.open = false;
+    details.dispatchEvent(new window.Event('toggle'));
+    expect(window.STATE.showRetrievalDebug).toBe(false);
+    expect(document.body.classList.contains('show-retrieval-debug')).toBe(false);
   });
 });
 

--- a/packages/memtomem/tests-js/search-filter-ux.test.mjs
+++ b/packages/memtomem/tests-js/search-filter-ux.test.mjs
@@ -141,10 +141,16 @@ describe('Search filters - add/remove UX', () => {
       final_total: 2,
     });
 
-    const badges = [...document.querySelectorAll('.result-item .score-badge')].map(el => el.textContent);
+    const scoreBadges = [...document.querySelectorAll('.result-item .score-badge')];
+    const badges = scoreBadges.map(el => el.textContent);
     expect(badges).toEqual(['Relevance 100%', 'Relevance 1%']);
     expect(badges.join(' ')).not.toContain('-');
     expect(document.getElementById('d-score').textContent).toBe('rank #1 · 100%');
+
+    // S1.2: the always-visible score badge's hover title is plain-language by
+    // default — it must NOT leak the raw "Raw reranker score …" tooltip.
+    expect(scoreBadges[0].getAttribute('title')).toBe('How closely this result matches your query.');
+    expect(scoreBadges.map(b => b.getAttribute('title')).join(' ')).not.toMatch(/Raw|percentile|score -/);
 
     // S1.2: raw score + retrieval source are debug-only (hidden by default via
     // .result-debug-meta), and the score-bar tooltip is plain-language. The raw
@@ -196,6 +202,46 @@ describe('Search filters - add/remove UX', () => {
     details.dispatchEvent(new window.Event('toggle'));
     expect(window.STATE.showRetrievalDebug).toBe(false);
     expect(document.body.classList.contains('show-retrieval-debug')).toBe(false);
+  });
+
+  it('keeps the score-badge title friendly across the live Advanced-details toggle', () => {
+    // Drive the real user path (render default → expand Advanced details), not
+    // a pre-seeded STATE, so a stale-on-toggle reintroduction would be caught.
+    const FRIENDLY = 'How closely this result matches your query.';
+    const stats = { bm25_candidates: 1, dense_candidates: 1, fused_total: 1, final_total: 1 };
+    const mk = (id) => ({
+      chunk: {
+        id, content: 'content', source_file: `/repo/${id}.md`,
+        chunk_type: 'paragraph', start_line: 1, end_line: 3,
+        heading_hierarchy: [], tags: [], namespace: 'default',
+        created_at: '2026-05-13T00:00:00Z', updated_at: '2026-05-13T00:00:00Z',
+        target_scope: 'user',
+      },
+      score: 0.0302, rank: 1, source: 'fused',
+    });
+
+    // Default render (debug off): badge title is plain-language.
+    window.renderResults([mk('a')], stats);
+    let badge = document.querySelector('.result-item .score-badge');
+    expect(badge.getAttribute('title')).toBe(FRIENDLY);
+
+    // Live-toggle Advanced details ON — the already-rendered badge title must
+    // NOT go stale/raw; the raw score instead becomes reachable via the
+    // now-revealed detail-panel #d-score.
+    const details = document.querySelector('.results-debug-details');
+    details.open = true;
+    details.dispatchEvent(new window.Event('toggle'));
+    expect(window.STATE.showRetrievalDebug).toBe(true);
+    expect(badge.getAttribute('title')).toBe(FRIENDLY);
+    expect(badge.getAttribute('title')).not.toMatch(/Raw|score 0\./);
+    expect(document.getElementById('d-score').classList.contains('result-debug-meta')).toBe(true);
+    expect(document.getElementById('d-score').title).toMatch(/Raw fused score/);
+
+    // A fresh render while debug is genuinely on (real state) still produces a
+    // plain-language badge title.
+    window.renderResults([mk('b')], stats);
+    badge = document.querySelector('.result-item .score-badge');
+    expect(badge.getAttribute('title')).toBe(FRIENDLY);
   });
 
   it('shows a friendly namespace label while keeping the full id reachable (S1.4)', () => {


### PR DESCRIPTION
## Why

Follow-on to #1434 (S1.1), continuing the Stage-1 "quick wins" of the
first-time-user comprehension work on the Web UI search surface. Two
independent de-jargon changes to the **search detail panel / result badges**,
each in its own commit.

## What

### S1.2 — gate search-detail retrieval internals behind "Advanced details"
The detail panel met new users with retrieval-engine internals by default: a
raw `score 0.0302` badge, a `fused`/`bm25` source badge, and a score-bar
tooltip reading `RRF 0.030159 / max 0.032787 (k=60, 2 sources)` — none of it
meaningful, and it duplicated the friendly **Relevance N%** bar beside it.

- `#d-score` and `#d-source` now carry the existing `.result-debug-meta` hide
  hook (same treatment the per-result source badge already gets in the list).
- The score-bar tooltip is now plain-language (new `search.relevance_tooltip`,
  en+ko); the raw retrieval math moves to `data-tooltip-debug`.
- The existing **"Advanced details"** expander (which already houses the source
  breakdown + pipeline funnel) now doubles as the reveal: opening it sets
  `body.show-retrieval-debug`, which surfaces the raw badges list-wide + in the
  detail panel and swaps the friendly tooltip for the raw math — all via CSS,
  no re-render. Open state is restored from `STATE` and the listener rebound on
  every `renderResults`.

### S1.4 — friendly namespace labels in results + detail
Long auto-namespaces (e.g. `claude:-Users-pdstudio-Work-agent-harness-memtomem`)
rendered raw as a badge in every result row and in the detail panel.

- Promotes the Home chart's `_formatHomeNsLabel` to a shared `formatNsLabel`
  and reuses it for the result-row ns badge and `#d-namespace`, with the **full
  id preserved** in `title` (+ `aria-label` on the detail badge).
- Short namespaces (≤28 chars) and the **namespace filter dropdown** keep full
  names (the filter needs exact match). Tier badges stay raw per the
  display-alias-free contract (ADR-0016 §7).
- Updated `settings-namespaces.js`'s donut legend, which referenced the old
  name across the module boundary, so the Namespaces panel doesn't throw.

## Test plan

- `tests-js` vitest: new assertions for the debug-meta hooks, plain-language
  default tooltip, raw math in `data-tooltip-debug`, the Advanced-details →
  `body.show-retrieval-debug` round-trip, and the friendly ns label + full-id
  `title`/`aria-label` in both the result row and detail panel. Full suite:
  **339 passed**.
- `test_i18n.py` (parity + jargon guard): **81 passed**.
- `ruff check` clean (no Python touched).
- `index.html` cache-bust bumped: `app.js` v=131→133, `style.css` v=119→120,
  `settings-namespaces.js` v=10→11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
