### PR TITLE
feat(web): land a brand-new install on Home instead of empty Search (S2.1)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -7,6 +7,14 @@ const HOME_ACTIVITY_TIMELINE_LIMIT = 1000;
 // ── Early declarations (referenced before their section) ──
 const _HELP_VISIBLE_KEY = 'm2m-help-visible';
 
+// Safe localStorage read — returns null when storage is unavailable. Some
+// locked-down private modes throw on any access (not just setItem), so boot
+// reads must route through this or a locked-down browser aborts app.js at module
+// load, before the UI (and the first-run landing fallback) ever wires up.
+function _lsGet(key) {
+  try { return localStorage.getItem(key); } catch { return null; }
+}
+
 // ── Unified global state ──
 const STATE = {
   lastSettingsSection: null,
@@ -101,7 +109,7 @@ const STATE = {
 
 // ── C3: Theme init ──
 (function initTheme() {
-  const saved = localStorage.getItem('m2m-theme');
+  const saved = _lsGet('m2m-theme');
   const el = document.documentElement;
   if (saved === 'light') {
     el.setAttribute('data-theme', 'light');
@@ -7063,25 +7071,58 @@ qs('d-pin-btn').addEventListener('click', () => {
 // ---------------------------------------------------------------------------
 
 function _loadSettings() {
-  return {
-    defaultTab: localStorage.getItem('m2m-default-tab') || 'search',
-  };
+  return { defaultTab: _lsGet('m2m-default-tab') || 'search' };
 }
+
+// S2.1 — a brand-new install lands on Home (orientation) instead of the empty
+// Search screen. "First run" means localStorage carries no app-owned state yet:
+// no key under the app's prefixes, including our own "seen" stamp. The prefix
+// scan keeps this robust as new persisted keys are added (search history, saved
+// queries, gateway state, …) so an existing user upgrading into this feature is
+// never misread as fresh and yanked off their usual landing.
+//
+// Exception: a few keys are written by the app itself on a cold boot and so are
+// present even on a genuinely fresh install — setIndexMode() persists the
+// applied default at module load (app.js:5570). Those are excluded below. The
+// invariant that this list is complete (no *other* boot-time write slips in
+// before we land) is pinned by the cold-boot first-run test, which lands on
+// Search instead of Home the moment a new boot-time write appears.
+const _BOOT_WRITTEN_LS_KEYS = new Set(['memtomem.index.mode']);
+function _hasPriorAppState() {
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k && (k.startsWith('m2m-') || k.startsWith('memtomem'))
+          && !_BOOT_WRITTEN_LS_KEYS.has(k)) return true;
+    }
+    return false;
+  } catch {
+    // Can't read storage (private mode) — treat as a returning user so we
+    // never force-route someone whose state we can't inspect.
+    return true;
+  }
+}
+function _isFirstRun() { return !_hasPriorAppState(); }
 
 // Deferred until DOMContentLoaded so sibling scripts (settings-config.js, etc.)
 // have parsed — activateTab('settings') calls loadConfig() defined there.
-document.addEventListener('DOMContentLoaded', () => {
-  const s = _loadSettings();
-  // top-k default is synced from server config via _syncSearchDefaults()
-  // Apply default tab only if no hash deep link is present
-  if (!location.hash.slice(1)) {
-    const currentActive = document.querySelector('.tab-btn.active');
-    const currentTab = currentActive ? currentActive.dataset.tab : null;
-    if (currentTab !== s.defaultTab) {
-      activateTab(s.defaultTab);
-    }
+function _applyLandingTab() {
+  // A deep-link hash is owned by the earlier hash handler — never override it.
+  if (location.hash.slice(1)) return;
+  const firstRun = _isFirstRun();
+  // Stamp the install as oriented, and only honor first-run routing if the
+  // stamp actually persisted — otherwise a private-mode session (setItem
+  // throws) would be force-routed to Home on every visit.
+  let stamped = false;
+  try { localStorage.setItem('m2m-app-initialized', '1'); stamped = true; } catch {}
+  const target = (firstRun && stamped) ? 'home' : _loadSettings().defaultTab;
+  const currentActive = document.querySelector('.tab-btn.active');
+  const currentTab = currentActive ? currentActive.dataset.tab : null;
+  if (currentTab !== target) {
+    activateTab(target);
   }
-});
+}
+document.addEventListener('DOMContentLoaded', _applyLandingTab);
 
 let _settingsRelease = null;
 function openSettingsModal() {

--- a/packages/memtomem/src/memtomem/web/static/i18n.js
+++ b/packages/memtomem/src/memtomem/web/static/i18n.js
@@ -8,7 +8,10 @@ const I18N = (() => {
   let _lang = 'en';
 
   function _detect() {
-    const stored = localStorage.getItem(_STORAGE_KEY);
+    // Read defensively — some locked-down private modes throw on any access,
+    // and a thrown _detect would abort i18n.init() during boot.
+    let stored = null;
+    try { stored = localStorage.getItem(_STORAGE_KEY); } catch { /* locked-down storage */ }
     if (stored && _SUPPORTED.includes(stored)) return stored;
     if (navigator.language && navigator.language.startsWith('ko')) return 'ko';
     return 'en';
@@ -118,7 +121,7 @@ const I18N = (() => {
   async function setLang(lang) {
     if (!_SUPPORTED.includes(lang)) return;
     _lang = lang;
-    localStorage.setItem(_STORAGE_KEY, lang);
+    try { localStorage.setItem(_STORAGE_KEY, lang); } catch { /* locked-down storage */ }
     document.documentElement.lang = lang;
     await _load(lang);
     applyDOM();

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1651,8 +1651,8 @@
   <script src="/vendor/prism-json.min.js?v=1"></script>
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
-  <script src="/i18n.js?v=5"></script>
-  <script src="/app.js?v=139"></script>
+  <script src="/i18n.js?v=6"></script>
+  <script src="/app.js?v=140"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=13"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>

--- a/packages/memtomem/tests-js/first-run-home.test.mjs
+++ b/packages/memtomem/tests-js/first-run-home.test.mjs
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+// S2.1 — a brand-new install lands on Home (orientation) instead of the empty
+// Search screen. Returning installs keep their saved default tab, and a
+// deep-link hash always wins. bootApp defaults to a returning install (it seeds
+// m2m-app-initialized); first-run tests opt in with { firstRun: true } or by
+// clearing localStorage before calling the landing helper directly.
+describe('First-run landing on Home (S2.1)', () => {
+  it('_isFirstRun() is true only when no app-owned localStorage key exists', async () => {
+    const dom = await bootApp();
+    const { window } = dom;
+
+    window.localStorage.clear();
+    expect(window._isFirstRun()).toBe(true);
+
+    // Any app-owned key (under the m2m-*/memtomem prefixes) marks the install as
+    // already used — the prefix scan catches keys a hand-list would miss, e.g.
+    // search history and saved queries written elsewhere in the app.
+    for (const key of [
+      'm2m-app-initialized', 'm2m-default-tab', 'm2m-theme', 'm2m-pins',
+      'm2m-saved-queries', 'memtomem_search_history', 'memtomem.sources_width',
+    ]) {
+      window.localStorage.clear();
+      window.localStorage.setItem(key, 'x');
+      expect(window._isFirstRun(), `${key} should mark a returning install`).toBe(false);
+    }
+
+    // memtomem.index.mode is written by the app on a cold boot (setIndexMode
+    // persists the default), so it is NOT a sign of prior use on its own.
+    window.localStorage.clear();
+    window.localStorage.setItem('memtomem.index.mode', 'compose');
+    expect(window._isFirstRun()).toBe(true);
+  });
+
+  it('routes a genuine first run to the Home tab and stamps the sentinel', async () => {
+    const dom = await bootApp({ firstRun: true });
+    const { window } = dom;
+    const { document, I18N } = window;
+    await I18N.init();
+
+    const active = document.querySelector('.tab-btn.active');
+    expect(active.dataset.tab).toBe('home');
+    // The first no-hash visit stamps the install so the next one is "returning".
+    expect(window.localStorage.getItem('m2m-app-initialized')).toBe('1');
+  });
+
+  it('leaves a returning install on the saved default (Search)', async () => {
+    const dom = await bootApp();
+    const { window } = dom;
+    const { document, I18N } = window;
+    await I18N.init();
+
+    const active = document.querySelector('.tab-btn.active');
+    expect(active.dataset.tab).toBe('search');
+  });
+
+  it('_applyLandingTab routes by first-run / default and yields to a deep link', async () => {
+    const dom = await bootApp();
+    const { window } = dom;
+    const { document, I18N } = window;
+    await I18N.init();
+
+    const calls = [];
+    window.activateTab = (name) => { calls.push(name); };
+
+    // First run (cleared storage) → Home.
+    window.localStorage.clear();
+    window._applyLandingTab();
+    expect(calls).toEqual(['home']);
+
+    // Returning install with an explicit saved default → that tab.
+    calls.length = 0;
+    window.localStorage.setItem('m2m-app-initialized', '1');
+    window.localStorage.setItem('m2m-default-tab', 'sources');
+    window._applyLandingTab();
+    expect(calls).toEqual(['sources']);
+
+    // A deep-link hash is owned by the earlier hash handler — no auto-routing.
+    calls.length = 0;
+    window.location.hash = '#timeline';
+    window._applyLandingTab();
+    expect(calls).toEqual([]);
+  });
+
+  it('does not force-route to Home when the sentinel cannot persist (private mode)', async () => {
+    const dom = await bootApp();
+    const { window } = dom;
+    const { I18N } = window;
+    await I18N.init();
+
+    const calls = [];
+    window.activateTab = (name) => { calls.push(name); };
+
+    // Fresh storage (would be first-run) but setItem throws like a locked-down
+    // private mode: getItem/scan still work, the stamp write fails. We must fall
+    // back to the default tab (Search) rather than route to Home on every visit.
+    // Boot already left Search active, so the fallback is a no-op — the point is
+    // that Home is NOT requested. Without the stamped-guard this would be ['home'].
+    window.localStorage.clear();
+    const protoSet = window.Storage.prototype.setItem;
+    window.Storage.prototype.setItem = () => { throw new Error('QuotaExceededError'); };
+    try {
+      window._applyLandingTab();
+    } finally {
+      window.Storage.prototype.setItem = protoSet;
+    }
+    expect(calls).not.toContain('home');
+    expect(calls).toEqual([]);
+  });
+
+  it('boots without crashing when storage throws on getItem (locked-down mode)', async () => {
+    // A storage that throws on every getItem (not just setItem) must not abort
+    // app.js at module load — initTheme reads a key before the landing logic.
+    const dom = await bootApp({ storageBlock: ['getItem'] });
+    const { window } = dom;
+    const { document } = window;
+
+    // app.js finished loading (functions defined) despite the boot-time read.
+    expect(typeof window.activateTab).toBe('function');
+    expect(window._lsGet('m2m-theme')).toBe(null);
+
+    // The deferred landing handler runs and falls back to a safe default tab.
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(document.querySelector('.tab-btn.active')?.dataset.tab).toBe('search');
+  });
+});

--- a/packages/memtomem/tests-js/setup/jsdom-app.mjs
+++ b/packages/memtomem/tests-js/setup/jsdom-app.mjs
@@ -102,6 +102,8 @@ export async function bootApp({
   scripts = ['i18n.js', 'app.js'],
   state = {},
   apiResponses = {},
+  firstRun = false,
+  storageBlock = [],
 } = {}) {
   let html = readStatic('index.html');
   // Strip every <script ...>...</script> element so JSDOM's loader
@@ -118,6 +120,21 @@ export async function bootApp({
 
   shimBrowserAPIs(window);
   window.fetch = makeFetchStub(apiResponses);
+
+  // Default tests to a returning install so boot lands on the historical Search
+  // default. S2.1 routes a *genuine* first run (empty localStorage) to Home,
+  // which triggers a dashboard load that would clobber test-seeded STATE. Tests
+  // exercising the first-run landing opt in with ``bootApp({ firstRun: true })``.
+  if (!firstRun) {
+    try { window.localStorage.setItem('m2m-app-initialized', '1'); } catch {}
+  }
+
+  // Simulate a locked-down storage (some private modes throw on access). Applied
+  // after the seed and before scripts load so a module-load read that isn't
+  // guarded would abort app.js — the boot must survive it. e.g. ['getItem'].
+  for (const method of storageBlock) {
+    window.Storage.prototype[method] = () => { throw new Error(`localStorage.${method} blocked`); };
+  }
 
   for (const filename of scripts) {
     const code = readStatic(filename);

--- a/packages/memtomem/tests/web/conftest.py
+++ b/packages/memtomem/tests/web/conftest.py
@@ -85,6 +85,28 @@ def mm_web_url() -> Iterator[str]:
         thread.join(timeout=5.0)
 
 
+@pytest.fixture(autouse=True)
+def _returning_install(request) -> None:
+    """Boot every browser spec as a returning install (S2.1).
+
+    S2.1 routes a *genuine* first run — a fresh context with no app-owned
+    localStorage key — to the Home tab for orientation. These specs each open a
+    fresh browser context, so without a seeded "seen" sentinel they would all
+    land on Home and fail the moment they touch a Search-tab element (tag
+    filters, result snippets, the skip-link to ``#main``). Seeding the sentinel
+    before navigation restores the historical Search default; a spec that wants
+    the first-run landing can clear it with its own ``add_init_script``.
+
+    Gated on the ``browser`` marker and requests ``page`` lazily so the
+    non-browser specs in this directory (CSS / asset-pin checks) aren't forced
+    to launch a browser in the no-browser test job.
+    """
+    if request.node.get_closest_marker("browser") is None:
+        return
+    page = request.getfixturevalue("page")
+    page.add_init_script("try { localStorage.setItem('m2m-app-initialized', '1'); } catch (e) {}")
+
+
 def install_default_stubs(page) -> None:
     """Stub every endpoint the SPA hits during boot so the page renders
     cleanly without any real components wired up.


### PR DESCRIPTION
## What & why

A fresh install opened on the Search tab's empty state ("Enter a query to
search") — no direction for someone who hasn't indexed anything yet. Now the
**first no-hash visit lands on the Home tab**, which #1439 (S2.3) reorganized
into an orientation-first view (the add → connect → search getting-started
block).

**Stacked on #1439 (S2.3).** Base is `feat/s2.3-home-orientation`; review/merge
that first. This is the second PR of Stage 2 in the first-time-UX campaign.

## Changes

- **First-run routing** — the first no-hash visit of a genuinely fresh install
  lands on Home and stamps a `m2m-app-initialized` sentinel. A saved default tab
  and a deep-link hash both still win; the stamp is written only on a no-hash
  visit, so a first-run user who arrives via a shared `#search` link still gets
  oriented on their next plain visit.
- **Robust first-run detection** — scans localStorage for any app-owned key
  (the `m2m-*`/`memtomem` prefixes) rather than a hand-list, so it stays correct
  as new persisted keys are added (search history, saved queries, gateway state,
  …). `memtomem.index.mode` is excluded because `setIndexMode()` persists the
  applied default on every cold boot (`app.js:5570`); the cold-boot first-run
  test pins that exclusion.
- **Locked-down storage hardening** (surfaced reviewing the landing reads) —
  some private modes throw on *any* localStorage access, not just `setItem`. A
  new `_lsGet()` safe-read routes the boot-path reads (`initTheme`,
  `_loadSettings`); `i18n.js` `_detect()`/`setLang()` are wrapped; and the
  landing only routes to Home when the sentinel write actually persisted —
  otherwise a private-mode session would be force-routed to Home on every visit.
  Without these, `app.js` aborted at module load before the landing fallback
  could run.

## Test plan

- New `tests-js/first-run-home.test.mjs`: prefix-scan (incl. search-history /
  saved-queries keys) + `memtomem.index.mode` exclusion, first-run → Home,
  returning → Search, deep-link precedence, `setItem`-throws → no force-route,
  `getItem`-throws → boots clean on the default tab.
- Shared `bootApp` harness gains a `firstRun` opt (seeds `m2m-app-initialized`
  by default so existing specs boot as returning installs — unchanged Search
  landing) and a `storageBlock` opt for the locked-down-storage regression.
- Full vitest **365** green; i18n + a11y green.
- Live (`mm web` + Playwright): fresh install → Home (even though
  `memtomem.index.mode` is written at boot, it's excluded), returning → Search,
  `#search` deep-link → Search; i18n still detects KO after the guards.
- Cache-bust: `app.js?v=140`, `i18n.js?v=6`.

Reviewed by Codex (SHIP after two NEEDS-FIX rounds addressing prior-use
detection completeness and locked-down-storage boot safety).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
