### PR TITLE
docs(guides): gloss search acronyms (BM25/dense/RRF) on first use

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -251,6 +251,10 @@ envelope shape.
 
 ## Search
 
+Search fuses two retrievers: **BM25** (keyword/lexical matching, via SQLite FTS5)
+and **dense** (semantic vector) search, combined with **RRF** (Reciprocal Rank
+Fusion). The variables below tune each retriever and the fusion.
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MEMTOMEM_SEARCH__DEFAULT_TOP_K` | `10` | Default number of search results |

--- a/docs/guides/context-gateway.md
+++ b/docs/guides/context-gateway.md
@@ -26,8 +26,8 @@ The CLI path (`mm context …`) works on any install. The Web UI path needs the
 uv tool install --reinstall 'memtomem[web]'   # or 'memtomem[all]'
 ```
 
-A BM25-only minimal install has the CLI but no `mm web`. Either path operates on
-the same Store, so you can mix them.
+A search-only minimal install (without the `web` extra) has the CLI but no
+`mm web`. Either path operates on the same Store, so you can mix them.
 
 ## The model — Store, Runtimes, Sync, Import
 

--- a/docs/guides/embeddings.md
+++ b/docs/guides/embeddings.md
@@ -1,6 +1,6 @@
 # Embedding Providers
 
-memtomem supports three embedding providers: **ONNX** (local, no server), **Ollama** (local server), and **OpenAI** (cloud). Embedding is optional — memtomem works with **BM25-only mode** (provider `none`, the default) for keyword search without any embedding setup. The provider, model, and vector dimension must always be set together — dimension is **not auto-detected**, and a mismatch will cause indexing errors.
+memtomem supports three embedding providers: **ONNX** (local, no server), **Ollama** (local server), and **OpenAI** (cloud). Embedding is optional — memtomem works with **BM25-only mode** (provider `none`, the default) for keyword search without any embedding setup. Embeddings add **dense** (semantic) search — finding notes by *meaning* rather than exact keywords — which memtomem fuses with BM25 keyword results into hybrid search. The provider, model, and vector dimension must always be set together — dimension is **not auto-detected**, and a mismatch will cause indexing errors.
 
 ## Supported Models
 

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -417,9 +417,11 @@ Agent:
 
 | Feature | Claude Code Built-in | memtomem |
 |---------|---------------------|---------|
-| Semantic search | None (full loading or filename-based) | BM25 + Dense + RRF hybrid search |
+| Semantic search | None (full loading or filename-based) | Hybrid search: keyword (BM25) + semantic (vector), fused with RRF |
 | Auto memory | MEMORY.md 200-line limit | Unlimited semantic search |
 | Hooks integration | Event emission only | Hooks + CLI for automation (SessionStart, UserPromptSubmit, PostToolUse, Stop) |
+
+*New to these terms? **BM25** is keyword search, **dense (vector)** is meaning-based search, and **RRF** (Reciprocal Rank Fusion) merges the two — see the [Reference glossary](../reference.md#glossary).*
 
 ---
 

--- a/docs/guides/integrations/claude-desktop.md
+++ b/docs/guides/integrations/claude-desktop.md
@@ -170,8 +170,11 @@ mem_search("Transformer attention mechanism")
 | Feature | Claude Desktop Built-in | memtomem |
 |---------|------------------------|---------|
 | Conversational AI | **Built-in** (Claude model) | None (complementary area) |
-| Hybrid search (BM25 + Dense) | None | BM25 + Dense + RRF fusion |
-| Markdown indexing | None | Heading-based semantic chunker |
+| Hybrid search | None | Keyword (BM25) + semantic (vector), fused with RRF |
+| Markdown indexing | None | Heading-aware chunking (splits Markdown at headings) |
+
+*New to these terms? **BM25** is keyword search, **dense (vector)** is meaning-based search, and **RRF** (Reciprocal Rank Fusion) merges the two — see the [Reference glossary](../reference.md#glossary).*
+
 ## Frequently Asked Questions
 
 **Q: Does this reduce Claude Desktop's own features?**

--- a/docs/guides/integrations/cursor.md
+++ b/docs/guides/integrations/cursor.md
@@ -175,8 +175,10 @@ Agent:
 
 | Feature | Cursor Built-in | memtomem |
 |---------|----------------|---------|
-| Hybrid search (BM25 + Dense) | None | BM25 + Dense + RRF fusion |
-| Markdown indexing | None | Heading-based semantic chunker |
+| Hybrid search | None | Keyword (BM25) + semantic (vector), fused with RRF |
+| Markdown indexing | None | Heading-aware chunking (splits Markdown at headings) |
+
+*New to these terms? **BM25** is keyword search, **dense (vector)** is meaning-based search, and **RRF** (Reciprocal Rank Fusion) merges the two — see the [Reference glossary](../reference.md#glossary).*
 
 ---
 


### PR DESCRIPTION
## What

Gloss the search/ML acronyms (**BM25**, **dense**, **RRF**, **FTS5**) on first use across the user-facing guides. These terms appear 50+ times with no plain-language explanation — the single most pervasive comprehension barrier in the guide set, especially for the integration docs whose audience isn't search/ML engineers.

## Changes

- **Integration comparison tables** (`claude-code.md`, `claude-desktop.md`, `cursor.md`) — standardized on one phrasing: *"keyword (BM25) + semantic (vector), fused with RRF"* and *"heading-aware chunking (splits Markdown at headings)"*, each followed by a one-line pointer to the existing `reference.md` glossary.
- **`configuration.md`** — the Search section now expands BM25 / FTS5 / dense / RRF once in a new intro sentence above the variable table.
- **`embeddings.md`** — glosses dense / semantic / hybrid inline in the intro.
- **`context-gateway.md`** — the prerequisite drops the bare "BM25-only" for the plainer *"search-only minimal install (without the `web` extra)"*.
- Incidental: adds the missing blank line before the Claude Desktop FAQ heading so the (now de-jargoned) comparison table renders correctly — it previously abutted the heading.

## Why this phrasing

Wording mirrors the repo `README` and the `reference.md` glossary, keeping the precise acronyms but leading with what they mean. No behavior or fact changes — terms only.

## Verification

- `pytest packages/memtomem/tests/test_docs_guards.py` — green (16 passed); the new `../reference.md#glossary` links resolve under the internal-link/anchor guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
