### PR TITLE
security(import): cap ZIP extraction resources for Notion import

### DIFF
--- a/packages/memtomem/src/memtomem/indexing/importers.py
+++ b/packages/memtomem/src/memtomem/indexing/importers.py
@@ -5,9 +5,106 @@ from __future__ import annotations
 import logging
 import re
 import zipfile
+from collections.abc import Callable
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+# ── Safe ZIP extraction ──────────────────────────────────────────────────
+#
+# ``zipfile.ZipFile.extractall`` normalizes ``..`` / absolute member names on
+# supported runtimes, but enforces no aggregate-size, member-count, or
+# compression-ratio bound — so a few-KB crafted archive can expand to
+# gigabytes and fill the disk (a decompression bomb). The import path is
+# MCP-reachable via ``mem_import_notion``. These caps are generous enough for
+# real Notion / Obsidian exports and only trip on pathological archives.
+_ZIP_MAX_TOTAL_BYTES = 2 * 1024**3  # 2 GiB aggregate uncompressed
+_ZIP_MAX_MEMBER_BYTES = 512 * 1024**2  # 512 MiB single member
+_ZIP_MAX_ENTRIES = 100_000  # member count
+_ZIP_MAX_RATIO = 200  # aggregate uncompressed:compressed
+_ZIP_RATIO_FLOOR_BYTES = 10 * 1024**2  # only ratio-check archives above this
+
+
+class UnsafeArchiveError(ValueError):
+    """An archive exceeds the safe-extraction resource caps, or a member name
+    would escape the extraction root."""
+
+
+def safe_extract_zip(
+    zip_path: Path,
+    dest_dir: Path,
+    *,
+    member_filter: Callable[[str], bool] | None = None,
+) -> None:
+    """Extract ``zip_path`` into ``dest_dir`` with traversal + resource caps.
+
+    Unlike a bare ``ZipFile.extractall``, this validates archive metadata up
+    front and rejects any member whose name resolves outside ``dest_dir`` —
+    failing closed on suspicious archives rather than silently normalizing
+    them.
+
+    When ``member_filter`` is given, only members whose name satisfies it are
+    extracted and counted toward the size / ratio caps; the rest are skipped
+    and never written to disk. This lets a caller that only consumes (say)
+    markdown ignore arbitrarily large attachments without either extracting
+    them (the decompression-bomb vector) or rejecting the whole archive over
+    them. Every member is still path-containment checked and counted toward
+    the entry cap regardless of the filter.
+
+    Raises:
+        UnsafeArchiveError: a member escapes ``dest_dir`` or the extracted set
+            exceeds a configured resource cap.
+    """
+    dest_root = dest_dir.resolve()
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        infos = zf.infolist()
+        if len(infos) > _ZIP_MAX_ENTRIES:
+            raise UnsafeArchiveError(f"archive has {len(infos)} entries (cap {_ZIP_MAX_ENTRIES})")
+
+        to_extract: list[zipfile.ZipInfo] = []
+        total_uncompressed = 0
+        total_compressed = 0
+        for info in infos:
+            # Containment: every member must land strictly under the root.
+            # Absolute names and ``..`` chains resolve outside it; an empty or
+            # ``.`` member name resolves to the root itself.
+            target = (dest_root / info.filename).resolve()
+            if target == dest_root:
+                if info.is_dir():
+                    continue
+                raise UnsafeArchiveError(f"member {info.filename!r} has no valid path")
+            if dest_root not in target.parents:
+                raise UnsafeArchiveError(f"member {info.filename!r} escapes the extraction root")
+            if info.is_dir():
+                continue
+            if member_filter is not None and not member_filter(info.filename):
+                continue
+            if info.file_size > _ZIP_MAX_MEMBER_BYTES:
+                raise UnsafeArchiveError(
+                    f"member {info.filename!r} is {info.file_size} bytes "
+                    f"(cap {_ZIP_MAX_MEMBER_BYTES})"
+                )
+            total_uncompressed += info.file_size
+            total_compressed += info.compress_size
+            to_extract.append(info)
+
+        if total_uncompressed > _ZIP_MAX_TOTAL_BYTES:
+            raise UnsafeArchiveError(
+                f"archive expands to {total_uncompressed} bytes (cap {_ZIP_MAX_TOTAL_BYTES})"
+            )
+        if (
+            total_compressed > 0
+            and total_uncompressed > _ZIP_RATIO_FLOOR_BYTES
+            and total_uncompressed / total_compressed > _ZIP_MAX_RATIO
+        ):
+            ratio = total_uncompressed / total_compressed
+            raise UnsafeArchiveError(
+                f"archive compression ratio {ratio:.0f}:1 exceeds cap {_ZIP_MAX_RATIO}:1"
+            )
+
+        for info in to_extract:
+            zf.extract(info, dest_root)
 
 
 async def import_notion(export_path: Path, output_dir: Path) -> list[Path]:
@@ -30,8 +127,13 @@ async def import_notion(export_path: Path, output_dir: Path) -> list[Path]:
     if export_path.suffix == ".zip":
         extract_dir = output_dir / "_notion_extract"
         extract_dir.mkdir(parents=True, exist_ok=True)
-        with zipfile.ZipFile(export_path, "r") as zf:
-            zf.extractall(extract_dir)
+        # Notion exports bundle markdown + attachments (images, PDFs, …); the
+        # importer only consumes ``*.md`` (see the rglob below), so extract just
+        # those — skipping arbitrarily large attachments instead of extracting
+        # them (the bomb vector) or rejecting the whole export over them.
+        safe_extract_zip(
+            export_path, extract_dir, member_filter=lambda n: n.lower().endswith(".md")
+        )
         source_dir = extract_dir
 
     imported: list[Path] = []

--- a/packages/memtomem/tests/test_importers.py
+++ b/packages/memtomem/tests/test_importers.py
@@ -1,12 +1,17 @@
 """Tests for Notion and Obsidian importers."""
 
+import zipfile
+
 import pytest
+from memtomem.indexing import importers
 from memtomem.indexing.importers import (
+    UnsafeArchiveError,
     _clean_notion_filename,
     _clean_notion_markdown,
     _convert_obsidian_syntax,
     import_notion,
     import_obsidian,
+    safe_extract_zip,
 )
 
 
@@ -166,3 +171,99 @@ class TestImportObsidian:
         imported = await import_obsidian(vault, output)
         assert len(imported) == 1
         assert imported[0].name == "real-note.md"
+
+
+class TestSafeExtractZip:
+    """Resource + traversal caps on ZIP extraction (decompression-bomb defense)."""
+
+    @staticmethod
+    def _make_zip(path, entries):
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for name, data in entries:
+                zf.writestr(name, data)
+        return path
+
+    def test_extracts_normal_zip(self, tmp_path):
+        z = self._make_zip(tmp_path / "ok.zip", [("a.md", "hi"), ("sub/b.md", "yo")])
+        dest = tmp_path / "out"
+        dest.mkdir()
+        safe_extract_zip(z, dest)
+        assert (dest / "a.md").read_text() == "hi"
+        assert (dest / "sub" / "b.md").read_text() == "yo"
+
+    def test_rejects_parent_traversal_member(self, tmp_path):
+        z = self._make_zip(tmp_path / "trav.zip", [("../escape.md", "x")])
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with pytest.raises(UnsafeArchiveError):
+            safe_extract_zip(z, dest)
+        assert not (tmp_path / "escape.md").exists()
+
+    def test_rejects_absolute_member(self, tmp_path):
+        z = self._make_zip(tmp_path / "abs.zip", [("/abs_escape.md", "x")])
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with pytest.raises(UnsafeArchiveError):
+            safe_extract_zip(z, dest)
+
+    def test_rejects_too_many_entries(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(importers, "_ZIP_MAX_ENTRIES", 1)
+        z = self._make_zip(tmp_path / "many.zip", [("a.md", "x"), ("b.md", "y")])
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with pytest.raises(UnsafeArchiveError):
+            safe_extract_zip(z, dest)
+
+    def test_rejects_oversize_aggregate(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(importers, "_ZIP_MAX_TOTAL_BYTES", 10)
+        z = self._make_zip(tmp_path / "big.zip", [("a.md", "x" * 100)])
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with pytest.raises(UnsafeArchiveError):
+            safe_extract_zip(z, dest)
+
+    def test_rejects_oversize_member(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(importers, "_ZIP_MAX_MEMBER_BYTES", 10)
+        z = self._make_zip(tmp_path / "bigm.zip", [("a.md", "x" * 100)])
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with pytest.raises(UnsafeArchiveError):
+            safe_extract_zip(z, dest)
+
+    def test_rejects_compression_bomb_ratio(self, tmp_path, monkeypatch):
+        # Floor to 0 so the small fixture is ratio-checked; cap at 5:1. A
+        # highly repetitive payload deflates far past that.
+        monkeypatch.setattr(importers, "_ZIP_RATIO_FLOOR_BYTES", 0)
+        monkeypatch.setattr(importers, "_ZIP_MAX_RATIO", 5)
+        z = self._make_zip(tmp_path / "bomb.zip", [("a.md", "A" * 100_000)])
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with pytest.raises(UnsafeArchiveError):
+            safe_extract_zip(z, dest)
+
+    def test_member_filter_skips_unmatched_members(self, tmp_path, monkeypatch):
+        # A would-be-oversized attachment is neither size-checked nor written
+        # when the filter excludes it; the matched markdown still extracts.
+        # (This is how import_notion ignores large Notion attachments instead
+        # of extracting them or rejecting the whole export.)
+        monkeypatch.setattr(importers, "_ZIP_MAX_MEMBER_BYTES", 50)
+        z = self._make_zip(
+            tmp_path / "mixed.zip",
+            [("note.md", "hello"), ("big.bin", "x" * 1000)],
+        )
+        dest = tmp_path / "out"
+        dest.mkdir()
+        safe_extract_zip(z, dest, member_filter=lambda n: n.lower().endswith(".md"))
+        assert (dest / "note.md").read_text() == "hello"
+        assert not (dest / "big.bin").exists()  # attachment skipped, not extracted
+
+    def test_rejects_root_entry_member(self, tmp_path):
+        # A file member naming the extraction root itself (e.g. ".") is rejected
+        # as UnsafeArchiveError, not a late zipfile error.
+        zpath = tmp_path / "root.zip"
+        with zipfile.ZipFile(zpath, "w") as zf:
+            zf.writestr(zipfile.ZipInfo("."), "x")
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with pytest.raises(UnsafeArchiveError):
+            safe_extract_zip(zpath, dest)


### PR DESCRIPTION
## Why

`import_notion()` extracted uploaded ZIP archives with a bare
`zipfile.ZipFile.extractall`, which enforces **no** aggregate-size,
per-member-size, file-count, or compression-ratio bound. A few-KB crafted
archive can expand to gigabytes and fill the disk (decompression bomb). The
path is MCP-reachable via `mem_import_notion`.

Path traversal itself was already contained: CPython's `extractall` strips
drive / leading-slash / `..` components on supported runtimes (3.12+), so this
is **hardening** (resource bounds + a local, testable extraction invariant),
not a traversal-bug fix.

## What

`safe_extract_zip(zip_path, dest_dir, *, member_filter=None)`:

- Validates archive metadata up front: entry-count, per-member and aggregate
  uncompressed size, and a compression-ratio sanity check (above a size floor).
- Rejects any member whose name resolves outside the extraction root — fails
  closed on `..`, absolute, and root/`.` member names instead of silently
  normalizing them.
- `member_filter` extracts only matching members (and only size/ratio-checks
  those); the rest are skipped and never written. `import_notion` passes
  `*.md`, so large Notion attachments are neither extracted (the bomb vector)
  nor cause a false rejection of the whole export.

## Caps (tunable module constants)

| Cap | Default |
|-----|---------|
| entry count | 100,000 |
| per-member uncompressed | 512 MiB |
| aggregate uncompressed | 2 GiB |
| compression ratio | 200:1 (only above a 10 MiB floor) |

## Tests (`test_importers.py`, +9)

- traversal / absolute / root-entry members rejected
- entry-count, per-member, aggregate, and ratio caps each reject
- `member_filter` skips (and does not size-check) unmatched members
- happy-path extraction + existing `import_notion` zip path still pass

## Validation

- `uv run pytest packages/memtomem/tests/test_importers.py` → 27 passed
- `ruff check` + `ruff format --check` clean; `mypy` clean (advisory)
- Reviewed by Codex → SHIP

Closes #1484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
