### PR TITLE
fix(docs): OpenAI key source + langfuse extra + localhost in getting-started.md

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -34,7 +34,7 @@ don't have to decide now.
 | **Keyword-only (BM25)** | None | Default. Fast, no external deps. Great for short, exact-term notes. |
 | **ONNX (local, no server)** | `uv tool install 'memtomem[onnx]'` | Semantic search without running a server. ~90 MB–2.3 GB model on first use. |
 | **Ollama (local server)** | Install [Ollama](https://ollama.com), then `ollama pull nomic-embed-text` (English) or `ollama pull bge-m3` (multilingual, ~2.3 GB). | Semantic search with full local control; best Korean/JP/CN quality with `bge-m3`. |
-| **OpenAI (cloud)** | `OPENAI_API_KEY` env var. | No local model to manage; pay-per-call. |
+| **OpenAI (cloud)** | OpenAI API key, set via `mm init` or `MEMTOMEM_EMBEDDING__API_KEY`. | No local model to manage; pay-per-call. |
 
 > **Multilingual tip**: if you work with Korean, Japanese, or Chinese,
 > pick Ollama with `bge-m3` or OpenAI `text-embedding-3-small` — both
@@ -108,6 +108,7 @@ uv pip install -e "packages/memtomem[all]"
 | `korean` | Korean tokenizer (`kiwipiepy`) |
 | `code` | Code chunking (`tree-sitter` for Python/JS/TS) |
 | `web` | Web UI (`fastapi`, `uvicorn`) |
+| `langfuse` | LLM tracing / observability via Langfuse |
 | `all` | All of the above |
 
 ```bash
@@ -399,7 +400,7 @@ mm ingest claude-memory    # index Claude Code auto-memory
 mm ingest gemini-memory    # index Gemini CLI / Antigravity CLI memory (GEMINI.md)
 mm ingest codex-memory     # index Codex CLI memory
 mm shell                   # interactive REPL
-mm web                     # launch Web UI (http://localhost:8080)
+mm web                     # launch Web UI (http://127.0.0.1:8080)
 ```
 
 ---


### PR DESCRIPTION
## Three verified accuracy issues in `getting-started.md`

### 1. OpenAI key is **not** read from `OPENAI_API_KEY` (major)

The "Pick an embedding path" table told users the OpenAI path is set up
with the standard `OPENAI_API_KEY` env var. memtomem never reads that
variable (`grep -rn OPENAI_API_KEY src/` → 0 hits). The OpenAI embedder
builds its auth header from `embedding.api_key` only
(`embedding/openai.py:40-41`), which is set via `mm init` (`--api-key`
flag or interactive prompt) or the `MEMTOMEM_EMBEDDING__API_KEY` env var
(prefix `MEMTOMEM_`, nested delimiter `__`). A user who exports only
`OPENAI_API_KEY` sends unauthenticated requests — a silent failure on the
documented happy path. Reworded the Setup cell.

### 2. Extras table omitted `langfuse` (minor)

`pyproject.toml:51` defines a 7th extra `langfuse`, and `all` pulls it in
(`:52`). The Option C extras table listed only onnx/ollama/openai/korean/
code/web, so `all` = "All of the above" was literally inaccurate and a
reader couldn't discover the extra. Added the `langfuse` row.

### 3. `localhost` vs `127.0.0.1` (nit)

The CLI-reference block printed `http://localhost:8080` while the rest of
the guide (and the source default, `web.py` `--host` default `127.0.0.1`)
uses `http://127.0.0.1:8080`. Unified to the canonical form.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
