### PR TITLE
fix(web): relabel keyboard-shortcut help "More" tab as "Settings"

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1464,7 +1464,7 @@
           <tr><td><kbd>c</kbd></td><td data-i18n="shortcut.copy">Copy selected chunk content</td></tr>
           <tr><td><kbd>Enter</kbd></td><td data-i18n="shortcut.open_detail">Open selected result detail</td></tr>
           <tr><td><kbd>Backspace</kbd></td><td data-i18n="shortcut.back">Back to results list from detail</td></tr>
-          <tr><td><kbd>1</kbd>–<kbd>8</kbd></td><td data-i18n="shortcut.switch_tabs">Switch tabs (Home=1 … More=8)</td></tr>
+          <tr><td><kbd>1</kbd>–<kbd>8</kbd></td><td data-i18n="shortcut.switch_tabs">Switch tabs (Home=1 … Settings=8)</td></tr>
           <tr><td><kbd>⌘K</kbd></td><td data-i18n="shortcut.cmd_palette">Command palette</td></tr>
           <tr><td><kbd>g</kbd> <kbd>s</kbd></td><td data-i18n="shortcut.go_sources">Go to Sources</td></tr>
           <tr><td><kbd>Esc</kbd></td><td data-i18n="shortcut.close">Close panel, dropdown, or modal</td></tr>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -1168,7 +1168,7 @@
   "shortcut.copy": "Copy selected chunk content",
   "shortcut.open_detail": "Open selected result detail",
   "shortcut.back": "Back to results list from detail",
-  "shortcut.switch_tabs": "Switch tabs (Home=1 … More=8)",
+  "shortcut.switch_tabs": "Switch tabs (Home=1 … Settings=8)",
   "shortcut.cmd_palette": "Command palette",
   "shortcut.go_sources": "Go to Sources",
   "shortcut.close": "Close panel, dropdown, or modal",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -1168,7 +1168,7 @@
   "shortcut.copy": "선택한 청크 내용 복사",
   "shortcut.open_detail": "선택한 결과 상세 보기",
   "shortcut.back": "상세에서 결과 목록으로 돌아가기",
-  "shortcut.switch_tabs": "탭 전환 (홈=1 … 더보기=8)",
+  "shortcut.switch_tabs": "탭 전환 (홈=1 … 설정=8)",
   "shortcut.cmd_palette": "명령 팔레트",
   "shortcut.go_sources": "소스로 이동",
   "shortcut.close": "패널, 드롭다운 또는 모달 닫기",

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -472,7 +472,7 @@ def test_shortcut_switch_tabs_copy_matches_tab_count() -> None:
     """#962 review P3 fold: the keyboard-shortcuts help row claims
     digits 1-N map to the main tabs. The Gateway tab promotion
     bumped N from 7 to 8 (Home/Search/Sources/Gateway/Index/Tags/
-    Timeline/More). Pin both the digit range row and the per-locale
+    Timeline/Settings). Pin both the digit range row and the per-locale
     ``shortcut.switch_tabs`` copy so a future tab add/remove can't
     silently leave a stale digit there.
     """


### PR DESCRIPTION
## What

The 8th top-level Web UI tab was renamed **More → Settings** (the
`nav.more` i18n key resolves to "Settings" / "설정"), but the
keyboard-shortcuts help still read `Switch tabs (Home=1 … More=8)`. This
relabels that copy — the last user-facing "More" tab reference.

Follow-up to #1461 (which corrected the same staleness in the docs).

## Changes

| File | Change |
|---|---|
| `locales/en.json` | `… More=8)` → `… Settings=8)` |
| `locales/ko.json` | `… 더보기=8)` → `… 설정=8)` |
| `index.html` | shortcut row fallback text matched to en locale |
| `tests/test_web_mode.py` | refreshed stale `Timeline/More` → `Timeline/Settings` in the test docstring |

## Why it's safe

- Pure copy change — **no i18n keys added/removed** (en/ko parity intact).
- **No JS/CSS touched** → no `?v=` cache-bust bump needed (locale JSON is served no-store).
- Digit range (`1`–`8`) and the 8-tab count are unchanged; `test_shortcut_switch_tabs_copy_matches_tab_count` still holds (it requires "8", forbids "7" — does not depend on the word "More").

## Test

- `pytest test_web_mode.py test_i18n.py` → 127 passed
- `vitest run` (tests-js) → 384 passed (56 files)
- `ruff check` + `format --check` clean; both locales valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)
