### PR TITLE
fix(web): sync project_local tier-badge fallback to de-jargoned annotation

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -840,7 +840,7 @@ function _formatValidityDate(unix) {
 // quiet) and a token-literal span for ``project_shared`` /
 // ``project_local``. The three tokens are rendered verbatim (no
 // display aliases — pinned by the Tiered Context Gateway v2 contract).
-// ``isContextRow`` adds the ``(no runtime fan-out)`` annotation for
+// ``isContextRow`` adds the ``(not synced to runtimes)`` annotation for
 // project_local context artifacts (agents / skills / commands) per
 // ADR-0011 §3 — memory rows skip the annotation because project_local
 // memory still fans out via memory's own contract.
@@ -859,7 +859,7 @@ function _tierBadgeHtml(targetScope, { isContextRow = false } = {}) {
     // reach the DOM (CI Playwright caught exactly that race).
     const annotationKey = 'settings.ctx.tier_no_fanout_annotation';
     const translated = typeof t === 'function' ? t(annotationKey) : annotationKey;
-    const annotation = translated === annotationKey ? '(no runtime fan-out)' : translated;
+    const annotation = translated === annotationKey ? '(not synced to runtimes)' : translated;
     return `${badge}<span class="tier-fanout-annotation">${annotation}</span>`;
   }
   return badge;

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1730,7 +1730,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=6"></script>
-  <script src="/app.js?v=143"></script>
+  <script src="/app.js?v=144"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=14"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>


### PR DESCRIPTION
## Why

The `browser` (Playwright + Chromium) CI job is red on `main`:
`test_tier_badge_html_helper_renders_project_tier_tokens_verbatim` asserts the
project_local context badge carries the canonical `(not synced to runtimes)`
annotation, but the badge rendered the old jargon `(no runtime fan-out)`.

Root cause: `_tierBadgeHtml`'s cold-boot **fallback literal** in `app.js` was
left as `(no runtime fan-out)` when the i18n value
(`settings.ctx.tier_no_fanout_annotation`) was de-jargoned to
`(not synced to runtimes)` during the #1352 / #1368 fan-out-jargon cleanup. The
fallback is taken whenever the locale fetch hasn't resolved yet (the documented
cold-boot window), so users — and the Playwright test — saw the stale text.

`en.json` and `ko.json` were already de-jargoned; only the JS fallback drifted.

## What

- `app.js`: sync the EN-literal fallback (and its doc comment) from
  `(no runtime fan-out)` → `(not synced to runtimes)` so the badge shows the
  same text whether or not i18n has loaded.
- `index.html`: bump the `app.js` cache-bust `?v=143` → `?v=144`.

## Verification

- The previously-failing test now passes.
- Full `pytest packages/memtomem/tests/web -m browser` suite: **256 passed**
  (was 1 failed / 255 passed).
- i18n parity + web invariants: 92 passed; vitest: 384 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
