### PR TITLE
feat(web): app-level Simple/Advanced progressive disclosure (S2.2)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -15,6 +15,20 @@ function _lsGet(key) {
   try { return localStorage.getItem(key); } catch { return null; }
 }
 
+// App-level Simple/Advanced progressive-disclosure flag (S2.2). A SECOND,
+// independent axis from the server-driven dev/prod ui-tier: this one is a
+// per-user persisted preference (Simple by default, gateway D-F precedent) that
+// demotes power-user surfaces (Tags, Timeline, the Settings → Data group) behind
+// an Advanced toggle in the global <header>. Declared early — next to _lsGet —
+// because the shared visibility predicate (_isUiTierVisible) reads it. The full
+// lifecycle contract lives on _applyAppSimpleMode below.
+const APP_SIMPLE_KEY = 'm2m-app-simple';
+const APP_SIMPLE_DEFAULT = true;  // Simple-when-unset (no stamp on boot)
+let _appSimple = (() => {
+  const stored = _lsGet(APP_SIMPLE_KEY);
+  return stored !== null ? stored === '1' : APP_SIMPLE_DEFAULT;
+})();
+
 // ── Unified global state ──
 const STATE = {
   lastSettingsSection: null,
@@ -157,8 +171,16 @@ const STATE = {
     // ``t()`` at build time, so they must run after the locale cache is
     // populated to avoid raw-key flashes.
     const hash = location.hash.slice(1);
-    if (hash && _visibleMainTabs().includes(hash)) {
-      activateTab(hash);
+    if (hash) {
+      if (_visibleMainTabs().includes(hash)) {
+        activateTab(hash);
+      } else if (document.querySelector(`.tab-btn[data-tab="${hash}"]`)) {
+        // A real tab that the current mode hides (e.g. a deep-link to #timeline
+        // while in Simple). Don't strand on an empty panel — the statically
+        // active tab stays; surface *why* the link didn't open so the user can
+        // flip to Advanced. (No dev main-tabs exist, so the advanced copy fits.)
+        showToast(t('toast.advanced_only_section'), 'info');
+      }
     }
   });
 })();
@@ -206,21 +228,85 @@ function _applyUiModeFilter() {
   if (typeof loadNamespaceDropdowns === 'function') loadNamespaceDropdowns();
 }
 
+// Single source of truth for "is this tab / settings-section button shown".
+// Composes the TWO orthogonal visibility axes — an element is visible only if
+// NEITHER hides it:
+//   * server dev/prod : data-ui-tier="dev" is hidden unless STATE.uiMode==='dev'
+//   * user Simple/Adv  : data-ui-adv="advanced" is hidden while _appSimple is on
+// Every navigation guard (boot-hash dispatch, popstate, arrow-nav,
+// activateTab, switchSettingsSection, the landing-default) routes through
+// _visibleMainTabs / _visibleSettingsSections, so a demoted surface can never be
+// *reached* while it is painted-hidden — closing the #1358 strand class for both
+// axes at once. The two channels never collide: dev/prod writes inline
+// style.display in _applyUiModeFilter; app-simple paints via the body.app-simple
+// CSS class. data-ui-adv is orthogonal to data-ui-tier (an element may carry
+// both); dev mode reveals dev-tier regardless of app-simple, and app-simple
+// independently governs the advanced (non-dev) surface.
+function _isUiTierVisible(btn) {
+  if (STATE.uiMode !== 'dev' && btn.dataset.uiTier === 'dev') return false;
+  if (_appSimple && btn.dataset.uiAdv === 'advanced') return false;
+  return true;
+}
+
 function _visibleMainTabs() {
-  const isProd = STATE.uiMode !== 'dev';
   return Array.from(document.querySelectorAll('.tab-btn'))
-    .filter(btn => !isProd || btn.dataset.uiTier !== 'dev')
+    .filter(_isUiTierVisible)
     .map(btn => btn.dataset.tab)
     .filter(Boolean);
 }
 
 function _visibleSettingsSections() {
-  const isProd = STATE.uiMode !== 'dev';
   return Array.from(document.querySelectorAll('.settings-nav-btn'))
-    .filter(btn => !isProd || btn.dataset.uiTier !== 'dev')
+    .filter(_isUiTierVisible)
     .map(btn => btn.dataset.section)
     .filter(Boolean);
 }
+
+// -- App Simple/Advanced lifecycle (S2.2) -------------------------------------
+// Mirror of the gateway's _ctxSimpleMode pattern, promoted to app level. The
+// toggle lives in the global <header> (outside <main> and every .tab-panel), so
+// it stays reachable on EVERY entry path — deep-link, reload-into-subsection,
+// Back/Forward — the central #1358 lesson that a persisted mode flag must never
+// hide its own escape hatch. Idempotent; safe to call on load and every flip.
+function _applyAppSimpleMode() {
+  document.body.classList.toggle('app-simple', _appSimple);
+  const btn = document.getElementById('app-mode-toggle');
+  if (!btn) return;
+  // aria-pressed reflects "Advanced engaged" (the expanded, non-default state),
+  // so the pressed/highlighted cue means "extra surfaces shown".
+  btn.setAttribute('aria-pressed', _appSimple ? 'false' : 'true');
+  const label = btn.querySelector('.app-mode-label');
+  if (!label) return;
+  // Mode-display label: shows the CURRENT mode. Drive it through the data-i18n
+  // attribute so i18n applyDOM (init + every langchange) keeps it translated;
+  // update textContent now only once the locale cache is populated (t() returns
+  // the raw key until then — the guard avoids a key flash, and t may not even be
+  // defined yet depending on script order).
+  const key = _appSimple ? 'nav.mode_simple' : 'nav.mode_advanced';
+  label.dataset.i18n = key;
+  const txt = typeof t === 'function' ? t(key) : key;
+  // Localized text once the cache is populated; otherwise a literal that still
+  // matches the CURRENT mode, so a persisted-Advanced boot never momentarily
+  // reads "Simple" before applyDOM runs. applyDOM (init + every langchange) then
+  // swaps in the translated string from the data-i18n attribute set above.
+  label.textContent = txt !== key ? txt : (_appSimple ? 'Simple' : 'Advanced');
+}
+
+// Flip the flag, persist (only on explicit user action — never stamped on boot,
+// so a fresh install has no key and the tri-state default yields Simple without
+// polluting first-run detection), and re-apply.
+function _setAppSimple(on) {
+  _appSimple = !!on;
+  try {
+    localStorage.setItem(APP_SIMPLE_KEY, _appSimple ? '1' : '0');
+  } catch { /* locked-down storage — in-memory flag still applies this session */ }
+  _applyAppSimpleMode();
+}
+
+// Apply the persisted flag once at module load. app.js is the last script before
+// </body>, so the header toggle markup already exists; advanced tabs are inert
+// until activated, so toggling the body class now causes no flash.
+_applyAppSimpleMode();
 
 // ---------------------------------------------------------------------------
 // Utilities
@@ -1309,17 +1395,23 @@ function activateTab(tabName, opts = {}) {
   //   * history mutation uses replaceState so cycling N tabs does not push
   //     N entries the user has to press Back through to escape
   const fromKeyboard = opts.fromKeyboard === true;
-  // In prod mode, hide dev-only tabs by redirecting to the first visible
-  // main tab instead of showing a dev panel the polished surface doesn't
-  // expose.
+  // Redirect to the first visible tab when the target is hidden by EITHER
+  // visibility axis (dev-only in prod, or advanced-only in Simple mode) instead
+  // of showing a panel whose tab button is off-screen. This single guard catches
+  // every programmatic caller (Home heatmap/Tags quick-actions, Cmd+K palette,
+  // number keys, g-prefix, a stale saved default) — the post-guard loaders never
+  // fire for a hidden tab, so no orphaned panel + no strand.
   const targetBtn = document.querySelector(`.tab-btn[data-tab="${tabName}"]`);
-  if (targetBtn && targetBtn.dataset.uiTier === 'dev' && STATE.uiMode !== 'dev') {
+  if (targetBtn) {
     const visible = _visibleMainTabs();
-    showToast(t('toast.dev_only_section'), 'info');
-    if (visible.length && visible[0] !== tabName) {
-      activateTab(visible[0], opts);
+    if (!visible.includes(tabName)) {
+      const devHidden = targetBtn.dataset.uiTier === 'dev' && STATE.uiMode !== 'dev';
+      showToast(t(devHidden ? 'toast.dev_only_section' : 'toast.advanced_only_section'), 'info');
+      if (visible.length && visible[0] !== tabName) {
+        activateTab(visible[0], opts);
+      }
+      return;
     }
-    return;
   }
 
   // Deactivate all main tabs. ``tabindex=-1`` keeps non-current tabs out of
@@ -1523,17 +1615,28 @@ function switchSettingsSection(sectionName) {
       return;
     }
   }
-  // In prod mode, redirect dev-only sections to the first visible one.
+  // Redirect to the first visible section when the target is hidden by EITHER
+  // axis (dev-only in prod, or the advanced Data group in Simple mode) — the
+  // section's loader (loadConfig / resetDedupPanel / …) must not run for a
+  // demoted section reached via a Home quick-action or the Cmd+K palette.
   const targetBtn = document.querySelector(
     `.settings-nav-btn[data-section="${sectionName}"]`,
   );
-  if (targetBtn && targetBtn.dataset.uiTier === 'dev' && STATE.uiMode !== 'dev') {
+  if (targetBtn) {
     const visible = _visibleSettingsSections();
-    showToast(t('toast.dev_only_section'), 'info');
-    if (visible.length && visible[0] !== sectionName) {
-      switchSettingsSection(visible[0]);
+    if (!visible.includes(sectionName)) {
+      const devHidden = targetBtn.dataset.uiTier === 'dev' && STATE.uiMode !== 'dev';
+      showToast(t(devHidden ? 'toast.dev_only_section' : 'toast.advanced_only_section'), 'info');
+      // Fall back to the first visible *Settings-tab* section (config, …), never
+      // a Gateway sidebar section: ctx-overview & friends share .settings-nav-btn
+      // but sit earlier in the DOM, so a bare visible[0] would yank the user to
+      // the Gateway tab instead of Settings → Config (Codex review).
+      const fallback = visible.find(s => !GATEWAY_SECTIONS.has(s));
+      if (fallback && fallback !== sectionName) {
+        switchSettingsSection(fallback);
+      }
+      return;
     }
-    return;
   }
   STATE.lastSettingsSection = sectionName;
   try { localStorage.setItem(LAST_SECTION_KEY, sectionName); } catch {}
@@ -1627,10 +1730,12 @@ function _arrowNavIndex(length, currentIdx, key) {
 
 document.querySelector('.tab-nav')?.addEventListener('keydown', (e) => {
   if (!['ArrowRight', 'ArrowLeft', 'Home', 'End'].includes(e.key)) return;
-  // Filter out dev-only buttons in prod mode so arrow nav matches what the
-  // user actually sees on screen — otherwise focus could land on a hidden tab.
+  // Walk only the tabs the user actually sees — otherwise ArrowRight/Left could
+  // land focus on (and activate) a tab hidden by either axis (dev-only in prod,
+  // advanced-only in Simple). Reuse the shared predicate so this never diverges.
+  const visible = new Set(_visibleMainTabs());
   const buttons = Array.from(document.querySelectorAll('.tab-nav .tab-btn'))
-    .filter(b => b.dataset.uiTier !== 'dev' || STATE.uiMode === 'dev');
+    .filter(b => visible.has(b.dataset.tab));
   const currentIdx = buttons.indexOf(document.activeElement);
   const nextIdx = _arrowNavIndex(buttons.length, currentIdx === -1 ? 0 : currentIdx, e.key);
   if (nextIdx < 0) return;
@@ -1658,6 +1763,32 @@ qs('theme-toggle').addEventListener('click', () => {
   localStorage.setItem('m2m-theme', goLight ? 'light' : 'dark');
 });
 
+// ── App-level Simple / Advanced toggle (S2.2) ──
+document.getElementById('app-mode-toggle')?.addEventListener('click', () => {
+  _setAppSimple(!_appSimple);
+  // Flipping INTO Simple can hide the tab/section the user is currently on —
+  // bounce to the first still-visible one so the panel + its nav cue never
+  // vanish from under them. (Flipping into Advanced only reveals, nothing to do.)
+  if (!_appSimple) return;
+  const activeTab = document.querySelector('.tab-btn.active');
+  const visibleTabs = _visibleMainTabs();
+  if (activeTab && !visibleTabs.includes(activeTab.dataset.tab)) {
+    activateTab(visibleTabs[0] || 'home');
+    return;
+  }
+  // On the Settings tab, the active *section* may be the one that just got
+  // demoted (Data group) — hop to the first visible section in place.
+  if (activeTab?.dataset.tab === 'settings') {
+    const activeSection = document.querySelector('.settings-nav-btn.active');
+    const visibleSections = _visibleSettingsSections();
+    if (activeSection && !visibleSections.includes(activeSection.dataset.section)) {
+      // First visible Settings-tab section (skip Gateway sidebar sections, which
+      // would bounce to the Gateway tab — see switchSettingsSection's note).
+      switchSettingsSection(visibleSections.find(s => !GATEWAY_SECTIONS.has(s)) || 'config');
+    }
+  }
+});
+
 // ── C1: Mobile back button ──
 qs('mobile-back-btn').addEventListener('click', () => {
   document.querySelector('.results-layout').classList.remove('mobile-detail');
@@ -1665,7 +1796,12 @@ qs('mobile-back-btn').addEventListener('click', () => {
 
 // ── History API: back/forward navigation + hash deep link ──
 window.addEventListener('popstate', (e) => {
-  if (e.state?.tab) activateTab(e.state.tab);
+  const tab = e.state?.tab;
+  // Gate on current visibility (mirrors the boot-hash dispatch): a history
+  // entry pushed while Tags/Timeline were visible must not replay
+  // activateTab('timeline') after the user flipped to Simple — that would strand
+  // them on a panel with no active tab button. Staying put is the safe floor.
+  if (tab && _visibleMainTabs().includes(tab)) activateTab(tab);
 });
 // Note: initial hash-based activateTab dispatch moved into the i18n init
 // handler above so ``t()``-backed JS widgets (Sources tab's Memory Dirs
@@ -7115,7 +7251,14 @@ function _applyLandingTab() {
   // throws) would be force-routed to Home on every visit.
   let stamped = false;
   try { localStorage.setItem('m2m-app-initialized', '1'); stamped = true; } catch {}
-  const target = (firstRun && stamped) ? 'home' : _loadSettings().defaultTab;
+  let target = (firstRun && stamped) ? 'home' : _loadSettings().defaultTab;
+  // Clamp a returning user's saved default (selectable as Tags/Timeline in the
+  // settings modal) to a currently-visible tab — otherwise Simple-by-default
+  // force-routes them onto a hidden advanced tab on every boot. The highest-
+  // probability real-world strand for this feature.
+  if (!_visibleMainTabs().includes(target)) {
+    target = _visibleMainTabs()[0] || 'home';
+  }
   const currentActive = document.querySelector('.tab-btn.active');
   const currentTab = currentActive ? currentActive.dataset.tab : null;
   if (currentTab !== target) {

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=123" />
+  <link rel="stylesheet" href="/style.css?v=124" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -22,6 +22,7 @@
       <span class="help-tip" data-help-i18n="glossary.units" tabindex="0" role="img" aria-label="Sources are the files you add. Chunks are the searchable pieces. Memories are everything together.">i</span>
     </div>
     <div class="header-actions">
+      <button id="app-mode-toggle" class="btn-ghost app-mode-toggle" type="button" aria-pressed="false" data-i18n-title="nav.app_mode_tip" data-i18n-aria-label="nav.app_mode_aria" title="Switch Simple / Advanced view" aria-label="Toggle Simple / Advanced view"><span class="app-mode-label" data-i18n="nav.mode_simple">Simple</span></button>
       <button id="settings-btn" class="btn-ghost btn-icon" data-i18n-title="header.settings_title" data-i18n-aria-label="header.settings_title" title="Settings" aria-label="Settings">⚙️</button>
       <button id="lang-toggle" class="btn-ghost btn-icon" data-i18n-title="header.lang_toggle_aria" data-i18n-aria-label="header.lang_toggle_aria" title="Switch language" aria-label="Switch language">EN</button>
       <button id="theme-toggle" class="btn-ghost btn-icon" data-i18n-title="header.theme_title" data-i18n-aria-label="header.theme_title" title="Toggle theme" aria-label="Toggle theme">🌙</button>
@@ -54,8 +55,8 @@
     <button id="tabbtn-sources" class="tab-btn" role="tab" aria-controls="tab-sources" aria-selected="false" tabindex="-1" data-ui-tier="prod" data-tab="sources" data-i18n="nav.sources">Sources</button>
     <button id="tabbtn-context-gateway" class="tab-btn" role="tab" aria-controls="tab-context-gateway" aria-selected="false" tabindex="-1" data-ui-tier="prod" data-tab="context-gateway" data-i18n="nav.context_gateway">Gateway</button>
     <button id="tabbtn-index" class="tab-btn" role="tab" aria-controls="tab-index" aria-selected="false" tabindex="-1" data-ui-tier="prod" data-tab="index" data-i18n="nav.index">Index</button>
-    <button id="tabbtn-tags" class="tab-btn" role="tab" aria-controls="tab-tags" aria-selected="false" tabindex="-1" data-ui-tier="prod" data-tab="tags" data-i18n="nav.tags">Tags</button>
-    <button id="tabbtn-timeline" class="tab-btn" role="tab" aria-controls="tab-timeline" aria-selected="false" tabindex="-1" data-ui-tier="prod" data-tab="timeline" data-i18n="nav.timeline">Timeline</button>
+    <button id="tabbtn-tags" class="tab-btn" role="tab" aria-controls="tab-tags" aria-selected="false" tabindex="-1" data-ui-tier="prod" data-ui-adv="advanced" data-tab="tags" data-i18n="nav.tags">Tags</button>
+    <button id="tabbtn-timeline" class="tab-btn" role="tab" aria-controls="tab-timeline" aria-selected="false" tabindex="-1" data-ui-tier="prod" data-ui-adv="advanced" data-tab="timeline" data-i18n="nav.timeline">Timeline</button>
     <button id="tabbtn-settings" class="tab-btn" role="tab" aria-controls="tab-settings" aria-selected="false" tabindex="-1" data-ui-tier="prod" data-tab="settings" data-i18n="nav.more">Settings</button>
   </nav>
 
@@ -163,9 +164,9 @@
             <button id="home-search-btn" class="btn-ghost" data-i18n="home.action.search" data-i18n-title="home.action.search_title" data-i18n-aria-label="home.action.search_title" title="Open the Search tab">Open Search</button>
             <button id="home-index-btn" class="btn-ghost" data-i18n="home.action.index" data-i18n-title="home.action.index_title" data-i18n-aria-label="home.action.index_title" title="Open the Index tab">Open Index</button>
             <button id="home-reindex-btn" class="btn-ghost" data-i18n="home.action.reindex" data-i18n-title="home.action.reindex_title" data-i18n-aria-label="home.action.reindex_title" title="Open Index and enable Force re-index. Indexing does not start until you run it.">Prepare Full Re-index</button>
-            <button id="home-export-btn" class="btn-ghost" data-i18n="home.action.export" data-i18n-title="home.action.export_title" data-i18n-aria-label="home.action.export_title" title="Open Settings to the Export / Import section">Open Export</button>
-            <button id="home-dedup-btn" class="btn-ghost" data-i18n="home.action.dedup" data-i18n-title="home.action.dedup_title" data-i18n-aria-label="home.action.dedup_title" title="Open Settings to the Deduplicate section. The scan does not start automatically.">Open Dedup Scan</button>
-            <button id="home-tags-btn" class="btn-ghost" data-i18n="home.action.tags" data-i18n-title="home.action.tags_title" data-i18n-aria-label="home.action.tags_title" title="Open the Tags tab">Open Tags</button>
+            <button id="home-export-btn" class="btn-ghost" data-ui-adv="advanced" data-i18n="home.action.export" data-i18n-title="home.action.export_title" data-i18n-aria-label="home.action.export_title" title="Open Settings to the Export / Import section">Open Export</button>
+            <button id="home-dedup-btn" class="btn-ghost" data-ui-adv="advanced" data-i18n="home.action.dedup" data-i18n-title="home.action.dedup_title" data-i18n-aria-label="home.action.dedup_title" title="Open Settings to the Deduplicate section. The scan does not start automatically.">Open Dedup Scan</button>
+            <button id="home-tags-btn" class="btn-ghost" data-ui-adv="advanced" data-i18n="home.action.tags" data-i18n-title="home.action.tags_title" data-i18n-aria-label="home.action.tags_title" title="Open the Tags tab">Open Tags</button>
           </div>
         </div>
         <div class="home-pinned card">
@@ -939,25 +940,25 @@
           </span>
         </button>
 
-        <button class="settings-nav-group" type="button" data-group="data" aria-expanded="false">
+        <button class="settings-nav-group" type="button" data-ui-adv="advanced" data-group="data" aria-expanded="false">
           <span class="nav-group-caret" aria-hidden="true">▸</span>
           <span data-i18n="settings.nav.data">Data</span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="dedup" data-group="data">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-ui-adv="advanced" data-section="dedup" data-group="data">
           <span class="nav-icon" aria-hidden="true">🧹</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.dedup">Deduplicate</span>
             <span class="nav-sub" data-i18n="settings.nav.dedup_sub">Remove near-duplicates</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="decay" data-group="data">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-ui-adv="advanced" data-section="decay" data-group="data">
           <span class="nav-icon" aria-hidden="true">⏲</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.decay">Age-out</span>
             <span class="nav-sub" data-i18n="settings.nav.decay_sub">Expire old memories</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="export" data-group="data">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-ui-adv="advanced" data-section="export" data-group="data">
           <span class="nav-icon" aria-hidden="true">⇅</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.export_import">Export / Import</span>
@@ -1652,12 +1653,12 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=6"></script>
-  <script src="/app.js?v=140"></script>
+  <script src="/app.js?v=141"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=13"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>
   <script src="/settings-maintenance.js?v=5"></script>
-  <script src="/settings-namespaces.js?v=11"></script>
+  <script src="/settings-namespaces.js?v=12"></script>
   <script src="/settings-harness.js?v=4"></script>
   <script src="/settings-hooks-watchdog.js?v=21"></script>
   <script src="/timeline.js?v=3"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -8,6 +8,10 @@
   "nav.timeline": "Timeline",
   "nav.more": "Settings",
   "nav.skip_to_main": "Skip to main content",
+  "nav.mode_simple": "Simple",
+  "nav.mode_advanced": "Advanced",
+  "nav.app_mode_tip": "Switch between the Simple and Advanced views. Advanced adds the Tags and Timeline tabs and the Settings → Data tools.",
+  "nav.app_mode_aria": "Toggle Simple / Advanced view",
 
   "header.stat_chunks": "— chunks",
   "header.stat_sources": "— sources",
@@ -1221,6 +1225,7 @@
   "toast.fts_rebuilt": "FTS index rebuilt ({count} chunks).",
   "toast.diff_shown": "Showing diff: history → current",
   "toast.dev_only_section": "Unknown section (dev-only)",
+  "toast.advanced_only_section": "That view lives in Advanced mode — switch to Advanced (top-right) to open it.",
   "toast.quick_action.open_search": "Opened Search.",
   "toast.quick_action.open_index": "Opened Index. Choose a source, then run indexing.",
   "toast.quick_action.reindex_ready": "Force re-index is selected. Review the source, then run indexing.",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -8,6 +8,10 @@
   "nav.timeline": "타임라인",
   "nav.more": "설정",
   "nav.skip_to_main": "본문으로 건너뛰기",
+  "nav.mode_simple": "간단히",
+  "nav.mode_advanced": "고급",
+  "nav.app_mode_tip": "간단히 보기와 고급 보기를 전환합니다. 고급에서는 태그·타임라인 탭과 설정 → 데이터 도구가 추가됩니다.",
+  "nav.app_mode_aria": "간단히 / 고급 보기 전환",
 
   "header.stat_chunks": "— 청크",
   "header.stat_sources": "— 소스",
@@ -1221,6 +1225,7 @@
   "toast.fts_rebuilt": "FTS 인덱스가 재구축되었습니다 ({count}개 청크).",
   "toast.diff_shown": "차이점 표시: 기록 → 현재",
   "toast.dev_only_section": "알 수 없는 섹션 (dev 전용)",
+  "toast.advanced_only_section": "이 화면은 고급 보기에 있어요 — 우측 상단에서 고급으로 전환하면 열립니다.",
   "toast.quick_action.open_search": "검색을 열었습니다.",
   "toast.quick_action.open_index": "인덱스를 열었습니다. 소스를 선택한 뒤 인덱싱을 실행하세요.",
   "toast.quick_action.reindex_ready": "강제 재인덱스가 선택되었습니다. 소스를 확인한 뒤 인덱싱을 실행하세요.",

--- a/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
@@ -612,21 +612,32 @@ _renderNsChart = function(namespaces) {
 // ═══════════════════════════════════════════════════════════════════════════
 
 function _buildCommands() {
+  // Only list destinations the current mode actually exposes — otherwise Simple
+  // mode (S2.2) would offer Tags / Timeline / Dedup / Export commands that just
+  // redirect away with a toast, and dev-tier entries would leak in prod. Route
+  // through the same predicates the nav guards use so the palette matches the
+  // visible surface. (Both are app.js globals; guard for load order.)
+  const visibleTabs = new Set(
+    typeof _visibleMainTabs === 'function' ? _visibleMainTabs() : [],
+  );
+  const visibleSections = new Set(
+    typeof _visibleSettingsSections === 'function' ? _visibleSettingsSections() : [],
+  );
   const tabs = [
-    { icon: '🏠', label: t('cmd.nav.home'), action: () => activateTab('home'), hint: '1' },
-    { icon: '🔍', label: t('cmd.nav.search'), action: () => activateTab('search'), hint: '2' },
-    { icon: '📁', label: t('cmd.nav.sources'), action: () => activateTab('sources'), hint: '3' },
-    { icon: '📥', label: t('cmd.nav.index'), action: () => activateTab('index'), hint: '4' },
-    { icon: '🏷', label: t('cmd.nav.tags'), action: () => activateTab('tags'), hint: '5' },
-    { icon: '📅', label: t('cmd.nav.timeline'), action: () => activateTab('timeline'), hint: '6' },
-    { icon: '⚙', label: t('cmd.nav.settings'), action: () => activateTab('settings'), hint: '7' },
-  ];
+    { icon: '🏠', label: t('cmd.nav.home'), action: () => activateTab('home'), hint: '1', tab: 'home' },
+    { icon: '🔍', label: t('cmd.nav.search'), action: () => activateTab('search'), hint: '2', tab: 'search' },
+    { icon: '📁', label: t('cmd.nav.sources'), action: () => activateTab('sources'), hint: '3', tab: 'sources' },
+    { icon: '📥', label: t('cmd.nav.index'), action: () => activateTab('index'), hint: '4', tab: 'index' },
+    { icon: '🏷', label: t('cmd.nav.tags'), action: () => activateTab('tags'), hint: '5', tab: 'tags' },
+    { icon: '📅', label: t('cmd.nav.timeline'), action: () => activateTab('timeline'), hint: '6', tab: 'timeline' },
+    { icon: '⚙', label: t('cmd.nav.settings'), action: () => activateTab('settings'), hint: '7', tab: 'settings' },
+  ].filter(c => visibleTabs.has(c.tab));
 
   const settings = [
-    { icon: '🔧', label: t('cmd.open.config'), action: () => { activateTab('settings'); switchSettingsSection('config'); } },
-    { icon: '📋', label: t('cmd.open.dedup'), action: () => { activateTab('settings'); switchSettingsSection('dedup'); } },
-    { icon: '📦', label: t('cmd.open.export_import'), action: () => { activateTab('settings'); switchSettingsSection('export'); } },
-  ];
+    { icon: '🔧', label: t('cmd.open.config'), action: () => { activateTab('settings'); switchSettingsSection('config'); }, section: 'config' },
+    { icon: '📋', label: t('cmd.open.dedup'), action: () => { activateTab('settings'); switchSettingsSection('dedup'); }, section: 'dedup' },
+    { icon: '📦', label: t('cmd.open.export_import'), action: () => { activateTab('settings'); switchSettingsSection('export'); }, section: 'export' },
+  ].filter(c => visibleSections.has(c.section));
 
   const actions = [
     { icon: '🔍', label: t('cmd.action.focus_search'), action: () => { activateTab('search'); qs('search-input').focus(); }, hint: '/' },

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -4126,6 +4126,22 @@ body.help-hidden #help-toggle { opacity: 0.5; }
    aria-pressed for assistive tech — never color-only). */
 .ctx-mode-toggle[aria-pressed="true"] { background: rgba(var(--accent-rgb), 0.12); border-color: var(--accent); color: var(--text); }
 .ctx-overview-simple { margin-top: 4px; }
+
+/* S2.2: app-level Simple/Advanced progressive disclosure. While the app is in
+   Simple mode, hide every surface demoted to Advanced (the Tags/Timeline tabs +
+   the Settings → Data group). Class-based (no inline style) so it composes with
+   the server dev/prod ui-tier filter — which owns the inline ``display`` channel
+   in _applyUiModeFilter — and with the settings-nav ``.collapsed-member`` class,
+   without any of the three stomping the others. Navigation is gated separately
+   in JS (_visibleMainTabs); this rule only paints. The header toggle lives in
+   global chrome (outside every panel), so unlike the gateway's section-scoped
+   ``.ctx-simple`` it needs no ``:has()`` guard to stay reachable. */
+body.app-simple [data-ui-adv="advanced"] { display: none; }
+/* Header mode toggle. aria-pressed="true" === Advanced engaged (the expanded,
+   non-default state) — highlight it so "extra surfaces shown" reads at a glance
+   (state also carried by aria-pressed for AT — never color-only). */
+.app-mode-toggle { font-size: 0.78rem; padding: 4px 10px; white-space: nowrap; }
+.app-mode-toggle[aria-pressed="true"] { background: rgba(var(--accent-rgb), 0.12); border-color: var(--accent); color: var(--text); }
 .ctx-simple-verdict { margin: 0 0 14px; font-size: 0.95rem; color: var(--text); }
 .ctx-simple-verdict--warn { color: var(--yellow); }
 .ctx-simple-verdict--muted { color: var(--muted); }

--- a/packages/memtomem/tests-js/app-simple-mode.test.mjs
+++ b/packages/memtomem/tests-js/app-simple-mode.test.mjs
@@ -1,0 +1,204 @@
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+// S2.2 — app-level Simple/Advanced progressive disclosure. Simple is the
+// default-when-unset (gateway D-F precedent): it demotes the Tags + Timeline
+// tabs and the Settings → Data group behind an Advanced toggle in the global
+// <header>. The toggle stays reachable on every entry path, and — the highest-
+// risk part — navigation is *gated* (not just painted) through the single
+// _visibleMainTabs / _visibleSettingsSections predicate so no deep-link,
+// saved-default, popstate, or programmatic jump can strand the user on a tab
+// whose button is hidden (the #1358 class).
+const ADVANCED_TABS = ['tags', 'timeline'];
+const ALWAYS_TABS = ['home', 'search', 'sources', 'context-gateway', 'index', 'settings'];
+const ADVANCED_SECTIONS = ['dedup', 'decay', 'export'];
+
+describe('App-level Simple/Advanced (S2.2)', () => {
+  it('defaults to Simple when no flag is stored, hiding the advanced surface', async () => {
+    const dom = await bootApp();
+    const { window } = dom;
+    const { document, I18N } = window;
+    await I18N.init();
+
+    expect(document.body.classList.contains('app-simple')).toBe(true);
+
+    const visible = window._visibleMainTabs();
+    for (const tab of ADVANCED_TABS) {
+      expect(visible, `${tab} hidden in Simple`).not.toContain(tab);
+    }
+    for (const tab of ALWAYS_TABS) {
+      expect(visible, `${tab} always visible`).toContain(tab);
+    }
+
+    const sections = window._visibleSettingsSections();
+    for (const sec of ADVANCED_SECTIONS) {
+      expect(sections, `${sec} hidden in Simple`).not.toContain(sec);
+    }
+    // The Settings General group stays reachable so the tab is never a dead end.
+    expect(sections).toContain('config');
+    expect(sections).toContain('namespaces');
+
+    // Toggle reflects the current mode: Simple => Advanced not engaged.
+    const toggle = document.getElementById('app-mode-toggle');
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    expect(toggle.querySelector('.app-mode-label').textContent).toBe('Simple');
+  });
+
+  it('boots expanded when the persisted flag is Advanced (0)', async () => {
+    const dom = await bootApp({ seedStorage: { 'm2m-app-simple': '0' } });
+    const { window } = dom;
+    const { document, I18N } = window;
+    await I18N.init();
+
+    expect(document.body.classList.contains('app-simple')).toBe(false);
+
+    const visible = window._visibleMainTabs();
+    for (const tab of [...ALWAYS_TABS, ...ADVANCED_TABS]) {
+      expect(visible, `${tab} visible in Advanced`).toContain(tab);
+    }
+    expect(window._visibleSettingsSections()).toEqual(
+      expect.arrayContaining(ADVANCED_SECTIONS),
+    );
+
+    const toggle = document.getElementById('app-mode-toggle');
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+    expect(toggle.querySelector('.app-mode-label').textContent).toBe('Advanced');
+  });
+
+  it('the header toggle flips, persists, and re-labels both ways', async () => {
+    const dom = await bootApp();
+    const { window } = dom;
+    const { document, I18N } = window;
+    await I18N.init();
+
+    const toggle = document.getElementById('app-mode-toggle');
+    const label = () => toggle.querySelector('.app-mode-label').textContent;
+
+    // Simple -> Advanced
+    toggle.click();
+    expect(window.localStorage.getItem('m2m-app-simple')).toBe('0');
+    expect(document.body.classList.contains('app-simple')).toBe(false);
+    expect(window._visibleMainTabs()).toEqual(expect.arrayContaining(ADVANCED_TABS));
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+    expect(label()).toBe('Advanced');
+
+    // Advanced -> Simple
+    toggle.click();
+    expect(window.localStorage.getItem('m2m-app-simple')).toBe('1');
+    expect(document.body.classList.contains('app-simple')).toBe(true);
+    expect(window._visibleMainTabs()).not.toContain('timeline');
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    expect(label()).toBe('Simple');
+  });
+
+  it('activateTab redirects away from an advanced tab while in Simple', async () => {
+    const dom = await bootApp();
+    const { window } = dom;
+    const { document, I18N } = window;
+    await I18N.init();
+
+    // Real activateTab so the guard runs (a spy would shadow the recursive
+    // redirect call). The guard must bounce to a visible tab, never strand.
+    window.activateTab('timeline');
+    const active = document.querySelector('.tab-btn.active');
+    expect(active.dataset.tab).not.toBe('timeline');
+    expect(window._visibleMainTabs()).toContain(active.dataset.tab);
+    expect(document.getElementById('tab-timeline')?.classList.contains('active')).toBe(false);
+  });
+
+  it('_applyLandingTab clamps a stale saved default-tab to a visible tab', async () => {
+    const dom = await bootApp();
+    const { window } = dom;
+    const { I18N } = window;
+    await I18N.init();
+
+    const calls = [];
+    window.activateTab = (name) => { calls.push(name); };
+
+    // Returning user whose saved default is now an advanced (hidden) tab must
+    // not be force-routed there on every boot — clamp to the first visible tab.
+    window.localStorage.setItem('m2m-app-initialized', '1');
+    window.localStorage.setItem('m2m-default-tab', 'timeline');
+    window._applyLandingTab();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).not.toBe('timeline');
+    expect(window._visibleMainTabs()).toContain(calls[0]);
+  });
+
+  it('popstate ignores a Back/Forward entry pointing at a now-hidden tab', async () => {
+    const dom = await bootApp();
+    const { window } = dom;
+    const { I18N } = window;
+    await I18N.init();
+
+    const calls = [];
+    window.activateTab = (name) => { calls.push(name); };
+
+    // History entry recorded while Timeline was visible, replayed after the user
+    // dropped back to Simple — must be swallowed, not re-activated.
+    window.dispatchEvent(new window.PopStateEvent('popstate', { state: { tab: 'timeline' } }));
+    expect(calls).not.toContain('timeline');
+    expect(calls).toHaveLength(0);
+
+    // A visible tab still navigates on Back/Forward.
+    window.dispatchEvent(new window.PopStateEvent('popstate', { state: { tab: 'sources' } }));
+    expect(calls).toEqual(['sources']);
+  });
+
+  it('the Cmd+K palette omits advanced commands in Simple, lists them in Advanced', async () => {
+    const dom = await bootApp({ scripts: ['i18n.js', 'app.js', 'settings-namespaces.js'] });
+    const { window } = dom;
+    const { I18N } = window;
+    await I18N.init();
+
+    const tabIds = (groups) => groups.flatMap(g => g.items).map(i => i.tab).filter(Boolean);
+    const sectionIds = (groups) => groups.flatMap(g => g.items).map(i => i.section).filter(Boolean);
+
+    // Simple (default): no Tags/Timeline tab commands, no Dedup/Export section
+    // commands — the palette must match the visible surface, not redirect away.
+    let groups = window._buildCommands();
+    expect(tabIds(groups)).not.toContain('tags');
+    expect(tabIds(groups)).not.toContain('timeline');
+    expect(sectionIds(groups)).not.toContain('dedup');
+    expect(sectionIds(groups)).not.toContain('export');
+    // Always-on destinations stay listed.
+    expect(tabIds(groups)).toEqual(expect.arrayContaining(['home', 'search', 'index']));
+    expect(sectionIds(groups)).toContain('config');
+
+    // Advanced: they reappear.
+    window._setAppSimple(false);
+    groups = window._buildCommands();
+    expect(tabIds(groups)).toEqual(expect.arrayContaining(['tags', 'timeline']));
+    expect(sectionIds(groups)).toEqual(expect.arrayContaining(['dedup', 'export']));
+  });
+
+  it('redirects a hidden Settings section to Config, never bounces to the Gateway tab', async () => {
+    const dom = await bootApp();
+    const { window } = dom;
+    const { document, I18N } = window;
+    await I18N.init();
+    // The fallback section (config) is the only loader that fires; stub it so
+    // switchSettingsSection runs end-to-end without settings-config.js.
+    window.loadConfig = () => {};
+    const tabCalls = [];
+    window.activateTab = (name) => { tabCalls.push(name); };
+
+    // dedup is hidden in Simple. The Gateway sidebar (ctx-overview, …) shares the
+    // .settings-nav-btn class and sorts first, so a naive visible[0] fallback
+    // would hop to the Gateway tab. It must land on a Settings-tab section.
+    window.switchSettingsSection('dedup');
+
+    expect(document.querySelector('.settings-nav-btn.active')?.dataset.section).toBe('config');
+    expect(tabCalls).not.toContain('context-gateway');
+  });
+
+  it('labels the toggle with the current mode even before i18n loads', async () => {
+    // Persisted Advanced, but I18N.init() has NOT run yet (t() still returns the
+    // raw key). The literal fallback must already read "Advanced" so the toggle
+    // never momentarily reports the wrong mode (Codex review, S2.2).
+    const dom = await bootApp({ seedStorage: { 'm2m-app-simple': '0' } });
+    const { window } = dom;
+    const label = window.document.querySelector('#app-mode-toggle .app-mode-label');
+    expect(label.textContent).toBe('Advanced');
+  });
+});

--- a/packages/memtomem/tests-js/setup/jsdom-app.mjs
+++ b/packages/memtomem/tests-js/setup/jsdom-app.mjs
@@ -104,6 +104,7 @@ export async function bootApp({
   apiResponses = {},
   firstRun = false,
   storageBlock = [],
+  seedStorage = {},
 } = {}) {
   let html = readStatic('index.html');
   // Strip every <script ...>...</script> element so JSDOM's loader
@@ -127,6 +128,14 @@ export async function bootApp({
   // exercising the first-run landing opt in with ``bootApp({ firstRun: true })``.
   if (!firstRun) {
     try { window.localStorage.setItem('m2m-app-initialized', '1'); } catch {}
+  }
+
+  // Test-controlled localStorage seeds, applied before scripts load so a
+  // module-load read sees them (e.g. the S2.2 ``m2m-app-simple`` flag, which is
+  // read once at app.js parse time). After the returning-install sentinel so a
+  // test can still override it.
+  for (const [k, v] of Object.entries(seedStorage)) {
+    try { window.localStorage.setItem(k, v); } catch {}
   }
 
   // Simulate a locked-down storage (some private modes throw on access). Applied

--- a/packages/memtomem/tests/web/conftest.py
+++ b/packages/memtomem/tests/web/conftest.py
@@ -87,15 +87,19 @@ def mm_web_url() -> Iterator[str]:
 
 @pytest.fixture(autouse=True)
 def _returning_install(request) -> None:
-    """Boot every browser spec as a returning install (S2.1).
+    """Boot every browser spec as a returning install on the full surface
+    (S2.1 + S2.2).
 
     S2.1 routes a *genuine* first run — a fresh context with no app-owned
-    localStorage key — to the Home tab for orientation. These specs each open a
-    fresh browser context, so without a seeded "seen" sentinel they would all
-    land on Home and fail the moment they touch a Search-tab element (tag
-    filters, result snippets, the skip-link to ``#main``). Seeding the sentinel
-    before navigation restores the historical Search default; a spec that wants
-    the first-run landing can clear it with its own ``add_init_script``.
+    localStorage key — to the Home tab for orientation. S2.2 then defaults a
+    fresh install to *Simple* mode, which hides the Tags + Timeline tabs and the
+    Settings → Data group. These specs each open a fresh browser context, so
+    without seeds they would (a) land on Home and (b) sit in Simple mode —
+    failing the moment they touch a Search element or a now-hidden advanced tab
+    (tag filters, the Timeline view, the skip-link to ``#main``). Seeding both
+    flags before navigation restores the historical full-surface Search default;
+    a spec that wants the first-run landing or Simple mode opts in by overriding
+    the relevant key with its own ``add_init_script``.
 
     Gated on the ``browser`` marker and requests ``page`` lazily so the
     non-browser specs in this directory (CSS / asset-pin checks) aren't forced
@@ -104,7 +108,12 @@ def _returning_install(request) -> None:
     if request.node.get_closest_marker("browser") is None:
         return
     page = request.getfixturevalue("page")
-    page.add_init_script("try { localStorage.setItem('m2m-app-initialized', '1'); } catch (e) {}")
+    page.add_init_script(
+        "try {"
+        " localStorage.setItem('m2m-app-initialized', '1');"
+        " localStorage.setItem('m2m-app-simple', '0');"
+        " } catch (e) {}"
+    )
 
 
 def install_default_stubs(page) -> None:

--- a/packages/memtomem/tests/web/test_app_simple_mode.py
+++ b/packages/memtomem/tests/web/test_app_simple_mode.py
@@ -1,0 +1,165 @@
+"""Browser tests for the app-level Simple/Advanced toggle (S2.2).
+
+S2.2 promotes the gateway's Simple-mode pattern to app level: a persisted
+``m2m-app-simple`` flag (Simple by default) demotes the Tags + Timeline tabs and
+the Settings → Data group behind an Advanced toggle in the global ``<header>``.
+
+These specs cover what the jsdom unit suite
+(``tests-js/app-simple-mode.test.mjs``) cannot: real-browser CSS visibility
+(``display:none`` from the linked stylesheet), and — the highest-risk property —
+that no entry path strands the user. The toggle must stay reachable on a
+deep-linked non-Home tab, and a deep link to a now-hidden advanced tab must not
+leave an orphaned panel (#1358).
+
+The autouse ``_returning_install`` fixture seeds ``m2m-app-simple='0'``
+(Advanced) so the rest of the browser suite keeps the full surface; each test
+here overrides it with its own ``add_init_script`` (registered after the
+fixture's, so last-write-wins) to pin the mode it exercises.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import install_default_stubs
+
+pytestmark = pytest.mark.browser
+
+_ADVANCED_TABS = ("tags", "timeline")
+_ALWAYS_TABS = ("home", "search", "sources", "context-gateway", "index", "settings")
+
+
+def _force_app_mode(page, *, simple: bool) -> None:
+    """Pin ``m2m-app-simple`` on every navigation, overriding the autouse seed."""
+    value = "1" if simple else "0"
+    page.add_init_script(
+        f"try {{ localStorage.setItem('m2m-app-simple', '{value}'); }} catch (e) {{}}"
+    )
+
+
+def test_simple_default_hides_tags_and_timeline_tabs(page, mm_web_url: str) -> None:
+    """In Simple mode the advanced tabs are CSS-hidden (present in the DOM,
+    ``display:none``) while the always-on tabs and the toggle stay visible."""
+    install_default_stubs(page)
+    _force_app_mode(page, simple=True)
+    page.goto(mm_web_url)
+    page.wait_for_selector(".tab-nav .tab-btn", timeout=5_000)
+
+    for tab in _ADVANCED_TABS:
+        assert page.locator(f'.tab-btn[data-tab="{tab}"]').is_hidden(), (
+            f"{tab} tab must be hidden in Simple mode"
+        )
+    for tab in _ALWAYS_TABS:
+        assert page.locator(f'.tab-btn[data-tab="{tab}"]').is_visible(), (
+            f"{tab} tab must stay visible in Simple mode"
+        )
+
+    toggle = page.locator("#app-mode-toggle")
+    assert toggle.is_visible()
+    assert toggle.get_attribute("aria-pressed") == "false"
+    assert (toggle.locator(".app-mode-label").text_content() or "").strip() == "Simple"
+
+    # The demoted Settings → Data group header is hidden too (checked on the
+    # Settings tab; the group header is never collapsed, so this is unambiguous).
+    page.evaluate("() => activateTab('settings')")
+    assert page.locator('.settings-nav-group[data-group="data"]').is_hidden()
+
+    # Home quick-actions that shortcut to advanced destinations are hidden too,
+    # so Simple users never click a button that just redirects with a false
+    # "Opened …" toast (Codex review). The always-on shortcuts stay.
+    page.evaluate("() => activateTab('home')")
+    for btn in ("home-export-btn", "home-dedup-btn", "home-tags-btn"):
+        assert page.locator(f"#{btn}").is_hidden(), f"{btn} must be hidden in Simple"
+    assert page.locator("#home-search-btn").is_visible()
+    assert page.locator("#home-index-btn").is_visible()
+
+
+def test_toggle_reveals_advanced_surface(page, mm_web_url: str) -> None:
+    """Clicking the header toggle from Simple flips to Advanced: the advanced
+    tabs + the Data group come back, and the toggle reports its pressed state."""
+    install_default_stubs(page)
+    _force_app_mode(page, simple=True)
+    page.goto(mm_web_url)
+    page.wait_for_selector(".tab-nav .tab-btn", timeout=5_000)
+
+    page.locator("#app-mode-toggle").click()
+    page.wait_for_function("() => !document.body.classList.contains('app-simple')", timeout=3_000)
+
+    for tab in _ADVANCED_TABS:
+        assert page.locator(f'.tab-btn[data-tab="{tab}"]').is_visible(), (
+            f"{tab} tab must be revealed in Advanced mode"
+        )
+    toggle = page.locator("#app-mode-toggle")
+    assert toggle.get_attribute("aria-pressed") == "true"
+    assert (toggle.locator(".app-mode-label").text_content() or "").strip() == "Advanced"
+
+    page.evaluate("() => activateTab('settings')")
+    assert page.locator('.settings-nav-group[data-group="data"]').is_visible()
+
+    page.evaluate("() => activateTab('home')")
+    assert page.locator("#home-tags-btn").is_visible()
+    assert page.locator("#home-export-btn").is_visible()
+
+
+def test_deeplink_to_advanced_tab_in_simple_does_not_strand(page, mm_web_url: str) -> None:
+    """A shared deep link to #timeline while in Simple must not orphan the user
+    on a hidden panel: the timeline panel never activates, a visible tab stays
+    active, and the toggle (the escape hatch) is still on screen."""
+    install_default_stubs(page)
+    _force_app_mode(page, simple=True)
+    page.goto(mm_web_url + "#timeline")
+    page.wait_for_selector(".tab-nav .tab-btn", timeout=5_000)
+
+    # The hidden tab's panel must not be the active one.
+    assert not page.locator("#tab-timeline").evaluate("el => el.classList.contains('active')")
+    active_tab = page.evaluate("() => document.querySelector('.tab-btn.active')?.dataset.tab")
+    assert active_tab is not None and active_tab != "timeline"
+    assert active_tab in _ALWAYS_TABS
+
+    # #1358: the escape hatch is reachable even on this bypassing entry path.
+    assert page.locator("#app-mode-toggle").is_visible()
+
+
+def test_toggle_reachable_on_deeplinked_non_home_tab(page, mm_web_url: str) -> None:
+    """The header toggle lives in global chrome, so a deep link to a *visible*
+    non-Home tab in Simple mode still shows a working toggle that reveals the
+    advanced surface — the core #1358 reachability guarantee."""
+    install_default_stubs(page)
+    _force_app_mode(page, simple=True)
+    page.goto(mm_web_url + "#sources")
+    page.wait_for_function(
+        "() => document.querySelector('.tab-btn.active')?.dataset.tab === 'sources'",
+        timeout=5_000,
+    )
+
+    toggle = page.locator("#app-mode-toggle")
+    assert toggle.is_visible() and toggle.is_enabled()
+    assert page.locator('.tab-btn[data-tab="timeline"]').is_hidden()
+
+    toggle.click()
+    page.wait_for_selector('.tab-btn[data-tab="timeline"]:visible', timeout=3_000)
+    # Revealing Advanced does not yank the user off their current tab.
+    assert (
+        page.evaluate("() => document.querySelector('.tab-btn.active')?.dataset.tab") == "sources"
+    )
+
+
+def test_hidden_settings_section_redirects_within_settings(page, mm_web_url: str) -> None:
+    """Opening a now-hidden Data-group section in Simple must redirect to a
+    Settings-tab section (Config), not bounce to the Gateway tab — the Gateway
+    sidebar shares .settings-nav-btn but belongs to a different tab (Codex)."""
+    install_default_stubs(page)
+    _force_app_mode(page, simple=True)
+    page.goto(mm_web_url)
+    page.wait_for_selector(".tab-nav .tab-btn", timeout=5_000)
+    page.evaluate("() => activateTab('settings')")
+
+    page.evaluate("() => switchSettingsSection('dedup')")
+
+    assert (
+        page.evaluate("() => document.querySelector('.tab-btn.active')?.dataset.tab") == "settings"
+    )
+    assert (
+        page.evaluate("() => document.querySelector('.settings-nav-btn.active')?.dataset.section")
+        == "config"
+    )


### PR DESCRIPTION
## What

App-level Simple/Advanced progressive disclosure (S2.2 of the first-time-UX campaign). A persisted `m2m-app-simple` flag — **Simple by default** — demotes the **Tags** and **Timeline** tabs and the **Settings → Data** group (dedup, decay, export) behind an **Advanced** toggle in the global header. New users meet a smaller, less jargon-heavy surface; power users flip once to Advanced (persisted) and stay.

## Why this shape

- **Two orthogonal axes.** The existing server-driven dev/prod tier (`data-ui-tier`) is untouched and keeps owning the inline-display channel in `_applyUiModeFilter`. This adds a separate per-user `data-ui-adv="advanced"` attribute + a `body.app-simple` CSS class. An element hides if *either* axis hides it; neither stomps the other.
- **No stranding (#1358).** A persisted mode flag that hides nav can trap a user who arrives by a path that bypasses the toggle. Two defenses: (1) the toggle lives in the global `<header>`, outside every tab panel, so it is reachable on every entry path (deep-link, reload, Back/Forward); (2) a single visibility predicate (`_visibleMainTabs` / `_visibleSettingsSections`) now gates **all** navigation — boot `#hash`, popstate (previously ungated), arrow-key nav, the activateTab/switchSettingsSection guards, the Cmd+K palette, and the saved default-tab clamp in `_applyLandingTab`.
- **No dead shortcuts / false success.** Simple mode hides the Home Export/Dedup/Tags quick-actions and prunes the matching Cmd+K commands, so a user never clicks an entry that just redirects with a toast. A hidden-section redirect skips the Gateway sidebar (shares `.settings-nav-btn` but belongs to another tab) and lands on the first Settings-tab section.

## Scope (confirmed)

- Advanced: **Tags + Timeline** tabs, **Settings → Data** group (dedup/decay/export).
- Always visible: Home, Search, Sources, Gateway, Index, Settings (General: config/namespaces), Danger Zone.

## Tests

- `tests-js/app-simple-mode.test.mjs` — default / persist / toggle / nav guards / landing clamp / popstate / palette filter / label fallback / section fallback (9).
- `tests/web/test_app_simple_mode.py` — real CSS hiding, deep-link redirect, toggle reachability on a deep-linked non-Home tab, within-Settings fallback (5).
- Browser `conftest` seeds Advanced so the rest of the suite keeps the full surface; the jsdom harness gains a `seedStorage` opt.
- Local gates: vitest 374, web browser 256, i18n 81, ruff clean.

## Review

Codex (2 NEEDS-FIX rounds → fixed → **SHIP**): false-success toasts (Home quick-actions + Cmd+K), label pre-i18n fallback, and a settings-section fallback that bounced to the Gateway tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
