### PR TITLE
docs(getting-started): first-time polish + ONNX-default example notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Hosted at **[memtomem.com](https://memtomem.com)** — also available as Markdow
 | Guide | Description |
 |-------|-------------|
 | [Getting Started](docs/guides/getting-started.md) | Install, setup wizard, first use |
+| [Example notebooks](examples/notebooks/) | Runnable Python-API walkthrough (start with `01_hello_memory.ipynb`, local ONNX — no server) |
 | [Reference](docs/guides/reference.md) | Complete feature reference for all tools and patterns |
 | [Configuration](docs/guides/configuration.md) | All `MEMTOMEM_*` environment variables |
 | [Embeddings](docs/guides/embeddings.md) | ONNX, Ollama, and OpenAI embedding providers |

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -2,6 +2,20 @@
 
 This guide takes you from zero to a working memtomem setup. You'll be able to index your notes and search them from your AI editor in under 5 minutes.
 
+> **Quickstart at a glance** — the whole flow in four commands; each step is
+> detailed below.
+>
+> ```bash
+> uv tool install 'memtomem[all]'    # 1. install (includes the mm CLI)
+> mm init                            # 2. configure (preset picker)
+> mm index ~/notes                   # 3. index your notes
+> mm search "deployment checklist"   # 4. search them
+> ```
+>
+> Don't want the CLI? `uvx` runs the server on demand — see
+> [Install → Option A](#option-a-from-pypi-recommended-for-most-users). New to
+> the ideas behind it? Start with [What is memtomem?](#what-is-memtomem).
+
 ---
 
 ## What is memtomem?
@@ -35,6 +49,10 @@ don't have to decide now.
 | **ONNX (local, no server)** | `uv tool install 'memtomem[onnx]'` | Semantic search without running a server. ~90 MB–2.3 GB model on first use. |
 | **Ollama (local server)** | Install [Ollama](https://ollama.com), then `ollama pull nomic-embed-text` (English) or `ollama pull bge-m3` (multilingual, ~2.3 GB). | Semantic search with full local control; best Korean/JP/CN quality with `bge-m3`. |
 | **OpenAI (cloud)** | OpenAI API key, set via `mm init` or `MEMTOMEM_EMBEDDING__API_KEY`. | No local model to manage; pay-per-call. |
+
+**Not sure?** For English-only notes, **ONNX** is the best default — local
+semantic search, no server to run, no API cost. The setup wizard's *English*
+preset picks it for you, and you can switch later by re-running `mm init`.
 
 > **Multilingual tip**: if you work with Korean, Japanese, or Chinese,
 > pick Ollama with `bge-m3` or OpenAI `text-embedding-3-small` — both
@@ -278,6 +296,10 @@ mm status
 
 ## First use
 
+> Prefer Python to an editor? The same index → search → add flow is a runnable
+> notebook: [`examples/notebooks/01_hello_memory.ipynb`](../../examples/notebooks/01_hello_memory.ipynb)
+> (local ONNX embeddings, no server needed).
+
 ### 1. Index your notes
 
 This one-shot command seeds the index with files already on disk. After
@@ -407,6 +429,35 @@ mm web                     # launch Web UI (http://127.0.0.1:8080)
 ---
 
 ## Troubleshooting
+
+### Indexed, but search returns nothing
+
+1. Confirm something was actually indexed — `mm status` should show a non-zero
+   chunk count. If it's `0`, your `memory_dirs` had no supported files (see the
+   next entry).
+2. Re-index explicitly against the folder your notes really live in:
+   `mm index ~/notes`.
+3. Broaden the query and drop filters — try a single common word before
+   narrowing with `--source-filter` / `--tag-filter` / `--namespace`.
+4. If you recently switched embedding models, the old vectors no longer match:
+   `mm embedding-reset --mode apply-current` then `mm index ~/notes`.
+
+### "Nothing gets indexed" — path outside your index roots
+
+`mm index PATH` only indexes files **within a configured index root** — your
+user-tier `indexing.memory_dirs` (what `mm init` sets up) or a project-tier
+`indexing.project_memory_dirs`. A path outside every root is a silent no-op:
+it logs `Path … resolves outside configured memory_dirs, skipping` and indexes
+nothing.
+
+1. Check the configured roots: `mm config show` (look for
+   `indexing.memory_dirs` and `indexing.project_memory_dirs`).
+2. To index a new folder, register it first — re-run `mm init` and set it at
+   the *Memory directory* step (or add it to `indexing.memory_dirs` in
+   `~/.memtomem/config.json`) — then `mm index ~/that-folder`.
+3. Make sure the folder has at least one supported file. Only these extensions
+   are indexed (`.md`, `.json`, `.yaml`, `.py`, `.js`, `.ts`, …) — a folder of
+   only `.pdf` or `.docx` files indexes nothing.
 
 ### "Ollama not found" or "not running"
 
@@ -575,6 +626,7 @@ rm -rf ~/.memtomem
 ## Next steps
 
 - [Reference](reference.md) — complete feature reference for all tools and patterns
+- [Example notebooks](../../examples/notebooks/) — runnable Python-API walkthrough; start with `01_hello_memory.ipynb` (local ONNX, no server needed)
 - [Configuration](configuration.md) — all `MEMTOMEM_*` environment variables
 - [Embeddings](embeddings.md) — ONNX, Ollama, OpenAI providers
 - [LLM Providers](llm-providers.md) — Ollama, OpenAI, and compatible endpoints

--- a/examples/notebooks/01_hello_memory.ipynb
+++ b/examples/notebooks/01_hello_memory.ipynb
@@ -26,18 +26,18 @@
    "source": [
     "## Prerequisites\n",
     "\n",
-    "- **memtomem** installed:\n",
+    "- **memtomem** with the ONNX extra — local dense embeddings, **no server to\n",
+    "  run**:\n",
     "  ```bash\n",
     "  # From PyPI\n",
-    "  uv pip install \"memtomem[ollama]\" jupyter ipykernel\n",
+    "  uv pip install \"memtomem[onnx]\" jupyter ipykernel\n",
     "  # Or from a source checkout\n",
-    "  uv pip install -e \"packages/memtomem[all]\" jupyter ipykernel\n",
+    "  uv pip install -e \"packages/memtomem[onnx]\" jupyter ipykernel\n",
     "  ```\n",
-    "- **Ollama** running locally with `nomic-embed-text` pulled:\n",
-    "  ```bash\n",
-    "  ollama serve\n",
-    "  ollama pull nomic-embed-text\n",
-    "  ```"
+    "\n",
+    "That's the whole setup — there is no embedding server to start. The first\n",
+    "search downloads the `bge-small-en-v1.5` model (~67 MB) into\n",
+    "`~/.memtomem/cache/fastembed/` and reuses it on every later run."
    ]
   },
   {
@@ -46,10 +46,10 @@
    "id": "08f5a16d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-11T02:09:13.489750Z",
-     "iopub.status.busy": "2026-04-11T02:09:13.489663Z",
-     "iopub.status.idle": "2026-04-11T02:09:13.555444Z",
-     "shell.execute_reply": "2026-04-11T02:09:13.555141Z"
+     "iopub.execute_input": "2026-06-27T03:32:51.148304Z",
+     "iopub.status.busy": "2026-06-27T03:32:51.148197Z",
+     "iopub.status.idle": "2026-06-27T03:32:51.328672Z",
+     "shell.execute_reply": "2026-06-27T03:32:51.328255Z"
     }
    },
    "outputs": [
@@ -57,27 +57,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Ollama is up.\n"
+      "ONNX embedding backend available.\n"
      ]
     }
    ],
    "source": [
-    "# Verify Ollama is reachable before doing anything else.\n",
-    "import httpx\n",
-    "\n",
+    "# Confirm the ONNX embedding backend is importable before doing anything else.\n",
+    "# fastembed runs the model locally in-process, so there is no server to check.\n",
     "try:\n",
-    "    r = httpx.get(\"http://localhost:11434/api/tags\", timeout=2)\n",
-    "    r.raise_for_status()\n",
-    "except Exception as e:\n",
+    "    import fastembed  # noqa: F401\n",
+    "except ModuleNotFoundError as e:\n",
     "    raise RuntimeError(\n",
-    "        \"Ollama is not reachable at http://localhost:11434.\\n\"\n",
-    "        \"Start it and pull the default embedding model:\\n\"\n",
-    "        \"  ollama serve\\n\"\n",
-    "        \"  ollama pull nomic-embed-text\\n\"\n",
-    "        \"then re-run this cell.\"\n",
+    "        \"fastembed is not installed. Install the ONNX extra and re-run this cell:\\n\"\n",
+    "        '  uv pip install \"memtomem[onnx]\" jupyter ipykernel'\n",
     "    ) from e\n",
     "\n",
-    "print(\"Ollama is up.\")"
+    "print(\"ONNX embedding backend available.\")"
    ]
   },
   {
@@ -93,17 +88,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "0ffbf8f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-11T02:09:13.556566Z",
-     "iopub.status.busy": "2026-04-11T02:09:13.556506Z",
-     "iopub.status.idle": "2026-04-11T02:09:14.096432Z",
-     "shell.execute_reply": "2026-04-11T02:09:14.096057Z"
+     "iopub.execute_input": "2026-06-27T03:32:51.329759Z",
+     "iopub.status.busy": "2026-06-27T03:32:51.329672Z",
+     "iopub.status.idle": "2026-06-27T03:32:51.896583Z",
+     "shell.execute_reply": "2026-06-27T03:32:51.896137Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "memtomem components ready. db=/tmp/tmp401a36hs/memory.db\n"
+     ]
+    }
+   ],
    "source": [
     "import json\n",
     "import os\n",
@@ -126,11 +129,13 @@
     "\n",
     "# 2. Override config via environment variables. Note the double underscore —\n",
     "#    pydantic-settings uses \"__\" as the nesting separator for section fields.\n",
+    "#    The ONNX provider runs locally via fastembed (no server); \"bge-small-en-v1.5\"\n",
+    "#    is the short alias for BAAI/bge-small-en-v1.5 (384-dim, ~67 MB).\n",
     "os.environ[\"MEMTOMEM_STORAGE__SQLITE_PATH\"] = str(db_path)\n",
     "os.environ[\"MEMTOMEM_INDEXING__MEMORY_DIRS\"] = json.dumps([str(notes_dir)])\n",
-    "os.environ[\"MEMTOMEM_EMBEDDING__PROVIDER\"] = \"ollama\"\n",
-    "os.environ[\"MEMTOMEM_EMBEDDING__MODEL\"] = \"nomic-embed-text\"\n",
-    "os.environ[\"MEMTOMEM_EMBEDDING__DIMENSION\"] = \"768\"\n",
+    "os.environ[\"MEMTOMEM_EMBEDDING__PROVIDER\"] = \"onnx\"\n",
+    "os.environ[\"MEMTOMEM_EMBEDDING__MODEL\"] = \"bge-small-en-v1.5\"\n",
+    "os.environ[\"MEMTOMEM_EMBEDDING__DIMENSION\"] = \"384\"\n",
     "\n",
     "# 3. Apply the same fields directly on the config object, and temporarily\n",
     "#    disable load_config_overrides() so the real ~/.memtomem/config.json\n",
@@ -170,21 +175,23 @@
    "id": "84f915ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-11T02:09:14.097698Z",
-     "iopub.status.busy": "2026-04-11T02:09:14.097582Z",
-     "iopub.status.idle": "2026-04-11T02:09:14.219368Z",
-     "shell.execute_reply": "2026-04-11T02:09:14.218914Z"
+     "iopub.execute_input": "2026-06-27T03:32:51.897720Z",
+     "iopub.status.busy": "2026-06-27T03:32:51.897635Z",
+     "iopub.status.idle": "2026-06-27T03:32:51.973592Z",
+     "shell.execute_reply": "2026-06-27T03:32:51.973233Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[04/11/26 11:09:14] </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> HTTP Request: <span style=\"color: #808000; text-decoration-color: #808000; font-weight: bold\">POST</span> <span style=\"color: #0000ff; text-decoration-color: #0000ff; text-decoration: underline\">http://localhost:11434/api/embed</span> <span style=\"color: #008000; text-decoration-color: #008000\">\"HTTP/1.1 200 OK\"</span>  <a href=\"file:///Users/pdstudio/.cache/uv/archive-v0/O4Y8eIGPPvWNha15A38Ys/lib/python3.13/site-packages/httpx/_client.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">_client.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/pdstudio/.cache/uv/archive-v0/O4Y8eIGPPvWNha15A38Ys/lib/python3.13/site-packages/httpx/_client.py#1740\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">1740</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[06/27/26 12:32:51] </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> Loading ONNX embedding model BAAI/bge-small-en-v1.<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">threads</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>,             <a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">onnx.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py#81\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">81</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         <span style=\"color: #808000; text-decoration-color: #808000\">cache_dir</span>=<span style=\"color: #800080; text-decoration-color: #800080\">/Users/you/.memtomem/cache/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">fastembed</span><span style=\"font-weight: bold\">)</span> …                      <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">          </span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m[04/11/26 11:09:14]\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m HTTP Request: \u001b[1;33mPOST\u001b[0m \u001b[4;94mhttp://localhost:11434/api/embed\u001b[0m \u001b[32m\"HTTP/1.1 200 OK\"\u001b[0m  \u001b]8;id=888149;file:///Users/pdstudio/.cache/uv/archive-v0/O4Y8eIGPPvWNha15A38Ys/lib/python3.13/site-packages/httpx/_client.py\u001b\\\u001b[2m_client.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=553115;file:///Users/pdstudio/.cache/uv/archive-v0/O4Y8eIGPPvWNha15A38Ys/lib/python3.13/site-packages/httpx/_client.py#1740\u001b\\\u001b[2m1740\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001b[2;36m[06/27/26 12:32:51]\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m Loading ONNX embedding model BAAI/bge-small-en-v1.\u001b[1;36m5\u001b[0m \u001b[1m(\u001b[0m\u001b[33mthreads\u001b[0m=\u001b[1;36m4\u001b[0m,             \u001b]8;id=263539;file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py\u001b\\\u001b[2monnx.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=876225;file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py#81\u001b\\\u001b[2m81\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m                    \u001b[0m         \u001b[33mcache_dir\u001b[0m=\u001b[35m/Users/you/.memtomem/cache/\u001b[0m\u001b[95mfastembed\u001b[0m\u001b[1m)\u001b[0m …                      \u001b[2m          \u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -194,47 +201,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "python-lists.md: indexed 1 chunks (total 1) in 74.3 ms\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> HTTP Request: <span style=\"color: #808000; text-decoration-color: #808000; font-weight: bold\">POST</span> <span style=\"color: #0000ff; text-decoration-color: #0000ff; text-decoration: underline\">http://localhost:11434/api/embed</span> <span style=\"color: #008000; text-decoration-color: #008000\">\"HTTP/1.1 200 OK\"</span>  <a href=\"file:///Users/pdstudio/.cache/uv/archive-v0/O4Y8eIGPPvWNha15A38Ys/lib/python3.13/site-packages/httpx/_client.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">_client.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/pdstudio/.cache/uv/archive-v0/O4Y8eIGPPvWNha15A38Ys/lib/python3.13/site-packages/httpx/_client.py#1740\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">1740</span></a>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m HTTP Request: \u001b[1;33mPOST\u001b[0m \u001b[4;94mhttp://localhost:11434/api/embed\u001b[0m \u001b[32m\"HTTP/1.1 200 OK\"\u001b[0m  \u001b]8;id=661650;file:///Users/pdstudio/.cache/uv/archive-v0/O4Y8eIGPPvWNha15A38Ys/lib/python3.13/site-packages/httpx/_client.py\u001b\\\u001b[2m_client.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=129301;file:///Users/pdstudio/.cache/uv/archive-v0/O4Y8eIGPPvWNha15A38Ys/lib/python3.13/site-packages/httpx/_client.py#1740\u001b\\\u001b[2m1740\u001b[0m\u001b]8;;\u001b\\\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "deployment.md: indexed 1 chunks (total 1) in 23.4 ms\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> HTTP Request: <span style=\"color: #808000; text-decoration-color: #808000; font-weight: bold\">POST</span> <span style=\"color: #0000ff; text-decoration-color: #0000ff; text-decoration: underline\">http://localhost:11434/api/embed</span> <span style=\"color: #008000; text-decoration-color: #008000\">\"HTTP/1.1 200 OK\"</span>  <a href=\"file:///Users/pdstudio/.cache/uv/archive-v0/O4Y8eIGPPvWNha15A38Ys/lib/python3.13/site-packages/httpx/_client.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">_client.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/pdstudio/.cache/uv/archive-v0/O4Y8eIGPPvWNha15A38Ys/lib/python3.13/site-packages/httpx/_client.py#1740\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">1740</span></a>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m HTTP Request: \u001b[1;33mPOST\u001b[0m \u001b[4;94mhttp://localhost:11434/api/embed\u001b[0m \u001b[32m\"HTTP/1.1 200 OK\"\u001b[0m  \u001b]8;id=45333;file:///Users/pdstudio/.cache/uv/archive-v0/O4Y8eIGPPvWNha15A38Ys/lib/python3.13/site-packages/httpx/_client.py\u001b\\\u001b[2m_client.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=465459;file:///Users/pdstudio/.cache/uv/archive-v0/O4Y8eIGPPvWNha15A38Ys/lib/python3.13/site-packages/httpx/_client.py#1740\u001b\\\u001b[2m1740\u001b[0m\u001b]8;;\u001b\\\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "docker-compose.md: indexed 1 chunks (total 1) in 21.2 ms\n"
+      "python-lists.md: indexed 1 chunks (total 1) in 63.0 ms\n",
+      "deployment.md: indexed 1 chunks (total 1) in 4.8 ms\n",
+      "docker-compose.md: indexed 1 chunks (total 1) in 5.1 ms\n"
      ]
     }
    ],
@@ -287,26 +256,13 @@
    "id": "b7b16d88",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-11T02:09:14.220497Z",
-     "iopub.status.busy": "2026-04-11T02:09:14.220406Z",
-     "iopub.status.idle": "2026-04-11T02:09:14.238179Z",
-     "shell.execute_reply": "2026-04-11T02:09:14.237738Z"
+     "iopub.execute_input": "2026-06-27T03:32:51.974678Z",
+     "iopub.status.busy": "2026-06-27T03:32:51.974610Z",
+     "iopub.status.idle": "2026-06-27T03:32:51.980526Z",
+     "shell.execute_reply": "2026-06-27T03:32:51.980168Z"
     }
    },
    "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> HTTP Request: <span style=\"color: #808000; text-decoration-color: #808000; font-weight: bold\">POST</span> <span style=\"color: #0000ff; text-decoration-color: #0000ff; text-decoration: underline\">http://localhost:11434/api/embed</span> <span style=\"color: #008000; text-decoration-color: #008000\">\"HTTP/1.1 200 OK\"</span>  <a href=\"file:///Users/pdstudio/.cache/uv/archive-v0/O4Y8eIGPPvWNha15A38Ys/lib/python3.13/site-packages/httpx/_client.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">_client.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/pdstudio/.cache/uv/archive-v0/O4Y8eIGPPvWNha15A38Ys/lib/python3.13/site-packages/httpx/_client.py#1740\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">1740</span></a>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m HTTP Request: \u001b[1;33mPOST\u001b[0m \u001b[4;94mhttp://localhost:11434/api/embed\u001b[0m \u001b[32m\"HTTP/1.1 200 OK\"\u001b[0m  \u001b]8;id=314617;file:///Users/pdstudio/.cache/uv/archive-v0/O4Y8eIGPPvWNha15A38Ys/lib/python3.13/site-packages/httpx/_client.py\u001b\\\u001b[2m_client.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=506283;file:///Users/pdstudio/.cache/uv/archive-v0/O4Y8eIGPPvWNha15A38Ys/lib/python3.13/site-packages/httpx/_client.py#1740\u001b\\\u001b[2m1740\u001b[0m\u001b]8;;\u001b\\\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -363,10 +319,10 @@
    "id": "08b3acbe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-11T02:09:14.239307Z",
-     "iopub.status.busy": "2026-04-11T02:09:14.239242Z",
-     "iopub.status.idle": "2026-04-11T02:09:14.241279Z",
-     "shell.execute_reply": "2026-04-11T02:09:14.240897Z"
+     "iopub.execute_input": "2026-06-27T03:32:51.981510Z",
+     "iopub.status.busy": "2026-06-27T03:32:51.981456Z",
+     "iopub.status.idle": "2026-06-27T03:32:51.983295Z",
+     "shell.execute_reply": "2026-06-27T03:32:51.983023Z"
     }
    },
    "outputs": [
@@ -374,10 +330,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "chunk id:         dee5c6db-5561-43bf-87e9-d32aca15e4e8\n",
+      "chunk id:         84964643-fc02-4417-9e1a-13f0cfeabd7b\n",
       "score (fused):    0.0328\n",
       "retriever source: fused\n",
-      "source file:      /private/var/folders/4n/mt3km5rs1bn_b0w_d6hvlmhc0000gn/T/tmp6f_wmf6_/notes/deployment.md\n",
+      "source file:      /tmp/tmp401a36hs/notes/deployment.md\n",
       "heading path:     ('# Deployment checklist',)\n",
       "tags:             ()\n",
       "namespace:        default\n",
@@ -418,8 +374,8 @@
     "| `search_pipeline.search(query)` | `mem_search(query=...)` |\n",
     "| `storage.*` mixin methods | `mem_do(action=..., params=...)` |\n",
     "\n",
-    "See [`docs/guides/hands-on-tutorial.md`](../../docs/guides/hands-on-tutorial.md)\n",
-    "for the MCP-client walkthrough."
+    "See [Getting Started → First use](../../docs/guides/getting-started.md#first-use)\n",
+    "for the same flow driven from your AI editor instead of Python."
    ]
   },
   {
@@ -432,17 +388,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "dfa99924",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-11T02:09:14.242319Z",
-     "iopub.status.busy": "2026-04-11T02:09:14.242260Z",
-     "iopub.status.idle": "2026-04-11T02:09:14.250840Z",
-     "shell.execute_reply": "2026-04-11T02:09:14.250559Z"
+     "iopub.execute_input": "2026-06-27T03:32:51.984269Z",
+     "iopub.status.busy": "2026-06-27T03:32:51.984214Z",
+     "iopub.status.idle": "2026-06-27T03:32:52.024254Z",
+     "shell.execute_reply": "2026-06-27T03:32:52.023940Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "clean.\n"
+     ]
+    }
+   ],
    "source": [
     "# Release connections and remove the temp directory.\n",
     "await close_components(comp)\n",
@@ -479,6 +443,734 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.2"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "0370b1d0360f4d4f898f814db890348c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "0a64480583b841fbaf357af2b9176780": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_d31c1d6a6ff349b886c1f7cb055fca18",
+       "placeholder": "​",
+       "style": "IPY_MODEL_d0573113d49f4e94ae97335d85d8be10",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 5/5 [00:05&lt;00:00,  3.19s/it]"
+      }
+     },
+     "0ffe97edb5d5488cbe13c3de78fb27a3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "169bb9cda36c4dc39b7dd5d8022f4ab5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_8213641b24cd44e38ae2f82797505fe7",
+        "IPY_MODEL_1e7d6f1eb9a94df3a389dd7e97010984",
+        "IPY_MODEL_0a64480583b841fbaf357af2b9176780"
+       ],
+       "layout": "IPY_MODEL_49e21fc03d604a90b315f1c4e9cfe4cc",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "1e7d6f1eb9a94df3a389dd7e97010984": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_8c621d2e1bde4d7db72de0e958722258",
+       "max": 5.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_ddc7a0e9781f4dd0a7988434bd1ea627",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 5.0
+      }
+     },
+     "4398d827d9b24c39ba213bd61532c86b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HBoxModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HBoxView",
+       "box_style": "",
+       "children": [
+        "IPY_MODEL_fa5497f1516746b899983e6228ddb60e",
+        "IPY_MODEL_f79185dd9d474121aa00a9e5ac6fde61",
+        "IPY_MODEL_62336f4d6acd4ea899f934fc200f346a"
+       ],
+       "layout": "IPY_MODEL_d0be5c00d2354bbdaacf5182b81d96fe",
+       "tabbable": null,
+       "tooltip": null
+      }
+     },
+     "49e21fc03d604a90b315f1c4e9cfe4cc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "61287636cbf14c678d1641c1efe34d76": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "62336f4d6acd4ea899f934fc200f346a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_ce23a38b5a2e4a03b4064c7518acd3a8",
+       "placeholder": "​",
+       "style": "IPY_MODEL_61287636cbf14c678d1641c1efe34d76",
+       "tabbable": null,
+       "tooltip": null,
+       "value": " 67.2M/? [00:05&lt;00:00, 13.1MB/s]"
+      }
+     },
+     "7be41424a4b3408890902ac649235ad7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "8213641b24cd44e38ae2f82797505fe7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_0370b1d0360f4d4f898f814db890348c",
+       "placeholder": "​",
+       "style": "IPY_MODEL_0ffe97edb5d5488cbe13c3de78fb27a3",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Fetching 5 files: 100%"
+      }
+     },
+     "86f9c999be6347138d463bfd6327c43f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": "20px"
+      }
+     },
+     "8c621d2e1bde4d7db72de0e958722258": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "96204ca8ce424cd493111b0b678954b5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "ce23a38b5a2e4a03b4064c7518acd3a8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "d0573113d49f4e94ae97335d85d8be10": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "d0be5c00d2354bbdaacf5182b81d96fe": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "d31c1d6a6ff349b886c1f7cb055fca18": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/base",
+       "_model_module_version": "2.0.0",
+       "_model_name": "LayoutModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "LayoutView",
+       "align_content": null,
+       "align_items": null,
+       "align_self": null,
+       "border_bottom": null,
+       "border_left": null,
+       "border_right": null,
+       "border_top": null,
+       "bottom": null,
+       "display": null,
+       "flex": null,
+       "flex_flow": null,
+       "grid_area": null,
+       "grid_auto_columns": null,
+       "grid_auto_flow": null,
+       "grid_auto_rows": null,
+       "grid_column": null,
+       "grid_gap": null,
+       "grid_row": null,
+       "grid_template_areas": null,
+       "grid_template_columns": null,
+       "grid_template_rows": null,
+       "height": null,
+       "justify_content": null,
+       "justify_items": null,
+       "left": null,
+       "margin": null,
+       "max_height": null,
+       "max_width": null,
+       "min_height": null,
+       "min_width": null,
+       "object_fit": null,
+       "object_position": null,
+       "order": null,
+       "overflow": null,
+       "padding": null,
+       "right": null,
+       "top": null,
+       "visibility": null,
+       "width": null
+      }
+     },
+     "ddc7a0e9781f4dd0a7988434bd1ea627": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "ProgressStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "bar_color": null,
+       "description_width": ""
+      }
+     },
+     "f6210e1ae07d4fdb842810aad3a6b73c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLStyleModel",
+      "state": {
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLStyleModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/base",
+       "_view_module_version": "2.0.0",
+       "_view_name": "StyleView",
+       "background": null,
+       "description_width": "",
+       "font_size": null,
+       "text_color": null
+      }
+     },
+     "f79185dd9d474121aa00a9e5ac6fde61": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "FloatProgressModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "ProgressView",
+       "bar_style": "success",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_86f9c999be6347138d463bfd6327c43f",
+       "max": 1.0,
+       "min": 0.0,
+       "orientation": "horizontal",
+       "style": "IPY_MODEL_96204ca8ce424cd493111b0b678954b5",
+       "tabbable": null,
+       "tooltip": null,
+       "value": 1.0
+      }
+     },
+     "fa5497f1516746b899983e6228ddb60e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "2.0.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "_dom_classes": [],
+       "_model_module": "@jupyter-widgets/controls",
+       "_model_module_version": "2.0.0",
+       "_model_name": "HTMLModel",
+       "_view_count": null,
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "2.0.0",
+       "_view_name": "HTMLView",
+       "description": "",
+       "description_allow_html": false,
+       "layout": "IPY_MODEL_7be41424a4b3408890902ac649235ad7",
+       "placeholder": "​",
+       "style": "IPY_MODEL_f6210e1ae07d4fdb842810aad3a6b73c",
+       "tabbable": null,
+       "tooltip": null,
+       "value": "Download complete: "
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -5,10 +5,13 @@ One quick-start notebook is kept here as a runnable demo of the Python API:
 - [`01_hello_memory.ipynb`](./01_hello_memory.ipynb) — install memtomem,
   index a folder, run a hybrid search, add a memory. ~5 minutes end-to-end.
 
+It runs against local ONNX embeddings — **no embedding server to start**; the
+model downloads once on first use.
+
 Run it with:
 
 ```bash
-uv pip install "memtomem[ollama]" jupyter ipykernel
+uv pip install "memtomem[onnx]" jupyter ipykernel
 uv run jupyter lab examples/notebooks/01_hello_memory.ipynb
 ```
 


### PR DESCRIPTION
## Why

The published quickstart surface (`README` → `getting-started.md` → example
notebook) had real friction for first-time users:

- `examples/notebooks/01_hello_memory.ipynb` hard-required a running **Ollama**
  server — its first cell raised if Ollama wasn't reachable, the heaviest
  possible prerequisite for someone who just installed memtomem. It also linked
  to `docs/guides/hands-on-tutorial.md`, which no longer exists in this repo
  (a broken link in published content).
- `README` and every guide had **zero** mentions of the example notebooks, so
  the one public notebook was undiscoverable.
- `getting-started.md` troubleshooting covered four cases but not the most
  common first-run dead ends.

## What

- **Notebook 01 → local ONNX, no server.** Switched to `provider=onnx`,
  `bge-small-en-v1.5` (384d, ~67 MB, downloads once); removed the Ollama-reachable
  check; refreshed cell outputs by re-executing with ONNX (no more Ollama HTTP
  log noise; local paths anonymized). Fixed the broken `hands-on-tutorial.md`
  link → `getting-started.md#first-use`.
- **getting-started.md (first-time polish):** a top *Quickstart at a glance*
  callout, an embedding-default recommendation (English → ONNX; multilingual →
  bge-m3 / OpenAI), two new troubleshooting entries — *"Indexed, but search
  returns nothing"* and *"Nothing gets indexed" — path outside your index
  roots* — and a pointer to the example notebooks.
- **Discoverability:** README docs table and `examples/notebooks/README.md` now
  surface the notebook; prereq switched from the `[ollama]` to the `[onnx]`
  extra.

## Verification

- Re-executed `01_hello_memory.ipynb` end-to-end with ONNX (no server) — all
  cells pass.
- Every command, flag, env var, and link verified against source (`mm search`
  filters, `mm index` index-root behavior via `all_index_roots()`, ONNX model
  alias/dimension, anchors).
- `test_docs_guards.py` (18) and `test_notebooks.py` (2) green; `ruff` clean.
- Codex review: **SHIP** (no blockers/majors).

> Follow-up (separate PR): promote example notebooks 02 & 03 from the private
> docs repo to public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
