### PR TITLE
docs(guides): add on-page tables of contents to the long guides

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -12,6 +12,37 @@ export MEMTOMEM_EMBEDDING__API_KEY=sk-...
 
 For interactive setup, run `mm init` instead of editing env vars by hand.
 
+**On this page**
+
+- [Precedence and merge behaviour](#precedence-and-merge-behaviour)
+- [Storage](#storage)
+- [Embedding](#embedding)
+- [Reset Flow](#reset-flow)
+- [Search](#search)
+- [Query Expansion](#query-expansion)
+- [Context Window](#context-window)
+- [Indexing](#indexing)
+- [Rerank (Cross-Encoder)](#rerank-cross-encoder)
+- [Access Frequency Boost](#access-frequency-boost)
+- [Importance Boost](#importance-boost)
+- [Decay](#decay)
+- [MMR (Maximal Marginal Relevance)](#mmr-maximal-marginal-relevance)
+- [Namespace](#namespace)
+- [Policy](#policy)
+- [Webhook](#webhook)
+- [Consolidation Schedule](#consolidation-schedule)
+- [Health Watchdog](#health-watchdog)
+- [Scheduler](#scheduler)
+- [LLM](#llm)
+- [Session Summary](#session-summary)
+- [Session Trace](#session-trace)
+- [Tool Mode](#tool-mode)
+- [Web UI Mode](#web-ui-mode)
+- [Context Gateway](#context-gateway)
+- [Hooks](#hooks)
+- [Advanced / operator environment variables](#advanced--operator-environment-variables)
+- [Querying and Modifying at Runtime](#querying-and-modifying-at-runtime)
+
 ## Precedence and merge behaviour
 
 memtomem resolves each field from up to four sources at startup, in order

--- a/docs/guides/context-gateway.md
+++ b/docs/guides/context-gateway.md
@@ -17,6 +17,20 @@ links out to [`reference.md`](reference.md#cli-reference) for the full command m
 [`configuration.md#context-gateway`](configuration.md#context-gateway) for the
 environment variables; it does not re-document those here.
 
+**On this page**
+
+- [Prerequisites](#prerequisites)
+- [The model — Store, Runtimes, Sync, Import](#the-model--store-runtimes-sync-import)
+- [Where copies live — the "Stored in" tiers](#where-copies-live--the-stored-in-tiers)
+- [The wiki — a separate global library, not the Store](#the-wiki--a-separate-global-library-not-the-store)
+- [Walkthrough — get this project's skills into your AI tools](#walkthrough--get-this-projects-skills-into-your-ai-tools)
+- [Sync vs Import — reading the status](#sync-vs-import--reading-the-status)
+- [From the Web UI — what the tab shows](#from-the-web-ui--what-the-tab-shows)
+- [From the CLI — the core loop](#from-the-cli--the-core-loop)
+- [Other artifact types and projects](#other-artifact-types-and-projects)
+- [Privacy and git safety](#privacy-and-git-safety)
+- [See also](#see-also)
+
 ## Prerequisites
 
 The CLI path (`mm context …`) works on any install. The Web UI path needs the

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -4,6 +4,20 @@
 **Prerequisites**: memtomem installation complete ([Quick Start](../getting-started.md)), Claude Code installed
 **Estimated Time**: About 15 minutes
 
+**On this page**
+
+- [Overview](#overview)
+- [MCP Server Setup](#mcp-server-setup)
+- [Verify Connection](#verify-connection)
+- [First Indexing](#first-indexing)
+- [Hooks Automation Setup](#hooks-automation-setup)
+- [Tool Usage Guidelines (Add to CLAUDE.md)](#tool-usage-guidelines-add-to-claudemd)
+- [Usage Scenarios](#usage-scenarios)
+- [Built-in Memory vs memtomem Comparison](#built-in-memory-vs-memtomem-comparison)
+- [Frequently Asked Questions](#frequently-asked-questions)
+- [Cross-runtime agent context with mm context](#cross-runtime-agent-context-with-mm-context)
+- [Next Steps](#next-steps)
+
 ---
 
 ## Overview

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -18,6 +18,22 @@
 
 ---
 
+**Jump to your editor**
+
+- [1. Claude Code](#1-claude-code)
+- [2. Cursor](#2-cursor)
+- [3. Windsurf](#3-windsurf)
+- [4. Claude Desktop](#4-claude-desktop)
+- [5. Gemini CLI](#5-gemini-cli)
+- [6. Kimi CLI](#6-kimi-cli)
+- [7. Codex CLI](#7-codex-cli)
+- [8. Antigravity](#8-antigravity)
+- [9. Verifying Your Connection](#9-verifying-your-connection)
+- [10. Environment Variable Overrides](#10-environment-variable-overrides)
+- [11. Network transports (advanced)](#11-network-transports-advanced)
+- [Troubleshooting](#troubleshooting)
+- [Next Steps](#next-steps)
+
 ## 1. Claude Code
 
 ### Pick a scope

--- a/docs/guides/multi-device-sync.md
+++ b/docs/guides/multi-device-sync.md
@@ -14,6 +14,20 @@ This guide describes the layout, what to commit (and what never to commit),
 the workflow around restarting the runtime after a pull, and `mm sync-doctor`
 — the read-only validator that catches the common footguns.
 
+**On this page**
+
+- [Easy mode — copy/paste setup](#easy-mode--copypaste-setup)
+- [When this fits](#when-this-fits)
+- [The layout — namespace-aligned directory tree](#the-layout--namespace-aligned-directory-tree)
+- [What syncs, what does not](#what-syncs-what-does-not)
+- [Post-pull workflow](#post-pull-workflow)
+- [Conflict policy](#conflict-policy)
+- [Auto-memory (Claude Code)](#auto-memory-claude-code)
+- [Obsidian as editor on top of git transport](#obsidian-as-editor-on-top-of-git-transport)
+- [mm sync-doctor — read-only validator](#mm-sync-doctor--read-only-validator)
+- [Anti-patterns](#anti-patterns)
+- [Verification — first-time setup smoke](#verification--first-time-setup-smoke)
+
 ## Easy mode — copy/paste setup
 
 Start here if you only want your personal memtomem memories to follow you

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -5,6 +5,28 @@
 
 > **New to memtomem?** Start with [Getting Started](getting-started.md) first. This guide is a complete reference for all features.
 
+**On this page**
+
+- [Glossary](#glossary)
+- [How memtomem Works](#how-memtomem-works)
+- [MCP Tools at a Glance](#mcp-tools-at-a-glance)
+- [1. Indexing — mem_index](#1-indexing--mem_index)
+- [2. Search — mem_search, mem_recall](#2-search--mem_search-mem_recall)
+- [3. Memory CRUD — mem_add, mem_batch_add, mem_edit, mem_delete](#3-memory-crud--mem_add-mem_batch_add-mem_edit-mem_delete)
+- [4. Namespace — mem_ns_*](#4-namespace--mem_ns_)
+- [5. Maintenance — mem_dedup_*, mem_decay_*, mem_auto_tag](#5-maintenance--mem_dedup_-mem_decay_-mem_auto_tag)
+- [6. Data — mem_export, mem_import](#6-data--mem_export-mem_import)
+- [7. Config — mem_stats, mem_status, mem_config, mem_embedding_reset](#7-config--mem_stats-mem_status-mem_config-mem_embedding_reset)
+- [8. Memory Policies — mem_policy_add, mem_policy_list, mem_policy_run](#8-memory-policies--mem_policy_add-mem_policy_list-mem_policy_run)
+- [9. Scheduled jobs — mm schedule, schedule_*](#9-scheduled-jobs--mm-schedule-schedule_)
+- [Web UI](#web-ui)
+- [CLI Reference](#cli-reference)
+- [Moving artifacts between tiers and projects](#moving-artifacts-between-tiers-and-projects)
+- [Troubleshooting](#troubleshooting)
+- [STM: Proactive Memory Surfacing (Optional)](#stm-proactive-memory-surfacing-optional)
+- [Uninstalling memtomem](#uninstalling-memtomem)
+- [Next Steps](#next-steps)
+
 ---
 
 ## Glossary


### PR DESCRIPTION
## What

Add an on-page table of contents to the six long guides that had none, so readers can jump to a section instead of scroll-hunting:

| Doc | Lines | TOC framing |
|-----|------:|-------------|
| `reference.md` | 1546 | On this page |
| `configuration.md` | 923 | On this page |
| `mcp-clients.md` | 645 | **Jump to your editor** |
| `multi-device-sync.md` | 538 | On this page |
| `integrations/claude-code.md` | 464 | On this page |
| `context-gateway.md` | 266 | On this page |

## Approach

- Compact **H2-level** anchor list inserted right after each doc's intro. H2-only keeps the lists scannable (reference.md alone has 60+ H3s).
- **Pure additions** — 111 insertions, 0 deletions. No heading is renamed, so every existing cross-doc anchor still resolves.
- `reference.md`'s `1.`–`9.` section numbering is **kept as-is**. Renumbering was considered (the synthesis flagged the mixed numbered/unnumbered sections) but rejected: it would change those anchors and break the in-text "section N" cross-references for no navigation gain the TOC doesn't already provide.

## Verification

- Anchors generated to match `test_docs_guards.py`'s `_slug` rules (GitHub-style), then verified: `pytest packages/memtomem/tests/test_docs_guards.py` green (16 passed) — `TestInternalDocLinksResolve` confirms all new TOC anchors resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
