### PR TITLE
docs(multi-device-sync): unify the synced-repo layout on ~/.memtomem/memories

### DIFF
--- a/docs/guides/multi-device-sync.md
+++ b/docs/guides/multi-device-sync.md
@@ -213,22 +213,39 @@ No explicit `namespace=` argument is required at ingest time.
 
 The fragment file itself is portable — `~/` expands at load time per the
 namespace-rules semantics. **However**, memtomem's loader only reads from
-`~/.memtomem/config.d/*.json`. Storing the fragment under your synced repo
-at e.g. `~/.memtomem-private/config.d/10-namespace-rules.json` does *not*
-make it active on the destination — the rules never apply unless the file
-appears at the canonical location. Two ways to bridge:
+`~/.memtomem/config.d/*.json`, and that directory sits *outside* your synced
+`~/.memtomem/memories` repo. So config.d is replicated **separately** from your
+memories: the rules never apply on another machine unless a copy of the fragment
+reaches that canonical location. Two ways to get it there:
 
-- **Symlink (recommended).** Edits flow back to the synced repo
+- **Copy (simplest).** Keep the fragment alongside your memories and copy it
+  into place on each machine. The policy rarely changes, so a one-time copy per
+  machine is usually enough:
+
+  ```bash
+  mkdir -p ~/.memtomem/config.d
+  cp ~/.memtomem/memories/config.d/10-namespace-rules.json \
+     ~/.memtomem/config.d/10-namespace-rules.json
+  ```
+
+- **Symlink (keeps it under git).** Store the fragment inside the memories repo
+  and symlink it into the canonical location, so edits flow back to git
   automatically:
 
   ```bash
   mkdir -p ~/.memtomem/config.d
-  ln -sf ~/.memtomem-private/config.d/10-namespace-rules.json \
+  ln -sf ~/.memtomem/memories/config.d/10-namespace-rules.json \
          ~/.memtomem/config.d/10-namespace-rules.json
   ```
 
-- **Copy.** Plain `cp` after each `git pull`. Simpler but drifts if you
-  edit the canonical copy without copying back.
+  Anything under `~/.memtomem/memories/` is indexed by default — including
+  `.json` — so the tracked copy would otherwise surface as a searchable
+  "memory". Exclude it with a fragment (see
+  [`exclude_patterns`](configuration.md#exclude-patterns)):
+
+  ```json
+  { "indexing": { "exclude_patterns": ["**/config.d/**"] } }
+  ```
 
 `mm sync-doctor` (below) flags a missing bridge.
 
@@ -238,9 +255,12 @@ appears at the canonical location. Two ways to bridge:
 
 - `~/.memtomem/memories/{shared,personal,work}/**/*.md` — content. Pure
   markdown, no embedded machine state.
-- `~/.memtomem/config.d/*.json` — *selected* fragments only. Pure-policy
-  fragments (namespace rules, rerank settings, default `top_k`) are
-  portable. Avoid fragments that embed local paths.
+- `~/.memtomem/config.d/*.json` — *selected* fragments only, **replicated
+  separately** from the memories repo (config.d lives outside
+  `~/.memtomem/memories`; see
+  [The layout](#the-layout--namespace-aligned-directory-tree)). Pure-policy
+  fragments (namespace rules, rerank settings, default `top_k`) are portable.
+  Avoid fragments that embed local paths.
 
 **Never sync** — your private repo's `.gitignore`:
 
@@ -303,7 +323,7 @@ Recommended sequence:
 # 1. Quiesce the runtime (Ctrl+C the foreground mm web; or end the MCP
 #    client session; or mm upgrade if you want a forced bounce).
 # 2. Pull.
-cd ~/.memtomem-private && git pull --rebase
+cd ~/.memtomem/memories && git pull --rebase
 # 3. Restart the runtime (mm web; or relaunch the MCP client).
 ```
 
@@ -382,7 +402,7 @@ from git's and would invalidate the layout / anti-patterns above.
 Two arrangements work, depending on whether you want the vault root to *be*
 the synced repo or to *contain* it:
 
-- **(a) Vault root = synced repo root.** Open `~/.memtomem-private/` itself
+- **(a) Vault root = synced repo root.** Open `~/.memtomem/memories/` itself
   as the vault. The namespace tree (`shared/`, `personal/`, `work/`,
   `local/`) becomes the vault's top-level folders, and the existing
   `path_glob` rules from [The layout](#the-layout--namespace-aligned-directory-tree)
@@ -475,7 +495,7 @@ checks and exits non-zero on any failure (warnings don't fail the exit
 code):
 
 ```text
-$ cd ~/.memtomem-private && mm sync-doctor
+$ cd ~/.memtomem/memories && mm sync-doctor
 ✓ no *.db files staged
 ✓ config.json absent from worktree
 ✓ config.d/ fragments present (3 files)
@@ -533,11 +553,11 @@ corruption or identity leaks:
 
 End-to-end smoke when you set up sync for the first time:
 
-1. **Single-machine round-trip.** Init the private repo, copy
-   `~/.memtomem/memories/shared/` in, write
-   `config.d/10-namespace-rules.json`, `git add -A && git status` — confirm
-   zero `*.db`, `cache/`, `config.json` staged. Run `mm sync-doctor` —
-   all checks pass.
+1. **Single-machine round-trip.** Init the `~/.memtomem/memories` repo, copy
+   your `shared/` tree in, bridge `~/.memtomem/config.d/10-namespace-rules.json`
+   into place (copy or symlink, above), `git add -A && git status` — confirm
+   zero `*.db`, `cache/`, `config.json` staged. Run `mm sync-doctor` — all
+   checks pass.
 2. **Bidirectional.** `mem_add` on machine A → commit/push → pull on
    machine B → run `mm index` (or rely on `startup_backfill`) → search
    the new note. Reverse direction. Both should return the new content.


### PR DESCRIPTION
## What

`docs/guides/multi-device-sync.md` described the git-synced repo three
incompatible ways, so the copy/paste steps contradicted each other:

- **Canonical** `~/.memtomem/memories` — Easy mode, the layout tree, namespace
  globs, "What syncs" (~18 references).
- **Undefined** `~/.memtomem-private/` — post-pull, Obsidian vault, sync-doctor
  (5 references); the path is first used as an "e.g." and never introduced.
- **A third hint** that the repo root is `~/.memtomem/` itself — "What syncs"
  lists `~/.memtomem/config.d/*.json`, which lives *outside* the `memories/` tree.

A reader who followed **Easy mode** ended up at `~/.memtomem/memories`, then
every later `cd ~/.memtomem-private` command (`git pull`, Obsidian, `mm
sync-doctor`) failed as written.

## Decision — unify on `~/.memtomem/memories`

This is the layout-model decision the issue flagged. Verified against source
that all artifacts are children of `~/.memtomem/`:

- `config.py:121` `sqlite_path = ~/.memtomem/memtomem.db` · `:190` memory default
  `~/.memtomem/memories` · `:1133` `config.json` · `:1217` `config.d` — so
  `config.d/` is a **sibling** of `memories/`, not inside it.
- `sync_doctor_cmd.py:342-352` runs on the cwd git root but reads `config.d`
  from the hardcoded canonical path; the `*.db`/`config.json` checks scan
  `git ls-files` of the cwd.

Rooting the repo at `~/.memtomem/memories` (rather than `~/.memtomem/`):

- keeps the synced repo **markdown-only** — the DB, `config.json`, and caches
  sit a level up and can't be staged by a stray `git add -A`;
- matches every other guide (`getting-started.md`, `reference.md`,
  `uninstall.md`) — no cross-doc drift.

`config.d/` can't co-sync in the same repo (it's outside `memories/`), so this
PR reframes it as a fragment **replicated separately** — copy, or symlink from
inside the repo — and notes that an in-repo copy must be excluded from indexing
(`.json` under `memory_dirs` is indexed by default).

## Changes (all in `multi-device-sync.md`)

- Rewrote the config.d bridging subsection: source is now the canonical
  `~/.memtomem/config.d/`, bridged from the memories repo via copy/symlink, with
  an `exclude_patterns` note for the symlink path.
- "What syncs" now flags `config.d/*.json` as replicated separately.
- Replaced the 3 `~/.memtomem-private` command refs (post-pull, Obsidian vault,
  sync-doctor) with `~/.memtomem/memories`.
- Adjusted the first-time-setup smoke step to bridge config.d rather than commit
  it into the memories repo.

## Notes

- Considered **repo root = `~/.memtomem/`** (lets config.d co-sync natively) and
  a **hybrid** (in-repo dot-dir for config.d) — both rejected: the former raises
  blast radius and forces a `getting-started.md` edit; the hybrid doesn't work
  because the indexer doesn't skip dot-dirs (`.json` still gets indexed).
- `test_docs_guards.py` passes (16/16); no H2 headings changed, so the on-page
  TOC from #1470 is unaffected.

Closes #1472

🤖 Generated with [Claude Code](https://claude.com/claude-code)
