### PR TITLE
security(web): validate Host/Origin on all /api/* reads; loopback-only memtomem-web

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,21 +29,28 @@ memtomem is alpha (`0.x`); only the latest published minor receives security fix
 `mm web` ships an unauthenticated SPA on the loopback interface. CORS is a
 browser readability boundary, not a write boundary — a malicious tab can
 issue CORS-simple `POST` requests against `http://127.0.0.1:<port>` and the
-handler still runs even if the response is unreadable. To close that gap,
-every unsafe-method request to `/api/**` (POST / PUT / PATCH / DELETE) is
-gated by a single middleware that checks three things at once:
+handler still runs even if the response is unreadable. DNS rebinding makes
+an attacker page same-origin, so it can also *read* GET responses. To close
+both gaps, a single middleware gates **every** request to `/api/**` — reads
+included; only `OPTIONS` preflights (owned by the CORS middleware) are
+skipped:
 
-1. **CSRF token** — `X-Memtomem-CSRF` must match the per-process token in
-   `app.state.csrf_token`. The SPA fetches it via `GET /api/session`
-   lazily on the first unsafe-method request (cached for the page
-   lifetime); the token rotates on every restart and is never persisted.
+1. **Host header** — must be a loopback hostname or an operator-supplied
+   `--trusted-host` entry. Checked on **every** `/api/**` request,
+   including GET reads. Defends DNS rebinding, where the socket peer is
+   `127.0.0.1` but the browser's URL bar (and the `Host:` header) is
+   attacker-controlled — without this a rebound page could read
+   `GET /api/export`.
 2. **Origin / Referer** — when present, must resolve to a loopback host
-   or an operator-supplied `--trusted-origin` entry. Defends drive-by
-   tabs whose Origin reveals the attacker domain.
-3. **Host header** — must be a loopback hostname or an operator-supplied
-   `--trusted-host` entry. Defends DNS rebinding, where the socket peer
-   is `127.0.0.1` but the browser's URL bar (and the `Host:` header) is
-   attacker-controlled.
+   or an operator-supplied `--trusted-origin` entry. Checked on every
+   `/api/**` request. Defends drive-by tabs whose Origin reveals the
+   attacker domain.
+3. **CSRF token** — `X-Memtomem-CSRF` must match the per-process token in
+   `app.state.csrf_token`. Required for **unsafe** methods (POST / PUT /
+   PATCH / DELETE) only. The SPA fetches it via `GET /api/session` lazily
+   (cached for the page lifetime); the token rotates on every restart and
+   is never persisted. `GET /api/session` is token-exempt but still
+   Host/Origin-checked.
 
 Failures return `403` with a JSON `{"detail": "..."}` body and a
 structured `web.csrf.observe` log record for after-the-fact auditing.

--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -446,9 +446,25 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+# Loopback bind hosts safe to expose the unauthenticated SPA on. Mirrors
+# ``cli/web.py:_LOOPBACK_BINDS`` (kept local so the ASGI entrypoint does not
+# eagerly import the CLI). ``mm web`` is the supported operational entrypoint
+# and also threads ``--trusted-host`` / ``--trusted-origin`` into the
+# CSRF/Origin/Host allow-list.
+_LOOPBACK_BIND_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
 def main() -> None:
-    """Run the web UI server."""
+    """Run the web UI server (direct ``memtomem-web`` ASGI entrypoint).
+
+    Loopback-only by design. ``mm web`` is the supported operational
+    entrypoint for any non-loopback bind (RFC #787 / SECURITY.md): it
+    threads ``--trusted-host`` / ``--trusted-origin`` into the
+    CSRF/Origin/Host allow-list, which this thin console script — serving
+    the module-level app singleton — cannot do.
+    """
     import argparse
+    import sys
 
     import uvicorn
 
@@ -459,6 +475,23 @@ def main() -> None:
 
     host = args.host or os.environ.get("MEMTOMEM_WEB__HOST", "127.0.0.1")
     port = args.port or int(os.environ.get("MEMTOMEM_WEB__PORT", "8080"))
+
+    # ``memtomem-web`` cannot configure the CSRF/Origin/Host allow-list (it
+    # serves the module-level app singleton), so a non-loopback bind would
+    # expose the unauthenticated SPA while every ``/api/*`` request still
+    # 403s on the Host check — a broken, misleading posture. Refuse it and
+    # route remote exposure through ``mm web`` or a reverse proxy.
+    if host not in _LOOPBACK_BIND_HOSTS:
+        sys.stderr.write(
+            f"memtomem-web: refusing to bind --host {host}. This entrypoint is "
+            f"loopback-only. To expose the Web UI off-loopback use `mm web --host "
+            f"{host} --allow-remote-ui --trusted-host <h> --trusted-origin <o>` "
+            "(the supported entrypoint), which configures the CSRF/Origin/Host "
+            "allow-list, or front a loopback bind with an authenticating reverse "
+            "proxy. See https://github.com/memtomem/memtomem/issues/787 .\n"
+        )
+        raise SystemExit(2)
+
     uvicorn.run("memtomem.web.app:app", host=host, port=port, reload=False)
 
 

--- a/packages/memtomem/src/memtomem/web/middleware/csrf.py
+++ b/packages/memtomem/src/memtomem/web/middleware/csrf.py
@@ -25,13 +25,19 @@ by ``app.state.csrf_enforce`` (default ``True`` in production via
 
 Invariants:
 
-* The middleware short-circuits on safe methods (``GET``/``HEAD``/
-  ``OPTIONS``) and on non-``/api/*`` paths. The SPA bootstrap, static
-  assets, and read-only API calls are unaffected.
-* ``GET /api/session`` is exempt from the token check so the SPA can
-  bootstrap the token in the first place. It is still subject to the
-  Origin/Host checks via the same observe path so a rebound origin
-  cannot harvest the token undetected.
+* Host / Origin are validated for **every** ``/api/*`` request, including
+  safe-method reads — this is the DNS-rebinding boundary and must not
+  depend on the HTTP method. A rebound origin must not be able to read
+  ``GET /api/export`` or harvest the token from ``GET /api/session``. The
+  middleware short-circuits only on non-``/api/*`` paths (SPA bootstrap,
+  static assets) and on ``OPTIONS`` preflights, which the CORS middleware
+  owns.
+* The ``X-Memtomem-CSRF`` token is required for every unsafe method
+  (``POST``/``PUT``/``PATCH``/``DELETE``) on ``/api/*``, including the
+  bootstrap path itself. Safe methods never carry a token; ``GET
+  /api/session`` (the bootstrap) is reachable for that reason, but — like
+  every ``/api/*`` GET — it is still Origin / Host checked, so a rebound
+  origin cannot harvest the token undetected.
 """
 
 from __future__ import annotations
@@ -48,13 +54,17 @@ logger = logging.getLogger(__name__)
 
 _LOOPBACK_HOSTS: frozenset[str] = frozenset({"127.0.0.1", "::1", "localhost"})
 
-# Methods that mutate state. Anything outside this set falls through the
-# middleware untouched — readers (``GET``), preflights (``OPTIONS``), and
-# cache validators (``HEAD``) do not need a CSRF token.
+# Methods that mutate state and therefore require the CSRF token. Safe
+# methods (``GET``/``HEAD``) still pass through the Host/Origin gate — they
+# only skip the token check. Only ``OPTIONS`` preflights and non-``/api/*``
+# paths bypass the middleware entirely.
 _UNSAFE_METHODS: frozenset[str] = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
-# The SPA fetches its token here; the route itself must be reachable
-# without a token, otherwise the bootstrap is a chicken-and-egg.
+# The SPA fetches its token here via GET. The route is reachable without a
+# token only because GET is a safe method (``dispatch`` keys the token check
+# on the method, not this path) — an unsafe method to this path is still
+# token-gated. Kept as a named protocol constant (the web-invariants registry
+# note references it).
 _TOKEN_BOOTSTRAP_PATH = "/api/session"
 
 
@@ -111,11 +121,21 @@ class CSRFGuardMiddleware(BaseHTTPMiddleware):
         path = request.url.path
         method = request.method.upper()
 
-        # Fast path for everything outside the gate's responsibility.
-        if method not in _UNSAFE_METHODS or not path.startswith("/api/"):
+        # Only ``/api/*`` is gated. Non-API paths (SPA bootstrap, static
+        # assets) and ``OPTIONS`` preflights (owned by the CORS middleware)
+        # fall through untouched.
+        if not path.startswith("/api/") or method == "OPTIONS":
             return await call_next(request)
 
-        token_required = path != _TOKEN_BOOTSTRAP_PATH
+        # Host / Origin are the DNS-rebinding boundary: validate them on
+        # every ``/api/*`` request, including safe-method reads, so a
+        # rebound origin cannot read ``GET /api/export`` or harvest the
+        # token from ``GET /api/session``. The CSRF token is required for
+        # every unsafe method — including the bootstrap path itself. The
+        # ``GET /api/session`` bootstrap is token-exempt only because GET is
+        # a safe method (no path carve-out), so an unsafe method to that path
+        # is still token-gated.
+        token_required = method in _UNSAFE_METHODS
         token_ok = self._check_token(request) if token_required else True
         origin_ok = self._check_origin(request)
         host_ok = self._check_host(request)
@@ -124,7 +144,14 @@ class CSRFGuardMiddleware(BaseHTTPMiddleware):
         # Single structured log line per gated request. Uses positional
         # ``%`` args so a logging filter that drops the formatted message
         # still sees the raw fields. Tests assert via ``caplog``.
-        logger.info(
+        #
+        # Unsafe methods and any would-block decision log at INFO (observe-mode
+        # rollback + audit trail). Passing safe-method reads (``GET``/``HEAD``)
+        # are the high-volume common case for the SPA, so they log at DEBUG to
+        # avoid flooding operator logs.
+        level = logging.INFO if (method in _UNSAFE_METHODS or would_block) else logging.DEBUG
+        logger.log(
+            level,
             "web.csrf.observe method=%s path=%s token_ok=%s origin_ok=%s host_ok=%s would_block=%s",
             method,
             path,

--- a/packages/memtomem/tests/test_web_csrf_middleware.py
+++ b/packages/memtomem/tests/test_web_csrf_middleware.py
@@ -88,11 +88,50 @@ def caplog_csrf(caplog):
     return caplog
 
 
-def test_get_does_not_emit_observe_event(caplog_csrf) -> None:
-    """Safe methods short-circuit the middleware entirely."""
+def test_get_api_with_hostile_host_is_gated_and_403(caplog_csrf) -> None:
+    """Safe-method reads are Host/Origin gated now (RFC #787). The default
+    TestClient sends ``Host: testserver`` (non-loopback), so a GET /api
+    read is blocked — closing the DNS-rebinding read exposure. The token
+    is not required for a GET, so the 403 is attributable to the host."""
     client = TestClient(_build_app())
     res = client.get("/api/ping")
+    assert res.status_code == 403
+    events = _parse_observe(caplog_csrf.records)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["method"] == "GET"
+    assert ev["path"] == "/api/ping"
+    assert ev["token_ok"] == "True"  # token not required for safe methods
+    assert ev["host_ok"] == "False"
+    assert ev["would_block"] == "True"
+
+
+def test_get_api_with_loopback_host_passes(caplog_csrf) -> None:
+    """A GET /api read from a loopback Host/Origin passes the gate.
+
+    Passing safe-method reads log at DEBUG (the high-volume common case),
+    so capture at DEBUG to see the observe line."""
+    caplog_csrf.set_level(logging.DEBUG, logger="memtomem.web.middleware.csrf")
+    client = TestClient(_build_app())
+    res = client.get(
+        "/api/ping",
+        headers={"Host": "127.0.0.1:8080", "Origin": "http://127.0.0.1:8080"},
+    )
     assert res.status_code == 200
+    events = _parse_observe(caplog_csrf.records)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["host_ok"] == "True"
+    assert ev["origin_ok"] == "True"
+    assert ev["would_block"] == "False"
+
+
+def test_options_preflight_is_not_gated(caplog_csrf) -> None:
+    """``OPTIONS`` preflights are owned by the CORS middleware and skip the
+    gate entirely — no observe line, no 403 from the CSRF guard."""
+    client = TestClient(_build_app())
+    res = client.options("/api/ping", headers={"Host": "evil.example.com"})
+    assert res.status_code != 403
     assert _parse_observe(caplog_csrf.records) == []
 
 
@@ -186,24 +225,62 @@ def test_delete_without_token_returns_403(caplog_csrf) -> None:
     assert events[0]["would_block"] == "True"
 
 
-def test_session_bootstrap_get_is_uncovered(caplog_csrf) -> None:
-    """``GET /api/session`` is a safe method — middleware doesn't gate."""
+def test_session_bootstrap_get_is_host_origin_checked(caplog_csrf) -> None:
+    """``GET /api/session`` is token-exempt (the bootstrap) but is still
+    Host/Origin gated, so a rebound origin cannot harvest the token. A
+    hostile Host (default ``testserver``) 403s even though token-exempt."""
     client = TestClient(_build_app())
     res = client.get("/api/session")
+    assert res.status_code == 403
+    events = _parse_observe(caplog_csrf.records)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["token_ok"] == "True"  # bootstrap is token-exempt
+    assert ev["host_ok"] == "False"
+    assert ev["would_block"] == "True"
+
+
+def test_session_bootstrap_get_loopback_returns_token(caplog_csrf) -> None:
+    """From a loopback Host the bootstrap returns the token as before.
+
+    Passing safe-method reads log at DEBUG, so capture at DEBUG."""
+    caplog_csrf.set_level(logging.DEBUG, logger="memtomem.web.middleware.csrf")
+    client = TestClient(_build_app())
+    res = client.get(
+        "/api/session",
+        headers={"Host": "127.0.0.1:8080", "Origin": "http://127.0.0.1:8080"},
+    )
     assert res.status_code == 200
-    assert _parse_observe(caplog_csrf.records) == []
+    assert res.json()["csrf"] == "test-token-abc"
+    events = _parse_observe(caplog_csrf.records)
+    assert len(events) == 1
+    assert events[0]["would_block"] == "False"
 
 
-def test_session_bootstrap_post_is_token_exempt(caplog_csrf) -> None:
-    """The token check is skipped only for the exact bootstrap path; the
-    Origin / Host parts of the gate still apply."""
+def test_post_to_session_subpath_requires_token(caplog_csrf) -> None:
+    """A sibling of the bootstrap path (``/api/session/echo``) is a normal
+    unsafe route — it requires the token like any other write."""
     client = TestClient(_build_app())
     res = client.post(
         "/api/session/echo",
         headers={"Host": "127.0.0.1:8080", "Origin": "http://127.0.0.1:8080"},
     )
-    # /api/session/echo is *not* the bootstrap path, so token is still
-    # required — and missing — so enforce mode 403s.
+    assert res.status_code == 403
+    events = _parse_observe(caplog_csrf.records)
+    assert len(events) == 1
+    assert events[0]["token_ok"] == "False"
+    assert events[0]["would_block"] == "True"
+
+
+def test_post_to_exact_bootstrap_path_requires_token(caplog_csrf) -> None:
+    """The bootstrap exemption is GET-only: an unsafe method to the *exact*
+    bootstrap path must still present the token (no path carve-out). Guards
+    against a future POST /api/session route silently bypassing CSRF."""
+    client = TestClient(_build_app())
+    res = client.post(
+        "/api/session",
+        headers={"Host": "127.0.0.1:8080", "Origin": "http://127.0.0.1:8080"},
+    )
     assert res.status_code == 403
     events = _parse_observe(caplog_csrf.records)
     assert len(events) == 1

--- a/packages/memtomem/tests/test_web_entrypoint_bind.py
+++ b/packages/memtomem/tests/test_web_entrypoint_bind.py
@@ -1,0 +1,67 @@
+"""Bind-safety pins for the direct ``memtomem-web`` entrypoint (RFC #787).
+
+``mm web`` refuses a non-loopback bind without ``--allow-remote-ui``
+(``cli/web.py:_validate_bind``). The thin ``memtomem-web`` console script
+(``memtomem.web.app:main``) must mirror that gate so the unauthenticated SPA
+cannot be exposed off-loopback by accident.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memtomem.web import app as webapp
+
+# ``main()`` imports uvicorn lazily; skip the whole module if it is absent.
+uvicorn = pytest.importorskip("uvicorn")
+
+
+@pytest.fixture
+def _spy_uvicorn(monkeypatch):
+    """Replace ``uvicorn.run`` with a spy so ``main()`` never really binds."""
+    calls: dict[str, object] = {}
+
+    def _fake_run(target, **kwargs):
+        calls["target"] = target
+        calls.update(kwargs)
+        calls["ran"] = True
+
+    monkeypatch.setattr(uvicorn, "run", _fake_run)
+    return calls
+
+
+def test_main_refuses_off_loopback_host(monkeypatch, _spy_uvicorn) -> None:
+    """memtomem-web is loopback-only: a non-loopback --host is refused
+    (it cannot configure the trusted-host/origin allow-list)."""
+    monkeypatch.setattr("sys.argv", ["memtomem-web", "--host", "0.0.0.0"])
+    monkeypatch.delenv("MEMTOMEM_WEB__HOST", raising=False)
+    with pytest.raises(SystemExit) as exc:
+        webapp.main()
+    assert exc.value.code == 2
+    assert "ran" not in _spy_uvicorn, "must not bind when refusing"
+
+
+def test_main_refuses_off_loopback_via_env(monkeypatch, _spy_uvicorn) -> None:
+    """A non-loopback bind smuggled in via MEMTOMEM_WEB__HOST is refused too."""
+    monkeypatch.setattr("sys.argv", ["memtomem-web"])
+    monkeypatch.setenv("MEMTOMEM_WEB__HOST", "0.0.0.0")
+    with pytest.raises(SystemExit) as exc:
+        webapp.main()
+    assert exc.value.code == 2
+    assert "ran" not in _spy_uvicorn
+
+
+def test_main_loopback_default_binds(monkeypatch, _spy_uvicorn) -> None:
+    monkeypatch.setattr("sys.argv", ["memtomem-web"])
+    monkeypatch.delenv("MEMTOMEM_WEB__HOST", raising=False)
+    webapp.main()
+    assert _spy_uvicorn["host"] == "127.0.0.1"
+    assert _spy_uvicorn["ran"] is True
+
+
+def test_main_explicit_loopback_host_binds(monkeypatch, _spy_uvicorn) -> None:
+    monkeypatch.setattr("sys.argv", ["memtomem-web", "--host", "::1"])
+    monkeypatch.delenv("MEMTOMEM_WEB__HOST", raising=False)
+    webapp.main()
+    assert _spy_uvicorn["host"] == "::1"
+    assert _spy_uvicorn["ran"] is True

--- a/packages/memtomem/tests/test_web_exclude_guard.py
+++ b/packages/memtomem/tests/test_web_exclude_guard.py
@@ -50,6 +50,12 @@ async def real_stack_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
     comp = await create_components(cfg)
     app = create_app(lifespan=None, mode="dev")
+    # This fixture wipes all MEMTOMEM_* env above for config hermeticity, which
+    # also drops the conftest autouse ``MEMTOMEM_WEB__CSRF_ENFORCE=0``, leaving
+    # enforce on. This is a route test (the Host/Origin gate is covered in
+    # test_web_csrf_middleware.py), so disable enforcement directly rather than
+    # threading a loopback Host into every request.
+    app.state.csrf_enforce = False
     app.state.storage = comp.storage
     app.state.embedder = comp.embedder
     app.state.search_pipeline = comp.search_pipeline


### PR DESCRIPTION
Fixes a DNS-rebinding read exposure in the `mm web` Web UI (advisory GHSA-2vm9-7v7j-hq68).

## Problem
`CSRFGuardMiddleware` was the only place a `Host`/`Origin` check ran, and it short-circuited every safe method before that check — and there is no `TrustedHostMiddleware`. So read-only `GET`/`HEAD` `/api/*` routes had no Host/Origin defense: under DNS rebinding (or an accidental off-loopback bind) a malicious page open while `mm web` runs could read the indexed memory corpus via `GET /api/export`. Writes stayed protected (unsafe methods still hit the Host check). Separately, the `memtomem-web` console entrypoint called `uvicorn.run` directly, bypassing `mm web`'s `_validate_bind` loopback safety.

## Fix
- Gate `Host`/`Origin` on **every** `/api/*` request, GET/HEAD included (OPTIONS excepted — CORS owns preflight). The CSRF *token* requirement stays scoped to unsafe methods, so `GET /api/session` bootstrap still works but is now Host/Origin-checked — matching the middleware docstring's previously-false invariant, corrected here along with the SECURITY.md guard section.
- The bootstrap token exemption is now GET-only, closing a latent carve-out where a future `POST /api/session` would have bypassed CSRF.
- `memtomem-web` is now loopback-only; remote exposure must route through `mm web` or a reverse proxy.

## Tests
`test_web_csrf_middleware.py`, `test_web_entrypoint_bind.py`, `test_web_exclude_guard.py` — GET hostile-`Host` 403 + loopback pass, `GET /api/session` host-checked, POST to the exact bootstrap path requires a token, OPTIONS carve-out, and `memtomem-web` bind-refusal pins.

Refs GHSA-2vm9-7v7j-hq68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
