### PR TITLE
fix(docs): four minor accuracy fixes (claude-desktop heading, claude-code, context-gateway, uninstall)

### DIFF
--- a/docs/guides/context-gateway.md
+++ b/docs/guides/context-gateway.md
@@ -151,7 +151,7 @@ machine):
 
 ```bash
 mm context sync --include=skills --scope user
-# fans out from ~/.memtomem/skills/ → ~/.{claude,gemini,codex,kimi}/...
+# fans out from ~/.memtomem/skills/ → ~/.claude/skills/, ~/.gemini/skills/, ~/.agents/skills/ (Codex), ~/.kimi/skills/
 ```
 
 ## Sync vs Import — reading the status

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -96,7 +96,7 @@ In Claude Code (or run `/memtomem:status` if using the plugin):
 Call the mem_status tool
 ```
 
-Example of a successful response (Ollama config; first 12 lines of the
+Example of a successful response (Ollama config; first 13 lines of the
 full report — the `Embedding` and `Dimension` rows change with the
 provider picked in the wizard):
 
@@ -441,7 +441,7 @@ Yes. Auto-memory automatically extracts from conversations, while memtomem only 
 
 ## Cross-runtime agent context with `mm context`
 
-If you also use Gemini CLI (or its Antigravity CLI successor) or Codex CLI on the same repo, treat `.memtomem/` as the single source of truth and let memtomem fan it out. Claude Code is the richest target — it preserves every canonical sub-agent field (`name`, `description`, `tools`, `model`, `skills`, `isolation`) without loss, so Claude is the natural place to author canonical agents and skills.
+If you also use Gemini CLI (or its Antigravity CLI successor) or Codex CLI on the same repo, treat `.memtomem/` as the single source of truth and let memtomem fan it out. Claude Code is the richest target — it preserves the canonical sub-agent fields most authors set (`name`, `description`, `tools`, `model`, `skills`, `isolation`), dropping only the rarely-used `kind` and `temperature`, so Claude is the natural place to author canonical agents and skills.
 
 ```bash
 # Mirror .memtomem/skills/<name>/SKILL.md to .claude/skills/, .gemini/skills/, .agents/skills/

--- a/docs/guides/integrations/claude-desktop.md
+++ b/docs/guides/integrations/claude-desktop.md
@@ -165,7 +165,7 @@ mem_search("Transformer attention mechanism")
 
 ---
 
-# Claude Desktop x memtomem Integration Guide > ## Built-in Features vs memtomem Comparison
+## Built-in Features vs memtomem Comparison
 
 | Feature | Claude Desktop Built-in | memtomem |
 |---------|------------------------|---------|

--- a/docs/guides/uninstall.md
+++ b/docs/guides/uninstall.md
@@ -97,7 +97,7 @@ The running server's pid/flock file lives **outside** `~/.memtomem/`
 under `$XDG_RUNTIME_DIR/memtomem/server.pid` (Linux w/ systemd) or
 `$TMPDIR/memtomem-$UID/server.pid` (macOS, BSD). It is cleaned by
 `mm uninstall` automatically; a manual cleanup is rarely needed but
-equivalent to `rm -rf "${XDG_RUNTIME_DIR:-/tmp}/memtomem"*`.
+equivalent to `rm -rf "${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/memtomem"*`.
 
 ## 4. Clean up project-scoped files (optional)
 


### PR DESCRIPTION
## Four small, source-verified corrections across the guide set

| File | Fix |
|------|-----|
| `integrations/claude-desktop.md` | Repair a **malformed heading** (line 168). It was a breadcrumb-generation artifact — `# … Integration Guide > ## Built-in Features …` — which renders as a second top-level `H1` mid-document, swallows the intended `H2`, and breaks the TOC. Now a clean `## Built-in Features vs memtomem Comparison`. |
| `integrations/claude-code.md` | The `mem_status` excerpt actually shows **13** physical lines (there's a blank separator before `Index stats`), not 12 — `head -n 12` would drop the displayed `Source files:` row. Updated "first 12 lines" → "first 13 lines". |
| `integrations/claude-code.md` | Soften "preserves **every** canonical sub-agent field … **without loss**" — the Claude renderer drops `kind` and `temperature` (`context/agents.py:384-394`; 8 author-able canonical fields, 6 kept). Now states only `kind`/`temperature` are dropped. |
| `context-gateway.md` | The skills user-tier fan-out comment used `~/.{claude,gemini,codex,kimi}/…`, which implies Codex skills land in `~/.codex/skills`. They actually fan out to **`~/.agents/skills`** (`_runtime_targets.py:67`, `:98-101`). Replaced the brace shorthand with the explicit per-runtime targets. |
| `uninstall.md` | The macOS manual-cleanup glob `${XDG_RUNTIME_DIR:-/tmp}/memtomem*` falls back to `/tmp`, but the macOS runtime dir is `$TMPDIR` (`/var/folders/.../T/`, `_runtime_paths.py:94-100`) — contradicting the path shown two lines above. Fallback now honors `$TMPDIR` before `/tmp`. |

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
