### PR TITLE
fix(docs): replace nonexistent `mm server` with `memtomem-server`

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -288,7 +288,8 @@ When enabled, search results include surrounding chunks from the same source fil
 ### `memory_dirs` — reactive watch vs one-shot seed
 
 `indexing.memory_dirs` is the source-of-truth list for the file watcher
-that `mm server` starts on boot. The watcher is **reactive only** — it
+that the running MCP server (`memtomem-server`) starts on boot. The
+watcher is **reactive only** — it
 reindexes files when the filesystem emits modify / create / move events
 for paths under these directories. Pre-existing files on disk at the
 time the watcher starts are **NOT auto-scanned**; you seed them once
@@ -300,7 +301,7 @@ with either
 Both paths are idempotent: chunks are content-hashed, so unchanged files
 are skipped on re-runs. This is why the `mm init` wizard's `Next steps`
 prints `mm index {memory_dir}` as step 1 — once seeded, subsequent edits
-flow through the watcher automatically (as long as `mm server` is
+flow through the watcher automatically (as long as the MCP server is
 running).
 
 > **Adding a folder via the Web UI** registers and indexes in one call:

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -280,9 +280,10 @@ mm status
 ### 1. Index your notes
 
 This one-shot command seeds the index with files already on disk. After
-this, the `mm server` file watcher keeps your `memory_dirs` in sync with
-new edits automatically — you only need to run `mm index` again when you
-add a brand-new directory or want a forced rebuild (`--force`).
+this, the MCP server's file watcher (`memtomem-server`, launched by your
+editor) keeps your `memory_dirs` in sync with new edits automatically —
+you only need to run `mm index` again when you add a brand-new directory
+or want a forced rebuild (`--force`).
 
 In your editor:
 ```

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -176,7 +176,7 @@ mem_index(path="~/personal/notes", namespace="personal")
 ### Auto-watch vs manual seed
 
 `MEMTOMEM_INDEXING__MEMORY_DIRS` feeds a file watcher that runs inside
-the `mm server` (MCP) process. The watcher is **reactive only** — it
+the `memtomem-server` (MCP) process. The watcher is **reactive only** — it
 reindexes files when the filesystem emits modify / create / move events.
 Two cases it does NOT cover:
 


### PR DESCRIPTION
## Problem

The user guides refer to **`mm server`** as the process that runs the
`memory_dirs` file watcher. That command does not exist: the `mm` CLI
registers no `server` subcommand (`cli/__init__.py:70-96`), so a user who
runs `mm server` gets `Error: No such command 'server'`.

The file watcher actually runs inside the MCP server entry point
**`memtomem-server`** (`[project.scripts]` → `memtomem.server:main`),
started by `app_lifespan` (`server/lifespan.py:97`) when the editor's MCP
host launches it. `mm web` also starts its own `FileWatcher`
(`web/app.py:409-411`).

## Fix

Replace `mm server` with the correct process name in all three guides
that mention it:

| File | Before | After |
|------|--------|-------|
| `getting-started.md` | "the `mm server` file watcher" | "the MCP server's file watcher (`memtomem-server`, launched by your editor)" |
| `configuration.md` | watcher "that `mm server` starts on boot" / "as long as `mm server` is running" | "that the running MCP server (`memtomem-server`) starts" / "as long as the MCP server is running" |
| `reference.md` | watcher "runs inside the `mm server` (MCP) process" | "runs inside the `memtomem-server` (MCP) process" |

Verified `grep -rn 'mm server'` over `README.md`, `packages/memtomem/README.md`,
`docs/guides/`, and `docs/adr/` now returns no hits.

Docs-only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
