### PR TITLE
feat(web): default new installs to the New-memory index mode (S1.6)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -2433,10 +2433,14 @@ qs('home-search-btn').addEventListener('click', () => {
 });
 qs('home-index-btn').addEventListener('click', () => {
   activateTab('index');
+  // These quick actions are folder-flow specific (focus index-path / set
+  // index-force), so force folder mode — the default is now compose (S1.6).
+  setIndexMode('folder');
   showQuickActionToast('toast.quick_action.open_index', 'index-path');
 });
 qs('home-reindex-btn').addEventListener('click', () => {
   activateTab('index');
+  setIndexMode('folder');
   qs('index-force').checked = true;
   showQuickActionToast('toast.quick_action.reindex_ready', 'index-path');
 });
@@ -5520,7 +5524,10 @@ function _readIndexMode() {
     const v = localStorage.getItem(INDEX_MODE_LS_KEY);
     if (v && INDEX_MODES.includes(v)) return v;
   } catch (_e) { /* private mode */ }
-  return 'folder';
+  // S1.6: a new install defaults to the most intuitive "New memory" (compose)
+  // mode rather than the technical folder scan. Returning users keep their
+  // saved choice (handled above).
+  return 'compose';
 }
 
 function setIndexMode(mode) {

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -747,27 +747,27 @@
       <button class="tab-help-bar-dismiss" data-help-tab="index" data-i18n-title="common.dismiss_help" data-i18n-aria-label="common.dismiss_help" title="Dismiss help" aria-label="Dismiss help">✕</button>
     </div>
     <div class="index-mode-toggle" role="tablist" data-i18n-aria-label="index.mode_aria" aria-label="Index mode">
-      <button id="index-mode-folder" class="btn-ghost btn-active"
-              role="tab" aria-selected="true" aria-controls="index-panel-folder"
+      <button id="index-mode-compose" class="btn-ghost btn-active"
+              role="tab" aria-selected="true" aria-controls="index-panel-compose"
               tabindex="0"
+              data-mode="compose" data-i18n="index.mode.compose">New memory</button>
+      <button id="index-mode-folder" class="btn-ghost"
+              role="tab" aria-selected="false" aria-controls="index-panel-folder"
+              tabindex="-1"
               data-mode="folder" data-i18n="index.mode.folder">Folder index</button>
       <button id="index-mode-upload" class="btn-ghost"
               role="tab" aria-selected="false" aria-controls="index-panel-upload"
               tabindex="-1"
               data-mode="upload" data-i18n="index.mode.upload">Upload files</button>
-      <button id="index-mode-compose" class="btn-ghost"
-              role="tab" aria-selected="false" aria-controls="index-panel-compose"
-              tabindex="-1"
-              data-mode="compose" data-i18n="index.mode.compose">New memory</button>
     </div>
     <div class="index-mode-guide" aria-live="polite">
-      <span data-mode-guide="folder" data-i18n="index.mode.folder_desc">Scan an existing directory in place.</span>
+      <span data-mode-guide="compose" data-i18n="index.mode.compose_desc">Write a new note directly into your memtomem memories.</span>
+      <span data-mode-guide="folder" data-i18n="index.mode.folder_desc" hidden>Scan an existing directory in place.</span>
       <span data-mode-guide="upload" data-i18n="index.mode.upload_desc" hidden>Copy files into memtomem uploads, then index them.</span>
-      <span data-mode-guide="compose" data-i18n="index.mode.compose_desc" hidden>Write a new note directly into your memtomem memories.</span>
     </div>
     <div class="index-layout">
       <div class="card index-panels">
-        <div id="index-panel-folder" class="index-panel" role="tabpanel" aria-labelledby="index-mode-folder">
+        <div id="index-panel-folder" class="index-panel" role="tabpanel" aria-labelledby="index-mode-folder" hidden>
           <p class="panel-help-text">
             <span data-i18n="index.folder_oneshot_hint">One-shot scan. For automatic re-indexing, use </span><a href="#" id="folder-hint-sources-link" class="link-inline" data-i18n="index.folder_oneshot_link">Sources → Add path</a><span data-i18n="index.folder_oneshot_suffix">.</span>
           </p>
@@ -833,7 +833,7 @@
           </p>
         </div>
 
-        <div id="index-panel-compose" class="index-panel" role="tabpanel" aria-labelledby="index-mode-compose" hidden>
+        <div id="index-panel-compose" class="index-panel" role="tabpanel" aria-labelledby="index-mode-compose">
           <label class="field-label" for="add-title" data-i18n="index.add_heading_label">Title</label>
           <input id="add-title" type="text" data-i18n-placeholder="index.add_heading_placeholder" placeholder="Optional heading" />
           <label class="field-label" for="add-tags" data-i18n="index.add_tags_label">Tags</label>
@@ -1622,7 +1622,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=5"></script>
-  <script src="/app.js?v=137"></script>
+  <script src="/app.js?v=138"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=12"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>

--- a/packages/memtomem/tests-js/index-default-mode.test.mjs
+++ b/packages/memtomem/tests-js/index-default-mode.test.mjs
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { bootApp, STATIC_DIR } from './setup/jsdom-app.mjs';
+
+// S1.6 — a new install defaults the Index tab to the most intuitive
+// "New memory" (compose) mode instead of the technical folder scan, and the
+// toggle lists it first. Returning users keep their saved choice.
+describe('Index default mode (S1.6)', () => {
+  it('defaults a fresh install to compose (New memory)', async () => {
+    const dom = await bootApp({ scripts: ['i18n.js', 'app.js'] });
+    const { window } = dom;
+    const { document } = window;
+
+    expect(window._readIndexMode()).toBe('compose');
+    // Module-load init applies the mode: compose tab active + panel visible.
+    expect(document.getElementById('index-mode-compose').classList.contains('btn-active')).toBe(true);
+    expect(document.getElementById('index-mode-compose').getAttribute('aria-selected')).toBe('true');
+    expect(document.getElementById('index-mode-compose').getAttribute('tabindex')).toBe('0');
+    expect(document.getElementById('index-panel-compose').hidden).toBe(false);
+    expect(document.getElementById('index-panel-folder').hidden).toBe(true);
+    expect(document.getElementById('index-mode-folder').classList.contains('btn-active')).toBe(false);
+  });
+
+  it('lists New memory (compose) first in the toggle', async () => {
+    const dom = await bootApp({ scripts: ['i18n.js', 'app.js'] });
+    const order = [...dom.window.document
+      .querySelectorAll('.index-mode-toggle [role="tab"]')].map(b => b.dataset.mode);
+    expect(order).toEqual(['compose', 'folder', 'upload']);
+  });
+
+  it('preserves a returning user\'s saved mode', async () => {
+    const dom = await bootApp({ scripts: ['i18n.js', 'app.js'] });
+    const { window } = dom;
+    const { document } = window;
+
+    window.localStorage.setItem('memtomem.index.mode', 'folder');
+    expect(window._readIndexMode()).toBe('folder');
+    window.setIndexMode(window._readIndexMode());
+    expect(document.getElementById('index-mode-folder').classList.contains('btn-active')).toBe(true);
+    expect(document.getElementById('index-mode-compose').classList.contains('btn-active')).toBe(false);
+    expect(document.getElementById('index-panel-folder').hidden).toBe(false);
+  });
+
+  it('static HTML shows the compose panel by default (pre-JS, no tab/panel mismatch)', () => {
+    const html = readFileSync(path.join(STATIC_DIR, 'index.html'), 'utf-8');
+    // The compose tab is statically selected, so the compose panel must be the
+    // unhidden one and folder/upload hidden — otherwise screen readers see a
+    // selected tab whose panel is hidden before app.js boots.
+    expect(/<div id="index-panel-compose"[^>]*\bhidden\b/.test(html)).toBe(false);
+    expect(/<div id="index-panel-folder"[^>]*\bhidden\b/.test(html)).toBe(true);
+    expect(/<div id="index-panel-upload"[^>]*\bhidden\b/.test(html)).toBe(true);
+  });
+
+  it('switches to folder mode for the Home folder/reindex quick actions', async () => {
+    const dom = await bootApp({ scripts: ['i18n.js', 'app.js'] });
+    const { window } = dom;
+    const { document } = window;
+    expect(window.STATE.indexMode).toBe('compose');
+
+    document.getElementById('home-index-btn').click();
+    expect(window.STATE.indexMode).toBe('folder');
+    expect(document.getElementById('index-panel-folder').hidden).toBe(false);
+
+    window.setIndexMode('compose');
+    document.getElementById('home-reindex-btn').click();
+    expect(window.STATE.indexMode).toBe('folder');
+    expect(document.getElementById('index-force').checked).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

Stage-1 first-time-user UX, final item. **Stacked on #1437 (S1.5+S1.7)** →
base is `feat/search-welcome-glossary`; rebased onto `main` as the stack lands.

The Index tab opened on "Folder index" — the most technical of the three add
methods — while the most intuitive "New memory" (compose) sat third. A
first-timer's most likely intent (jot one memory) was the least reachable.

## What

- **Reversible default flip:** `_readIndexMode()` falls back to `compose`
  instead of `folder` for a fresh install. A returning user's saved
  `memtomem.index.mode` is still honored, so nobody's existing choice changes.
- **Reorder + consistent static state:** "New memory" is now leftmost, and
  the static tab **and panel** state both reflect the compose default
  (compose tab selected + compose panel unhidden; folder/upload hidden) — no
  selected-tab-vs-visible-panel mismatch before/without JS.
- **Folder-flow quick actions:** `home-index-btn` and `home-reindex-btn`
  (which focus `#index-path` / set `#index-force`, both folder-panel controls)
  now call `setIndexMode('folder')` after activating the Index tab, so they
  don't land on the New-memory panel under the new default.

No onboarding docs reference the index-mode default (checked `docs/guides`,
`docs/adr`, `README`), so no doc fan-out is needed for this flip.

## Test plan

- `index-default-mode.test.mjs` (new): fresh install resolves to compose
  (active tab + visible panel + tab order compose/folder/upload); saved
  `folder` preserved; raw `index.html` has the compose panel unhidden +
  folder/upload hidden (pre-JS); Home folder/reindex quick actions force
  folder mode (+ `index-force`).
- Full `tests-js`: **355 passed**.
- Cache-bust app.js v=138.

Reviewed independently by Codex (SHIP) after iterating on two flip
consequences it caught (pre-JS panel/tab mismatch; folder quick actions
landing on the compose panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
