### PR TITLE
docs(guides): lead provider guides with the choice, not the setup

### DIFF
--- a/docs/guides/embeddings.md
+++ b/docs/guides/embeddings.md
@@ -2,6 +2,18 @@
 
 memtomem supports three embedding providers: **ONNX** (local, no server), **Ollama** (local server), and **OpenAI** (cloud). Embedding is optional — memtomem works with **BM25-only mode** (provider `none`, the default) for keyword search without any embedding setup. The provider, model, and vector dimension must always be set together — dimension is **not auto-detected**, and a mismatch will cause indexing errors.
 
+## Which provider should I choose?
+
+Embeddings are **opt-in** — out of the box memtomem runs keyword-only search with no model and no server. Pick a provider by what you need:
+
+- **Stay on the default (`none`)** — BM25 keyword search, no model download, no server. Works immediately; `mm init` recommends it for a first run.
+- **Want semantic ("by meaning") search?** → **ONNX** with `all-MiniLM-L6-v2`. Runs locally in-process, ~90 MB downloaded automatically on first use — the simplest on-ramp to dense search, and what `mm init` suggests once you opt into embeddings.
+- **Already run an Ollama server?** → **Ollama** with `nomic-embed-text`, to reuse that daemon instead of embedding in-process.
+- **Want cloud accuracy with no local compute?** → **OpenAI** with `text-embedding-3-small` (needs an API key; text is sent to OpenAI).
+- **Multilingual (Korean / Chinese / Japanese)?** → **`bge-m3`** on ONNX or Ollama (1024-dim; ~2.3 GB on ONNX).
+
+Switch any time with `mm init` (interactive) or `mm embedding-reset` (handles the dimension migration safely). Whichever you pick, set the provider, model, and dimension together — choose a row from the table below.
+
 ## Supported Models
 
 | Model | Provider | Dimension | Best for |

--- a/docs/guides/llm-providers.md
+++ b/docs/guides/llm-providers.md
@@ -12,6 +12,17 @@ export MEMTOMEM_LLM__PROVIDER=ollama
 # model defaults to gemma4:e2b, base_url to localhost:11434
 ```
 
+## What LLM Powers
+
+Enabling an LLM upgrades four features. Each degrades gracefully — if a call fails, the heuristic fallback (the "disabled" column) runs automatically:
+
+| Feature | LLM enabled | LLM disabled (default) |
+|---------|-------------|------------------------|
+| Query expansion (`strategy="llm"`) | LLM synonym generation | Disabled — original query used |
+| Entity extraction (`mem_entity_scan`) | LLM structured extraction | Regex + pattern matching |
+| Auto-tagging (`mem_auto_tag`) | LLM semantic tagging | Keyword frequency heuristic |
+| Consolidation (`auto_consolidate`) | LLM summary | Bullet-point extraction |
+
 ## Supported Providers
 
 ### Ollama (local, default)
@@ -112,17 +123,6 @@ Code, use `claude mcp add` instead of editing a file. See
   }
 }
 ```
-
-## What LLM Powers
-
-| Feature | LLM enabled | LLM disabled (default) |
-|---------|-------------|------------------------|
-| Query expansion (`strategy="llm"`) | LLM synonym generation | Disabled — original query used |
-| Entity extraction (`mem_entity_scan`) | LLM structured extraction | Regex + pattern matching |
-| Auto-tagging (`mem_auto_tag`) | LLM semantic tagging | Keyword frequency heuristic |
-| Consolidation (`auto_consolidate`) | LLM summary | Bullet-point extraction |
-
-All features gracefully degrade: if LLM is enabled but a call fails, the heuristic fallback runs automatically.
 
 ## Configuration Reference
 


### PR DESCRIPTION
## What

Make both provider guides **decision-first** — lead with "which one should I pick?" instead of setup mechanics. Part of the docs/guides user-friendliness campaign (sibling to #1469, #1470, #1471).

### `embeddings.md`
Added a short **"Which provider should I choose?"** section right after the intro. The guide already stated the default (provider `none`, BM25-only) but offered no provider-selection guidance — a newcomer couldn't tell ONNX from Ollama from OpenAI without reading the whole page. The new list maps need → provider:

- stay on `none` for keyword-only (the zero-setup default),
- ONNX `all-MiniLM-L6-v2` for local semantic search,
- Ollama to reuse an existing daemon,
- OpenAI for cloud accuracy,
- `bge-m3` for multilingual.

### `llm-providers.md`
Moved the **"What LLM Powers"** value table from second-to-last (after Quick Start + every provider section) to directly under Quick Start, so the reader sees what enabling an LLM actually buys before wading through setup. The standalone graceful-degradation sentence is folded into the table intro.

## Why

The campaign diagnosis flagged these as the two guides where the *decision* a reader needs to make is buried beneath setup detail. This is the lowest-risk fix: no new facts, just reordering and one new decision section.

## Verification

- All facts checked against source — **not** the doc:
  - default embedding provider `none`: `packages/memtomem/src/memtomem/config.py:44`
  - `mm init` recommends keyword-only first / ONNX for dense: `cli/init_cmd.py:410-411`
  - LLM defaults (`gemma4:e2b` / `gpt-4.1-mini` / `claude-haiku-4-5-20251001`): `llm/factory.py:15-17`
- `uv run pytest packages/memtomem/tests/test_docs_guards.py` → **16 passed**.
- No factual changes; the "What LLM Powers" table content is byte-identical to before, only relocated.

## Sibling-PR notes

Branched from `origin/main` (does not contain the open campaign PRs). No TOC conflict — #1470 did not add a TOC to either of these guides. #1469 de-jargoned search acronyms in `embeddings.md`; this PR only *adds* a section near the top and does not touch those lines, so the two should merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
