### PR TITLE
docs(guides): add a suggested reading-order index

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,19 +151,19 @@ See [MCP Client Setup](docs/guides/mcp-clients.md) for Cursor / Windsurf / Claud
 
 ## Documentation
 
-Hosted at **[memtomem.com](https://memtomem.com)** — also available as Markdown in this repo:
+Hosted at **[memtomem.com](https://memtomem.com)** — also available as Markdown in this repo. New to memtomem? The guides have a [suggested reading order](docs/guides/README.md). The table below follows it:
 
 | Guide | Description |
 |-------|-------------|
 | [Getting Started](docs/guides/getting-started.md) | Install, setup wizard, first use |
 | [Example notebooks](examples/notebooks/) | Runnable Python-API walkthrough (start with `01_hello_memory.ipynb`, local ONNX — no server) |
-| [Reference](docs/guides/reference.md) | Complete feature reference for all tools and patterns |
+| [MCP Client Setup](docs/guides/mcp-clients.md) | Editor-specific configuration |
 | [Configuration](docs/guides/configuration.md) | All `MEMTOMEM_*` environment variables |
 | [Embeddings](docs/guides/embeddings.md) | ONNX, Ollama, and OpenAI embedding providers |
 | [LLM Providers](docs/guides/llm-providers.md) | Ollama, OpenAI, Anthropic, and compatible endpoints |
-| [MCP Client Setup](docs/guides/mcp-clients.md) | Editor-specific configuration |
 | [Context Gateway](docs/guides/context-gateway.md) | Share Skills, Commands, and Subagents across your AI tools from one Store |
 | [Multi-device sync](docs/guides/multi-device-sync.md) | Sync markdown memories across personal devices via a private git repo |
+| [Reference](docs/guides/reference.md) | Complete feature reference for all tools and patterns |
 | [Uninstalling memtomem](docs/guides/uninstall.md) | Clean removal steps |
 
 ---

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,41 @@
+# memtomem guides
+
+Every guide stands on its own, but if you're picking up memtomem for the first
+time this is the suggested reading order — get set up, tune to taste, then reach
+for the reference as you need it.
+
+## Set up
+
+1. **[Getting Started](getting-started.md)** — install, the setup wizard, and
+   your first memories. A working setup in under five minutes.
+2. **[MCP Client Setup](mcp-clients.md)** — connect any MCP editor — Claude Code,
+   Cursor, Codex CLI, Antigravity, Windsurf, Claude Desktop, Gemini / Kimi CLI.
+   New here? Claude Code is the one-command setup. Per-editor deep dives:
+   - [Claude Code](integrations/claude-code.md)
+   - [Cursor](integrations/cursor.md)
+   - [Claude Desktop](integrations/claude-desktop.md)
+
+## Tune
+
+3. **[Configuration](configuration.md)** — every `MEMTOMEM_*` setting and how the
+   config layers (`config.json`, `config.d/` fragments, environment variables)
+   merge.
+4. **[Embeddings](embeddings.md)** — embedding providers and the model matrix:
+   BM25-only (the default), ONNX, Ollama, and OpenAI.
+5. **[LLM Providers](llm-providers.md)** — enable the LLM-powered features (query
+   expansion, fact extraction): Ollama, OpenAI, Anthropic, and compatible
+   endpoints.
+
+## Power features
+
+6. **[Context Gateway](context-gateway.md)** — keep one Store of Skills,
+   Commands, and Subagents and sync it to every AI tool you use.
+7. **[Multi-device sync](multi-device-sync.md)** — sync your markdown memories
+   across personal devices via a private git repo.
+
+## Reference & lifecycle
+
+8. **[Reference](reference.md)** — the complete reference for every action, tool,
+   and pattern. Reach for it once you're set up.
+9. **[Uninstalling memtomem](uninstall.md)** — clean removal, with `--keep-data`
+   to preserve your memories.


### PR DESCRIPTION
## What

Give the guides an explicit reading order without touching any filenames.

- New **`docs/guides/README.md`** — GitHub renders it as the `docs/guides/`
  folder landing page. It lists the nine guides **1→9** in a
  **set up → tune → power features → reference & lifecycle** flow, with the
  per-editor integration guides nested under *MCP Client Setup*.
- README's `## Documentation` section now links to that index and its table is
  reordered to match the same flow (Reference moves to the end, where lookup
  belongs).

## Why this shape

The request was to number the guides "in flow order". These render as plain
GitHub Markdown (the site lives in a separate repo), and the files have ~60+
inbound links plus external/PyPI references — so `NN_` filename prefixes would
break every existing URL and keep the number in the URL. An ordered index gets
the same flow-order discoverability with **zero renames and zero broken links**.

## Not in this PR (deferred by design)

Splitting the long guides (`reference.md` 1,581 lines, `configuration.md` 958) is
a separate, anchor-sensitive change — those files are deep-linked by `#anchor`
from 30+ sites — so it's left for its own scoped PR.

## Checks

- `test_docs_guards.py` passes (16/16). The new `README.md` is picked up by the
  guides' link-resolution and no-jsonc-fence guards; all links resolve and no
  filenames changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
