### PR TITLE
security(import): provenance-aware redaction gate on bundle import (ADR-0006 F.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Security
+
+- **JSON bundle import now enforces the secret-redaction trust boundary
+  (ADR-0006 Axis F.3).** `POST /api/export/import` and the MCP `mem_import`
+  tool previously upserted every bundle record without the redaction scan that
+  guards all other write surfaces — the sole batch-write ingress with no gate.
+  Imports are now provenance-aware: a bundle this install exported (carrying a
+  valid local-provenance HMAC marker, written by `mem_export` / the export
+  endpoint) round-trips unchanged, while a foreign or unverifiable bundle is
+  scanned per-record — across its full retrievable surface (content, heading,
+  source path, and tags, since every field of a foreign bundle is
+  attacker-controlled) — and the whole import is rejected if any record contains
+  a secret-shaped value. Pass `force_unsafe=true` (the MCP argument or the import
+  form field) to override after review — the bypass is audit-logged.
+  **Behavior change:** importing a foreign bundle that contains a secret now
+  fails by default where it previously imported silently; the web surface
+  returns HTTP 403 `redaction_blocked`. (#1483)
+
 ## [0.3.1] — 2026-06-24
 
 A first-time-user experience pass over the web UI, plus a non-ASCII tag-storage

--- a/docs/adr/0006-web-ui-folder-upload-redaction.md
+++ b/docs/adr/0006-web-ui-folder-upload-redaction.md
@@ -425,6 +425,16 @@ In rough order, all in `packages/memtomem/src/memtomem/`:
   `export.import_memories` narrows to the provenance-verified path. Importing a
   foreign bundle that contains a secret is a behavior change — telegraph it in
   the next minor's CHANGELOG.
+  - *Scan surface (follow-up-PR refinement).* Import is the one write surface
+    where **every** field — including metadata — arrives verbatim from an
+    untrusted bundle and is then embedded (`retrieval_content` = heading +
+    content), stored, and retrievable. So the foreign-bundle scan covers the
+    full retrievable surface (`content` + `heading_hierarchy` + `source_file` +
+    `tags`), a deliberate widening beyond the `content`-only scan that the
+    locally-derived-metadata surfaces (`mem_add` / `mem_batch_add`) use. This is
+    field coverage, not a new pattern set (Axis C's `DEFAULT_PATTERNS` is
+    unchanged), and it never touches self-exports (their scan is skipped), so
+    round-trip fidelity is unaffected.
 
 ## Considered & rejected upstream
 

--- a/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
@@ -242,6 +242,18 @@ def _collect_inventory(db_path: Path) -> _Inventory:
         if candidate.exists():
             db_paths.append(candidate)
 
+    # Per-install provenance HMAC key sidecar (ADR-0006 Axis F.3). It is a
+    # persistent secret derived from the DB stem (``<db-stem>.provenance_key``),
+    # not a ``<db-name><suffix>`` sibling, so the loop above misses it. Group it
+    # with the database so ``keep_data=False`` wipes it — otherwise a reinstall
+    # at the same path reuses the old key and keeps trusting prior self-export
+    # markers (handles custom storage paths via ``key_path_for_db``).
+    from memtomem import provenance
+
+    key_path = provenance.key_path_for_db(db_path)
+    if key_path.exists():
+        db_paths.append(key_path)
+
     config_json = state_dir / "config.json"
     config_files = [config_json] if config_json.exists() else []
 

--- a/packages/memtomem/src/memtomem/provenance.py
+++ b/packages/memtomem/src/memtomem/provenance.py
@@ -1,0 +1,249 @@
+"""Local-provenance marker for export/import bundles (ADR-0006 Axis F.3).
+
+A bundle this install exported carries an HMAC-SHA256 marker over its
+canonical chunk payload, keyed by a per-install secret stored as a sidecar
+next to the SQLite DB (``<db-stem>.provenance_key``). On import, a valid
+marker means the bundle is a *self-export* and round-trips unchanged (the
+redaction re-scan is skipped); an absent or invalid marker means the bundle is
+foreign and runs the per-record redaction gate
+(``privacy.enforce_write_guard``).
+
+What the marker proves — and does not
+-------------------------------------
+It proves **local provenance** (this install's storage produced the bundle),
+NOT that every chunk passed redaction. Legacy pre-guard rows, prior
+``force_unsafe`` writes, and content from the still-unguarded folder-index path
+can all appear in a self-export. F.3 is therefore an explicit
+*local-provenance round-trip exemption* (ADR-0006 Axis F): we re-import our own
+export as-is, trusting the local user's earlier storage decisions, rather than
+re-proving redaction on data that already lives in this install. The stronger
+per-chunk-redaction-provenance alternative is deferred.
+
+Threat model
+------------
+* **Forgery.** A foreign author cannot compute a valid marker without the
+  per-install key, so key secrecy is load-bearing. The key file is created and
+  read with symlink-safe, owner-private, exclusive semantics
+  (``O_CREAT|O_EXCL|O_NOFOLLOW`` + a post-open ``fstat`` that requires a regular
+  file owned by the current user with no group/other permission bits) so a file
+  or symlink pre-planted in a misconfigured storage directory (e.g. a shared
+  ``MEMTOMEM_STORAGE__SQLITE_PATH``) cannot leak or fix the key. Verification
+  fails *safe* — any key-file anomaly is treated as "no key" → bundle foreign →
+  re-scanned, never an exception. Signing fails *closed* — a suspicious
+  existing key (symlink / non-regular / wrong owner / loose mode) raises rather
+  than signing with an attacker-influenced secret.
+* **Modification / injection.** The HMAC binds the entire canonical ``chunks``
+  list, so editing, adding, or removing any record invalidates the marker.
+* **Replay / lift (accepted property).** An *unchanged* self-export re-imports
+  as self — that is the intended round-trip. A third party who holds your old
+  export already holds its plaintext; re-importing it only restores data this
+  install itself produced. The revocation lever is to delete or rotate the
+  sidecar key (``<db-stem>.provenance_key``): every prior export then verifies
+  as foreign and is re-scanned.
+
+``_canonical_chunks`` is deterministic for the *current* bundle-chunk schema
+(ints + strings + lists, no floats); it is not RFC-8785 canonical JSON. Any
+future change that makes import trust or behavior depend on a non-``chunks``
+bundle field (``version`` / ``exported_at`` / ``total_chunks``) must bump
+``SCHEME`` or fold that field into the signed payload.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import secrets
+import stat
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+SCHEME = "memtomem-bundle-provenance-v1"
+ALGO = "HMAC-SHA256"
+_KEY_BYTES = 32
+# A 32-byte key is 64 hex chars; cap the read so a giant file planted at the
+# key path can't be slurped into memory.
+_KEY_READ_CAP = 4096
+
+
+class ProvenanceKeyError(Exception):
+    """Raised when the provenance key file is unsafe to sign with."""
+
+
+def key_path_for_db(db_path: Path | str) -> Path:
+    """Sidecar key path for a SQLite DB: ``<db-stem>.provenance_key``.
+
+    ``~/.memtomem/memtomem.db`` → ``~/.memtomem/memtomem.provenance_key``. Tying
+    the key to the DB path means the existing storage-isolation knob
+    (``MEMTOMEM_STORAGE__SQLITE_PATH``, worktree / HOME overrides) isolates the
+    key for free, and a DB moved without its sidecar degrades safely (its old
+    exports verify as foreign and are re-scanned).
+    """
+    return Path(db_path).expanduser().with_suffix(".provenance_key")
+
+
+def _decode_key(raw: bytes) -> bytes | None:
+    try:
+        key = bytes.fromhex(raw.decode("ascii").strip())
+    except (ValueError, UnicodeDecodeError):
+        return None
+    return key if len(key) == _KEY_BYTES else None
+
+
+def _fd_is_safe(fd: int) -> tuple[bool, str]:
+    """Validate an *opened* key fd: regular file, owner-only, no group/other.
+
+    Validating ``os.fstat(fd)`` (the inode actually opened) rather than only a
+    pre-open ``lstat`` closes the TOCTOU window — the bytes we read came from
+    the inode we vetted. Owner / mode checks are POSIX-only; Windows lacks the
+    same permission model, so there a regular file is accepted.
+    """
+    st = os.fstat(fd)
+    if not stat.S_ISREG(st.st_mode):
+        return False, "not a regular file"
+    if os.name == "posix":
+        if hasattr(os, "getuid") and st.st_uid != os.getuid():
+            return False, "not owned by the current user"
+        if st.st_mode & 0o077:
+            return False, "group/other-accessible (must be 0o600)"
+    return True, ""
+
+
+def _read_existing_key(path: Path, *, strict: bool) -> bytes | None:
+    """Read a key file with symlink-safe, owner-private validation.
+
+    Returns the 32-byte key, or ``None`` if the file is absent / malformed /
+    unsafe. "Unsafe" = a symlink, a non-regular file, a file not owned by the
+    current user, or one with group/other permission bits — any of which would
+    let a foreign party in a shared/misconfigured storage dir plant or read the
+    HMAC key and forge a "self" marker. On an unsafe key: ``strict=True``
+    (export/sign) raises ``ProvenanceKeyError`` (fail closed — never sign with
+    an attacker-influenced key); ``strict=False`` (verify) returns ``None`` so
+    the bundle falls through to the foreign re-scan path (fail safe).
+    """
+    try:
+        lst = os.lstat(path)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        if strict:
+            raise ProvenanceKeyError(f"cannot stat provenance key {path}: {exc}") from exc
+        return None
+
+    # Reject symlinks before opening; ``O_NOFOLLOW`` + the post-open ``fstat``
+    # below are the authoritative checks, this is just an early, clear reject.
+    if stat.S_ISLNK(lst.st_mode):
+        msg = f"provenance key {path} is a symlink; refusing to follow"
+        if strict:
+            raise ProvenanceKeyError(msg)
+        logger.warning("%s — treating bundle as foreign", msg)
+        return None
+
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        if strict:
+            raise ProvenanceKeyError(f"cannot open provenance key {path}: {exc}") from exc
+        return None
+    try:
+        ok, reason = _fd_is_safe(fd)
+        if not ok:
+            msg = f"provenance key {path} is unsafe ({reason}); refusing to trust it"
+            if strict:
+                raise ProvenanceKeyError(msg)
+            logger.warning("%s — treating bundle as foreign", msg)
+            return None
+        raw = os.read(fd, _KEY_READ_CAP)
+    finally:
+        os.close(fd)
+    return _decode_key(raw)
+
+
+def load_key_for_verify(key_path: Path) -> bytes | None:
+    """Return the install key for verification, or ``None`` if absent/unsafe.
+
+    Never creates a key and never raises: a missing or anomalous key file means
+    "cannot prove provenance" → the caller treats the bundle as foreign and
+    re-scans it.
+    """
+    return _read_existing_key(Path(key_path), strict=False)
+
+
+def load_or_create_key_for_export(key_path: Path) -> bytes:
+    """Return the install key for signing, creating it on first export.
+
+    Creation is symlink-safe and exclusive (``O_CREAT|O_EXCL|O_NOFOLLOW``,
+    ``0o600``). A pre-existing but unsafe key (symlink / non-regular) raises
+    ``ProvenanceKeyError`` rather than signing with an attacker-influenced key.
+    """
+    path = Path(key_path)
+    existing = _read_existing_key(path, strict=True)
+    if existing is not None:
+        return existing
+
+    key = secrets.token_bytes(_KEY_BYTES)
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags, 0o600)
+    except FileExistsError:
+        # A concurrent export created the key first — read it back (strict).
+        existing = _read_existing_key(path, strict=True)
+        if existing is None:
+            raise ProvenanceKeyError(
+                f"provenance key {path} appeared during creation but is unreadable"
+            ) from None
+        return existing
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o600)
+        os.write(fd, key.hex().encode("ascii"))
+    finally:
+        os.close(fd)
+    return key
+
+
+def _canonical_chunks(chunks: list[dict]) -> bytes:
+    # Deterministic for the current chunk schema (no floats); ``sort_keys``
+    # makes it insensitive to dict key order, and signing the parsed objects
+    # (not the pretty-printed bundle text) makes it insensitive to indentation.
+    return json.dumps(chunks, sort_keys=True, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+
+
+def sign_chunks(chunks: list[dict], key: bytes) -> str:
+    """HMAC-SHA256 hex digest over ``SCHEME + "\\n" + canonical(chunks)``."""
+    payload = SCHEME.encode("ascii") + b"\n" + _canonical_chunks(chunks)
+    return hmac.new(key, payload, hashlib.sha256).hexdigest()
+
+
+def make_marker(chunks: list[dict], key: bytes) -> dict[str, str]:
+    """Build the bundle ``provenance`` marker for ``chunks``."""
+    return {"scheme": SCHEME, "algo": ALGO, "signature": sign_chunks(chunks, key)}
+
+
+def verify_marker(chunks: list[dict], marker: object, key: bytes | None) -> bool:
+    """True iff ``marker`` is a valid local-provenance HMAC over ``chunks``.
+
+    Returns ``False`` (foreign) on a missing key, a malformed/absent marker, a
+    scheme/algo mismatch, or a signature mismatch — every non-self path is the
+    safe one (the caller then runs the redaction gate).
+    """
+    if key is None or not isinstance(marker, dict):
+        return False
+    if marker.get("scheme") != SCHEME or marker.get("algo") != ALGO:
+        return False
+    sig = marker.get("signature")
+    if not isinstance(sig, str):
+        return False
+    try:
+        return hmac.compare_digest(sign_chunks(chunks, key), sig)
+    except TypeError:
+        # ``hmac.compare_digest`` raises on a non-ASCII ``str`` — our digest is
+        # always lowercase hex, so any non-ASCII signature is foreign, not ours.
+        return False

--- a/packages/memtomem/src/memtomem/server/tools/export_import.py
+++ b/packages/memtomem/src/memtomem/server/tools/export_import.py
@@ -67,6 +67,7 @@ async def mem_import(
     namespace: str | None = None,
     on_conflict: str = "skip",
     preserve_ids: bool = False,
+    force_unsafe: bool = False,
     ctx: CtxType = None,
 ) -> str:
     """Import memory chunks from a JSON bundle file (produced by mem_export).
@@ -86,8 +87,16 @@ async def mem_import(
         preserve_ids: For non-conflicting records in a v2 bundle, reuse the
             bundle's original chunk UUID (skipped if already claimed by
             unrelated content). Ignored when ``on_conflict="duplicate"``.
+        force_unsafe: Bypass the redaction gate when importing a *foreign*
+            bundle (one not exported by this install) whose records contain
+            secret-shaped values. Self-exports round-trip without this. The
+            bypass is audit-logged (ADR-0006 Axis F.3).
     """
-    from memtomem.tools.export_import import _VALID_ON_CONFLICT, import_chunks
+    from memtomem.tools.export_import import (
+        ImportPrivacyError,
+        _VALID_ON_CONFLICT,
+        import_chunks,
+    )
 
     app = await _get_app_initialized(ctx)
 
@@ -103,14 +112,23 @@ async def mem_import(
     if not source.exists():
         return f"File not found: {source}"
 
-    stats = await import_chunks(
-        app.storage,
-        app.embedder,
-        source,
-        namespace=namespace,
-        on_conflict=on_conflict,  # type: ignore[arg-type]
-        preserve_ids=preserve_ids,
-    )
+    try:
+        stats = await import_chunks(
+            app.storage,
+            app.embedder,
+            source,
+            namespace=namespace,
+            on_conflict=on_conflict,  # type: ignore[arg-type]
+            preserve_ids=preserve_ids,
+            force_unsafe=force_unsafe,
+            surface="mem_import",
+        )
+    except ImportPrivacyError as exc:
+        return (
+            f"Error: {exc.blocked_records} bundle record(s) match privacy "
+            "pattern(s); import rejected. Retry with force_unsafe=True to "
+            "bypass (audit-logged)."
+        )
 
     return (
         f"Import complete ({on_conflict=}, {preserve_ids=}):\n"

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -273,6 +273,16 @@ class SqliteBackend(
         self._meta.store_dimension(dim)
 
     @property
+    def db_path(self) -> Path:
+        """Filesystem path of the SQLite database file (``~`` expanded).
+
+        Mirrors how :meth:`initialize` resolves ``sqlite_path``. Used by the
+        export/import provenance marker to locate its sidecar key next to the
+        DB (``memtomem.provenance.key_path_for_db``).
+        """
+        return Path(self._config.sqlite_path).expanduser()
+
+    @property
     def stored_embedding_info(self) -> dict:
         """Return the embedding config actually stored in the DB."""
         assert self._meta is not None

--- a/packages/memtomem/src/memtomem/tools/export_import.py
+++ b/packages/memtomem/src/memtomem/tools/export_import.py
@@ -49,6 +49,10 @@ class ExportBundle:
     exported_at: str = ""
     total_chunks: int = 0
     chunks: list[dict] = field(default_factory=list)
+    # Local-provenance marker (ADR-0006 Axis F.3). Present on self-exports;
+    # ``None`` on hand-crafted / pre-F.3 bundles, which then import as foreign.
+    # See ``memtomem.provenance``.
+    provenance: dict | None = None
 
     def to_json(self, *, indent: int = 2) -> str:
         return json.dumps(asdict(self), ensure_ascii=False, indent=indent)
@@ -61,6 +65,7 @@ class ExportBundle:
             exported_at=data.get("exported_at", ""),
             total_chunks=data.get("total_chunks", 0),
             chunks=data.get("chunks", []),
+            provenance=data.get("provenance"),
         )
 
 
@@ -75,6 +80,25 @@ class ImportStats:
     updated_chunks: int = 0
 
 
+class ImportPrivacyError(Exception):
+    """Raised when a foreign bundle's records hit the redaction guard.
+
+    ADR-0006 Axis F.3: bundles without a valid local-provenance marker are
+    scanned per-record on import and the whole import is rejected (atomically,
+    mirroring ``mem_batch_add``) if any record contains a secret-shaped value,
+    unless ``force_unsafe=True``. ``blocked_records`` is a *record* count (not a
+    regex-span count) so each ingress can render its native error without
+    echoing the matched bytes.
+    """
+
+    def __init__(self, blocked_records: int) -> None:
+        self.blocked_records = blocked_records
+        super().__init__(
+            f"{blocked_records} bundle record(s) match privacy pattern(s); import "
+            "rejected. Retry with force_unsafe=True to bypass (audit-logged)."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Export
 # ---------------------------------------------------------------------------
@@ -87,8 +111,14 @@ async def export_chunks(
     tag_filter: str | None = None,
     since: datetime | None = None,
     namespace_filter: str | None = None,
+    provenance_key_path: Path | None = None,
+    stamp_provenance: bool = True,
 ) -> ExportBundle:
     """Export indexed chunks to an ExportBundle (and optionally to a JSON file).
+
+    The bundle is stamped with a local-provenance marker (ADR-0006 Axis F.3) so
+    a re-import on this same install round-trips unchanged (the redaction gate
+    is skipped for verified self-exports); see ``memtomem.provenance``.
 
     Args:
         storage: StorageBackend instance.
@@ -96,9 +126,17 @@ async def export_chunks(
         source_filter: Only include chunks whose source_file contains this substring.
         tag_filter: Only include chunks that have this exact tag.
         since: Only include chunks created at or after this datetime.
+        provenance_key_path: Override the per-install key file location (the
+            sidecar next to the DB by default). Intended for tests.
+        stamp_provenance: Sign the bundle with the per-install key (default).
+            Pass ``False`` for count-only callers (e.g. the ``/export/stats``
+            preview) so a read-shaped request neither creates the key file nor
+            fails on a key-file problem unrelated to counting.
     Returns:
-        ExportBundle with the selected chunks.
+        ExportBundle with the selected chunks; a provenance marker is attached
+        when ``stamp_provenance`` is set.
     """
+    from memtomem import provenance
     from memtomem.search.pipeline import match_source_filter_substring
 
     source_files = await storage.get_all_source_files()
@@ -119,10 +157,16 @@ async def export_chunks(
                 continue
             records.append(_chunk_to_dict(chunk))
 
+    marker: dict | None = None
+    if stamp_provenance:
+        key_path = provenance_key_path or provenance.key_path_for_db(storage.db_path)
+        marker = provenance.make_marker(records, provenance.load_or_create_key_for_export(key_path))
+
     bundle = ExportBundle(
         exported_at=datetime.now(timezone.utc).isoformat(),
         total_chunks=len(records),
         chunks=records,
+        provenance=marker,
     )
 
     if output_path is not None:
@@ -158,6 +202,72 @@ def _chunk_to_dict(chunk: Chunk) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def _import_scan_text(chunk: Chunk) -> str:
+    """The retrievable surface scanned on a foreign import (ADR-0006 Axis F.3).
+
+    Import is the one write surface where *every* field — including metadata —
+    arrives verbatim from an untrusted bundle and is then embedded
+    (``retrieval_content`` = heading hierarchy + content), stored, and
+    retrievable. So the foreign-bundle redaction scan covers the full
+    retrievable surface here (content + heading + ``source_file`` + ``tags``),
+    not just ``content`` as on the locally-derived-metadata write surfaces
+    (``mem_add`` / ``mem_batch_add``). Self-exports skip this scan entirely, so
+    the wider coverage never affects round-trip fidelity — it only closes the
+    metadata-smuggling vector on genuinely foreign bundles.
+    """
+    return "\n".join(
+        [chunk.retrieval_content, str(chunk.metadata.source_file), *chunk.metadata.tags]
+    )
+
+
+def _enforce_import_redaction(
+    parsed: list[tuple[Chunk, str | None]],
+    *,
+    force_unsafe: bool,
+    surface: str,
+) -> None:
+    """Per-record redaction gate for a foreign bundle (ADR-0006 Axis F.2).
+
+    Scans the full retrievable surface of each record (see
+    :func:`_import_scan_text`). Mirrors ``mem_batch_add``'s transactional shape:
+    collect each record's decision with ``record_outcome=False``, reject the
+    whole import on any block (recording ``blocked`` per blocked record and
+    raising :class:`ImportPrivacyError`), and only commit per-record ``pass`` /
+    ``bypassed`` counters once the import is known to proceed. ``scope="user"``
+    because import upserts user-tier storage rows, never a git-tracked
+    ``project_shared`` tier — so ``blocked_project_shared`` cannot arise here.
+    """
+    from memtomem import privacy
+
+    decisions: list[tuple[str, int]] = []  # (decision, hit_count)
+    for chunk, _ in parsed:
+        guard = privacy.enforce_write_guard(
+            _import_scan_text(chunk),
+            surface=surface,
+            force_unsafe=force_unsafe,
+            scope="user",
+            record_outcome=False,
+        )
+        decisions.append((guard.decision, len(guard.hits)))
+
+    blocked = [d for d in decisions if d[0] == "blocked"]
+    if blocked:
+        for _ in blocked:
+            privacy.record("blocked", surface)
+        raise ImportPrivacyError(blocked_records=len(blocked))
+
+    for (decision, hit_count), (chunk, _) in zip(decisions, parsed):
+        if decision == "bypassed":
+            privacy.record("bypassed", surface)
+            privacy.emit_bypass_audit(
+                surface=surface,
+                content_chars=len(chunk.content),
+                hits=hit_count,
+            )
+        else:
+            privacy.record("pass", surface)
+
+
 async def import_chunks(
     storage: SqliteBackend,
     embedder: EmbeddingProvider,
@@ -165,8 +275,21 @@ async def import_chunks(
     namespace: str | None = None,
     on_conflict: OnConflict = "skip",
     preserve_ids: bool = False,
+    force_unsafe: bool = False,
+    provenance_key_path: Path | None = None,
+    surface: str = "import",
 ) -> ImportStats:
     """Import chunks from a JSON bundle file.
+
+    Trust boundary (ADR-0006 Axis F.3): a bundle this install exported carries a
+    valid local-provenance marker and round-trips unchanged. A bundle with an
+    absent or invalid marker is *foreign* — every well-formed record's full
+    retrievable surface (content + heading + ``source_file`` + ``tags``; see
+    :func:`_import_scan_text`) is scanned with ``privacy.enforce_write_guard``
+    and the whole import is rejected with :class:`ImportPrivacyError` if any
+    record matches a secret pattern, unless ``force_unsafe=True`` (bypass is
+    audit-logged). The scan runs before any embed/upsert, so rejection is atomic
+    — no partial import.
 
     Each chunk is re-embedded and upserted. Conflict resolution against the
     target DB's existing ``content_hash`` set is controlled by ``on_conflict``:
@@ -200,9 +323,18 @@ async def import_chunks(
         namespace: Override the namespace for all imported chunks.
         on_conflict: Strategy for hash collisions. See above.
         preserve_ids: Opt-in UUID preservation for new inserts (v2 bundles).
+        force_unsafe: Bypass the redaction gate for a foreign bundle whose
+            records match secret patterns (audit-logged).
+        provenance_key_path: Override the per-install key file location (the
+            sidecar next to the DB by default). Intended for tests.
+        surface: Audit/counter label for the redaction guard ("mem_import",
+            "web_api_import", …).
     Returns:
         ImportStats with total / imported / skipped / failed / conflict_skipped
         / updated counts.
+    Raises:
+        ImportPrivacyError: a foreign bundle has secret-bearing record(s) and
+            ``force_unsafe`` is not set.
     """
     if on_conflict not in _VALID_ON_CONFLICT:
         raise ValueError(
@@ -223,15 +355,31 @@ async def import_chunks(
     if not bundle.chunks:
         return ImportStats(0, 0, 0, 0)
 
+    # ADR-0006 Axis F.3: a valid local-provenance marker (verified over the raw
+    # bundle records, before any parse/mutation) means this is a self-export, so
+    # the redaction re-scan is skipped to preserve a deterministic round-trip.
+    # Any absent/invalid marker → foreign → run the per-record gate below.
+    from memtomem import provenance
+
+    key_path = provenance_key_path or provenance.key_path_for_db(storage.db_path)
+    is_self_export = provenance.verify_marker(
+        bundle.chunks, bundle.provenance, provenance.load_key_for_verify(key_path)
+    )
+
     skipped = 0
     parsed: list[tuple[Chunk, str | None]] = []  # (chunk, bundle_chunk_id_or_None)
 
-    for record in bundle.chunks:
+    for idx, record in enumerate(bundle.chunks):
         try:
             chunk, bundle_chunk_id = _dict_to_chunk(record, namespace_override=namespace)
             parsed.append((chunk, bundle_chunk_id))
         except Exception as exc:
-            logger.warning("Skipping malformed record: %s", exc)
+            # Never interpolate ``exc`` into the log: parse errors raised by
+            # ``datetime.fromisoformat`` / ``int()`` / ``ChunkType(...)`` embed
+            # the offending field value, which in a *foreign* bundle could be a
+            # secret-shaped string. Log the record index and exception class
+            # only — matched bytes must not reach the log sink.
+            logger.warning("Skipping malformed bundle record %d (%s)", idx, type(exc).__name__)
             skipped += 1
 
     if not parsed:
@@ -241,6 +389,11 @@ async def import_chunks(
             skipped_chunks=skipped,
             failed_chunks=0,
         )
+
+    # Foreign bundles run the F.2 redaction gate on every well-formed record
+    # (malformed records were already dropped above and are never scanned).
+    if not is_self_export:
+        _enforce_import_redaction(parsed, force_unsafe=force_unsafe, surface=surface)
 
     conflict_skipped = 0
     updated = 0

--- a/packages/memtomem/src/memtomem/web/routes/export.py
+++ b/packages/memtomem/src/memtomem/web/routes/export.py
@@ -48,7 +48,11 @@ async def export_stats(
     """Return chunk count that would be exported (without downloading)."""
     from memtomem.tools.export_import import export_chunks
 
-    bundle = await export_chunks(storage, source_filter=source, tag_filter=tag, since=since)
+    # Count-only preview: skip provenance signing so this read endpoint neither
+    # creates the per-install key file nor fails on a key-file problem.
+    bundle = await export_chunks(
+        storage, source_filter=source, tag_filter=tag, since=since, stamp_provenance=False
+    )
     return ExportStatsResponse(total_chunks=bundle.total_chunks)
 
 
@@ -57,14 +61,24 @@ async def import_memories(
     file: UploadFile,
     on_conflict: str = Form("skip"),
     preserve_ids: bool = Form(False),
+    force_unsafe: bool = Form(False),
     storage=Depends(get_storage),
     embedder=Depends(get_embedder),
 ) -> ImportResponse:
-    """Import chunks from a previously exported JSON bundle (multipart upload)."""
+    """Import chunks from a previously exported JSON bundle (multipart upload).
+
+    Foreign bundles (not exported by this install) are scanned per-record and
+    rejected with HTTP 403 ``redaction_blocked`` if a record contains a
+    secret-shaped value, unless ``force_unsafe`` is set (ADR-0006 Axis F.3).
+    """
     import tempfile
     from pathlib import Path
 
-    from memtomem.tools.export_import import _VALID_ON_CONFLICT, import_chunks
+    from memtomem.tools.export_import import (
+        ImportPrivacyError,
+        _VALID_ON_CONFLICT,
+        import_chunks,
+    )
 
     if not file.filename or not file.filename.endswith(".json"):
         raise HTTPException(status_code=422, detail="Only .json bundle files are accepted.")
@@ -90,7 +104,21 @@ async def import_memories(
             tmp_path,
             on_conflict=on_conflict,  # type: ignore[arg-type]
             preserve_ids=preserve_ids,
+            force_unsafe=force_unsafe,
+            surface="web_api_import",
         )
+    except ImportPrivacyError as exc:
+        # Mirrors the web_api_add 403 shape (system.py); ``blocked_records`` is a
+        # record count (not a regex-span count). Matched bytes never leave the
+        # server. The SPA override toggle is the ADR-0006 PR-B follow-up.
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "detail": "redaction_blocked",
+                "blocked_records": exc.blocked_records,
+                "surface": "web_api_import",
+            },
+        ) from exc
     finally:
         tmp_path.unlink(missing_ok=True)
 

--- a/packages/memtomem/tests/test_import_provenance_gate.py
+++ b/packages/memtomem/tests/test_import_provenance_gate.py
@@ -1,0 +1,457 @@
+"""ADR-0006 Axis F.3 — provenance-aware redaction gate on bundle import.
+
+Pins the trust-boundary behavior issue #1483 builds:
+
+* A **foreign** bundle (no valid local-provenance marker) carrying a
+  secret-shaped value is rejected by default and accepted only with the
+  explicit ``force_unsafe`` override — across the core ``import_chunks`` path,
+  the MCP ``mem_import`` tool, and the Web ``POST /export/import`` route.
+* A **self-export** (valid provenance marker) round-trips unchanged: the
+  redaction re-scan is skipped, so a self-exported bundle that legitimately
+  contains a secret imports without ``force_unsafe``.
+* Tampering with (or appending to) a signed bundle invalidates the marker, so
+  it falls back to the foreign gate.
+* Malformed records are dropped before the scan, and a single blocked record
+  rejects the whole import atomically (no partial commit).
+* Per-install key file handling is symlink-safe and fails closed on signing /
+  safe on verify.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from memtomem import provenance
+from memtomem.config import StorageConfig
+from memtomem.models import Chunk, ChunkMetadata, ChunkType
+from memtomem.storage.sqlite_backend import SqliteBackend
+from memtomem.tools.export_import import (
+    ImportPrivacyError,
+    export_chunks,
+    import_chunks,
+)
+
+# Matches DEFAULT_PATTERNS: ``api_key=`` (pattern 0) and ``sk-…`` (pattern 2).
+_SECRET = "api_key=sk-abcdefghijklmnopqrstuvwxyz0123"
+_CLEAN = "# Notes\nOrdinary prose about caching, retries, and backoff.\n"
+
+
+# --- fixtures / helpers ----------------------------------------------------
+
+
+class _FakeEmbedder:
+    """Hermetic dim-8 embedder — no model download."""
+
+    def __init__(self, dim: int = 8) -> None:
+        self._dim = dim
+
+    @property
+    def dimension(self) -> int:
+        return self._dim
+
+    @property
+    def model_name(self) -> str:
+        return "fake-test"
+
+    async def embed_texts(self, texts, *, on_progress=None):
+        return [[0.1] * self._dim for _ in texts]
+
+    async def embed_query(self, query):
+        return [0.1] * self._dim
+
+    async def close(self) -> None:
+        pass
+
+
+async def _make_storage(tmp_path: Path, name: str = "t") -> SqliteBackend:
+    cfg = StorageConfig()
+    cfg.sqlite_path = tmp_path / f"{name}.db"
+    storage = SqliteBackend(cfg, dimension=8)
+    await storage.initialize()
+    return storage
+
+
+def _record(content: str, *, source: str = "notes.md", ns: str = "default") -> dict:
+    return {
+        "chunk_id": str(uuid4()),
+        "content_hash": "",  # recomputed by Chunk.__post_init__
+        "content": content,
+        "source_file": source,
+        "heading_hierarchy": [],
+        "chunk_type": "raw_text",
+        "start_line": 1,
+        "end_line": 1,
+        "language": "en",
+        "tags": [],
+        "namespace": ns,
+        "created_at": "2026-06-30T00:00:00+00:00",
+    }
+
+
+def _bundle_dict(records: list[dict], *, marker: dict | None = None) -> dict:
+    return {
+        "version": "2",
+        "exported_at": "2026-06-30T00:00:00+00:00",
+        "total_chunks": len(records),
+        "chunks": records,
+        "provenance": marker,
+    }
+
+
+def _write_bundle(path: Path, records: list[dict], *, marker: dict | None = None) -> Path:
+    path.write_text(json.dumps(_bundle_dict(records, marker=marker)), encoding="utf-8")
+    return path
+
+
+def _make_chunk(content: str, *, source: str = "a.md", ns: str = "default") -> Chunk:
+    meta = ChunkMetadata(
+        source_file=Path(source),
+        heading_hierarchy=(),
+        chunk_type=ChunkType("raw_text"),
+        start_line=1,
+        end_line=1,
+        language="en",
+        tags=(),
+        namespace=ns,
+    )
+    chunk = Chunk(
+        content=content,
+        metadata=meta,
+        id=uuid4(),
+        created_at=datetime.now(timezone.utc),
+    )
+    chunk.embedding = [0.1] * 8
+    return chunk
+
+
+# --- core import_chunks gate ----------------------------------------------
+
+
+async def test_foreign_bundle_with_secret_rejected_by_default(tmp_path):
+    storage = await _make_storage(tmp_path)
+    bundle = _write_bundle(tmp_path / "foreign.json", [_record(_SECRET)], marker=None)
+
+    with pytest.raises(ImportPrivacyError) as ei:
+        await import_chunks(storage, _FakeEmbedder(), bundle)
+    assert ei.value.blocked_records == 1
+    # Atomic reject — nothing committed.
+    assert len(await storage.recall_chunks(limit=100)) == 0
+
+
+async def test_foreign_bundle_with_secret_imports_with_force_unsafe(tmp_path):
+    storage = await _make_storage(tmp_path)
+    bundle = _write_bundle(tmp_path / "foreign.json", [_record(_SECRET)], marker=None)
+
+    stats = await import_chunks(storage, _FakeEmbedder(), bundle, force_unsafe=True)
+    assert stats.imported_chunks == 1
+    assert len(await storage.recall_chunks(limit=100)) == 1
+
+
+async def test_foreign_clean_bundle_imports_without_force(tmp_path):
+    storage = await _make_storage(tmp_path)
+    bundle = _write_bundle(tmp_path / "clean.json", [_record(_CLEAN)], marker=None)
+
+    stats = await import_chunks(storage, _FakeEmbedder(), bundle)
+    assert stats.imported_chunks == 1
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("heading_hierarchy", [_SECRET]),  # embedded via retrieval_content
+        ("source_file", _SECRET),  # stored + displayed
+        ("tags", [_SECRET]),  # stored + filterable
+    ],
+)
+async def test_foreign_bundle_secret_in_metadata_is_gated(tmp_path, field, value):
+    """ADR-0006 F.3: import scans the full retrievable surface, so a secret
+    smuggled into attacker-controlled metadata (not just ``content``) is
+    rejected by default and admitted only with ``force_unsafe``."""
+    storage = await _make_storage(tmp_path)
+    rec = _record(_CLEAN)
+    rec[field] = value
+    bundle = _write_bundle(tmp_path / f"meta_{field}.json", [rec], marker=None)
+
+    with pytest.raises(ImportPrivacyError):
+        await import_chunks(storage, _FakeEmbedder(), bundle)
+    assert len(await storage.recall_chunks(limit=100)) == 0
+
+    stats = await import_chunks(storage, _FakeEmbedder(), bundle, force_unsafe=True)
+    assert stats.imported_chunks == 1
+
+
+async def test_self_export_with_secret_roundtrips_unchanged(tmp_path):
+    """A self-exported bundle (valid marker) with a secret imports without
+    force_unsafe — the marker is honored and the re-scan is skipped."""
+    key_path = tmp_path / "self.provenance_key"
+    src = await _make_storage(tmp_path, "src")
+    await src.upsert_chunks([_make_chunk(_CLEAN + _SECRET, source="secretnote.md")])
+
+    bundle_path = tmp_path / "self.json"
+    bundle = await export_chunks(src, output_path=bundle_path, provenance_key_path=key_path)
+    assert bundle.provenance and bundle.provenance["scheme"] == provenance.SCHEME
+
+    # Fresh install sharing the same key → marker verifies → no force_unsafe.
+    dst = await _make_storage(tmp_path, "dst")
+    stats = await import_chunks(dst, _FakeEmbedder(), bundle_path, provenance_key_path=key_path)
+    assert stats.imported_chunks == 1
+    rows = await dst.recall_chunks(limit=100)
+    assert any(_SECRET in c.content for c in rows)
+
+
+async def test_self_export_verifies_only_with_matching_key(tmp_path):
+    """The same self-export imported under a *different* install key is foreign
+    and gets gated (proves the marker is key-bound, not just present)."""
+    key_path = tmp_path / "src.provenance_key"
+    src = await _make_storage(tmp_path, "src")
+    await src.upsert_chunks([_make_chunk(_CLEAN + _SECRET, source="secretnote.md")])
+    bundle_path = tmp_path / "self.json"
+    await export_chunks(src, output_path=bundle_path, provenance_key_path=key_path)
+
+    dst = await _make_storage(tmp_path, "dst")
+    other_key = tmp_path / "other.provenance_key"  # absent → no key → foreign
+    with pytest.raises(ImportPrivacyError):
+        await import_chunks(dst, _FakeEmbedder(), bundle_path, provenance_key_path=other_key)
+
+
+async def test_tampered_self_export_is_gated(tmp_path):
+    """Appending a record to a validly-signed bundle invalidates the marker."""
+    key_path = tmp_path / "k.provenance_key"
+    key = provenance.load_or_create_key_for_export(key_path)
+    records = [_record(_CLEAN, source="clean.md")]
+    marker = provenance.make_marker(records, key)
+
+    # Tamper: append a secret-bearing record after signing.
+    tampered = records + [_record(_SECRET, source="evil.md")]
+    bundle = _write_bundle(tmp_path / "tampered.json", tampered, marker=marker)
+
+    storage = await _make_storage(tmp_path)
+    with pytest.raises(ImportPrivacyError):
+        await import_chunks(storage, _FakeEmbedder(), bundle, provenance_key_path=key_path)
+
+
+async def test_malformed_record_not_scanned_and_atomic_reject(tmp_path):
+    """A malformed record is dropped pre-scan; a single blocked record rejects
+    the whole import (the clean record is not committed)."""
+    storage = await _make_storage(tmp_path)
+    records = [
+        {"not_a": "valid record"},  # missing content/source_file → skipped
+        _record(_CLEAN, source="clean.md"),
+        _record(_SECRET, source="secret.md"),
+    ]
+    bundle = _write_bundle(tmp_path / "mixed.json", records, marker=None)
+
+    with pytest.raises(ImportPrivacyError) as ei:
+        await import_chunks(storage, _FakeEmbedder(), bundle)
+    assert ei.value.blocked_records == 1  # only the secret record, not the malformed one
+    assert len(await storage.recall_chunks(limit=100)) == 0  # nothing committed
+
+
+async def test_empty_bundle_is_noop(tmp_path):
+    storage = await _make_storage(tmp_path)
+    bundle = _write_bundle(tmp_path / "empty.json", [], marker=None)
+    stats = await import_chunks(storage, _FakeEmbedder(), bundle)
+    assert stats.total_chunks == 0 and stats.imported_chunks == 0
+
+
+# --- per-install key file handling ----------------------------------------
+
+
+def test_export_key_file_is_owner_private(tmp_path):
+    key_path = tmp_path / "perm.provenance_key"
+    provenance.load_or_create_key_for_export(key_path)
+    assert key_path.exists()
+    if os.name == "posix":
+        assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+
+
+def test_symlinked_key_is_foreign_on_verify_and_fails_closed_on_export(tmp_path):
+    real = tmp_path / "real_key"
+    real.write_text("ab" * 32, encoding="utf-8")  # 32-byte key as 64 hex chars
+    link = tmp_path / "linked.provenance_key"
+    try:
+        os.symlink(real, link)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unsupported on this platform")
+
+    # Verify side fails *safe*: a symlinked key is treated as no key → foreign.
+    assert provenance.load_key_for_verify(link) is None
+    # Sign side fails *closed*: refuse to sign with a symlinked key.
+    with pytest.raises(provenance.ProvenanceKeyError):
+        provenance.load_or_create_key_for_export(link)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX permission model")
+def test_group_or_world_accessible_key_rejected(tmp_path):
+    """A regular key with group/other permission bits cannot be trusted — an
+    attacker who can read it could forge markers — so it is foreign on verify
+    and fails closed on export (Codex review hardening)."""
+    key_path = tmp_path / "loose.provenance_key"
+    key_path.write_text("ab" * 32, encoding="utf-8")  # valid 32-byte hex key
+    os.chmod(key_path, 0o644)  # group/other readable
+
+    assert provenance.load_key_for_verify(key_path) is None
+    with pytest.raises(provenance.ProvenanceKeyError):
+        provenance.load_or_create_key_for_export(key_path)
+
+
+def test_verify_missing_key_is_foreign(tmp_path):
+    assert provenance.load_key_for_verify(tmp_path / "nope.key") is None
+
+
+# --- MCP ingress: mem_import ----------------------------------------------
+
+
+async def test_mem_import_foreign_secret_rejected_then_force_unsafe(tmp_path, monkeypatch):
+    import memtomem.server.tools.export_import as mcp_ei
+
+    storage = await _make_storage(tmp_path)
+    app = SimpleNamespace(storage=storage, embedder=_FakeEmbedder())
+
+    async def _fake_get_app(ctx):
+        return app
+
+    monkeypatch.setattr(mcp_ei, "_get_app_initialized", _fake_get_app)
+    bundle = _write_bundle(tmp_path / "foreign.json", [_record(_SECRET)], marker=None)
+
+    msg = await mcp_ei.mem_import(input_file=str(bundle))
+    assert "rejected" in msg.lower()
+    assert "force_unsafe" in msg
+    assert len(await storage.recall_chunks(limit=100)) == 0
+
+    msg2 = await mcp_ei.mem_import(input_file=str(bundle), force_unsafe=True)
+    assert "Import complete" in msg2
+    assert len(await storage.recall_chunks(limit=100)) == 1
+
+
+# --- Web ingress: POST /export/import -------------------------------------
+
+
+def _web_app(storage, embedder):
+    from fastapi import FastAPI
+
+    from memtomem.web.deps import get_embedder, get_storage
+    from memtomem.web.routes import export as web_export
+
+    app = FastAPI()
+    app.include_router(web_export.router)
+    app.dependency_overrides[get_storage] = lambda: storage
+    app.dependency_overrides[get_embedder] = lambda: embedder
+    return app
+
+
+async def test_web_import_foreign_secret_403_then_force_unsafe(tmp_path):
+    storage = await _make_storage(tmp_path)
+    app = _web_app(storage, _FakeEmbedder())
+    payload = json.dumps(_bundle_dict([_record(_SECRET)], marker=None))
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        res = await client.post(
+            "/export/import",
+            files={"file": ("foreign.json", payload, "application/json")},
+        )
+        assert res.status_code == 403, res.text
+        detail = res.json()["detail"]
+        assert detail["detail"] == "redaction_blocked"
+        assert detail["surface"] == "web_api_import"
+        assert detail["blocked_records"] == 1
+        assert _SECRET not in res.text  # matched bytes never leak
+
+        res2 = await client.post(
+            "/export/import",
+            files={"file": ("foreign.json", payload, "application/json")},
+            data={"force_unsafe": "true"},
+        )
+        assert res2.status_code == 200, res2.text
+        assert res2.json()["imported_chunks"] == 1
+
+
+# --- review-hardening regressions ------------------------------------------
+
+
+async def test_secret_in_malformed_field_not_leaked_to_logs(tmp_path, caplog):
+    """A foreign bundle hiding a secret in a field that fails parsing (here
+    ``created_at`` → ``datetime.fromisoformat`` raises ``ValueError`` embedding
+    the value) must drop the record WITHOUT echoing the secret bytes to the log
+    sink. Regression for the parse-error log-leak (Codex review)."""
+    import logging
+
+    storage = await _make_storage(tmp_path)
+    bad = _record(_CLEAN)
+    bad["created_at"] = _SECRET  # fromisoformat(secret) -> ValueError(secret)
+    bundle = _write_bundle(tmp_path / "leak.json", [bad], marker=None)
+
+    with caplog.at_level(logging.WARNING):
+        stats = await import_chunks(storage, _FakeEmbedder(), bundle)
+
+    assert stats.skipped_chunks == 1
+    assert len(await storage.recall_chunks(limit=100)) == 0
+    assert _SECRET not in caplog.text
+    assert "sk-" not in caplog.text
+
+
+async def test_force_unsafe_import_records_bypass_and_audits(tmp_path, monkeypatch):
+    """ADR-0006 E.1/F.3: a ``force_unsafe`` import of a foreign secret-bearing
+    bundle records a ``bypassed`` counter and emits a structured audit line
+    (carrying counts, never the matched bytes)."""
+    from memtomem import privacy
+
+    recorded: list[tuple[str, str]] = []
+    audits: list[dict] = []
+    monkeypatch.setattr(privacy, "record", lambda outcome, tool: recorded.append((outcome, tool)))
+    monkeypatch.setattr(
+        privacy,
+        "emit_bypass_audit",
+        lambda *, surface, content_chars, hits, audit_context=None: audits.append(
+            {"surface": surface, "hits": hits}
+        ),
+    )
+
+    storage = await _make_storage(tmp_path)
+    bundle = _write_bundle(tmp_path / "foreign.json", [_record(_SECRET)], marker=None)
+    stats = await import_chunks(
+        storage, _FakeEmbedder(), bundle, force_unsafe=True, surface="mem_import"
+    )
+
+    assert stats.imported_chunks == 1
+    assert ("bypassed", "mem_import") in recorded
+    assert audits and audits[0]["surface"] == "mem_import" and audits[0]["hits"] >= 1
+
+
+def test_non_ascii_signature_is_foreign_not_error(tmp_path):
+    """A marker whose signature carries non-ASCII bytes must verify ``False``
+    (foreign), not raise from ``hmac.compare_digest`` (Codex/crypto-lens)."""
+    key = provenance.load_or_create_key_for_export(tmp_path / "k.provenance_key")
+    bad_marker = {
+        "scheme": provenance.SCHEME,
+        "algo": provenance.ALGO,
+        "signature": "ñ" * 64,  # non-ASCII str
+    }
+    assert provenance.verify_marker([_record(_CLEAN)], bad_marker, key) is False
+
+
+async def test_self_export_unicode_content_roundtrips(tmp_path):
+    """Non-ASCII content + source/heading round-trips: the canonical payload is
+    ``ensure_ascii=False`` over the parsed objects, so the marker still verifies
+    on the same install (determinism invariant, beyond ASCII)."""
+    key_path = tmp_path / "u.provenance_key"
+    src = await _make_storage(tmp_path, "src")
+    await src.upsert_chunks([_make_chunk("한국어 메모 🔐 with a café", source="유니코드.md")])
+
+    bundle_path = tmp_path / "uni.json"
+    bundle = await export_chunks(src, output_path=bundle_path, provenance_key_path=key_path)
+    assert bundle.provenance is not None
+
+    dst = await _make_storage(tmp_path, "dst")
+    stats = await import_chunks(dst, _FakeEmbedder(), bundle_path, provenance_key_path=key_path)
+    assert stats.imported_chunks == 1

--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -114,6 +114,9 @@ def _seed_state(home: Path, *, with_db: bool = True, with_fragments: bool = True
         (state / "memtomem.db").write_bytes(b"sqlite-fake")
         (state / "memtomem.db-wal").write_bytes(b"wal")
         (state / "memtomem.db-shm").write_bytes(b"shm")
+        # Per-install provenance key sidecar (ADR-0006 Axis F.3) — a secret that
+        # must be wiped with the data, not left for a same-path reinstall.
+        (state / "memtomem.provenance_key").write_text("ab" * 32, encoding="utf-8")
     (state / "memories").mkdir()
     (state / "memories" / "x.md").write_text("# hello", encoding="utf-8")
     (state / ".current_session").write_text("sess-id", encoding="utf-8")
@@ -154,8 +157,9 @@ class TestKeepConfig:
         assert (state / "config.json").exists()
         assert (state / "config.d" / "claude.json").exists()
         assert (state / "config.json.bak-2026-04-22T00-00-00").exists()
-        # data side wiped
+        # data side wiped (incl. the provenance key — it is data, not config)
         assert not (state / "memtomem.db").exists()
+        assert not (state / "memtomem.provenance_key").exists()
         assert not (state / "memories" / "x.md").exists()
 
 
@@ -169,6 +173,8 @@ class TestKeepData:
         assert result.exit_code == 0, result.output
         assert (state / "memtomem.db").exists()
         assert (state / "memtomem.db-wal").exists()
+        # keeping data keeps the provenance key, so prior self-exports still verify
+        assert (state / "memtomem.provenance_key").exists()
         assert (state / "memories" / "x.md").exists()
         # config side wiped
         assert not (state / "config.json").exists()
@@ -186,6 +192,7 @@ class TestCustomStoragePath:
         custom_db = custom_dir / "foo.db"
         custom_db.write_bytes(b"sqlite-fake")
         (custom_dir / "foo.db-wal").write_bytes(b"wal")
+        (custom_dir / "foo.provenance_key").write_text("ab" * 32, encoding="utf-8")
         (custom_dir / "unrelated.txt").write_text("user file", encoding="utf-8")
 
         # Seed config that points to the custom path
@@ -198,9 +205,10 @@ class TestCustomStoragePath:
         result = CliRunner().invoke(cli, ["uninstall", "-y"])
         assert result.exit_code == 0, result.output
         assert "custom storage path" in result.output
-        # custom DB siblings deleted
+        # custom DB siblings + provenance key deleted
         assert not custom_db.exists()
         assert not (custom_dir / "foo.db-wal").exists()
+        assert not (custom_dir / "foo.provenance_key").exists()
         # unrelated sibling left alone
         assert (custom_dir / "unrelated.txt").exists(), "non-DB siblings must NOT be deleted"
 

--- a/packages/memtomem/tests/test_web_invariants_registry.py
+++ b/packages/memtomem/tests/test_web_invariants_registry.py
@@ -306,9 +306,18 @@ _REDACTION_EXEMPT: dict[str, str] = {
     "system.trigger_index": "control plane; operates on existing files; "
     "redaction happens at file-ingest time inside the indexer",
     "system.reindex_all": "control plane; operates on existing files",
-    "export.import_memories": "import bypass: archived chunks already "
-    "passed redaction at original write time and re-scanning would "
-    "corrupt deterministic round-trip",
+    # Bundle import is redaction-gated in the shared ``tools/export_import.py::
+    # import_chunks`` path, not in this route handler body — so the AST walk
+    # (which inspects handler bodies only) correctly leaves it exempt here.
+    # ADR-0006 Axis F.3: a self-export carrying a valid local-provenance marker
+    # round-trips unchanged (re-scan skipped); a foreign/unverified bundle is
+    # scanned per-record (``privacy.enforce_write_guard``) and rejected on a
+    # secret hit unless ``force_unsafe`` is passed.
+    "export.import_memories": (
+        "redaction enforced in the shared import_chunks() path (ADR-0006 F.3): "
+        "self-exports with a valid provenance marker round-trip unchanged, foreign "
+        "bundles are gated per-record; the guard is not in this handler body"
+    ),
     "watchdog.watchdog_run_now": "control plane; no payload",
 }
 


### PR DESCRIPTION
## Summary

Closes #1483. Implements **ADR-0006 Axis F, Decision F.3** (provenance-aware
redaction gate on bundle import).

JSON bundle import was the **sole batch-write ingress with no redaction scan**:
`tools/export_import.py::import_chunks()` embedded and upserted every record
without `privacy.enforce_write_guard()`, an asymmetric bypass of the trust
boundary every other write surface enforces. Both ingresses share it — web
`POST /api/export/import` and MCP `mem_import`.

## Design (F.3 — verify-or-gate)

- **New `memtomem/provenance.py`** stamps each export with an **HMAC-SHA256**
  marker over the canonical chunk payload, keyed by a per-install secret stored
  as a sidecar next to the SQLite DB (`<db-stem>.provenance_key`).
- **Import verifies the marker over the raw bundle records.** A valid marker ⇒
  self-export ⇒ round-trip unchanged (re-scan skipped). An absent or invalid
  marker ⇒ foreign ⇒ per-record `enforce_write_guard(scope="user")`,
  **atomically** rejecting the whole import on any secret hit (mirrors
  `mem_batch_add`) unless `force_unsafe` is passed (audit-logged).
- **Foreign-bundle scan covers the full retrievable surface** — `content` +
  `heading_hierarchy` + `source_file` + `tags`. Import is the one write surface
  where *every* field is attacker-controlled and the metadata is embedded
  (`retrieval_content`), stored, and retrievable; this is wider field coverage
  than the `content`-only scan on locally-derived-metadata surfaces, not a new
  pattern set. Self-exports skip the scan, so round-trip fidelity is unaffected.
- **Threaded through both ingresses**: `mem_import` returns a clean error
  string; web import returns **HTTP 403 `redaction_blocked`** (matched bytes
  never leave the server).

### Threat model

- **Forgery** needs the per-install key. Key handling is symlink-safe and
  owner-private (`O_CREAT|O_EXCL|O_NOFOLLOW`, `0o600`, post-open `fstat`
  requiring a regular file owned by the current user with no group/other bits).
  **Verify fails safe** (any key anomaly ⇒ foreign ⇒ re-scan, never raises);
  **signing fails closed** (a suspicious existing key raises rather than signing
  with an attacker-influenced secret).
- **Modification / injection**: the HMAC binds the entire canonical `chunks`
  list, so editing/adding/removing any record invalidates the marker.
- **Caveat (per ADR-0006)**: the marker proves *local provenance*, not
  per-chunk redaction. Re-importing your own export is the intended round-trip;
  the revocation lever is to rotate the sidecar key.

## Review hardening (Codex + adversarial multi-lens review)

- **No secret bytes to logs.** Malformed-record parse errors are logged by
  record index + exception class only — `datetime.fromisoformat` / `int()` /
  `ChunkType()` embed the offending field value in the exception, which for a
  foreign bundle could be a secret-shaped string.
- **`mm uninstall` wipes the key sidecar** with the data (`keep_data=False`;
  preserved with `--keep-data`). Otherwise a same-path reinstall reused the old
  per-install key and kept trusting prior self-export markers (custom paths
  handled via `key_path_for_db`).
- **`verify_marker` returns `False`** (foreign) on a non-ASCII signature instead
  of raising `TypeError` from `hmac.compare_digest`.

## Behavior change

Importing a **foreign** bundle that contains a secret-shaped value (in content
*or* the now-scanned metadata) now fails by default where it previously imported
silently; the web surface returns HTTP 403 `redaction_blocked`. Telegraphed in
`CHANGELOG.md` under `[Unreleased] › Security`.

The Web UI override toggle is the ADR-0006 **PR-B** follow-up; this PR lands the
gate + `force_unsafe` on the MCP and HTTP API surfaces.

## Tests

`tests/test_import_provenance_gate.py` (new) pins, across the core
`import_chunks` path **and** both ingresses (MCP `mem_import`, web
`POST /export/import`):

- foreign bundle with a secret → rejected by default; accepted with
  `force_unsafe`;
- **secret smuggled into `heading_hierarchy` / `source_file` / `tags`** →
  gated (full-surface scan);
- self-export (valid marker) with a secret → round-trips unchanged; non-ASCII
  (Korean + emoji) content round-trips;
- marker is **key-bound**; tampering/appending invalidates it;
- malformed records dropped pre-scan **without leaking the field value to logs**;
- single blocked record → atomic reject; `force_unsafe` records the `bypassed`
  audit trail;
- key file owner-private; symlink fails-safe-on-verify / fails-closed-on-sign;
  group/world-accessible key rejected; non-ASCII signature → foreign.

`tests/test_uninstall_cmd.py`: the `.provenance_key` sidecar is wiped on full
uninstall, preserved with `--keep-data`, and removed for custom storage paths.

`tests/test_web_invariants_registry.py`: the `export.import_memories` exemption
justification is rewritten from the now-false "re-scanning would corrupt
round-trip" to the provenance-aware policy (the guard lives in the shared
`import_chunks()` path, not the route-handler body the AST walk inspects).

Local: `ruff check` + `ruff format --check` clean; `mypy` clean on changed
files; targeted + regression suites green (`711 passed` across
export/import/privacy/redaction/uninstall/provenance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
