### PR TITLE
docs(notebooks): promote example notebooks 02 (indexing & filters) and 03 (agent memory)

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -626,7 +626,7 @@ rm -rf ~/.memtomem
 ## Next steps
 
 - [Reference](reference.md) — complete feature reference for all tools and patterns
-- [Example notebooks](../../examples/notebooks/) — runnable Python-API walkthrough; start with `01_hello_memory.ipynb` (local ONNX, no server needed)
+- Example notebooks — runnable Python-API walkthroughs (local ONNX, no server): [Hello memory](../../examples/notebooks/01_hello_memory.ipynb), [Indexing & filters](../../examples/notebooks/02_index_and_filter.ipynb), [Agent memory patterns](../../examples/notebooks/03_agent_memory_patterns.ipynb)
 - [Configuration](configuration.md) — all `MEMTOMEM_*` environment variables
 - [Embeddings](embeddings.md) — ONNX, Ollama, OpenAI providers
 - [LLM Providers](llm-providers.md) — Ollama, OpenAI, and compatible endpoints

--- a/examples/notebooks/02_index_and_filter.ipynb
+++ b/examples/notebooks/02_index_and_filter.ipynb
@@ -1,0 +1,998 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b4aaad1f",
+   "metadata": {},
+   "source": [
+    "# 02 — Indexing and filters\n",
+    "\n",
+    "**Audience:** developers using memtomem as a Python library who want to index a\n",
+    "directory of notes and scope searches with source / tag / namespace filters.\n",
+    "\n",
+    "In this notebook you will:\n",
+    "\n",
+    "1. Index a small directory of markdown notes in one call.\n",
+    "2. Use `source_filter`, `tag_filter`, and `namespace` to scope searches.\n",
+    "3. Read the BM25-vs-dense retrieval mix from each hit's `source` field.\n",
+    "4. Switch to the `kiwipiepy` tokenizer so full-text search works on Korean\n",
+    "   content (final section).\n",
+    "\n",
+    "Like notebook 01, everything runs against a temp directory and against local\n",
+    "ONNX embeddings — there is no embedding server to start."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13e732a7",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "- **memtomem** with the ONNX extra (local dense embeddings, **no server**):\n",
+    "  ```bash\n",
+    "  # From PyPI\n",
+    "  uv pip install \"memtomem[onnx]\" jupyter ipykernel\n",
+    "  # Or from a source checkout\n",
+    "  uv pip install -e \"packages/memtomem[onnx]\" jupyter ipykernel\n",
+    "  ```\n",
+    "- For the Korean section at the end, also install the `korean` extra:\n",
+    "  `uv pip install \"memtomem[korean]\"`. If it is not installed the Korean\n",
+    "  cells raise `ImportError` with a clear message; you can safely stop there."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "63f1a894",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T04:23:38.392510Z",
+     "iopub.status.busy": "2026-06-27T04:23:38.392339Z",
+     "iopub.status.idle": "2026-06-27T04:23:38.574670Z",
+     "shell.execute_reply": "2026-06-27T04:23:38.574345Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ONNX embedding backend available.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Confirm the ONNX embedding backend is importable before doing anything else.\n",
+    "# fastembed runs the model locally in-process, so there is no server to check.\n",
+    "try:\n",
+    "    import fastembed  # noqa: F401\n",
+    "except ModuleNotFoundError as e:\n",
+    "    raise RuntimeError(\n",
+    "        \"fastembed is not installed. Install the ONNX extra and re-run this cell:\\n\"\n",
+    "        '  uv pip install \"memtomem[onnx]\" jupyter ipykernel'\n",
+    "    ) from e\n",
+    "\n",
+    "print(\"ONNX embedding backend available.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8724250b",
+   "metadata": {},
+   "source": [
+    "## Step 1 — Set up components"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ad48d771",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T04:23:38.575867Z",
+     "iopub.status.busy": "2026-06-27T04:23:38.575778Z",
+     "iopub.status.idle": "2026-06-27T04:23:39.133148Z",
+     "shell.execute_reply": "2026-06-27T04:23:39.132792Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "memtomem components ready. db=/tmp/tmp99xot0ne/memory.db\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from memtomem.config import Mem2MemConfig\n",
+    "from memtomem.server.component_factory import (\n",
+    "    Components,\n",
+    "    create_components,\n",
+    "    close_components,\n",
+    ")\n",
+    "\n",
+    "# 1. Create an isolated temp directory so nothing lands in ~/.memtomem.\n",
+    "tmp = tempfile.TemporaryDirectory()\n",
+    "tmp_path = Path(tmp.name)\n",
+    "db_path = tmp_path / \"memory.db\"\n",
+    "notes_dir = tmp_path / \"notes\"\n",
+    "notes_dir.mkdir()\n",
+    "\n",
+    "# 2. Override config via environment variables. Note the double underscore —\n",
+    "#    pydantic-settings uses \"__\" as the nesting separator for section fields.\n",
+    "#    The ONNX provider runs locally via fastembed (no server); \"bge-small-en-v1.5\"\n",
+    "#    is the short alias for BAAI/bge-small-en-v1.5 (384-dim, ~67 MB).\n",
+    "os.environ[\"MEMTOMEM_STORAGE__SQLITE_PATH\"] = str(db_path)\n",
+    "os.environ[\"MEMTOMEM_INDEXING__MEMORY_DIRS\"] = json.dumps([str(notes_dir)])\n",
+    "os.environ[\"MEMTOMEM_EMBEDDING__PROVIDER\"] = \"onnx\"\n",
+    "os.environ[\"MEMTOMEM_EMBEDDING__MODEL\"] = \"bge-small-en-v1.5\"\n",
+    "os.environ[\"MEMTOMEM_EMBEDDING__DIMENSION\"] = \"384\"\n",
+    "\n",
+    "# 3. Apply the same fields directly on the config object, and temporarily\n",
+    "#    disable load_config_overrides() so the real ~/.memtomem/config.json\n",
+    "#    cannot leak into this notebook. This mirrors the pattern used in\n",
+    "#    packages/memtomem/tests/conftest.py.\n",
+    "config = Mem2MemConfig()\n",
+    "config.storage.sqlite_path = db_path\n",
+    "config.indexing.memory_dirs = [notes_dir]\n",
+    "# enable_auto_ns is OFF by default; turn it on so indexing derives a\n",
+    "# namespace from each file's immediate parent folder (Step 6).\n",
+    "config.namespace.enable_auto_ns = True\n",
+    "\n",
+    "import memtomem.config as _cfg\n",
+    "\n",
+    "_orig_loader = _cfg.load_config_overrides\n",
+    "_cfg.load_config_overrides = lambda c: None\n",
+    "try:\n",
+    "    comp: Components = await create_components(config)\n",
+    "finally:\n",
+    "    _cfg.load_config_overrides = _orig_loader\n",
+    "\n",
+    "print(f\"memtomem components ready. db={db_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a82d6ab",
+   "metadata": {},
+   "source": [
+    "## Step 2 — Create a realistic notes layout\n",
+    "\n",
+    "We lay out a small project-style directory with a couple of subfolders. We\n",
+    "turned on `enable_auto_ns` in the setup cell (it is **off** by default); with\n",
+    "it enabled, indexing derives a namespace from each file's immediate parent\n",
+    "folder, so files under `notes/engineering/` land in namespace `engineering`\n",
+    "and files under `notes/ops/` land in `ops`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "eda838d9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T04:23:39.134292Z",
+     "iopub.status.busy": "2026-06-27T04:23:39.134215Z",
+     "iopub.status.idle": "2026-06-27T04:23:39.137011Z",
+     "shell.execute_reply": "2026-06-27T04:23:39.136673Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "notes/engineering/auth-design.md\n",
+      "notes/engineering/search-pipeline.md\n",
+      "notes/ops/deployment.md\n",
+      "notes/ops/oncall-runbook.md\n"
+     ]
+    }
+   ],
+   "source": [
+    "engineering = notes_dir / \"engineering\"\n",
+    "ops = notes_dir / \"ops\"\n",
+    "engineering.mkdir()\n",
+    "ops.mkdir()\n",
+    "\n",
+    "# Tags live in YAML frontmatter (`tags: [...]`) — that is what memtomem promotes\n",
+    "# to chunk metadata and what `tag_filter` matches against.\n",
+    "files = {\n",
+    "    engineering / \"auth-design.md\": \"\"\"---\n",
+    "tags: [auth, jwt, compliance]\n",
+    "---\n",
+    "# Auth service redesign\n",
+    "\n",
+    "We are replacing the cookie-based session middleware with signed JWTs.\n",
+    "Rationale: compliance flagged session storage in the previous design.\n",
+    "\"\"\",\n",
+    "    engineering / \"search-pipeline.md\": \"\"\"---\n",
+    "tags: [search, retrieval]\n",
+    "---\n",
+    "# Search pipeline notes\n",
+    "\n",
+    "Hybrid retrieval fuses BM25 with dense vectors using reciprocal rank\n",
+    "fusion. The cross-encoder reranker is an optional post-step.\n",
+    "\"\"\",\n",
+    "    ops / \"deployment.md\": \"\"\"---\n",
+    "tags: [deploy, ops]\n",
+    "---\n",
+    "# Deployment checklist\n",
+    "\n",
+    "Run database migrations in a dry-run first. Confirm rollbacks work.\n",
+    "Promote to production only after staging smoke tests pass.\n",
+    "\"\"\",\n",
+    "    ops / \"oncall-runbook.md\": \"\"\"---\n",
+    "tags: [ops, oncall]\n",
+    "---\n",
+    "# On-call runbook\n",
+    "\n",
+    "When latency alerts fire, open the Grafana request-path dashboard first.\n",
+    "If the error rate is > 1%, page the platform lead and start a rollback.\n",
+    "\"\"\",\n",
+    "}\n",
+    "\n",
+    "for path, content in files.items():\n",
+    "    path.write_text(content, encoding=\"utf-8\")\n",
+    "\n",
+    "print(\"\\n\".join(str(p.relative_to(tmp_path)) for p in sorted(files)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e92bb53",
+   "metadata": {},
+   "source": [
+    "## Step 3 — Bulk index with `index_path`\n",
+    "\n",
+    "`IndexEngine.index_path()` walks the directory, hashes each chunk, and only\n",
+    "re-embeds chunks whose content actually changed. The returned\n",
+    "`IndexingStats` lets you see how much work happened."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "61da8280",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T04:23:39.137854Z",
+     "iopub.status.busy": "2026-06-27T04:23:39.137810Z",
+     "iopub.status.idle": "2026-06-27T04:23:39.250390Z",
+     "shell.execute_reply": "2026-06-27T04:23:39.249985Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[06/27/26 13:23:39] </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> Loading ONNX embedding model BAAI/bge-small-en-v1.<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">threads</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>,             <a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">onnx.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py#81\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">81</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         <span style=\"color: #808000; text-decoration-color: #808000\">cache_dir</span>=<span style=\"color: #800080; text-decoration-color: #800080\">/Users/you/.memtomem/cache/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">fastembed</span><span style=\"font-weight: bold\">)</span> …                      <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">          </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m[06/27/26 13:23:39]\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m Loading ONNX embedding model BAAI/bge-small-en-v1.\u001b[1;36m5\u001b[0m \u001b[1m(\u001b[0m\u001b[33mthreads\u001b[0m=\u001b[1;36m4\u001b[0m,             \u001b]8;id=282101;file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py\u001b\\\u001b[2monnx.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=825516;file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py#81\u001b\\\u001b[2m81\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m                    \u001b[0m         \u001b[33mcache_dir\u001b[0m=\u001b[35m/Users/you/.memtomem/cache/\u001b[0m\u001b[95mfastembed\u001b[0m\u001b[1m)\u001b[0m …                      \u001b[2m          \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> Loading ONNX embedding model BAAI/bge-small-en-v1.<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">threads</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>,             <a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">onnx.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py#81\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">81</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         <span style=\"color: #808000; text-decoration-color: #808000\">cache_dir</span>=<span style=\"color: #800080; text-decoration-color: #800080\">/Users/you/.memtomem/cache/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">fastembed</span><span style=\"font-weight: bold\">)</span> …                      <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">          </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m Loading ONNX embedding model BAAI/bge-small-en-v1.\u001b[1;36m5\u001b[0m \u001b[1m(\u001b[0m\u001b[33mthreads\u001b[0m=\u001b[1;36m4\u001b[0m,             \u001b]8;id=492429;file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py\u001b\\\u001b[2monnx.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=585199;file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py#81\u001b\\\u001b[2m81\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m                    \u001b[0m         \u001b[33mcache_dir\u001b[0m=\u001b[35m/Users/you/.memtomem/cache/\u001b[0m\u001b[95mfastembed\u001b[0m\u001b[1m)\u001b[0m …                      \u001b[2m          \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total files:     4\n",
+      "total chunks:    4\n",
+      "indexed chunks:  4\n",
+      "skipped chunks:  0\n",
+      "deleted chunks:  0\n",
+      "duration:        110.5 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "stats = await comp.index_engine.index_path(notes_dir)\n",
+    "\n",
+    "print(f\"total files:     {stats.total_files}\")\n",
+    "print(f\"total chunks:    {stats.total_chunks}\")\n",
+    "print(f\"indexed chunks:  {stats.indexed_chunks}\")\n",
+    "print(f\"skipped chunks:  {stats.skipped_chunks}\")\n",
+    "print(f\"deleted chunks:  {stats.deleted_chunks}\")\n",
+    "print(f\"duration:        {stats.duration_ms:.1f} ms\")\n",
+    "if stats.errors:\n",
+    "    print(\"errors:\")\n",
+    "    for e in stats.errors:\n",
+    "        print(f\"  - {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae10c3c8",
+   "metadata": {},
+   "source": [
+    "## Step 4 — Filter by source path\n",
+    "\n",
+    "`source_filter` accepts either a substring or a glob (if it contains\n",
+    "`*`, `?`, or `[`). Pass a substring to pin a search to a subdirectory or\n",
+    "file name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c880ef20",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T04:23:39.251365Z",
+     "iopub.status.busy": "2026-06-27T04:23:39.251308Z",
+     "iopub.status.idle": "2026-06-27T04:23:39.259252Z",
+     "shell.execute_reply": "2026-06-27T04:23:39.258954Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== source_filter='ops/' ===\n",
+      "  [1] deployment.md  score=0.033  ns=ops\n",
+      "  [2] oncall-runbook.md  score=0.016  ns=ops\n",
+      "\n",
+      "=== source_filter='*.md' (glob) ===\n",
+      "  [1] deployment.md  score=0.033  ns=ops\n",
+      "  [2] oncall-runbook.md  score=0.016  ns=ops\n",
+      "  [3] search-pipeline.md  score=0.016  ns=engineering\n",
+      "  [4] auth-design.md  score=0.016  ns=engineering\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "def show(title, results):\n",
+    "    print(f\"=== {title} ===\")\n",
+    "    for r in results:\n",
+    "        name = Path(r.chunk.metadata.source_file).name\n",
+    "        print(f\"  [{r.rank}] {name}  score={r.score:.3f}  ns={r.chunk.metadata.namespace}\")\n",
+    "    if not results:\n",
+    "        print(\"  (no results)\")\n",
+    "    print()\n",
+    "\n",
+    "\n",
+    "results, _ = await comp.search_pipeline.search(\n",
+    "    query=\"checklist\",\n",
+    "    source_filter=\"ops/\",\n",
+    "    top_k=5,\n",
+    ")\n",
+    "show(\"source_filter='ops/'\", results)\n",
+    "\n",
+    "results, _ = await comp.search_pipeline.search(\n",
+    "    query=\"checklist\",\n",
+    "    source_filter=\"*.md\",\n",
+    "    top_k=5,\n",
+    ")\n",
+    "show(\"source_filter='*.md' (glob)\", results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tagstep_md",
+   "metadata": {},
+   "source": [
+    "## Step 5 — Filter by tag\n",
+    "\n",
+    "`tag_filter` scopes a search to chunks that carry a given tag. Tags come from\n",
+    "each note's YAML frontmatter (the `tags: [...]` block at the top of the file).\n",
+    "Pass a single tag, or a comma-separated string for several."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "tagstep_code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T04:23:39.260274Z",
+     "iopub.status.busy": "2026-06-27T04:23:39.260223Z",
+     "iopub.status.idle": "2026-06-27T04:23:39.267141Z",
+     "shell.execute_reply": "2026-06-27T04:23:39.266798Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== tag_filter='auth' ===\n",
+      "  [1] auth-design.md  score=0.033  ns=engineering\n",
+      "\n",
+      "=== tag_filter='ops' ===\n",
+      "  [1] deployment.md  score=0.033  ns=ops\n",
+      "  [2] oncall-runbook.md  score=0.033  ns=ops\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "results, _ = await comp.search_pipeline.search(\n",
+    "    query=\"design\",\n",
+    "    tag_filter=\"auth\",\n",
+    "    top_k=5,\n",
+    ")\n",
+    "show(\"tag_filter='auth'\", results)\n",
+    "\n",
+    "results, _ = await comp.search_pipeline.search(\n",
+    "    query=\"rollback\",\n",
+    "    tag_filter=\"ops\",\n",
+    "    top_k=5,\n",
+    ")\n",
+    "show(\"tag_filter='ops'\", results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d99fe74d",
+   "metadata": {},
+   "source": [
+    "## Step 6 — Filter by namespace\n",
+    "\n",
+    "Because we enabled `enable_auto_ns` in the setup cell, files under\n",
+    "`engineering/` landed in namespace `engineering` and files under `ops/` landed\n",
+    "in namespace `ops`. You can pass a single namespace string or a list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "44977fea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T04:23:39.268124Z",
+     "iopub.status.busy": "2026-06-27T04:23:39.268062Z",
+     "iopub.status.idle": "2026-06-27T04:23:39.274752Z",
+     "shell.execute_reply": "2026-06-27T04:23:39.274396Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== namespace='engineering' ===\n",
+      "  [1] auth-design.md  score=0.033  ns=engineering\n",
+      "  [2] search-pipeline.md  score=0.016  ns=engineering\n",
+      "\n",
+      "=== namespace=['ops', 'engineering'] ===\n",
+      "  [1] auth-design.md  score=0.033  ns=engineering\n",
+      "  [2] oncall-runbook.md  score=0.016  ns=ops\n",
+      "  [3] deployment.md  score=0.016  ns=ops\n",
+      "  [4] search-pipeline.md  score=0.016  ns=engineering\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "results, _ = await comp.search_pipeline.search(\n",
+    "    query=\"service design\",\n",
+    "    namespace=\"engineering\",\n",
+    "    top_k=5,\n",
+    ")\n",
+    "show(\"namespace='engineering'\", results)\n",
+    "\n",
+    "results, _ = await comp.search_pipeline.search(\n",
+    "    query=\"service design\",\n",
+    "    namespace=[\"ops\", \"engineering\"],\n",
+    "    top_k=5,\n",
+    ")\n",
+    "show(\"namespace=['ops', 'engineering']\", results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d79038d",
+   "metadata": {},
+   "source": [
+    "## Step 7 — See the BM25-vs-dense mix on each hit\n",
+    "\n",
+    "Every result carries a `source` field showing which retriever surfaced it:\n",
+    "`bm25` (keyword only), `dense` (vector only), or `fused` (both legs agreed and\n",
+    "RRF combined them). Reading it tells you *why* a hit landed where it did, and\n",
+    "`stats` reports how many candidates each leg produced.\n",
+    "\n",
+    "`rrf_weights=[bm25_weight, dense_weight]` biases the fusion toward one leg —\n",
+    "both retrievers always run; the weights only tilt the blend. memtomem caches\n",
+    "identical queries, so re-issuing the *same* query with different weights returns\n",
+    "the cached ranking; change the query (or the configured default weights) to make\n",
+    "a re-weighting take effect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5a246049",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T04:23:39.275648Z",
+     "iopub.status.busy": "2026-06-27T04:23:39.275600Z",
+     "iopub.status.idle": "2026-06-27T04:23:39.280294Z",
+     "shell.execute_reply": "2026-06-27T04:23:39.279960Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bm25 candidates:  2\n",
+      "dense candidates: 4\n",
+      "\n",
+      "  deployment.md             score=0.033 via=fused\n",
+      "  oncall-runbook.md         score=0.032 via=fused\n",
+      "  auth-design.md            score=0.016 via=dense\n",
+      "  search-pipeline.md        score=0.016 via=dense\n"
+     ]
+    }
+   ],
+   "source": [
+    "results, stats = await comp.search_pipeline.search(\n",
+    "    query=\"rollback after failed deploy\",\n",
+    "    top_k=5,\n",
+    ")\n",
+    "\n",
+    "print(f\"bm25 candidates:  {stats.bm25_candidates}\")\n",
+    "print(f\"dense candidates: {stats.dense_candidates}\\n\")\n",
+    "\n",
+    "for r in results:\n",
+    "    name = Path(r.chunk.metadata.source_file).name\n",
+    "    print(f\"  {name:25s} score={r.score:.3f} via={r.source}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d29cf61e",
+   "metadata": {},
+   "source": [
+    "## Non-English content: Korean with the `kiwipiepy` tokenizer\n",
+    "\n",
+    "memtomem's default FTS5 tokenizer is `unicode61`, which works well for most\n",
+    "whitespace-separated languages but is a poor fit for Korean. The `korean`\n",
+    "optional extra installs `kiwipiepy`, a morphological analyser that splits\n",
+    "Korean text into meaningful tokens before indexing.\n",
+    "\n",
+    "We will:\n",
+    "\n",
+    "1. Write two short Korean notes into a brand-new temp directory.\n",
+    "2. Index them with the default `unicode61` tokenizer and search for\n",
+    "   `롤아웃`.\n",
+    "3. Re-create components with `config.search.tokenizer = \"kiwipiepy\"` and\n",
+    "   re-run the same query.\n",
+    "\n",
+    "We compare how each tokenizer splits the text and confirm both configurations\n",
+    "work end-to-end. On this toy corpus the two converge; kiwipiepy's\n",
+    "morpheme-level splitting is what pays off on larger, more varied Korean\n",
+    "content."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df11bf96",
+   "metadata": {},
+   "source": [
+    "### What the tokenizers actually do\n",
+    "\n",
+    "Before we run a search, let's look directly at what each tokenizer\n",
+    "produces for the same Korean sentence. `memtomem.storage.fts_tokenizer`\n",
+    "exposes two helpers: `set_tokenizer(name)` and\n",
+    "`tokenize_for_fts(text, for_query=False)`. We can call them directly to\n",
+    "inspect the token stream that FTS5 will see."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "55a9727f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T04:23:39.281236Z",
+     "iopub.status.busy": "2026-06-27T04:23:39.281181Z",
+     "iopub.status.idle": "2026-06-27T04:23:40.019767Z",
+     "shell.execute_reply": "2026-06-27T04:23:40.019427Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "unicode61 (insert): 프로덕션 롤아웃을 시작하기 전에 스테이징에서 통합 테스트를 거친다\n",
+      "unicode61 (query):  롤아웃*\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> kiwipiepy tokenizer loaded successfully                            <a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/storage/fts_tokenizer.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">fts_tokenizer.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/storage/fts_tokenizer.py#51\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">51</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m kiwipiepy tokenizer loaded successfully                            \u001b]8;id=329599;file:///Users/you/memtomem/packages/memtomem/src/memtomem/storage/fts_tokenizer.py\u001b\\\u001b[2mfts_tokenizer.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=366010;file:///Users/you/memtomem/packages/memtomem/src/memtomem/storage/fts_tokenizer.py#51\u001b\\\u001b[2m51\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "kiwipiepy (insert): 프로덕션 롤 아웃 을 시작 하 기 전 에 스테이징 에서 통합 테스트 를 거치 ᆫ다\n",
+      "kiwipiepy (query):  롤* 아웃*\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    import kiwipiepy  # noqa: F401\n",
+    "except ImportError as e:\n",
+    "    raise ImportError(\n",
+    "        \"kiwipiepy is required for this Korean tokenizer comparison. Install with:\\n\"\n",
+    "        '  uv pip install \"memtomem[korean]\"'\n",
+    "    ) from e\n",
+    "\n",
+    "from memtomem.storage.fts_tokenizer import set_tokenizer, tokenize_for_fts\n",
+    "\n",
+    "sample = \"프로덕션 롤아웃을 시작하기 전에 스테이징에서 통합 테스트를 거친다\"\n",
+    "\n",
+    "set_tokenizer(\"unicode61\")\n",
+    "print(\"unicode61 (insert):\", tokenize_for_fts(sample))\n",
+    "print(\"unicode61 (query): \", tokenize_for_fts(\"롤아웃\", for_query=True))\n",
+    "print()\n",
+    "\n",
+    "set_tokenizer(\"kiwipiepy\")\n",
+    "print(\"kiwipiepy (insert):\", tokenize_for_fts(sample))\n",
+    "print(\"kiwipiepy (query): \", tokenize_for_fts(\"롤아웃\", for_query=True))\n",
+    "\n",
+    "# Reset to unicode61 so the rest of the notebook is not surprised.\n",
+    "set_tokenizer(\"unicode61\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96442031",
+   "metadata": {},
+   "source": [
+    "Notice the difference:\n",
+    "\n",
+    "- `unicode61` passes the text through unchanged on insert and appends a\n",
+    "  `*` to each whitespace-separated word at query time. The indexed token\n",
+    "  is `롤아웃을` (with the object particle `을` glued on) and the query\n",
+    "  becomes `롤아웃*`. Prefix matching saves the day here because `롤아웃`\n",
+    "  is a prefix of `롤아웃을`.\n",
+    "- `kiwipiepy` runs morphological analysis on both sides. On insert it\n",
+    "  breaks `롤아웃을` into the morphemes `롤` + `아웃` + `을`, and the query\n",
+    "  `롤아웃` becomes `롤* 아웃*`. Matching now happens morpheme-by-morpheme —\n",
+    "  the document carries the `롤` and `아웃` tokens the query asks for —\n",
+    "  instead of leaning on one coarse prefix over the particle-glued word.\n",
+    "\n",
+    "On toy content the two strategies often converge, but on larger corpora\n",
+    "`kiwipiepy`'s splits line up better with how Koreans actually search.\n",
+    "Let's run an actual hybrid search against each tokenizer to confirm that\n",
+    "both configurations work end-to-end."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "e4d5f434",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T04:23:40.020918Z",
+     "iopub.status.busy": "2026-06-27T04:23:40.020863Z",
+     "iopub.status.idle": "2026-06-27T04:23:40.060805Z",
+     "shell.execute_reply": "2026-06-27T04:23:40.060518Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "query: '롤아웃'\n",
+      "seeded notes: ['deploy.md', 'oncall.md']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Tear down the English-only components so we can start fresh with a\n",
+    "# different tokenizer. The tokenizer is applied during create_components()\n",
+    "# and the FTS5 index is rebuilt against a fresh database.\n",
+    "await close_components(comp)\n",
+    "\n",
+    "kr_tmp = tempfile.TemporaryDirectory()\n",
+    "kr_path = Path(kr_tmp.name)\n",
+    "kr_notes = kr_path / \"notes\"\n",
+    "kr_notes.mkdir()\n",
+    "\n",
+    "(kr_notes / \"deploy.md\").write_text(\n",
+    "    \"# 배포 준비 메모\\n\\n\"\n",
+    "    \"우리 팀은 프로덕션 롤아웃을 시작하기 전에 스테이징에서 통합 테스트를 거친다. \"\n",
+    "    \"각 서비스의 헬스체크가 성공해야만 다음 단계로 넘어간다.\\n\",\n",
+    "    encoding=\"utf-8\",\n",
+    ")\n",
+    "(kr_notes / \"oncall.md\").write_text(\n",
+    "    \"# 온콜 런북\\n\\n\"\n",
+    "    \"런북은 항상 최신 상태를 유지해야 한다. 지연 시간 경보가 울리면 Grafana \"\n",
+    "    \"대시보드부터 열고, 오류율이 1 퍼센트를 넘으면 플랫폼 리드를 호출한다.\\n\",\n",
+    "    encoding=\"utf-8\",\n",
+    ")\n",
+    "\n",
+    "query = \"롤아웃\"\n",
+    "print(f\"query: {query!r}\")\n",
+    "print(\"seeded notes:\", sorted(p.name for p in kr_notes.iterdir()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "cd737942",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T04:23:40.061872Z",
+     "iopub.status.busy": "2026-06-27T04:23:40.061808Z",
+     "iopub.status.idle": "2026-06-27T04:23:41.029681Z",
+     "shell.execute_reply": "2026-06-27T04:23:41.029259Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[06/27/26 13:23:40] </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> Loading ONNX embedding model BAAI/bge-small-en-v1.<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">threads</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>,             <a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">onnx.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py#81\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">81</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         <span style=\"color: #808000; text-decoration-color: #808000\">cache_dir</span>=<span style=\"color: #800080; text-decoration-color: #800080\">/Users/you/.memtomem/cache/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">fastembed</span><span style=\"font-weight: bold\">)</span> …                      <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">          </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m[06/27/26 13:23:40]\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m Loading ONNX embedding model BAAI/bge-small-en-v1.\u001b[1;36m5\u001b[0m \u001b[1m(\u001b[0m\u001b[33mthreads\u001b[0m=\u001b[1;36m4\u001b[0m,             \u001b]8;id=645458;file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py\u001b\\\u001b[2monnx.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=537109;file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py#81\u001b\\\u001b[2m81\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m                    \u001b[0m         \u001b[33mcache_dir\u001b[0m=\u001b[35m/Users/you/.memtomem/cache/\u001b[0m\u001b[95mfastembed\u001b[0m\u001b[1m)\u001b[0m …                      \u001b[2m          \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> Loading ONNX embedding model BAAI/bge-small-en-v1.<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">threads</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>,             <a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">onnx.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py#81\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">81</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         <span style=\"color: #808000; text-decoration-color: #808000\">cache_dir</span>=<span style=\"color: #800080; text-decoration-color: #800080\">/Users/you/.memtomem/cache/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">fastembed</span><span style=\"font-weight: bold\">)</span> …                      <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">          </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m Loading ONNX embedding model BAAI/bge-small-en-v1.\u001b[1;36m5\u001b[0m \u001b[1m(\u001b[0m\u001b[33mthreads\u001b[0m=\u001b[1;36m4\u001b[0m,             \u001b]8;id=6687;file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py\u001b\\\u001b[2monnx.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=658413;file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py#81\u001b\\\u001b[2m81\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m                    \u001b[0m         \u001b[33mcache_dir\u001b[0m=\u001b[35m/Users/you/.memtomem/cache/\u001b[0m\u001b[95mfastembed\u001b[0m\u001b[1m)\u001b[0m …                      \u001b[2m          \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- unicode61 — 2 hit(s) ---\n",
+      "  [1] deploy.md    score=0.033 — 우리 팀은 프로덕션 롤아웃을 시작하기 전에 스테이징에서 통합 테스트를 거친다. 각 서비스의 헬스체크가 성공해...\n",
+      "  [2] oncall.md    score=0.016 — 런북은 항상 최신 상태를 유지해야 한다. 지연 시간 경보가 울리면 Grafana 대시보드부터 열고, 오류율이...\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> Loading ONNX embedding model BAAI/bge-small-en-v1.<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">threads</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>,             <a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">onnx.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py#81\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">81</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         <span style=\"color: #808000; text-decoration-color: #808000\">cache_dir</span>=<span style=\"color: #800080; text-decoration-color: #800080\">/Users/you/.memtomem/cache/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">fastembed</span><span style=\"font-weight: bold\">)</span> …                      <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">          </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m Loading ONNX embedding model BAAI/bge-small-en-v1.\u001b[1;36m5\u001b[0m \u001b[1m(\u001b[0m\u001b[33mthreads\u001b[0m=\u001b[1;36m4\u001b[0m,             \u001b]8;id=111330;file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py\u001b\\\u001b[2monnx.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=434057;file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py#81\u001b\\\u001b[2m81\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m                    \u001b[0m         \u001b[33mcache_dir\u001b[0m=\u001b[35m/Users/you/.memtomem/cache/\u001b[0m\u001b[95mfastembed\u001b[0m\u001b[1m)\u001b[0m …                      \u001b[2m          \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> Loading ONNX embedding model BAAI/bge-small-en-v1.<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">threads</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>,             <a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">onnx.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py#81\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">81</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         <span style=\"color: #808000; text-decoration-color: #808000\">cache_dir</span>=<span style=\"color: #800080; text-decoration-color: #800080\">/Users/you/.memtomem/cache/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">fastembed</span><span style=\"font-weight: bold\">)</span> …                      <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">          </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m Loading ONNX embedding model BAAI/bge-small-en-v1.\u001b[1;36m5\u001b[0m \u001b[1m(\u001b[0m\u001b[33mthreads\u001b[0m=\u001b[1;36m4\u001b[0m,             \u001b]8;id=422958;file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py\u001b\\\u001b[2monnx.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=394563;file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py#81\u001b\\\u001b[2m81\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m                    \u001b[0m         \u001b[33mcache_dir\u001b[0m=\u001b[35m/Users/you/.memtomem/cache/\u001b[0m\u001b[95mfastembed\u001b[0m\u001b[1m)\u001b[0m …                      \u001b[2m          \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> kiwipiepy tokenizer loaded successfully                            <a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/storage/fts_tokenizer.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">fts_tokenizer.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/storage/fts_tokenizer.py#51\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">51</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m                   \u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m kiwipiepy tokenizer loaded successfully                            \u001b]8;id=6261;file:///Users/you/memtomem/packages/memtomem/src/memtomem/storage/fts_tokenizer.py\u001b\\\u001b[2mfts_tokenizer.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=291571;file:///Users/you/memtomem/packages/memtomem/src/memtomem/storage/fts_tokenizer.py#51\u001b\\\u001b[2m51\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- kiwipiepy — 2 hit(s) ---\n",
+      "  [1] deploy.md    score=0.033 — 우리 팀은 프로덕션 롤아웃을 시작하기 전에 스테이징에서 통합 테스트를 거친다. 각 서비스의 헬스체크가 성공해...\n",
+      "  [2] oncall.md    score=0.016 — 런북은 항상 최신 상태를 유지해야 한다. 지연 시간 경보가 울리면 Grafana 대시보드부터 열고, 오류율이...\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def search_with_tokenizer(tokenizer_name: str) -> None:\n",
+    "    \"\"\"Stand up a fresh Components instance with a specific tokenizer.\"\"\"\n",
+    "    db = kr_path / f\"{tokenizer_name}.db\"\n",
+    "    os.environ[\"MEMTOMEM_STORAGE__SQLITE_PATH\"] = str(db)\n",
+    "    os.environ[\"MEMTOMEM_INDEXING__MEMORY_DIRS\"] = json.dumps([str(kr_notes)])\n",
+    "    os.environ[\"MEMTOMEM_EMBEDDING__PROVIDER\"] = \"onnx\"\n",
+    "    os.environ[\"MEMTOMEM_EMBEDDING__MODEL\"] = \"bge-small-en-v1.5\"\n",
+    "    os.environ[\"MEMTOMEM_EMBEDDING__DIMENSION\"] = \"384\"\n",
+    "\n",
+    "    cfg = Mem2MemConfig()\n",
+    "    cfg.storage.sqlite_path = db\n",
+    "    cfg.indexing.memory_dirs = [kr_notes]\n",
+    "    cfg.search.tokenizer = tokenizer_name\n",
+    "\n",
+    "    _cfg.load_config_overrides = lambda c: None\n",
+    "    try:\n",
+    "        local = await create_components(cfg)\n",
+    "    finally:\n",
+    "        _cfg.load_config_overrides = _orig_loader\n",
+    "\n",
+    "    await local.index_engine.index_path(kr_notes)\n",
+    "    results, stats = await local.search_pipeline.search(query=query, top_k=5)\n",
+    "\n",
+    "    print(f\"--- {tokenizer_name} — {stats.final_total} hit(s) ---\")\n",
+    "    for r in results:\n",
+    "        name = Path(r.chunk.metadata.source_file).name\n",
+    "        snippet = r.chunk.content[:60].replace(\"\\n\", \" \")\n",
+    "        print(f\"  [{r.rank}] {name:12s} score={r.score:.3f} — {snippet}...\")\n",
+    "    if not results:\n",
+    "        print(\"  (no hits)\")\n",
+    "    print()\n",
+    "\n",
+    "    await close_components(local)\n",
+    "\n",
+    "\n",
+    "try:\n",
+    "    import kiwipiepy  # noqa: F401\n",
+    "except ImportError as e:\n",
+    "    raise ImportError(\n",
+    "        \"kiwipiepy is required for the Korean tokenizer. Install with:\\n\"\n",
+    "        '  uv pip install \"memtomem[korean]\"'\n",
+    "    ) from e\n",
+    "\n",
+    "await search_with_tokenizer(\"unicode61\")\n",
+    "await search_with_tokenizer(\"kiwipiepy\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b7e3470",
+   "metadata": {},
+   "source": [
+    "### Reading the comparison\n",
+    "\n",
+    "Both tokenizers return the same document here because the example is\n",
+    "small and unicode61's prefix wildcard compensates for its coarse\n",
+    "splitting. The takeaway is not that `kiwipiepy` wins in every case — it\n",
+    "is that `kiwipiepy` splits Korean into morphologically-correct tokens\n",
+    "before FTS5 sees them, which matters on larger corpora where vocabulary\n",
+    "is diverse and prefix matching gets noisy.\n",
+    "\n",
+    "If you want to use `kiwipiepy` in a real memtomem install, either set\n",
+    "`MEMTOMEM_SEARCH__TOKENIZER=kiwipiepy` or rerun `mm init` and pick the\n",
+    "Korean option from the wizard."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1ccc174",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "19d31181",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T04:23:41.030902Z",
+     "iopub.status.busy": "2026-06-27T04:23:41.030837Z",
+     "iopub.status.idle": "2026-06-27T04:23:41.033888Z",
+     "shell.execute_reply": "2026-06-27T04:23:41.033571Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "clean.\n"
+     ]
+    }
+   ],
+   "source": [
+    "kr_tmp.cleanup()\n",
+    "tmp.cleanup()\n",
+    "\n",
+    "for key in (\n",
+    "    \"MEMTOMEM_STORAGE__SQLITE_PATH\",\n",
+    "    \"MEMTOMEM_INDEXING__MEMORY_DIRS\",\n",
+    "    \"MEMTOMEM_EMBEDDING__PROVIDER\",\n",
+    "    \"MEMTOMEM_EMBEDDING__MODEL\",\n",
+    "    \"MEMTOMEM_EMBEDDING__DIMENSION\",\n",
+    "):\n",
+    "    os.environ.pop(key, None)\n",
+    "\n",
+    "print(\"clean.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/03_agent_memory_patterns.ipynb
+++ b/examples/notebooks/03_agent_memory_patterns.ipynb
@@ -1,0 +1,586 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "371446f6",
+   "metadata": {},
+   "source": [
+    "# 03 — Agent memory patterns: sessions, events, scratch\n",
+    "\n",
+    "**Audience:** developers building agent-style memory — sessions, events, and\n",
+    "working memory (scratch) — on the memtomem Python API.\n",
+    "\n",
+    "memtomem ships with first-class primitives for agent-style memory:\n",
+    "\n",
+    "- **Sessions** record the lifespan of an agent run. Each session can hold a\n",
+    "  sequence of events.\n",
+    "- **Events** are timestamped records of what the agent did (`search`,\n",
+    "  `decide`, `observe`, …).\n",
+    "- **Scratch (working memory)** is a key-value store that lives for the\n",
+    "  duration of a task, optionally scoped to a session and with a TTL.\n",
+    "\n",
+    "In this notebook we walk through one agent-style turn end-to-end, using the\n",
+    "storage mixins directly. Everything runs against a temp directory and local\n",
+    "ONNX embeddings — no server required."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17c55cbd",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "- **memtomem** with the ONNX extra — local embeddings, **no server**:\n",
+    "  ```bash\n",
+    "  # From PyPI\n",
+    "  uv pip install \"memtomem[onnx]\" jupyter ipykernel\n",
+    "  # Or from a source checkout\n",
+    "  uv pip install -e \"packages/memtomem[onnx]\" jupyter ipykernel\n",
+    "  ```\n",
+    "\n",
+    "This notebook is mostly DB-only (sessions, events, scratch); only the final\n",
+    "time-based recall step indexes a note, which uses the local ONNX model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "8d7400f8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T03:56:06.284483Z",
+     "iopub.status.busy": "2026-06-27T03:56:06.284330Z",
+     "iopub.status.idle": "2026-06-27T03:56:06.480101Z",
+     "shell.execute_reply": "2026-06-27T03:56:06.479750Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ONNX embedding backend available.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Confirm the ONNX embedding backend is importable before doing anything else.\n",
+    "# fastembed runs the model locally in-process, so there is no server to check.\n",
+    "try:\n",
+    "    import fastembed  # noqa: F401\n",
+    "except ModuleNotFoundError as e:\n",
+    "    raise RuntimeError(\n",
+    "        \"fastembed is not installed. Install the ONNX extra and re-run this cell:\\n\"\n",
+    "        '  uv pip install \"memtomem[onnx]\" jupyter ipykernel'\n",
+    "    ) from e\n",
+    "\n",
+    "print(\"ONNX embedding backend available.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9e2d61c",
+   "metadata": {},
+   "source": [
+    "## Step 1 — Set up components"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b513f408",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T03:56:06.481257Z",
+     "iopub.status.busy": "2026-06-27T03:56:06.481161Z",
+     "iopub.status.idle": "2026-06-27T03:56:07.047826Z",
+     "shell.execute_reply": "2026-06-27T03:56:07.047427Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "memtomem components ready. db=/tmp/tmpf9st9_2j/memory.db\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import os\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from memtomem.config import Mem2MemConfig\n",
+    "from memtomem.server.component_factory import (\n",
+    "    Components,\n",
+    "    create_components,\n",
+    "    close_components,\n",
+    ")\n",
+    "\n",
+    "# 1. Create an isolated temp directory so nothing lands in ~/.memtomem.\n",
+    "tmp = tempfile.TemporaryDirectory()\n",
+    "tmp_path = Path(tmp.name)\n",
+    "db_path = tmp_path / \"memory.db\"\n",
+    "notes_dir = tmp_path / \"notes\"\n",
+    "notes_dir.mkdir()\n",
+    "\n",
+    "# 2. Override config via environment variables. Note the double underscore —\n",
+    "#    pydantic-settings uses \"__\" as the nesting separator for section fields.\n",
+    "#    The ONNX provider runs locally via fastembed (no server); \"bge-small-en-v1.5\"\n",
+    "#    is the short alias for BAAI/bge-small-en-v1.5 (384-dim, ~67 MB).\n",
+    "os.environ[\"MEMTOMEM_STORAGE__SQLITE_PATH\"] = str(db_path)\n",
+    "os.environ[\"MEMTOMEM_INDEXING__MEMORY_DIRS\"] = json.dumps([str(notes_dir)])\n",
+    "os.environ[\"MEMTOMEM_EMBEDDING__PROVIDER\"] = \"onnx\"\n",
+    "os.environ[\"MEMTOMEM_EMBEDDING__MODEL\"] = \"bge-small-en-v1.5\"\n",
+    "os.environ[\"MEMTOMEM_EMBEDDING__DIMENSION\"] = \"384\"\n",
+    "\n",
+    "# 3. Apply the same fields directly on the config object, and temporarily\n",
+    "#    disable load_config_overrides() so the real ~/.memtomem/config.json\n",
+    "#    cannot leak into this notebook. This mirrors the pattern used in\n",
+    "#    packages/memtomem/tests/conftest.py.\n",
+    "config = Mem2MemConfig()\n",
+    "config.storage.sqlite_path = db_path\n",
+    "config.indexing.memory_dirs = [notes_dir]\n",
+    "\n",
+    "import memtomem.config as _cfg\n",
+    "\n",
+    "_orig_loader = _cfg.load_config_overrides\n",
+    "_cfg.load_config_overrides = lambda c: None\n",
+    "try:\n",
+    "    comp: Components = await create_components(config)\n",
+    "finally:\n",
+    "    _cfg.load_config_overrides = _orig_loader\n",
+    "\n",
+    "print(f\"memtomem components ready. db={db_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4620c8f9",
+   "metadata": {},
+   "source": [
+    "## Step 2 — Start a session\n",
+    "\n",
+    "Sessions need a UUID you supply yourself. The `agent_id` is a free-form\n",
+    "label for whichever agent is running, and `namespace` is a memtomem\n",
+    "namespace that lets you segment episodic memory by project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1828fe5d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T03:56:07.048974Z",
+     "iopub.status.busy": "2026-06-27T03:56:07.048891Z",
+     "iopub.status.idle": "2026-06-27T03:56:07.051071Z",
+     "shell.execute_reply": "2026-06-27T03:56:07.050656Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "session started: 4f44079c-ff9c-44a1-bd9c-9dfd8abb574e\n"
+     ]
+    }
+   ],
+   "source": [
+    "import uuid\n",
+    "from datetime import datetime, timezone\n",
+    "\n",
+    "session_id = str(uuid.uuid4())\n",
+    "\n",
+    "await comp.storage.create_session(\n",
+    "    session_id=session_id,\n",
+    "    agent_id=\"demo-agent\",\n",
+    "    namespace=\"research\",\n",
+    "    metadata={\"task\": \"investigate retrieval quality\"},\n",
+    ")\n",
+    "\n",
+    "print(f\"session started: {session_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0820224",
+   "metadata": {},
+   "source": [
+    "## Step 3 — Log events as the agent works\n",
+    "\n",
+    "Each call to `add_session_event()` appends a row to the session log. The\n",
+    "`event_type` is free-form; common values are `search`, `observe`, `decide`,\n",
+    "`tool_call`, `reflect`, `error`. The `chunk_ids` list lets you link an event\n",
+    "back to the retrieval result that justified it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "720b8478",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T03:56:07.051966Z",
+     "iopub.status.busy": "2026-06-27T03:56:07.051915Z",
+     "iopub.status.idle": "2026-06-27T03:56:07.053750Z",
+     "shell.execute_reply": "2026-06-27T03:56:07.053508Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "three events logged\n"
+     ]
+    }
+   ],
+   "source": [
+    "await comp.storage.add_session_event(\n",
+    "    session_id=session_id,\n",
+    "    event_type=\"search\",\n",
+    "    content=\"hybrid retrieval tuning\",\n",
+    ")\n",
+    "\n",
+    "await comp.storage.add_session_event(\n",
+    "    session_id=session_id,\n",
+    "    event_type=\"observe\",\n",
+    "    content=\"default rrf_k=60 works for short queries, suffers on long ones\",\n",
+    ")\n",
+    "\n",
+    "await comp.storage.add_session_event(\n",
+    "    session_id=session_id,\n",
+    "    event_type=\"decide\",\n",
+    "    content=\"try rrf_k=30 + rerank=True for queries > 16 tokens\",\n",
+    ")\n",
+    "\n",
+    "print(\"three events logged\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99de1bd5",
+   "metadata": {},
+   "source": [
+    "## Step 4 — Use scratch (working memory) for intermediate state\n",
+    "\n",
+    "Scratch entries are meant for short-lived, task-scoped values — things you\n",
+    "would normally put on an agent's blackboard or in a dict passed through\n",
+    "node state. Scoping an entry to `session_id` lets memtomem clean it up when\n",
+    "the session ends."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "230b2c34",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T03:56:07.054678Z",
+     "iopub.status.busy": "2026-06-27T03:56:07.054634Z",
+     "iopub.status.idle": "2026-06-27T03:56:07.056671Z",
+     "shell.execute_reply": "2026-06-27T03:56:07.056351Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "current_hypothesis: long queries benefit from lower rrf_k\n",
+      "scratch entries for this session: 2\n",
+      "  current_hypothesis   -> long queries benefit from lower rrf_k\n",
+      "  pending_todo         -> re-run tuning on the 200-query eval set\n"
+     ]
+    }
+   ],
+   "source": [
+    "await comp.storage.scratch_set(\n",
+    "    key=\"current_hypothesis\",\n",
+    "    value=\"long queries benefit from lower rrf_k\",\n",
+    "    session_id=session_id,\n",
+    ")\n",
+    "\n",
+    "await comp.storage.scratch_set(\n",
+    "    key=\"pending_todo\",\n",
+    "    value=\"re-run tuning on the 200-query eval set\",\n",
+    "    session_id=session_id,\n",
+    ")\n",
+    "\n",
+    "fetched = await comp.storage.scratch_get(\"current_hypothesis\")\n",
+    "print(\"current_hypothesis:\", fetched[\"value\"] if fetched else \"(missing)\")\n",
+    "\n",
+    "scratch_rows = await comp.storage.scratch_list(session_id=session_id)\n",
+    "print(f\"scratch entries for this session: {len(scratch_rows)}\")\n",
+    "for row in scratch_rows:\n",
+    "    print(f\"  {row['key']:20s} -> {row['value']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea4731ba",
+   "metadata": {},
+   "source": [
+    "## Step 5 — Replay the event log\n",
+    "\n",
+    "At any time you can ask memtomem for the full event stream of a session.\n",
+    "This is how you would rebuild an agent's trajectory or show a human\n",
+    "reviewer what happened."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "6bb04629",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T03:56:07.057524Z",
+     "iopub.status.busy": "2026-06-27T03:56:07.057474Z",
+     "iopub.status.idle": "2026-06-27T03:56:07.059187Z",
+     "shell.execute_reply": "2026-06-27T03:56:07.058890Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 event(s) in session 4f44079c…\n",
+      "  [search  ] hybrid retrieval tuning\n",
+      "  [observe ] default rrf_k=60 works for short queries, suffers on long ones\n",
+      "  [decide  ] try rrf_k=30 + rerank=True for queries > 16 tokens\n"
+     ]
+    }
+   ],
+   "source": [
+    "events = await comp.storage.get_session_events(session_id)\n",
+    "\n",
+    "print(f\"{len(events)} event(s) in session {session_id[:8]}…\")\n",
+    "for e in events:\n",
+    "    print(f\"  [{e['event_type']:8s}] {e['content']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11c0bb93",
+   "metadata": {},
+   "source": [
+    "## Step 6 — End the session\n",
+    "\n",
+    "`end_session()` records a summary plus arbitrary metadata (we tuck the\n",
+    "event type counts in there for bookkeeping). After the session ends the\n",
+    "scratch entries that were scoped to it can be dropped via\n",
+    "`scratch_cleanup(session_id=...)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d9be8048",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T03:56:07.060111Z",
+     "iopub.status.busy": "2026-06-27T03:56:07.060045Z",
+     "iopub.status.idle": "2026-06-27T03:56:07.062212Z",
+     "shell.execute_reply": "2026-06-27T03:56:07.061850Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "session closed, 2 scratch entries cleaned up\n",
+      "event counts: {'search': 1, 'observe': 1, 'decide': 1}\n"
+     ]
+    }
+   ],
+   "source": [
+    "event_counts: dict[str, int] = {}\n",
+    "for e in events:\n",
+    "    event_counts[e[\"event_type\"]] = event_counts.get(e[\"event_type\"], 0) + 1\n",
+    "\n",
+    "await comp.storage.end_session(\n",
+    "    session_id=session_id,\n",
+    "    summary=\"explored rrf_k tradeoff, planned eval re-run\",\n",
+    "    metadata={\"event_counts\": event_counts},\n",
+    ")\n",
+    "\n",
+    "dropped = await comp.storage.scratch_cleanup(session_id=session_id)\n",
+    "print(f\"session closed, {dropped} scratch entries cleaned up\")\n",
+    "print(\"event counts:\", event_counts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "48826f6b",
+   "metadata": {},
+   "source": [
+    "## Step 7 — Time-based recall\n",
+    "\n",
+    "`storage.recall_chunks()` is the building block behind the `mem_recall`\n",
+    "MCP tool. It returns chunks created inside a time window, with optional\n",
+    "source and namespace filters — no query embedding required. We will index\n",
+    "one note, then recall everything that was added in the last minute."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cd405641",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T03:56:07.063137Z",
+     "iopub.status.busy": "2026-06-27T03:56:07.063073Z",
+     "iopub.status.idle": "2026-06-27T03:56:07.128980Z",
+     "shell.execute_reply": "2026-06-27T03:56:07.128562Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[06/27/26 12:56:07] </span><span style=\"color: #000080; text-decoration-color: #000080\">INFO    </span> Loading ONNX embedding model BAAI/bge-small-en-v1.<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #808000; text-decoration-color: #808000\">threads</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>,             <a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">onnx.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py#81\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">81</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                    </span>         <span style=\"color: #808000; text-decoration-color: #808000\">cache_dir</span>=<span style=\"color: #800080; text-decoration-color: #800080\">/Users/you/.memtomem/cache/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">fastembed</span><span style=\"font-weight: bold\">)</span> …                      <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">          </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m[06/27/26 12:56:07]\u001b[0m\u001b[2;36m \u001b[0m\u001b[34mINFO    \u001b[0m Loading ONNX embedding model BAAI/bge-small-en-v1.\u001b[1;36m5\u001b[0m \u001b[1m(\u001b[0m\u001b[33mthreads\u001b[0m=\u001b[1;36m4\u001b[0m,             \u001b]8;id=910299;file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py\u001b\\\u001b[2monnx.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=192491;file:///Users/you/memtomem/packages/memtomem/src/memtomem/embedding/onnx.py#81\u001b\\\u001b[2m81\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m                    \u001b[0m         \u001b[33mcache_dir\u001b[0m=\u001b[35m/Users/you/.memtomem/cache/\u001b[0m\u001b[95mfastembed\u001b[0m\u001b[1m)\u001b[0m …                      \u001b[2m          \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 chunk(s) in the last minute:\n",
+      "  finding.md           # Retrieval finding\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Drop a fresh note so we have something to recall.\n",
+    "recall_note = notes_dir / \"finding.md\"\n",
+    "recall_note.write_text(\n",
+    "    \"# Retrieval finding\\n\\n\"\n",
+    "    \"Hybrid mode beats dense-only on short factual queries but loses on \"\n",
+    "    \"long narrative queries, probably because BM25 saturation dominates.\\n\",\n",
+    "    encoding=\"utf-8\",\n",
+    ")\n",
+    "await comp.index_engine.index_file(recall_note)\n",
+    "\n",
+    "from datetime import timedelta\n",
+    "\n",
+    "since = datetime.now(timezone.utc) - timedelta(minutes=1)\n",
+    "\n",
+    "recent = await comp.storage.recall_chunks(since=since, limit=10)\n",
+    "print(f\"{len(recent)} chunk(s) in the last minute:\")\n",
+    "for chunk in recent:\n",
+    "    name = Path(chunk.metadata.source_file).name\n",
+    "    head = \" / \".join(chunk.metadata.heading_hierarchy) or \"(no heading)\"\n",
+    "    print(f\"  {name:20s} {head}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd0300bd",
+   "metadata": {},
+   "source": [
+    "## Mapping to the MCP tool surface\n",
+    "\n",
+    "Most calls above have an MCP-tool equivalent. In `core` tool mode the session\n",
+    "and scratch tools live behind the `mem_do` meta-tool; time-based recall uses\n",
+    "the core `mem_recall` tool directly.\n",
+    "\n",
+    "| Python call | MCP equivalent |\n",
+    "|-------------|----------------|\n",
+    "| `storage.create_session(...)` | `mem_do(action=\"session_start\")` |\n",
+    "| `storage.end_session(...)` | `mem_do(action=\"session_end\")` |\n",
+    "| `storage.scratch_set(...)` | `mem_do(action=\"scratch_set\")` |\n",
+    "| `storage.scratch_get(...)` | `mem_do(action=\"scratch_get\")` |\n",
+    "| `storage.recall_chunks(...)` | `mem_recall(...)` |\n",
+    "\n",
+    "Per-event logging (`add_session_event`) and event replay (`get_session_events`)\n",
+    "are Python-API-only — there is no standalone MCP tool for them. An agent driving\n",
+    "memtomem over MCP records the session lifecycle with the tools above and gets\n",
+    "the event summary back from `mem_session_end`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f614f766",
+   "metadata": {},
+   "source": [
+    "## Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ed0e6c2e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-27T03:56:07.130102Z",
+     "iopub.status.busy": "2026-06-27T03:56:07.130037Z",
+     "iopub.status.idle": "2026-06-27T03:56:07.169779Z",
+     "shell.execute_reply": "2026-06-27T03:56:07.169458Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "clean.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Release connections and remove the temp directory.\n",
+    "await close_components(comp)\n",
+    "tmp.cleanup()\n",
+    "\n",
+    "# Clean up the environment variables we set.\n",
+    "for key in (\n",
+    "    \"MEMTOMEM_STORAGE__SQLITE_PATH\",\n",
+    "    \"MEMTOMEM_INDEXING__MEMORY_DIRS\",\n",
+    "    \"MEMTOMEM_EMBEDDING__PROVIDER\",\n",
+    "    \"MEMTOMEM_EMBEDDING__MODEL\",\n",
+    "    \"MEMTOMEM_EMBEDDING__DIMENSION\",\n",
+    "):\n",
+    "    os.environ.pop(key, None)\n",
+    "\n",
+    "print(\"clean.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -1,22 +1,27 @@
 # memtomem — example notebooks
 
-One quick-start notebook is kept here as a runnable demo of the Python API:
+Runnable Jupyter notebooks that walk through memtomem's Python API. Each is
+self-contained, runs against a throwaway temp directory, and never touches your
+real `~/.memtomem/`. They use local **ONNX** embeddings — there is no embedding
+server to start; the model downloads once on first use.
 
-- [`01_hello_memory.ipynb`](./01_hello_memory.ipynb) — install memtomem,
-  index a folder, run a hybrid search, add a memory. ~5 minutes end-to-end.
+| # | Notebook | What it covers | Time |
+|---|----------|----------------|------|
+| 01 | [`01_hello_memory.ipynb`](./01_hello_memory.ipynb) | Initialise components, add a few memories, run your first hybrid search. The minimum viable tour. | ~5 min |
+| 02 | [`02_index_and_filter.ipynb`](./02_index_and_filter.ipynb) | Bulk-index a directory; scope searches with `source` / `tag` / `namespace` filters; inspect BM25-vs-dense via `rrf_weights`; switch to the `kiwipiepy` tokenizer for Korean. | ~15 min |
+| 03 | [`03_agent_memory_patterns.ipynb`](./03_agent_memory_patterns.ipynb) | Agent-style memory: sessions, events, scratch (working memory), and time-based recall. | ~10 min |
 
-It runs against local ONNX embeddings — **no embedding server to start**; the
-model downloads once on first use.
-
-Run it with:
+## Setup
 
 ```bash
+# ONNX is enough for all three; add ',korean' for notebook 02's Korean section.
 uv pip install "memtomem[onnx]" jupyter ipykernel
-uv run jupyter lab examples/notebooks/01_hello_memory.ipynb
+uv run jupyter lab examples/notebooks/
 ```
 
-The other scenario notebooks (indexing & filters, agent memory patterns,
-search tuning, LangGraph integration, lifecycle, embedding providers, LLM
-features) live in the private `memtomem/memtomem-docs` repo under
-`memtomem/examples/notebooks/`. They were moved out of the public repo to
-keep the beginner surface small while still providing a working quick-start.
+Each notebook checks that its embedding backend is importable in the first cell
+and stops early with a clear message if a required extra is missing.
+
+More scenario notebooks (search tuning, LangGraph integration, lifecycle,
+embedding-provider comparison, LLM features) live in the private
+`memtomem/memtomem-docs` repo — the public set is kept small and beginner-first.


### PR DESCRIPTION
## Why

PR #1463 made the one public example notebook beginner-friendly. This promotes
two more scenario notebooks from the private `memtomem-docs` repo so the public
series actually teaches indexing/filtering and agent-memory patterns — while
keeping every claim accurate against the current code.

> Stacked on #1463 (base branch `docs/first-time-notebook-onnx-polish`). Review/merge that first.

## What

- **`02_index_and_filter.ipynb`** — bulk index a directory; scope with
  `source_filter`, **`tag_filter`** (now a real demo backed by YAML-frontmatter
  tags), and `namespace`; read the BM25-vs-dense mix from each hit's `source`;
  the `kiwipiepy` tokenizer for Korean.
- **`03_agent_memory_patterns.ipynb`** — sessions, events, scratch (working
  memory), and time-based recall, with an accurate MCP-tool mapping.
- Both: an **Audience** header, **local ONNX** embeddings (no server), and
  fully re-executed outputs.
- `examples/notebooks/README.md` now indexes 01/02/03; `getting-started.md`
  Next-steps links all three (PROMOTION-CRITERIA inbound-link rule).

## Accuracy fixes surfaced by re-running

Re-executing against current source caught several stale claims inherited from
the private copies — all fixed and Codex-verified:

- `enable_auto_ns` is **off** by default (notebook called it the default) → now
  enabled explicitly so the namespace section returns results.
- The notebook promised `tag_filter` but never used it → added real frontmatter
  tags + a working `tag_filter` step.
- `kiwipiepy` import guard now precedes the tokenizer demo → users without
  `[korean]` get a clear `ImportError` instead of mislabeled output.
- The `rrf_weights` "turn a retriever off" comparison was masked by query
  caching (and never disabled a retriever) → replaced with an honest
  `source`/`via` inspection of the BM25-vs-dense mix.
- 03's MCP mapping listed non-existent `mem_do` actions → now lists only real
  ones and flags event log/replay as Python-API-only.

## Verification

- Both notebooks re-executed end-to-end with ONNX (no server); outputs refreshed
  and home/temp paths anonymized.
- `test_notebooks.py` + `test_docs_guards.py` green.
- Every API call / action / tokenizer claim verified against source.
- Codex review: **SHIP**.

> Follow-up after merge: `git rm` the two notebooks from `memtomem-docs` and
> update its private index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
