### PR TITLE
docs(claude-code): progressive disclosure for the hooks section

### DIFF
--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -161,19 +161,6 @@ mem_index(path="~/notes", recursive=True)
 You can automate memtomem using Claude Code's hooks system.
 Add the following to `~/.claude/settings.json`:
 
-> **Tier** (ADR-0010 §3; ADR-0016 §2 settings special-case): for
-> settings, the `hooks.target_scope` tier selects the **runtime fan-out
-> target** under `~/.claude/` or `<project>/.claude/`, not a canonical
-> residency — settings have one canonical file at
-> `<project>/.memtomem/settings.json` regardless of tier. The three
-> values: `user` (default) → `~/.claude/settings.json`; `project_shared`
-> → `<project>/.claude/settings.json` (committed); `project_local` →
-> `<project>/.claude/settings.local.json` (gitignored). CLI
-> per-invocation override: `mm context sync --include=settings
-> --scope=project_local`. In the Web Context Gateway, the Hooks panel
-> follows the selected tier (`target_scope`) just like Skills and
-> Subagents.
-
 ```json
 {
   "hooks": {
@@ -222,6 +209,24 @@ Add the following to `~/.claude/settings.json`:
 > milliseconds) it converts the unit for you — author the canonical value in
 > seconds.
 
+<details>
+<summary>Which settings file gets written? (hook tiers)</summary>
+
+> **Tier** (ADR-0010 §3; ADR-0016 §2 settings special-case): for
+> settings, the `hooks.target_scope` tier selects the **runtime fan-out
+> target** under `~/.claude/` or `<project>/.claude/`, not a canonical
+> residency — settings have one canonical file at
+> `<project>/.memtomem/settings.json` regardless of tier. The three
+> values: `user` (default) → `~/.claude/settings.json`; `project_shared`
+> → `<project>/.claude/settings.json` (committed); `project_local` →
+> `<project>/.claude/settings.local.json` (gitignored). CLI
+> per-invocation override: `mm context sync --include=settings
+> --scope=project_local`. In the Web Context Gateway, the Hooks panel
+> follows the selected tier (`target_scope`) just like Skills and
+> Subagents.
+
+</details>
+
 ### Hook Event Summary
 
 | Hook Event | Trigger Timing | memtomem Action |
@@ -230,19 +235,6 @@ Add the following to `~/.claude/settings.json`:
 | `UserPromptSubmit` | When a prompt is submitted | `mm search` → Automatically inject relevant memory into context |
 | `PostToolUse` (Write) | After new file creation | `mm index --debounce-window 5` → Record the file in the debounce queue and drain entries silent ≥5s; rapid consecutive writes restart the window so a burst is indexed once at the end |
 | `Stop` | When the agent stops | `mm index --flush; mm session end --auto` → Synchronously flush any pending debounced files, then close the session with a structured summary |
-
-### Automation Flow
-
-```
-Claude Code starts
-  → SessionStart hook → mm session start --idempotent (resume or open)
-  → User submits prompt (>20 chars)
-  → UserPromptSubmit hook → mem_search context injection
-  → Claude creates new files
-  → PostToolUse hook → mm index --debounce-window 5 (record + drain stale)
-  → Agent stops
-  → Stop hook → mm index --flush; mm session end --auto
-```
 
 ### Important Caveats
 
@@ -272,6 +264,9 @@ mm context settings-doctor               # exits 0 if clean, 1 if duplicates
 mm context settings-doctor --json        # structured output for scripting
 mm context settings-doctor --scope=project_local   # one-shot scope override
 ```
+
+<details>
+<summary>Fixing duplicates — migrate and copy hooks across tiers and projects</summary>
 
 The match is by canonical signature (event + matcher + command shape, with
 whitespace normalized) so a hand-edited variant of a memtomem-managed entry
@@ -319,6 +314,8 @@ Re-runs are idempotent no-ops; a same-matcher rule with different content
 at the destination is skipped with the colliding entry named (never
 duplicated). When several entries share `(event, matcher)`, disambiguate
 with `--hook-command <substring>`.
+
+</details>
 
 ---
 


### PR DESCRIPTION
## What

Apply **progressive disclosure + dedup** to the *Hooks Automation Setup* section of the Claude Code integration guide. Part of the docs/guides user-friendliness campaign (sibling to #1469, #1470, #1471, #1473).

The section described the same four-hook pipeline **three times** and then ran ~60 lines of tier-migration command reference inline, burying the copy-paste recipe:

- **Dropped the "Automation Flow" ASCII diagram.** It re-renders the *Hook Event Summary* table — same four events (`SessionStart`/`UserPromptSubmit`/`PostToolUse`/`Stop`), same actions, same lifecycle order. The only annotations it carried (the `>20 chars` guard, "resume or open") already appear in *Important Caveats* and the table's `SessionStart` row, so nothing unique is lost.
- **Moved the dense ADR "Tier" blockquote** out from *between* "Add the following…" and the JSON block into a collapsed `<details>` after the config, so the happy path reads instruction → copy-paste JSON.
- **Folded the `settings-migrate` / `settings-copy` command reference** into a `<details>`, keeping the detection entry point (`settings-doctor`) visible. Collapsed, not removed.

## Why

The campaign diagnosis flagged the hooks section (~170 lines) as the densest, most repetitive part of the integration guides. A first-time reader wants the minimal working config; the tier routing, lifecycle re-rendering, and cross-project migration tooling are power-user material that should be one click away, not inline.

## Verification

- `uv run pytest packages/memtomem/tests/test_docs_guards.py` → **16 passed**, including:
  - `TestPluginHooksDocsParity` — the `settings.json` JSON block and its command strings are **untouched** and still match the plugin's shipped `hooks.json`.
  - `TestInternalDocLinksResolve` — no broken anchors (the removed/relocated content is all H3-level; no inbound links point at it).
- The `## Hooks Automation Setup` H2 heading is unchanged, so #1470's on-page TOC anchor stays valid.
- The relocated "Tier" blockquote and the folded migrate/copy reference are **byte-identical** to before — only wrapped in `<details>`.

## Sibling-PR notes

Branched from `origin/main`. #1470 adds an H2-only TOC to this file — this PR changes only H3-level structure inside the hooks section, so the TOC is unaffected. #1469 touches the "Built-in Memory vs memtomem Comparison" table (far below the hooks section); no line overlap. Should merge cleanly in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
