### PR TITLE
fix(context): don't silently swap clean rows in `install --all --force`

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -2624,16 +2624,26 @@ def _run_install_all(
             click.secho(f"  ✗ {c.asset_type}/{c.name}: {exc}", fg="red")
             failures += 1
         else:
-            removed_note = (
-                f" ({len(pinned.files_removed)} leftover file(s) removed)"
-                if pinned.files_removed
-                else ""
-            )
-            click.secho(
-                f"  ✓ {c.asset_type}/{c.name}: installed at pin {c.pin_commit[:12]}{removed_note}",
-                fg="green",
-            )
-            successes += 1
+            if pinned.was_no_op:
+                # Clean row re-classified clean under --force: left untouched
+                # (no silent re-extraction). Counts as skipped, not installed.
+                click.secho(
+                    f"  - {c.asset_type}/{c.name}: already installed (clean, untouched)",
+                    fg="cyan",
+                )
+                skipped += 1
+            else:
+                removed_note = (
+                    f" ({len(pinned.files_removed)} leftover file(s) removed)"
+                    if pinned.files_removed
+                    else ""
+                )
+                click.secho(
+                    f"  ✓ {c.asset_type}/{c.name}: installed at pin "
+                    f"{c.pin_commit[:12]}{removed_note}",
+                    fg="green",
+                )
+                successes += 1
 
     parts: list[str] = []
     if successes:

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -122,6 +122,14 @@ class InstallResult:
     ``files_removed`` is populated only by the ``install --all --force``
     re-extraction path, which reconciles dest-only leftovers against the
     pinned commit's file set (#1247); a fresh install never removes.
+
+    ``was_no_op=True`` is set only by ``install --all``'s
+    :func:`_apply_pinned_install` when a ``--force`` row re-classifies CLEAN
+    AND its recorded digests differ from the pin's bytes (a clean install
+    taken off a dirty wiki working tree): the row is left untouched rather
+    than silently re-extracted, so nothing is written or removed
+    (``files_written=0``). It is reachable only under ``--force`` — without
+    it the caller skips clean rows before calling this helper.
     """
 
     asset_type: Literal["skills", "agents", "commands"]
@@ -131,6 +139,7 @@ class InstallResult:
     dest: Path
     files_written: int
     files_removed: tuple[Path, ...] = ()
+    was_no_op: bool = False
 
 
 @dataclass(frozen=True)
@@ -1130,9 +1139,17 @@ class ProjectInstallClassification:
     - ``"install"`` — dest is missing. Will extract bytes at the pinned
       commit and write the lockfile entry (``installed_at`` refreshes;
       ``wiki_commit`` stays at the pin).
-    - ``"skip"`` — dest exists and is clean. Default behavior is no-op;
-      ``--force`` re-extracts at the pin (no ``.bak`` since there's
-      nothing to preserve).
+    - ``"skip"`` — dest exists and is clean (matches its recorded
+      install). Default behavior is no-op. Under ``--force``,
+      :func:`_apply_pinned_install` re-extracts the pin ONLY when the
+      recorded digests equal the pin's bytes (a true no-op that also
+      reconciles stale dest-only leftovers, #1247); if they DIFFER — a
+      clean install taken off a dirty wiki working tree, whose bytes the
+      pin never described (ADR-0008 ``wiki_commit`` provenance
+      imprecision) — the row is left untouched (``was_no_op``) rather than
+      silently swapped to the pin's bytes with no ``.bak``. (A row that
+      goes dirty between classify and apply re-classifies ``refuse``/dirty,
+      not ``skip``, so its ``.bak`` is still taken — #1247 id 13.)
     - ``"refuse"`` — the restore can't be proven safe: dest exists with
       local edits, the entry's ``installed_at`` is unusable over an
       existing dest, or a live flat-layout sibling would be shadowed
@@ -1371,6 +1388,15 @@ def _apply_pinned_install(
       preserved, ``installed_at`` refreshed).
     - ``state="skip"`` + ``force=False``: caller skips; this helper
       shouldn't be reached (defense in depth — raises if it is).
+    - ``state="skip"`` + ``force=True``: re-classified below. If still
+      CLEAN and the recorded digests DIFFER from the pin's bytes (a clean
+      install taken off a dirty wiki working tree — ADR-0008 ``wiki_commit``
+      provenance imprecision), returns a no-op :class:`InstallResult`
+      (``was_no_op=True``) WITHOUT re-extracting, so the installed bytes
+      are not silently swapped for the pin's with no ``.bak``. If the
+      recorded digests EQUAL the pin's bytes, it falls through to a normal
+      re-extraction (a content no-op that still reconciles stale dest-only
+      leftovers, #1247).
     - ``state="refuse"`` + ``force=False``: raise
       :class:`StaleInstallError` (caller already aborted batch; defense
       in depth).
@@ -1383,7 +1409,8 @@ def _apply_pinned_install(
       row). With ``force`` the FRESH at-risk set (dirty subset, or
       EVERY current file when unprovable — mirroring ``_apply_update``)
       is ``shutil.copy2``'d to ``<file>.bak`` before extraction, so a
-      clean-at-classify row edited mid-prompt still gets its ``.bak``.
+      clean-at-classify row edited mid-prompt still gets its ``.bak``;
+      a row that re-classifies clean is the ``was_no_op`` case above.
     - A dirty flat-layout sibling is re-probed the same way (design-gate
       fold): one that APPEARED during the prompt refuses without
       ``force``; with ``force`` the flat file stays on disk (shadowed,
@@ -1436,6 +1463,45 @@ def _apply_pinned_install(
             f"installed_at) — local edits cannot be ruled out; pass --force to "
             f"overwrite (every current file gets a .bak sibling)"
         )
+
+    # Data-safety no-op (ADR-0008 wiki_commit provenance imprecision): a single
+    # install/update copies the wiki WORKING TREE but pins HEAD, so a clean
+    # install taken off a *dirty* wiki holds bytes the recorded pin never
+    # described. Such a row re-classifies CLEAN here (dest == its recorded
+    # digests), and --force would then re-extract the pin over it — SILENTLY
+    # swapping the installed bytes for the pin's, with no .bak (files_to_bak is
+    # empty on a clean row). `install --all` reproduces the RECORDED install, so
+    # leave that row untouched. The check is narrow on purpose: only when the
+    # recorded digests (== the clean dest) differ from the bytes the pin would
+    # extract. When they MATCH (the dest already equals the pin), fall through
+    # so --force's re-extraction can still reconcile away stale dest-only
+    # leftovers (#1247). A pre-digest entry has no comparable digests
+    # (``digests_from_entry`` → None) and keeps its legacy re-extract behavior;
+    # a VALID EMPTY map (``{}`` — a digest-bearing install that copied zero
+    # files) is honored, so a pin that would extract files over it counts as a
+    # divergence rather than a fall-through (``is not None``, not truthiness —
+    # Codex gate). (Reachable only under --force: without it the caller skips
+    # clean rows; a row edited mid-prompt re-classifies "dirty" here, not
+    # "clean", so the #1247 id 13 .bak guarantee is preserved.)
+    if report.reason == "clean":
+        recorded_digests = digests_from_entry(classification.lock_entry or {})
+        pin_digests = {
+            rel: hashlib.sha256(
+                wiki.read_asset_file_at_commit(pin, asset_type, name, rel)
+            ).hexdigest()
+            for rel in wiki.asset_files_at_commit(pin, asset_type, name)
+            if not is_copy_skipped_rel(rel)
+        }
+        if recorded_digests is not None and recorded_digests != pin_digests:
+            return InstallResult(
+                asset_type=cast('Literal["skills", "agents", "commands"]', asset_type),
+                name=name,
+                wiki_commit=pin,
+                installed_at=cast(str, (classification.lock_entry or {}).get("installed_at", "")),
+                dest=dest,
+                files_written=0,
+                was_no_op=True,
+            )
 
     # Flat-layout re-probe (#1247 id 13 design gate): a dirty flat sibling
     # that appeared during the prompt while dest is absent would be silently

--- a/packages/memtomem/tests/test_context_install_all.py
+++ b/packages/memtomem/tests/test_context_install_all.py
@@ -271,6 +271,90 @@ def test_yes_force_emits_destructive_warning(wiki_root: Path, tmp_path: Path, mo
     assert "destructive" in result.output.lower()
 
 
+def test_clean_install_off_dirty_wiki_survives_all_force(
+    wiki_root: Path, tmp_path: Path, monkeypatch
+) -> None:
+    """Regression: a clean row installed off a *dirty* wiki working tree must not
+    be silently swapped by ``install --all --force``.
+
+    A single install copies the wiki WORKING TREE but pins HEAD (ADR-0008's
+    accepted ``wiki_commit`` provenance imprecision), so a clean install taken
+    off a dirty wiki holds bytes the pin never described. ``--force`` used to
+    re-extract the pin over such a clean row with NO ``.bak`` — a silent
+    destructive swap. It must now leave the row untouched (the recorded digests
+    differ from the pin's bytes); ``--force`` re-extraction is reserved for
+    dirty/unprovable rows, which always get a ``.bak``.
+    """
+    _initialized_wiki(wiki_root)
+    # Commit v1, then edit the wiki WORKING TREE without committing: HEAD still
+    # points at the v1 commit, but the working tree now holds v2 (wiki dirty).
+    pin = _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v1\n"})
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"working-tree-v2\n")
+    # The single install copies the working tree (v2) yet pins HEAD (v1): the
+    # recorded digests describe bytes the pin's commit does not contain.
+    install_skill(tmp_path, "foo")
+    dest = tmp_path / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    assert dest.read_bytes() == b"working-tree-v2\n"
+    lock_doc = json.loads((tmp_path / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == pin
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["install", "--all", "--yes", "--force"])
+
+    assert result.exit_code == 0, result.output
+    # The installed bytes are preserved — NOT silently swapped to the pin's v1.
+    assert dest.read_bytes() == b"working-tree-v2\n"
+    # Nothing was overwritten, so no .bak was created.
+    assert not dest.with_suffix(dest.suffix + ".bak").exists()
+    # Reported as skipped (untouched), not installed.
+    assert "1 installed" not in result.output
+    assert "skipped" in result.output
+    # Pin invariance.
+    lock_doc = json.loads((tmp_path / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == pin
+
+
+def test_clean_empty_install_off_dirty_wiki_survives_all_force(
+    wiki_root: Path, tmp_path: Path, monkeypatch
+) -> None:
+    """A VALID EMPTY recorded digest map (``digests={}``) must be honored, not
+    treated as "no digests" (Codex gate).
+
+    If the wiki working tree has no copyable file at single-install time, the
+    install records ``digests={}`` (a valid empty map, not ``None``) while the
+    pin's commit still contains files. ``install --all --force`` must not fall
+    through and silently resurrect the pin's files over the recorded-empty dest
+    with no ``.bak``. The guard distinguishes ``{}`` (honor: divergence) from
+    ``None`` (pre-digest: legacy re-extract).
+    """
+    _initialized_wiki(wiki_root)
+    # The pinned commit contains SKILL.md...
+    _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"committed\n"})
+    # ...but the dirty working tree has no copyable file (only a skip-filtered
+    # ``.bak``), so the single install copies zero files and records digests={}.
+    asset = wiki_root / "skills" / "foo"
+    (asset / "SKILL.md").unlink()
+    (asset / "SKILL.md.bak").write_bytes(b"skipped\n")
+    install_skill(tmp_path, "foo")
+    dest = tmp_path / ".memtomem" / "skills" / "foo"
+    lock_doc = json.loads((tmp_path / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["files"] == []
+    assert lock_doc["skills"]["foo"]["digests"] == {}
+    assert not (dest / "SKILL.md").exists()
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["install", "--all", "--yes", "--force"])
+
+    assert result.exit_code == 0, result.output
+    # The pin's SKILL.md must NOT be silently resurrected over the empty dest.
+    assert not (dest / "SKILL.md").exists()
+    assert not (dest / "SKILL.md.bak").exists()
+    assert "1 installed" not in result.output
+    assert "skipped" in result.output
+
+
 # ── orphan / error paths ────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What

`mm context install --all --force` could silently overwrite a project's
installed asset bytes with the pinned commit's bytes — no `.bak`, no warning —
whenever the asset had been installed off a *dirty* wiki working tree.

## Why

A single `mm context install`/`update` copies the wiki **working tree** but
records `wiki_commit = HEAD` (ADR-0008:212-217 documents this as an accepted
`wiki_commit` provenance imprecision). So a clean install off a dirty wiki
holds bytes the recorded pin never described. `install --all --force` then:

1. re-classifies the row **clean** (dest matches its recorded digests),
2. takes no `.bak` (nothing dirty),
3. re-extracts the pinned commit's bytes over the dest.

→ the installed bytes are silently swapped for the committed-HEAD bytes, with
no backup. Every other `--force` path leaves a `.bak`; only this clean-row path
did not. It also reproduces for a teammate who clones the project + `lock.json`
and runs `install --all`, which undercuts ADR-0008's cross-machine
reproducibility intent.

## Fix (data-safety only)

In `_apply_pinned_install`, when a row re-classifies clean, compare its recorded
digests against the bytes the pin would extract:

- **differ** (clean install off a dirty wiki) → leave the row untouched
  (`was_no_op`); never silently swap.
- **match** (the dest already equals the pin) → fall through to the normal
  re-extraction, so `--force` still reconciles stale dest-only leftovers
  (#1247).
- a valid empty digest map (`{}`) is honored as a divergence; only a pre-digest
  entry (`None`) keeps the legacy re-extract behavior.

`InstallResult` gains `was_no_op` (mirrors `UpdateResult`); the CLI counts an
untouched clean row as *skipped*, not installed.

ADR-0008's working-tree-install behavior is intentionally **preserved** — making
install committed-only would be a separate, larger ADR change, deliberately out
of scope here.

## Tests

- `test_clean_install_off_dirty_wiki_survives_all_force` — install off a dirty
  wiki → `install --all --force` → installed bytes survive, no `.bak`, counted
  skipped. Verified RED before the fix (dest silently became the pinned bytes).
- `test_clean_empty_install_off_dirty_wiki_survives_all_force` — a valid empty
  recorded digest map (`{}`) is honored, not treated as "no digests". Verified
  RED before the guard fix.

`#1247`-adjacent behavior preserved: a row that goes dirty between classify and
apply still re-classifies dirty (not clean) and gets its `.bak`; the
`test_force_reextraction_removes_stale_dest_only_file` reconcile path still
runs when the dest equals the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
