### PR TITLE
docs(web): correct stale CSRF bootstrap comment in app.js

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -317,9 +317,11 @@ _applyAppSimpleMode();
 // token at create_app() and exposes it via GET /api/session. The api()
 // helper (and the FormData uploaders that bypass it — see ``ensureCsrfToken``
 // callsites) thread the token through every unsafe-method request via
-// ``X-Memtomem-CSRF``. Stage 1 server-side is observe-only, so a missing
-// header just produces a log line; stage 2 will enforce. We do the work now
-// so the flip is a server-side toggle, not a coordinated client release.
+// ``X-Memtomem-CSRF``. Server-side enforcement is default-on: a missing or
+// invalid token on an unsafe method is rejected (set
+// ``MEMTOMEM_WEB__CSRF_ENFORCE=0`` to fall back to observe-only logging). The
+// client threads the token unconditionally, so the server-side posture stays a
+// toggle rather than a coordinated client release.
 let _csrfToken = null;
 let _csrfTokenPromise = null;
 const _UNSAFE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);


### PR DESCRIPTION
## What

The `app.js` CSRF token bootstrap comment still described server-side enforcement as observe-only — *"Stage 1 server-side is observe-only … stage 2 will enforce"* — but stage-2 enforcement has been **default-on** since the `MEMTOMEM_WEB__CSRF_ENFORCE` flip (`resolve_csrf_enforce_from_env` returns enforce unless explicitly disabled; `app.py:208` "Stage-2 default: enforce"). The served comment misstated the current security posture for anyone reading the client source.

Updated to describe the real behavior: enforcement is default-on, `MEMTOMEM_WEB__CSRF_ENFORCE=0` falls back to observe-only logging, and the client threads the token unconditionally so the posture remains a server-side toggle.

## Scope / notes

- **Comment-only**, single file. No runtime/served-behavior change.
- `index.html` `?v=144` is **intentionally not bumped** — there is no behavioral change to invalidate client caches for, and no automated guard ties an `app.js` byte change to the asset version.
- Surfaced as an out-of-scope nit during review of an unrelated change; filed separately to keep one focused change per PR.

## Test

`npx vitest run csrf-token-bootstrap` (from `packages/memtomem/tests-js`) — 4 passed; the spec pins the `api()` helper behavior, which this comment edit does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
