### PR TITLE
fix(web): reframe the Home orientation Gateway step (syncs skills, not memories)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -81,13 +81,13 @@
           </div>
           <div class="home-orientation-step">
             <span class="home-orientation-step-num" aria-hidden="true">2</span>
-            <span class="home-orientation-step-text" data-i18n="home.orientation.step_connect">Connect your agent so it can reuse them.</span>
-            <button id="home-orientation-connect" class="btn-ghost" data-i18n="home.orientation.step_connect_cta">Open Gateway</button>
+            <span class="home-orientation-step-text" data-i18n="home.orientation.step_search">Search everything by meaning, anytime.</span>
+            <button id="home-orientation-search" class="btn-ghost" data-i18n="home.orientation.step_search_cta">Try a search</button>
           </div>
           <div class="home-orientation-step">
             <span class="home-orientation-step-num" aria-hidden="true">3</span>
-            <span class="home-orientation-step-text" data-i18n="home.orientation.step_search">Search everything by meaning, anytime.</span>
-            <button id="home-orientation-search" class="btn-ghost" data-i18n="home.orientation.step_search_cta">Try a search</button>
+            <span class="home-orientation-step-text" data-i18n="home.orientation.step_connect">Sync your skills, subagents, and commands out to Claude Code, Codex, and more.</span>
+            <button id="home-orientation-connect" class="btn-ghost" data-i18n="home.orientation.step_connect_cta">Open Gateway</button>
           </div>
         </div>
       </details>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -46,7 +46,7 @@
   "home.orientation.intro": "Three steps to start using memtomem.",
   "home.orientation.step_add": "Add your notes, docs, and code.",
   "home.orientation.step_add_cta": "Add memories",
-  "home.orientation.step_connect": "Connect your agent so it can reuse them.",
+  "home.orientation.step_connect": "Sync your skills, subagents, and commands out to Claude Code, Codex, and more.",
   "home.orientation.step_connect_cta": "Open Gateway",
   "home.orientation.step_search": "Search everything by meaning, anytime.",
   "home.orientation.step_search_cta": "Try a search",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -46,7 +46,7 @@
   "home.orientation.intro": "memtomem 을 시작하는 3단계입니다.",
   "home.orientation.step_add": "메모·문서·코드를 추가하세요.",
   "home.orientation.step_add_cta": "기억 추가",
-  "home.orientation.step_connect": "에이전트를 연결해 기억을 재사용하세요.",
+  "home.orientation.step_connect": "스킬·서브에이전트·명령을 Claude Code·Codex 등으로 동기화하세요.",
   "home.orientation.step_connect_cta": "게이트웨이 열기",
   "home.orientation.step_search": "언제든 의미 기반으로 검색하세요.",
   "home.orientation.step_search_cta": "검색해보기",

--- a/packages/memtomem/tests-js/home-orientation.test.mjs
+++ b/packages/memtomem/tests-js/home-orientation.test.mjs
@@ -21,7 +21,7 @@ describe('First-run Home orientation block (S2.3)', () => {
     expect(details.closest('.home-layout').classList.contains('orientation-open')).toBe(true);
   });
 
-  it('wires the three add → connect → search CTAs to their tabs', async () => {
+  it('wires the three add → search → connect CTAs to their tabs', async () => {
     const dom = await bootApp({ scripts: ['i18n.js', 'app.js'] });
     const { window } = dom;
     const { document, I18N } = window;
@@ -33,10 +33,12 @@ describe('First-run Home orientation block (S2.3)', () => {
     const calls = [];
     window.activateTab = (name) => { calls.push(name); };
 
+    // Clicked in the rendered order: add (memory) → search (memory) →
+    // connect (Gateway = skill/subagent/command sync, a distinct surface).
     document.getElementById('home-orientation-add').click();
-    document.getElementById('home-orientation-connect').click();
     document.getElementById('home-orientation-search').click();
-    expect(calls).toEqual(['index', 'context-gateway', 'search']);
+    document.getElementById('home-orientation-connect').click();
+    expect(calls).toEqual(['index', 'search', 'context-gateway']);
   });
 
   it('persists the collapse choice and restores it on the next load', async () => {


### PR DESCRIPTION
## What

The first-run **Getting started** orientation block (shipped in #1439, S2.3) framed step 2 — the Context Gateway — as *"Connect your agent so it can reuse them"* (i.e. reuse your memories). That's a misdescription: the Gateway syncs **context artifacts** (skills, subagents, commands, MCP servers) out to coding agents; reusing *memories* is what **Search** does. The description (reuse memories) and the CTA (Open Gateway) pointed at different things, which misled first-time users.

## Change

- Reword `home.orientation.step_connect` (en + ko) to describe the Gateway accurately: *"Sync your skills, subagents, and commands out to Claude Code, Codex, and more."* / *"스킬·서브에이전트·명령을 Claude Code·Codex 등으로 동기화하세요."*
- Reorder the three steps so the memory loop is contiguous and the Gateway reads as a distinct capability: **Add → Search → Connect (Gateway)**.

Before → after (Korean UI):

```
1) 메모·문서·코드를 추가하세요.            [기억 추가]
2) 에이전트를 연결해 기억을 재사용하세요.   [게이트웨이 열기]   ← misframed
3) 언제든 의미 기반으로 검색하세요.        [검색해보기]
```
```
1) 메모·문서·코드를 추가하세요.            [기억 추가]
2) 언제든 의미 기반으로 검색하세요.        [검색해보기]
3) 스킬·서브에이전트·명령을               [게이트웨이 열기]
   Claude Code·Codex 등으로 동기화하세요.
```

## Notes

- CTAs are wired by element id, so only the markup order, step numbers, and the `step_connect` copy change — no JS.
- `tests-js/home-orientation.test.mjs` updated to the new order; i18n parity + literal scans green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
