### PR TITLE
security(privacy): expand secret-class redaction patterns (#1488)

### DIFF
--- a/packages/memtomem/src/memtomem/privacy.py
+++ b/packages/memtomem/src/memtomem/privacy.py
@@ -1,18 +1,36 @@
 """Content redaction guard at the LTM trust boundary.
 
-The pattern set is duplicated from memtomem-stm
-``proxy/privacy.py:DEFAULT_PATTERNS`` as of commit ``a98636e``,
-**secrets-only subset**. STM's full pattern set includes patterns whose
-semantic category is PII (e.g., email addresses) rather than secret-class.
-Those are excluded by design here because PII false positives on prose
-ingress would be unworkable; redaction at the LTM ingress is the trust
-boundary where blocking semantics demand a tight false-positive profile.
+The pattern set has two provenance tiers, both secret-class only:
+
+1. **STM-synced subset** — mirrored from memtomem-stm
+   ``proxy/privacy.py:CREDENTIAL_PATTERNS``, audited current as of STM
+   commit ``3e585b5`` (previously pinned at ``a98636e``; the only STM
+   change to the credential set since was splitting the email/PII
+   pattern out of its ``DEFAULT_PATTERNS`` into a separate
+   ``PII_PATTERNS`` list — correctly excluded here). STM's full set also
+   carries PII patterns (email, etc.); those are excluded by design
+   because PII false positives on prose ingress would be unworkable.
+
+2. **LTM-origin additions** (issue #1488) — secret-class provider-token
+   patterns added directly at this trust boundary, ahead of STM. LTM is
+   the authoritative gate and may legitimately be stricter than STM's
+   compression-routing signal, so a superset is fine. For routing
+   coherence these should be mirrored back into STM's
+   ``CREDENTIAL_PATTERNS`` (reverse sync, tracked separately); until then
+   LTM is a strict superset.
+
+Redaction at the LTM ingress is the trust boundary where blocking
+semantics demand a tight false-positive profile.
 
 Sync rule (asymmetric):
 
 - STM additions of secret-class patterns (provider tokens, key formats,
   PEM-style headers, etc.) require sync into this module + a SHA bump in
   this docstring.
+- LTM-origin secret-class additions (tier 2 above) flow the OTHER way:
+  they should be mirrored into STM's ``CREDENTIAL_PATTERNS`` for routing
+  coherence, but LTM does not block on that — the trust boundary tightens
+  here first.
 - STM additions of PII-class patterns (email, phone, name, address, etc.)
   do NOT auto-sync. Including any new PII-class pattern here requires a
   separate decision pass — the false-positive profile in prose ingress is
@@ -62,6 +80,70 @@ DEFAULT_PATTERNS: tuple[str, ...] = (
     # dotted identifiers.
     r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b",
     r"(?i)(BEGIN\s+(RSA|EC|OPENSSH|DSA|PGP)\s+PRIVATE\s+KEY)",
+    # --- LTM-origin secret-class additions (issue #1488) -------------------
+    # Added directly at this trust boundary, ahead of STM (see module
+    # docstring, provenance tier 2). All are case-SENSITIVE on purpose:
+    # provider prefixes are fixed-case (``sk-``, ``AIza``, ``glpat-``,
+    # ``hf_``, ``gh*_``) — do NOT wrap these under ``(?i)`` or you
+    # reintroduce false positives (``AIZA``, ``GLPAT-``). Bounded greedy
+    # segments ({20,200}), bounded digit-lookaheads ({0,33}), and exact
+    # lengths on the hyphen-inclusive tokens keep ``scan()`` linear-time:
+    # a crafted ``sk-proj-``/``glpat-`` repetition cannot drive O(n^2)
+    # backtracking (pinned by
+    # test_privacy_long_content::test_crafted_repetition_*).
+    #
+    # Modern OpenAI keys (sk-proj-/sk-svcacct-/sk-admin-): the legacy
+    # ``sk-[a-zA-Z0-9]{20,}`` rule above MISSES these — the hyphen after the
+    # class word halts the alphanumeric run before {20,}. Anchored on the
+    # embedded ``T3BlbkFJ`` marker (base64 of "OpenAI") between two
+    # base64url segments → near-zero FP. Segments bounded {20,200}
+    # (real-world pre/post-marker segments are 58 or 74 chars). The trailing
+    # segment carries a ``(?![A-Za-z0-9_-])`` terminal guard (same class as
+    # the Anthropic fix): without it the capped greedy would match the first
+    # 200 chars of a longer token-char run. The pre-marker segment needs no
+    # guard — the literal ``T3BlbkFJ`` is its terminator.
+    r"\bsk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{20,200}T3BlbkFJ[A-Za-z0-9_-]{20,200}(?![A-Za-z0-9_-])",
+    # Anthropic keys (sk-ant-apiNN-/adminNN-): also missed by the legacy
+    # rule (hyphen after "ant"). Anchored on the exact canonical body —
+    # 93 base64url chars + the literal "AA" terminal (a bit-alignment
+    # artifact every real key carries; gitleaks + trufflehog both pin it).
+    # The exact length + AA terminal is what rejects digit-bearing kebab
+    # slugs like "sk-ant-api03-release-notes-2026-migration-guide" (a loose
+    # ``{20,}`` body matched those). The terminal guard is
+    # ``(?![A-Za-z0-9_-])``, NOT ``\b``: ``-`` is in the body charset, so a
+    # bare ``\b`` would treat ``AA-`` as a boundary and let a 93-char kebab
+    # slug ending ``...AA-more-doc`` through. The OAuth token
+    # (sk-ant-oat01-) has no canonical length and is omitted rather than
+    # matched loosely — a follow-up once a stable shape exists (gitleaks
+    # issue #2104).
+    r"\bsk-ant-(?:api|admin)\d{2}-[A-Za-z0-9_-]{93}AA(?![A-Za-z0-9_-])",
+    # GitHub token family completion: gho_ (OAuth), ghu_ (user-to-server),
+    # ghs_ (server-to-server / Actions GITHUB_TOKEN), ghr_ (refresh). Same
+    # base62 shape as the already-covered ghp_ (excluded from the class to
+    # avoid duplicating it). {36,} min — ghs_ tokens run longer than 40.
+    r"\bgh[ousr]_[A-Za-z0-9]{36,}\b",
+    # Google API key (GCP / Firebase / Maps / Gemini): fixed AIza + 35
+    # base64url chars (39 total). Trailing negative lookahead pins the exact
+    # length so it won't fire on the AIza-prefixed head of a longer blob.
+    r"\bAIza[0-9A-Za-z_-]{35}(?![0-9A-Za-z_-])",
+    # GitLab personal access token: unique ``glpat-`` literal + the exact
+    # classic 20-char body (gitleaks ``glpat-[\w-]{20}``) with a terminal
+    # guard. Exact length is what rejects digit-bearing kebab slugs like
+    # "glpat-form-builder-component-name-2026" — a ``{20,}`` superset
+    # matched those. Newer 17.x routable tokens (longer body + a
+    # ".<checksum>" suffix) are a separate dot-anchored follow-up.
+    r"\bglpat-[0-9A-Za-z_-]{20}(?![0-9A-Za-z_-])",
+    # Hugging Face access token (this repo loads HF models). The short
+    # ``hf_`` prefix is collision-prone (hf_hub, hf_model), so: exact
+    # 34-char alnum body (trufflehog charset — digits matter), both word
+    # boundaries, and a digit-in-body lookahead to reject letter-only
+    # identifiers.
+    r"\bhf_(?=[A-Za-z0-9]{0,33}[0-9])[A-Za-z0-9]{34}\b",
+    # PyPI / TestPyPI upload token (this repo publishes to PyPI). The
+    # macaroon header ``AgEIcHlwaS5vcmc`` / ``AgENdGVzdC5weXBpLm9yZw``
+    # (base64 of "pypi.org" / "test.pypi.org") is an exact fingerprint →
+    # lowest FP of the set.
+    r"\bpypi-Ag(?:EIcHlwaS5vcmc|ENdGVzdC5weXBpLm9yZw)[A-Za-z0-9_-]{50,}",
 )
 
 
@@ -153,7 +235,7 @@ def to_js_pattern(pat: str) -> tuple[str, str]:
     - **Inline flag negation** like ``(?-i)`` or ``(?i-m:...)`` —
       same per-segment-scope problem as mid-pattern lifts.
     - **Named groups** ``(?P<name>...)`` — JS uses ``(?<name>...)`` and
-      a rewrite is not implemented (none of the current 9 patterns use
+      a rewrite is not implemented (none of the current patterns use
       named groups).
     - **Inline comments** ``(?#comment)`` — no JS equivalent.
     - **Python-only anchors** ``\\A`` and ``\\Z`` — use ``^`` / ``$``

--- a/packages/memtomem/tests/test_privacy.py
+++ b/packages/memtomem/tests/test_privacy.py
@@ -6,9 +6,13 @@ wire-in tests for ``mem_add`` / ``mem_batch_add`` live in
 
 Drift-prevention notes embedded as test pins:
 
-- ``test_pattern_count_pinned_at_nine`` — the parent set is intentionally
-  the secrets-only subset of STM's ``DEFAULT_PATTERNS`` (10 patterns), with
-  the email/PII pattern excluded by design.
+- ``test_pattern_count_pinned`` — the parent set is the STM-synced
+  secrets-only subset (email/PII excluded by design) plus the LTM-origin
+  secret-class additions of #1488; the exact count is pinned so a silent
+  add/drop fails loudly.
+- ``test_fixtures_cover_every_pattern`` — every DEFAULT_PATTERNS entry has
+  a paired positive/negative JS-translation fixture, so a new pattern
+  cannot be added without a parity fixture.
 - ``test_clean_inputs_have_no_hit`` — direct contract pin: well-formed
   contact-note prose (emails, phone numbers, plain text) must pass
   through untouched. Future drift toward PII inclusion would break this
@@ -35,8 +39,11 @@ def _reset_counters():
 
 
 class TestPatternSurface:
-    def test_pattern_count_pinned_at_nine(self):
-        assert len(privacy.DEFAULT_PATTERNS) == 9
+    def test_pattern_count_pinned(self):
+        # 9 STM-synced secret-class patterns + 7 LTM-origin additions
+        # (#1488). Bump deliberately when adding a pattern so a silent
+        # add/drop surfaces here.
+        assert len(privacy.DEFAULT_PATTERNS) == 16
 
     @pytest.mark.parametrize(
         "clean_input",
@@ -67,6 +74,22 @@ class TestScan:
             "AKIAIOSFODNN7EXAMPLE",
             "eyJhbGciOiJIUzI1NiJ9.eyJzdWIicm9vdA.SflKxwRJSMeK",
             "-----BEGIN RSA PRIVATE KEY-----",
+            # --- #1488 LTM-origin additions (all examples are FAKE) -----
+            # Modern OpenAI key: legacy ``sk-`` rule misses these (hyphen
+            # after "proj" halts the run) — must hit via the T3BlbkFJ rule.
+            "sk-proj-FAKE0aaaa1111bbbb2222cccc3333T3Blbk" + "FJEXAMPLE0dddd4444eeee5555ffff6666",
+            # Anthropic key (FAKE) — exact 93-char body + AA terminal.
+            "sk-ant-api03-" + ("FAKEfake0123456789" * 6)[:93] + "AA",
+            # GitHub server-to-server token (gh*_ family, FAKE).
+            "ghs_FAKEfake0123456789FAKEfake0123456789",
+            # Google API key, AIza + 35 (FAKE).
+            "AIzaSy0_-BcdSy0_-BcdSy0_-BcdSy0_-BcdSy0",
+            # GitLab PAT (FAKE) — exact 20-char body.
+            "glpat-" + ("FAKEfake0123456789" * 2)[:20],
+            # Hugging Face token, hf_ + 34 (FAKE).
+            "hf" + "_FAKEfake0123456789FAKEfake01234567",
+            # PyPI upload token, macaroon header (FAKE).
+            "pypi-AgEIcHlwaS5vcmcFAKEfake0123456789FAKEfake0123456789FAKEfake0123456789",
         ],
     )
     def test_each_secret_pattern_hits(self, secret_sample):
@@ -354,6 +377,37 @@ _PATTERN_FIXTURES: tuple[tuple[str, str], ...] = (
     ("eyJhbGciOiJIUzI1NiJ9.eyJzdWIicm9vdA.SflKxwRJSMeK", "eyJ-not-a-jwt"),
     # 8: PEM private key header
     ("-----BEGIN RSA PRIVATE KEY-----", "RSA public key"),
+    # 9: OpenAI modern (sk-proj-/svcacct-/admin-, T3BlbkFJ-anchored).
+    #    Negative: a kebab slug with the prefix but no marker.
+    (
+        "sk-proj-FAKE0aaaa1111bbbb2222cccc3333T3Blbk" + "FJEXAMPLE0dddd4444eeee5555ffff6666",
+        "sk-project-management-tool",
+    ),
+    # 10: Anthropic (sk-ant-NN-, exact 93-char body + AA). Negative: a
+    #     digit-bearing kebab slug carrying the infix (a loose body matched
+    #     it; the exact length + AA terminal rejects it).
+    (
+        "sk-ant-api03-" + ("FAKEfake0123456789" * 6)[:93] + "AA",
+        "sk-ant-api03-release-notes-2026-migration-guide",
+    ),
+    # 11: GitHub gh*_ family completion. Negative: an English word that
+    #     starts "gho" but is not a gho_ token.
+    ("ghs_FAKEfake0123456789FAKEfake0123456789", "ghost_writer_mode_enabled"),
+    # 12: Google API key (AIza + exactly 35). Negative: too short.
+    ("AIzaSy0_-BcdSy0_-BcdSy0_-BcdSy0_-BcdSy0", "AIzaShortKey"),
+    # 13: GitLab PAT (glpat-, exact 20-char body). Negative: a digit-bearing
+    #     "glpat-" kebab slug (a {20,} superset matched it; exact length
+    #     rejects it).
+    ("glpat-" + ("FAKEfake0123456789" * 2)[:20], "glpat-form-builder-component-name-2026"),
+    # 14: Hugging Face (hf_ + exactly 34, digit-guarded). Negative: a
+    #     34-char letter-only run (no digit) directly after hf_.
+    ("hf" + "_FAKEfake0123456789FAKEfake01234567", "hf" + "_abcdefghijklmnopqrstuvwxyzabcdefgh"),
+    # 15: PyPI / TestPyPI macaroon token. Negative: the prefix without the
+    #     fixed base64 header.
+    (
+        "pypi-AgEIcHlwaS5vcmcFAKEfake0123456789FAKEfake0123456789FAKEfake0123456789",
+        "pypi-package-name-here",
+    ),
 )
 
 
@@ -366,6 +420,14 @@ class TestJsPatternTranslation:
     Python ``re`` is equivalent to running the original pattern, so a
     successful Python match guarantees an identical JS match.
     """
+
+    def test_fixtures_cover_every_pattern(self):
+        # Every DEFAULT_PATTERNS entry must have a paired positive/negative
+        # fixture so the parity test below covers the whole set — a new
+        # pattern cannot be added without its parity fixture (and a
+        # contributor who appends a pattern but forgets the fixture fails
+        # here rather than shipping an untranslated/untested entry).
+        assert len(_PATTERN_FIXTURES) == len(privacy.DEFAULT_PATTERNS)
 
     @pytest.mark.parametrize(
         "idx,positive,negative",
@@ -467,3 +529,110 @@ class TestJsPatternTranslation:
             assert set(flags) <= allowed, (
                 f"Translator emitted unexpected flag in {flags!r}; allowed: {sorted(allowed)}"
             )
+
+
+# ---------------------------------------------------------------------------
+# #1488 — LTM-origin secret-class additions: per-pattern positive coverage +
+# near-miss false-positive guards. Every token example is FAKE (embedded
+# FAKE/EXAMPLE markers, never a live credential) but structurally correct
+# against the provider format. The near-misses lock the FP-defense
+# mechanisms (the T3BlbkFJ OpenAI marker, the digit-in-body lookaheads, and
+# the exact-length anchors) so a future loosening of any pattern fails loudly.
+# ---------------------------------------------------------------------------
+
+_NEW_PATTERN_POSITIVES = [
+    # OpenAI modern (T3BlbkFJ-anchored): proj / svcacct / admin.
+    "sk-proj-FAKE0aaaa1111bbbb2222cccc3333T3Blbk" + "FJEXAMPLE0dddd4444eeee5555ffff6666",
+    "sk-svcacct-FAKE_svc-0123456789aaaaaaaaaaaaaaaaaT3Blbk"
+    + "FJEXAMPLE_only-9876543210bbbbbbbbbbbbbbbbb",
+    "sk-admin-FAKE0not0real0123456789aaaaaaaaaaaaaaaaaaaaT3Blbk"
+    + "FJEXAMPLE0only0987654321bbbbbbbbbbbbbbbbbbbb",
+    # Anthropic: api03 / admin01 (exact 93-char body + AA terminal). oat01
+    # is intentionally NOT covered (no canonical shape — see privacy.py).
+    "sk-ant-api03-" + ("FAKEfake0123456789" * 6)[:93] + "AA",
+    "sk-ant-admin01-" + ("FAKEfake0123456789" * 6)[:93] + "AA",
+    # GitHub gh*_ family (gho / ghu / ghs / ghr), each 36-char base62 body.
+    "gho_FAKEfake0123456789FAKEfake0123456789",
+    "ghu_FAKEfake0123456789FAKEfake0123456789",
+    "ghs_FAKEfake0123456789FAKEfake0123456789",
+    "ghr_FAKEfake0123456789FAKEfake0123456789",
+    # Google API key: AIza + exactly 35.
+    "AIzaSy0_-BcdSy0_-BcdSy0_-BcdSy0_-BcdSy0",
+    # GitLab PAT (exact 20-char body).
+    "glpat-" + ("FAKEfake0123456789" * 2)[:20],
+    # Hugging Face: hf_ + exactly 34.
+    "hf" + "_FAKEfake0123456789FAKEfake01234567",
+    # PyPI (prod) + TestPyPI (test) macaroon tokens.
+    "pypi-AgEIcHlwaS5vcmcFAKEfake0123456789FAKEfake0123456789FAKEfake0123456789",
+    "pypi-AgENdGVzdC5weXBpLm9yZwFAKEfake0123456789FAKEfake0123456789FAKEfake0123456789",
+]
+
+_NEW_PATTERN_NEAR_MISSES = [
+    # OpenAI: the sk-<class>- prefix but no T3BlbkFJ marker (kebab slug).
+    "sk-proj-some-feature-branch-name-without-any-marker-here",
+    "sk-admin-dashboard-component-wrapper-container-element",
+    # OpenAI: the marker present but no sk-<class>- prefix.
+    "a sentence that happens to mention T3BlbkFJ as base64 of OpenAI here",
+    # OpenAI: marker present but the post-marker segment runs past the {200}
+    # cap into more token chars — the trailing terminal guard rejects the
+    # over-long run (a bare capped greedy matched its first 200 chars).
+    "sk-proj-" + "a" * 20 + "T3BlbkFJ" + "b" * 200 + "-followup-doc",
+    # Anthropic: infix shape but not the exact 93-char + AA token body
+    # (kebab slugs, with and without digits — the digit-bearing one is the
+    # case a digit-guard alone would have let through).
+    "sk-ant-colony-simulation-readme-design-notes",
+    "sk-ant-api03-readme-design-notes-only-letters-here",
+    "sk-ant-api03-release-notes-2026-migration-guide",
+    # Anthropic: a full 93-char body ending in the "AA" marker but followed
+    # by a token char (-). A bare \b terminal would accept "AA-"; the
+    # (?![A-Za-z0-9_-]) terminal rejects it.
+    "sk-ant-api03-" + "x" * 93 + "AA-followup-doc",
+    # Anthropic: 'api' not followed by two digits.
+    "sk-ant-api-gateway-architecture-doc",
+    # GitHub: a word starting with the prefix letters, not a token.
+    "ghost_writer_mode_enabled_for_the_editor",
+    "the ghs_ prefix is mentioned but not a token",
+    "gho_tooShort",
+    # Google: too short, and prefix inside an identifier (no word boundary).
+    "AIzaShort",
+    "MosaicAIzaPrefixedInsideAnIdentifierWordBoundaryFails",
+    # GitLab: 'glpat-' kebab slugs (with and without digits) and 'glpattern'
+    # (no hyphen) — none is the exact 20-char token body. The digit-bearing
+    # slugs are the cases a digit-guard alone would have let through.
+    "glpat-form-builder-component-name-no-digits",
+    "glpat-form-builder-component-name-2026",
+    "glpat-release-2026-secret-scanner-doc",
+    "glpattern-matching-utility-helper-module",
+    # Hugging Face: identifier (underscore breaks the run) + a 34-letter
+    # no-digit run directly after hf_.
+    "hf_hidden_states_from_the_transformer",
+    "hf" + "_abcdefghijklmnopqrstuvwxyzabcdefgh",
+    # PyPI: the prefix without the fixed macaroon header.
+    "pypi-package-upload-instructions-doc",
+    "pypi-AgSomethingElseEntirelyNotTheRealHeader1234567890abcdefghij",
+]
+
+
+class TestNewSecretPatterns1488:
+    @pytest.mark.parametrize("sample", _NEW_PATTERN_POSITIVES)
+    def test_new_pattern_positive_hits(self, sample):
+        assert privacy.scan(sample), f"FAKE token shape must be redacted: {sample[:40]!r}"
+
+    @pytest.mark.parametrize("text", _NEW_PATTERN_NEAR_MISSES)
+    def test_new_pattern_near_miss_does_not_hit(self, text):
+        # The contract is "no false positive from the #1488 additions"
+        # (indices >= 9). A near-miss may legitimately stay clean of the
+        # legacy 0-8 rules too, but those are pinned elsewhere; here we
+        # isolate the new set so a future loosening surfaces precisely.
+        offending = [h.pattern_index for h in privacy.scan(text) if h.pattern_index >= 9]
+        assert not offending, f"#1488 pattern(s) {offending} false-positived on {text[:50]!r}"
+
+    def test_ghp_still_covered_by_legacy_not_duplicated(self):
+        # ghp_ stays the legacy index-2 rule's job; the new gh[ousr]_
+        # pattern (index 11) deliberately excludes 'p' to avoid a
+        # duplicate hit. Locks the dedup intent + guards against the
+        # change accidentally dropping ghp_ coverage.
+        ghp = "ghp_" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"  # ghp_ + 36 base62
+        idxs = {h.pattern_index for h in privacy.scan(ghp)}
+        assert 2 in idxs, "ghp_ must still be caught by the legacy index-2 rule"
+        assert 11 not in idxs, "gh[ousr]_ (index 11) must exclude 'p' — no duplication"

--- a/packages/memtomem/tests/test_privacy_long_content.py
+++ b/packages/memtomem/tests/test_privacy_long_content.py
@@ -109,7 +109,7 @@ class TestLongContentScan:
 
     def test_one_megabyte_scan_under_perf_ceiling(self):
         # Soft ceiling — not a microbenchmark, just a quadratic-regression
-        # guard. The 9 current patterns are short prefix-anchored regexes
+        # guard. The current patterns are short prefix-anchored regexes
         # and ``re.finditer`` over 1 MB completes in single-digit ms on
         # CI hardware; 200 ms gives ample headroom for jitter while
         # still catching an accidental O(N^2) rewrite.
@@ -121,4 +121,32 @@ class TestLongContentScan:
         assert elapsed < 0.2, (
             f"1MB scan took {elapsed * 1000:.1f} ms — exceeds the 200 ms "
             "ceiling, suggesting a non-linear regression"
+        )
+
+    @pytest.mark.parametrize(
+        "blob",
+        [
+            "glpat-" * 60_000,  # digit-lookahead pattern, class incl. '-'
+            "sk-proj-" * 50_000,  # greedy segment + required T3BlbkFJ marker
+            "sk-ant-api00-" * 30_000,  # digit-lookahead after a literal prefix
+            "glpat-sk-proj-AIzahf_gho_" * 40_000,  # ~1MB mixed prefixes
+        ],
+        ids=["glpat-rep", "sk-proj-rep", "sk-ant-rep", "mixed-1mb"],
+    )
+    def test_crafted_repetition_scans_linearly(self, blob: str):
+        # #1488 adds patterns with bounded greedy segments ({20,200}) and
+        # bounded digit-lookaheads ({0,128}/{0,33}). A naive UNbounded form
+        # (e.g. ``glpat-(?=[0-9A-Za-z_-]*[0-9])…`` whose class contains '-')
+        # is O(N^2) on a crafted prefix repetition: each of ~N/6 prefix
+        # positions scans the rest of the buffer for a digit that never
+        # comes. This pins linear-time behavior so a future maintainer who
+        # drops the bound regresses here loudly rather than shipping a
+        # quadratic scan past the trust boundary.
+        start = time.perf_counter()
+        privacy.scan(blob)
+        elapsed = time.perf_counter() - start
+        assert elapsed < 0.5, (
+            f"crafted {len(blob)}-char repetition scanned in {elapsed * 1000:.1f} ms — "
+            "exceeds the 500 ms ceiling, indicating an O(N^2) backtracking regression "
+            "in one of the #1488 bounded patterns"
         )

--- a/packages/memtomem/tests/test_privacy_long_content.py
+++ b/packages/memtomem/tests/test_privacy_long_content.py
@@ -108,18 +108,24 @@ class TestLongContentScan:
         )
 
     def test_one_megabyte_scan_under_perf_ceiling(self):
-        # Soft ceiling — not a microbenchmark, just a quadratic-regression
-        # guard. The current patterns are short prefix-anchored regexes
-        # and ``re.finditer`` over 1 MB completes in single-digit ms on
-        # CI hardware; 200 ms gives ample headroom for jitter while
-        # still catching an accidental O(N^2) rewrite.
+        # Soft ceiling — not a microbenchmark, just a non-linear-regression
+        # guard. ``scan()`` runs one ``re.finditer`` pass per pattern, so cost
+        # grows linearly with the pattern count: the 16 short prefix-anchored
+        # ``DEFAULT_PATTERNS`` take ~100 ms locally and ~200 ms on a loaded CI
+        # runner for a 1 MB input (#1488 grew the set 9 -> 16, each added
+        # secret class a linear pass — no single hot spot). The 500 ms ceiling
+        # — matching ``test_crafted_repetition_scans_linearly`` below — keeps
+        # ~2x headroom over that worst case while still catching a genuine
+        # non-linear rewrite (e.g. a naive overlap-window scan that re-reads
+        # large prefixes), which would run in seconds at 1 MB, not hundreds of
+        # ms. The dedicated O(N^2) backtracking guard is that sibling test.
         text = ("a" * 999_980) + _SECRET
         start = time.perf_counter()
         hits = privacy.scan(text)
         elapsed = time.perf_counter() - start
         assert hits, "Sanity check: the secret must still be detected"
-        assert elapsed < 0.2, (
-            f"1MB scan took {elapsed * 1000:.1f} ms — exceeds the 200 ms "
+        assert elapsed < 0.5, (
+            f"1MB scan took {elapsed * 1000:.1f} ms — exceeds the 500 ms "
             "ceiling, suggesting a non-linear regression"
         )
 


### PR DESCRIPTION
## Why

The secret-class redaction detector at the LTM trust boundary (`privacy.py`)
missed several currently-issued provider token formats. Most importantly, the
legacy `sk-[a-zA-Z0-9]{20,}` rule does **not** match modern OpenAI keys
(`sk-proj-`/`sk-svcacct-`/`sk-admin-`) or any Anthropic key (`sk-ant-`): the
hyphen after the class word halts the alphanumeric run before `{20,}`, so the
most common keys issued today slip straight through the gate.

## What

7 prefix-anchored, near-zero-FP secret-class patterns, each cross-checked
against the gitleaks / GitHub secret-scanning / trufflehog canonical regexes:

| Provider | Shape | Fills |
|---|---|---|
| OpenAI modern | `sk-(proj\|svcacct\|admin)-…T3BlbkFJ…` | legacy rule misses hyphen-infixed keys |
| Anthropic | `sk-ant-(api\|admin)NN- + 93 + AA` | same hyphen gap; harness model provider |
| GitHub | `gh[ousr]_…{36,}` | gho/ghu/ghs/ghr (ghp_ already covered) |
| Google | `AIza…{35}` | GCP / Firebase / Gemini |
| GitLab | `glpat-…{20}` | classic PAT |
| Hugging Face | `hf_…{34}` | repo loads HF models |
| PyPI / TestPyPI | `pypi-Ag<macaroon-header>…` | repo publishes to PyPI |

All patterns:
- are **case-sensitive** (fixed-case provider prefixes) — a code comment warns
  against wrapping them under `(?i)`;
- carry a **terminal guard** on every capped/exact hyphen-or-underscore-inclusive
  trailing segment, so a hyphenated kebab slug or a longer token-char run cannot
  produce a false positive (the gate **blocks** writes on a hit, so prose FPs are
  costly);
- keep `scan()` **linear-time** — a crafted `glpat-`/`sk-proj-` repetition cannot
  drive O(n²) backtracking (pinned by a new perf-guard test).

### Provenance / cross-repo

These are **LTM-origin** secret-class additions, ahead of memtomem-stm. The
module docstring is restructured into two provenance tiers (STM-synced subset +
LTM-origin) and the STM sync watermark bumped `a98636e → 3e585b5` (audit
confirmed STM added no new secret-class patterns since `a98636e` — it only split
the email/PII pattern out of its `DEFAULT_PATTERNS`). LTM is the authoritative
trust boundary and may be stricter than STM's routing signal; mirroring these
back into STM's `CREDENTIAL_PATTERNS` is tracked as a reverse-sync follow-up in
#1491.

**Deferred (documented in code):** Anthropic `sk-ant-oat01-` (no canonical
length yet — gitleaks #2104) and GitLab 17.x routable tokens (distinct
dot-checksum shape); adding them loosely would reintroduce prose FPs.

## Tests

- per-pattern positive + near-miss negative coverage (incl. digit-bearing kebab
  slugs, `…AA-` and over-cap token-tail FPs);
- a fixture-parity guard (every `DEFAULT_PATTERNS` entry has a JS-translation
  fixture);
- JS-RegExp translation parity (all 7 compile + match in V8);
- a ReDoS / linearity guard on crafted prefix repetitions.

Fake-token fixtures are assembled by concatenation so the contiguous secret
shape never appears as a literal — this keeps GitHub push-protection from
flagging the test data while the runtime value still exercises the pattern.

## Validation

- `uv run pytest -k privacy` plus the privacy-dependent surfaces (web routes,
  redaction write surfaces, mem CRUD, import/sync block surfaces) → green
- `ruff check` + `ruff format --check` clean; `mypy` clean (advisory)
- repo-wide FP sweep: the 7 new patterns fire only on intentional test fixtures
- Reviewed by Codex (4 rounds → SHIP); 3 real false-positive bugs caught and fixed

Closes #1488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
