### PR TITLE
security(index): enforce redaction trust boundary on bulk folder indexing (ADR-0006 PR-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Security
+
+- **Bulk folder indexing now enforces the secret-redaction trust boundary
+  (ADR-0006 PR-A).** Previously `mm reindex`, the Web UI Index / Sources flows
+  (`trigger_index`, `reindex_all`, `memory-dirs/add` auto-index, `index_stream`),
+  the file watcher, `mem_index`, `mem_fetch`, and file import (`mem_import_*`) all
+  pulled files straight into the store without the secret-class redaction scan
+  that single-file upload, `mem_add` / `mem_edit`, and JSON import already ran —
+  so a stray API key in a bulk-indexed folder crossed the write boundary
+  silently. The gate now lives at the `IndexEngine._index_file` chokepoint that
+  every indexing entrypoint funnels through: secret-bearing files are skipped
+  (not indexed) and reported via a new `blocked_files` / `blocked_paths` count on
+  the index response, the SSE `complete` event, and the `mm index` summary. Bulk
+  indexing continues past a flagged file instead of aborting the whole run.
+  Pass `mm index --force-unsafe` (audit-logged) to index flagged files anyway;
+  the bypass is hard-refused for the git-tracked `project_shared` tier. Content
+  that already passed a write-ingress guard (`mem_add` / `mem_edit`, upload,
+  chunk edit, …) is not re-scanned, so no existing write path regresses.
+
 ## [0.3.2] — 2026-06-30
 
 A security release. The Web UI now validates `Host`/`Origin` on every `/api/*`

--- a/docs/adr/0006-web-ui-folder-upload-redaction.md
+++ b/docs/adr/0006-web-ui-folder-upload-redaction.md
@@ -419,13 +419,19 @@ Axes A–E are decided but only **partially built**:
   are route-layer guards, **not** the engine-layer
   `IndexEngine._index_file(force_unsafe=…)` + `PrivacyRejection` seam the
   "Implementation outline" describes.
-- **Folder-index — not yet guarded.** `trigger_index` (`web/routes/system.py:1282`),
-  `reindex_all` (`:885`), and `memory-dirs/add (auto_index)` (`:664`) call
-  `IndexEngine.index_path(...)`; `index_stream` (`:1252`) calls
-  `index_path_stream(...)`. None of these guard, and `IndexEngine` itself has
-  no `enforce_write_guard` call. The single-chokepoint design from A.3 / B.2 is
-  still unbuilt for these surfaces; the "Implementation outline" below
-  describes that pending work.
+- **Folder-index — guarded (PR-A, 2026-07-01).** The single-chokepoint design
+  from A.3 / B.2 is now built: `IndexEngine._index_file()` resolves scope, then
+  calls `privacy.enforce_write_guard(content, surface="index", scope=…,
+  force_unsafe=…)` and raises `PrivacyRejection` on a hit without `force_unsafe`.
+  Bulk entrypoints (`index_path` / `index_path_stream` — `trigger_index`,
+  `reindex_all`, `memory-dirs/add` auto_index, `index_stream`, `mm reindex`,
+  `mem_index`, the watcher) catch it per file and aggregate into
+  `IndexingStats.blocked_files` / `blocked_paths`, so one flagged file does not
+  abort the run; single-file `index_file` lets it propagate so callers roll back
+  or surface it rather than silently succeeding. Callers that already ran
+  `enforce_write_guard` at their ingress layer pass `already_scanned=True` to
+  skip the gate (see the outline note below). `mm index --force-unsafe` ships the
+  bulk escape hatch.
 - **Import (Axis F.3) — built (#1490).** Both ingresses — MCP `mem_import` and
   web `POST /api/export/import` — route through `tools/export_import.py`
   `import_chunks`, which verifies the local-provenance marker and, for an
@@ -433,10 +439,9 @@ Axes A–E are decided but only **partially built**:
   record (`:244`) and rejects the whole import on a secret hit (`:257`) unless
   `force_unsafe`. Self-exports skip the scan, preserving round-trip.
 
-So the B.2 reject behavior is live for upload and import. The decision
-(A.3 + B.2 + C.1 + D.2 + E.1 + F.3) stands; the folder-index gate and the
-Web UI override toggle (Axis E.1 for the bulk/import surfaces, PR-B) remain to
-implement.
+So the B.2 reject behavior is live for upload, import, **and folder-index**
+(PR-A). The decision (A.3 + B.2 + C.1 + D.2 + E.1 + F.3) stands; only the Web UI
+override toggle (Axis E.1 for the bulk surfaces, PR-B) remains to implement.
 
 ## Implementation outline (when triggered)
 
@@ -461,6 +466,37 @@ In rough order, all in `packages/memtomem/src/memtomem/`:
     shape — so MCP and bulk bypass land in the same `mem_add_redaction_stats`
     snapshot and the same log sink. (Whether to add a persistent audit
     table is the open sub-question called out in axis E.)
+  - **Built as (2026-07-01), with deviations from the outline above** — a Codex
+    design gate surfaced that the literal outline breaks existing contracts:
+    - The gate calls `privacy.enforce_write_guard` (which records + audits) rather
+      than raw `privacy.scan`, so bulk bypasses land in the `mem_add_redaction_stats`
+      snapshot per the axis-E intent above — no separate `record(...)` call needed.
+    - **Ingress-guarded callers skip the gate** (`_index_file(..., already_scanned=True)`)
+      instead of threading `force_unsafe` through them. `mem_edit` / web chunk
+      edit+delete re-index the *whole file* after a line-range mutation and rely on
+      `index_file()` **raising** to roll back or delete stale chunks; a gate that
+      re-scanned the whole file would (a) re-block content already adjudicated
+      elsewhere in the file, (b) double-count/-audit, and (c) on `mem_delete`
+      (which has no `force_unsafe` param) block a legitimate delete. Skipping is
+      correct: the boundary is already enforced at their ingress `enforce_write_guard`.
+      The guarded set: `mem_add` / `mem_edit` / `mem_batch_add` / `mem_delete`,
+      `upload_files`, compose/`add_memory`, web chunk edit/delete, CLI `mm mem add`,
+      CLI agent `share`, and LangGraph `add`.
+    - **Blocked files are a return-path aggregate for bulk, a raised exception for
+      single-file.** `PrivacyRejection` (path + hit count, never the matched bytes)
+      is raised in `_index_file`; `index_path` / `index_path_stream` catch it per
+      file and aggregate into `IndexingStats.blocked_files` / `blocked_paths`
+      (surfaced in `IndexResponse`, the SSE `complete` event, `reindex_all` /
+      `memory-dirs/add` JSON, `mem_index`, and the `mm index` summary); un-adjudicated
+      single-file callers (`mem_fetch`, `mem_import_*`, session summary, `mm index <file>`,
+      the watcher) catch it and surface an error instead of reporting false success.
+      A `blocked_project_shared_files` counter travels alongside `blocked_files`
+      so surfaces give scope-correct guidance — a `project_shared` block is
+      hard-refused even with `force_unsafe`, so the CLI tells the user to move
+      the file to `user`/`project_local` or remove the secret rather than to
+      retry with `--force-unsafe`.
+    - **PR-C's `mm index --force-unsafe` shipped with PR-A** (not deferred) so a
+      false positive on bulk index has an escape hatch in the same release.
 - **PR-B — Web UI override toggle + audit surface.**
   - Add an "Index without privacy gate (audit-logged)" checkbox to the
     Index tab and the Sources `+ 경로 추가` modal. On submit, pass
@@ -470,10 +506,12 @@ In rough order, all in `packages/memtomem/src/memtomem/`:
     counters are visible alongside MCP bypass counters. If the open
     sub-question on axis E resolves to "add a persistent audit
     table," that's a follow-up PR with its own schema work.
-- **PR-C (optional, gated by separate signal) — CLI parity.**
-  - `mm index --force-unsafe` plumbing reuses PR-A's `IndexEngine`
-    parameter. Hold until a CLI user reports needing it; the bulk
-    workflow is web-driven for now.
+- **PR-C — CLI parity. Shipped with PR-A (2026-07-01).**
+  - `mm index --force-unsafe` reuses PR-A's `IndexEngine` `force_unsafe`
+    parameter (threaded through `cli/_index_progress.run_with_progress`), and the
+    `mm index` summary reports the blocked count + paths. Shipped together with
+    PR-A rather than held, so a false positive on bulk index has a documented
+    recourse in the same release.
 
 ## Consequences
 

--- a/packages/memtomem/src/memtomem/cli/_index_progress.py
+++ b/packages/memtomem/src/memtomem/cli/_index_progress.py
@@ -72,6 +72,7 @@ async def run_with_progress(
     recursive: bool = True,
     force: bool = False,
     namespace: str | None = None,
+    force_unsafe: bool = False,
 ) -> dict[str, Any]:
     """Stream ``index_path_stream`` across ``paths`` with a click.progressbar.
 
@@ -119,6 +120,12 @@ async def run_with_progress(
         "duration_ms": 0.0,
         "errors": [],
         "bar_rendered": False,
+        # ADR-0006 PR-A: files skipped by the redaction gate (count + paths),
+        # aggregated from each stream's ``complete`` event. ``blocked_project_shared``
+        # is the subset that is hard-refused even with force_unsafe.
+        "blocked": 0,
+        "blocked_paths": [],
+        "blocked_project_shared": 0,
     }
 
     # Throttle clock for ``chunk_progress`` label refreshes. Mirrors the web
@@ -180,7 +187,11 @@ async def run_with_progress(
         async with cli_components() as comp:
             for p in paths:
                 async for evt in comp.index_engine.index_path_stream(
-                    p, recursive=recursive, force=force, namespace=namespace
+                    p,
+                    recursive=recursive,
+                    force=force,
+                    namespace=namespace,
+                    force_unsafe=force_unsafe,
                 ):
                     if evt["type"] == "discovery":
                         # Authoritative bar-length source. Engine emits this
@@ -230,6 +241,9 @@ async def run_with_progress(
                         # Single-path is the dominant case so this is a
                         # simple aggregation rather than tracking per-path.
                         agg["duration_ms"] += evt.get("duration_ms", 0.0)
+                        agg["blocked"] += evt.get("blocked_files", 0)
+                        agg["blocked_project_shared"] += evt.get("blocked_project_shared_files", 0)
+                        agg["blocked_paths"].extend(evt.get("blocked_paths") or [])
                         errs = evt.get("errors") or []
                         if errs:
                             agg["errors"].extend(errs)

--- a/packages/memtomem/src/memtomem/cli/agent_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/agent_cmd.py
@@ -306,7 +306,8 @@ async def _run_share(chunk_id: str, target: str, force_unsafe: bool = False) -> 
         date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         path = base / f"{date_str}.md"
         append_entry(path, chunk.content, title=title, tags=tags)
-        stats = await comp.index_engine.index_file(path, namespace=target)
+        # Guarded above (``enforce_write_guard``); skip the engine gate (ADR-0006 PR-A).
+        stats = await comp.index_engine.index_file(path, namespace=target, already_scanned=True)
 
     click.echo(f"Shared to namespace '{target}'.")
     click.echo(f"- File: {path}")

--- a/packages/memtomem/src/memtomem/cli/indexing.py
+++ b/packages/memtomem/src/memtomem/cli/indexing.py
@@ -52,6 +52,16 @@ import click
     is_flag=True,
     help="Emit one JSON line of the result (works with --debounce-window/--flush/--status).",
 )
+@click.option(
+    "--force-unsafe",
+    "force_unsafe",
+    is_flag=True,
+    help=(
+        "Bypass the redaction gate for this bulk index — index files that trip "
+        "secret-class patterns anyway (audit-logged). Off by default; the gate "
+        "otherwise skips secret-bearing files and reports them (ADR-0006)."
+    ),
+)
 def index(
     path: str,
     recursive: bool,
@@ -61,6 +71,7 @@ def index(
     do_flush: bool,
     do_status: bool,
     as_json: bool,
+    force_unsafe: bool,
 ) -> None:
     """Index files at PATH into the knowledge base.
 
@@ -72,6 +83,13 @@ def index(
     modes = [debounce_window is not None, do_flush, do_status]
     if sum(modes) > 1:
         raise click.UsageError("--debounce-window, --flush, and --status are mutually exclusive.")
+    if force_unsafe and any(modes):
+        # The debounce queue carries only (path, namespace, force); it does not
+        # thread force_unsafe, so accepting it there would silently ignore it.
+        raise click.UsageError(
+            "--force-unsafe only applies to direct indexing, not "
+            "--debounce-window / --flush / --status."
+        )
 
     if do_status:
         _print_status(as_json=as_json)
@@ -92,14 +110,20 @@ def index(
         return
 
     try:
-        asyncio.run(_index(path, recursive, force, namespace))
+        asyncio.run(_index(path, recursive, force, namespace, force_unsafe))
     except click.ClickException:
         raise
     except Exception as e:
         raise click.ClickException(str(e)) from e
 
 
-async def _index(path: str, recursive: bool, force: bool, namespace: str | None) -> None:
+async def _index(
+    path: str,
+    recursive: bool,
+    force: bool,
+    namespace: str | None,
+    force_unsafe: bool = False,
+) -> None:
     """Stream-index ``path`` with a live progress bar (issue #656).
 
     Uses the shared :func:`memtomem.cli._index_progress.run_with_progress`
@@ -131,6 +155,7 @@ async def _index(path: str, recursive: bool, force: bool, namespace: str | None)
             recursive=recursive,
             force=force,
             namespace=namespace,
+            force_unsafe=force_unsafe,
         )
     except KeyboardInterrupt:
         click.echo()
@@ -154,7 +179,32 @@ async def _index(path: str, recursive: bool, force: bool, namespace: str | None)
         f"{agg['indexed']} new, {agg['skipped']} unchanged, "
         f"{agg['deleted']} deleted ({agg['duration_ms']:.0f}ms)"
     )
+    if agg["blocked"]:
+        # ADR-0006 PR-A: name the secret-bearing files that were skipped. Give
+        # scope-correct guidance — project_shared is hard-refused even with
+        # --force-unsafe, so don't tell the user to retry it there.
+        ps = agg["blocked_project_shared"]
+        bypassable = agg["blocked"] - ps
+        click.secho(f"  {agg['blocked']} file(s) blocked by redaction guard:", fg="yellow")
+        for p in agg["blocked_paths"]:
+            click.secho(f"    {p}", fg="yellow")
+        if bypassable:
+            click.secho(
+                "  → re-run with --force-unsafe to index the non-project_shared "
+                "files anyway (audit-logged).",
+                fg="yellow",
+            )
+        if ps:
+            click.secho(
+                f"  → {ps} file(s) are in the project_shared tier — hard-refused; "
+                "--force-unsafe does not apply. Move them to user/project_local "
+                "or remove the secret.",
+                fg="yellow",
+            )
     for err in agg["errors"]:
+        if "redaction_blocked" in err:
+            # Already surfaced above with a clearer message + hint.
+            continue
         click.echo(click.style(f"  ERROR: {err}", fg="red"))
 
 

--- a/packages/memtomem/src/memtomem/cli/ingest_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/ingest_cmd.py
@@ -253,8 +253,17 @@ async def _ingest_files_with_components(
     total_skipped = 0
     total_deleted = 0
     errors: list[str] = []
+    # ADR-0006 PR-A: ingested files are un-adjudicated, so the engine redaction
+    # gate is active — skip + record secret-bearing files rather than aborting
+    # the whole ingest run on the first hit.
+    from memtomem.indexing.engine import PrivacyRejection
+
     for f in files:
-        stats = await comp.index_engine.index_file(f, namespace=namespace)
+        try:
+            stats = await comp.index_engine.index_file(f, namespace=namespace)
+        except PrivacyRejection as exc:
+            errors.append(f"{f.name}: redaction_blocked (hits={exc.hit_count})")
+            continue
         total_indexed += stats.indexed_chunks
         total_skipped += stats.skipped_chunks
         total_deleted += stats.deleted_chunks

--- a/packages/memtomem/src/memtomem/cli/memory.py
+++ b/packages/memtomem/src/memtomem/cli/memory.py
@@ -219,7 +219,8 @@ async def _add(
 
         target.parent.mkdir(parents=True, exist_ok=True)
         append_entry(target, content, title=title, tags=tags)
-        stats = await comp.index_engine.index_file(target)
+        # Guarded above (``enforce_write_guard``); skip the engine gate (ADR-0006 PR-A).
+        stats = await comp.index_engine.index_file(target, already_scanned=True)
 
         # Apply tags to indexed chunks (chunker doesn't parse tag text from content)
         if tags and stats.indexed_chunks > 0:

--- a/packages/memtomem/src/memtomem/cli/shell.py
+++ b/packages/memtomem/src/memtomem/cli/shell.py
@@ -216,7 +216,8 @@ async def _cmd_add(comp, args: list[str]) -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
 
     append_entry(target, content)
-    stats = await comp.index_engine.index_file(target)
+    # Guarded above (``enforce_write_guard``); skip the engine gate (ADR-0006 PR-A).
+    stats = await comp.index_engine.index_file(target, already_scanned=True)
 
     click.secho(f"Added to {target.name} ({stats.indexed_chunks} chunks indexed)", fg="green")
 
@@ -301,3 +302,6 @@ async def _cmd_index(comp, args: list[str]) -> None:
         f"Done: {stats.total_files} files, {stats.indexed_chunks} chunks ({stats.duration_ms}ms)",
         fg="green",
     )
+    if stats.blocked_files:
+        # ADR-0006 PR-A: secret-bearing files skipped by the redaction gate.
+        click.secho(f"  {stats.blocked_files} file(s) blocked by redaction guard", fg="yellow")

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -30,6 +30,7 @@ from memtomem.config import (
     memory_dir_kind,
     provider_for_category,
 )
+from memtomem import privacy
 from memtomem.indexing.differ import DiffResult, compute_diff
 from memtomem.models import Chunk, IndexingStats
 
@@ -344,6 +345,28 @@ async def _resolved_zero() -> int:
     return 0
 
 
+class PrivacyRejection(Exception):
+    """Raised by :meth:`IndexEngine._index_file` when a file's content trips the
+    secret-redaction guard during **un-adjudicated** indexing (ADR-0006 PR-A).
+
+    Bulk entrypoints (``index_path`` / ``index_path_stream``) catch this per file
+    and aggregate it into :attr:`IndexingStats.blocked_files`; single-file
+    ``index_file`` callers let it propagate so their own rollback / error
+    surfacing runs. Callers that already ran ``privacy.enforce_write_guard`` at
+    their ingress layer pass ``already_scanned=True`` and never trigger this.
+
+    Carries only the hit **count** and file path — never the matched bytes
+    (secret-in-log hygiene).
+    """
+
+    def __init__(self, *, path: Path, hit_count: int, scope: str, decision: str) -> None:
+        self.path = path
+        self.hit_count = hit_count
+        self.scope = scope
+        self.decision = decision
+        super().__init__(f"redaction_blocked: {path.name} (hits={hit_count}, decision={decision})")
+
+
 class _IndexFileBase(TypedDict):
     total: int
     indexed: int
@@ -354,6 +377,14 @@ class _IndexFileBase(TypedDict):
 
 class IndexFileResult(_IndexFileBase, total=False):
     new_chunk_ids: list[UUID]
+    # Set to 1 by the stream path when a file is skipped by the ADR-0006
+    # redaction gate; aggregated into ``IndexingStats.blocked_files``. The
+    # non-stream path tracks blocks via the raised ``PrivacyRejection`` instead.
+    blocked: int
+    # 1 when the blocked file was ``project_shared`` (hard-refused, not
+    # bypassable with force_unsafe) — aggregated into
+    # ``IndexingStats.blocked_project_shared_files``.
+    blocked_project_shared: int
 
 
 class IndexEngine:
@@ -425,11 +456,15 @@ class IndexEngine:
         recursive: bool = True,
         force: bool = False,
         namespace: str | None = None,
+        *,
+        force_unsafe: bool = False,
     ) -> IndexingStats:
         self._active_runs += 1
         try:
             async with self._index_lock:
-                return await self._index_path_inner(path, recursive, force, namespace)
+                return await self._index_path_inner(
+                    path, recursive, force, namespace, force_unsafe=force_unsafe
+                )
         finally:
             self._active_runs -= 1
 
@@ -439,6 +474,8 @@ class IndexEngine:
         recursive: bool = True,
         force: bool = False,
         namespace: str | None = None,
+        *,
+        force_unsafe: bool = False,
     ) -> IndexingStats:
         start = time.monotonic()
         path = path.resolve()
@@ -457,15 +494,33 @@ class IndexEngine:
 
         async def _bounded(fp: Path) -> IndexFileResult:
             async with sem:
-                return await self._index_file(fp, force, namespace=namespace)
+                return await self._index_file(
+                    fp, force, namespace=namespace, force_unsafe=force_unsafe
+                )
 
         raw_results = await asyncio.gather(*[_bounded(f) for f in files], return_exceptions=True)
         file_results: list[IndexFileResult] = []
         all_errors: list[str] = []
+        blocked_paths: list[str] = []
+        blocked_project_shared = 0
         for i, r in enumerate(raw_results):
             if isinstance(r, dict):
                 file_results.append(r)
                 all_errors.extend(r.get("errors", []))
+            elif isinstance(r, PrivacyRejection):
+                # ADR-0006 PR-A: un-adjudicated bulk index hit a secret-bearing
+                # file. Skip it, record it as blocked, and continue the run so a
+                # single flagged file doesn't abort indexing the whole tree.
+                # Preserve scope/decision so callers give correct guidance:
+                # project_shared is hard-refused even with force_unsafe.
+                logger.warning("Indexing blocked by redaction guard for %s: %s", files[i], r)
+                blocked_paths.append(str(files[i]))
+                if r.scope == "project_shared":
+                    blocked_project_shared += 1
+                all_errors.append(
+                    f"{files[i].name}: redaction_blocked "
+                    f"(hits={r.hit_count}, scope={r.scope}, decision={r.decision})"
+                )
             elif isinstance(r, Exception):
                 logger.error("Indexing failed for %s: %s", files[i], r)
                 all_errors.append(f"{files[i].name}: {r}")
@@ -495,6 +550,9 @@ class IndexEngine:
             errors=tuple(all_errors),
             new_chunk_ids=tuple(all_new_chunk_ids),
             resolved_namespaces=tuple(resolved_ns),
+            blocked_files=len(blocked_paths),
+            blocked_paths=tuple(blocked_paths),
+            blocked_project_shared_files=blocked_project_shared,
         )
 
     def resolve_namespaces_for(
@@ -533,8 +591,19 @@ class IndexEngine:
         file_path: Path,
         force: bool = False,
         namespace: str | None = None,
+        *,
+        force_unsafe: bool = False,
+        already_scanned: bool = False,
     ) -> IndexingStats:
         """Index a single file. Convenience wrapper for external callers.
+
+        ``already_scanned=True`` skips the ADR-0006 redaction gate for callers
+        that already ran ``privacy.enforce_write_guard`` on the new content at
+        their own ingress layer (``mem_add`` / ``mem_edit`` / upload / chunk
+        edit, …); the whole-file reindex must not re-litigate or double-count
+        that content. Un-adjudicated single-file callers (``mem_fetch``, file
+        import, ``mm index <file>``) leave it ``False`` and must catch the
+        resulting :class:`PrivacyRejection`.
 
         ``force=True`` re-embeds every chunk in the file but preserves chunk
         identity (UUID) and per-chunk personalization (``access_count``,
@@ -582,7 +651,13 @@ class IndexEngine:
 
                 resolved_path = file_path.resolve()
                 with _file_lock(_lock_path_for(resolved_path)):
-                    result = await self._index_file(resolved_path, force, namespace=namespace)
+                    result = await self._index_file(
+                        resolved_path,
+                        force,
+                        namespace=namespace,
+                        force_unsafe=force_unsafe,
+                        already_scanned=already_scanned,
+                    )
                 duration = (time.monotonic() - start) * 1000
         finally:
             self._active_runs -= 1
@@ -744,6 +819,8 @@ class IndexEngine:
         namespace: str | None = None,
         *,
         on_chunk_progress: Callable[[int, int], None] | None = None,
+        force_unsafe: bool = False,
+        already_scanned: bool = False,
     ) -> IndexFileResult:
         # Return shape: total/indexed/skipped/deleted (ints), errors (list[str]),
         # new_chunk_ids (list[UUID]). Early zero-result paths may omit
@@ -800,6 +877,42 @@ class IndexEngine:
         if self._registry.get(file_path.suffix) is None:
             return {"total": 0, "indexed": 0, "skipped": 0, "deleted": 0, "errors": []}
 
+        # ADR-0006 Axes A.3/B.2 — secret-redaction trust boundary for
+        # un-adjudicated indexing. Resolve scope first (needed both here and by
+        # ``_apply_scope`` below) so a ``force_unsafe`` bulk index of a
+        # ``project_shared`` file is hard-refused, then scan the raw content
+        # before any chunk/embed/store work. Callers that already ran
+        # ``privacy.enforce_write_guard`` at their own ingress layer pass
+        # ``already_scanned=True`` to skip this — the boundary is enforced there,
+        # and re-scanning the whole file would double-count and re-litigate
+        # already-stored content (e.g. a prior ``force_unsafe`` write elsewhere
+        # in the same file). See ADR-0006 "Implementation outline (PR-A)".
+        scope_val, project_root = self._resolve_scope(file_path)
+        if not already_scanned:
+            guard = privacy.enforce_write_guard(
+                content,
+                surface="index",
+                force_unsafe=force_unsafe,
+                scope=scope_val,
+                audit_context={"path": str(file_path)},
+            )
+            if guard.decision in ("blocked", "blocked_project_shared"):
+                # Never log the matched bytes — only the hit count.
+                logger.warning(
+                    "redaction_blocked: %s (hits=%d, scope=%s)",
+                    file_path.name,
+                    len(guard.hits),
+                    scope_val,
+                )
+                raise PrivacyRejection(
+                    path=file_path,
+                    hit_count=len(guard.hits),
+                    scope=scope_val,
+                    decision=guard.decision,
+                )
+            if guard.decision not in ("pass", "bypassed"):
+                raise RuntimeError(f"unexpected enforce_write_guard decision: {guard.decision!r}")
+
         new_chunks = self._registry.chunk_file(file_path, content)
 
         # Post-processing: merge short chunks + add overlap
@@ -837,7 +950,8 @@ class IndexEngine:
         # safe — the new chunks already carry the correct defaults).
         # The CHANGELOG ADR-0011 PR-B entry documents the
         # post-deregistration reindex requirement.
-        scope_val, project_root = self._resolve_scope(file_path)
+        # ``scope_val`` / ``project_root`` were resolved above (just before the
+        # redaction gate); reuse them here rather than re-resolving.
         if scope_val != "user" or project_root is not None:
             new_chunks = self._apply_scope(new_chunks, scope_val, project_root)
 
@@ -965,6 +1079,8 @@ class IndexEngine:
         recursive: bool = True,
         force: bool = False,
         namespace: str | None = None,
+        *,
+        force_unsafe: bool = False,
     ):
         """Like index_path(), but yields progress dicts as each file is processed.
 
@@ -1018,6 +1134,9 @@ class IndexEngine:
                     "duration_ms": 0.0,
                     "errors": [],
                     "resolved_namespaces": [],
+                    "blocked_files": 0,
+                    "blocked_paths": [],
+                    "blocked_project_shared_files": 0,
                 }
                 return
 
@@ -1033,8 +1152,16 @@ class IndexEngine:
             # what was actually applied — single render across both stream
             # and non-stream paths (see ``_index_path_inner``).
             resolved_ns_for_event = self.resolve_namespaces_for(files, namespace)
-            agg = {"total_chunks": 0, "indexed": 0, "skipped": 0, "deleted": 0}
+            agg = {
+                "total_chunks": 0,
+                "indexed": 0,
+                "skipped": 0,
+                "deleted": 0,
+                "blocked": 0,
+                "blocked_project_shared": 0,
+            }
             all_errors: list[str] = []
+            blocked_paths: list[str] = []
 
             for i, fp in enumerate(files, start=1):
                 # Per-file queue forwards ``chunk_progress`` ticks from the
@@ -1070,6 +1197,7 @@ class IndexEngine:
                             force,
                             namespace=namespace,
                             on_chunk_progress=cb,
+                            force_unsafe=force_unsafe,
                         )
                     finally:
                         queue.put_nowait(DONE)
@@ -1083,6 +1211,27 @@ class IndexEngine:
                         yield event
                     try:
                         result = await task
+                    except PrivacyRejection as exc:
+                        # ADR-0006 PR-A: un-adjudicated bulk index hit a
+                        # secret-bearing file. Skip it, record it blocked, and
+                        # continue the stream (mirrors the non-stream branch in
+                        # ``_index_path_inner``).
+                        logger.warning(
+                            "Stream indexing blocked by redaction guard for %s: %s", fp, exc
+                        )
+                        blocked_paths.append(str(fp))
+                        result = {
+                            "total": 0,
+                            "indexed": 0,
+                            "skipped": 0,
+                            "deleted": 0,
+                            "errors": [
+                                f"{fp.name}: redaction_blocked "
+                                f"(hits={exc.hit_count}, scope={exc.scope}, decision={exc.decision})"
+                            ],
+                            "blocked": 1,
+                            "blocked_project_shared": 1 if exc.scope == "project_shared" else 0,
+                        }
                     except Exception as exc:
                         logger.error("Stream indexing failed for %s: %s", fp, exc)
                         # Same shape as non-stream's
@@ -1111,6 +1260,8 @@ class IndexEngine:
                 agg["indexed"] += result["indexed"]
                 agg["skipped"] += result["skipped"]
                 agg["deleted"] += result["deleted"]
+                agg["blocked"] += result.get("blocked", 0)
+                agg["blocked_project_shared"] += result.get("blocked_project_shared", 0)
                 all_errors.extend(result.get("errors", []))
                 yield {
                     "type": "progress",
@@ -1132,6 +1283,9 @@ class IndexEngine:
                 "duration_ms": round(duration, 1),
                 "errors": all_errors,
                 "resolved_namespaces": resolved_ns_for_event,
+                "blocked_files": agg["blocked"],
+                "blocked_paths": blocked_paths,
+                "blocked_project_shared_files": agg["blocked_project_shared"],
             }
         finally:
             self._active_runs -= 1

--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -178,6 +178,13 @@ class FileWatcher:
             try:
                 stats = await self._engine.index_path(d, recursive=True)
                 total_indexed += stats.indexed_chunks
+                if stats.blocked_files:
+                    # ADR-0006 PR-A: secret-bearing files skipped during backfill.
+                    logger.warning(
+                        "Startup backfill %s: %d file(s) blocked by redaction guard",
+                        d,
+                        stats.blocked_files,
+                    )
                 if stats.indexed_chunks or stats.deleted_chunks:
                     logger.info(
                         "Startup backfill %s: indexed=%d skipped=%d deleted=%d",
@@ -226,6 +233,8 @@ class FileWatcher:
                 continue
 
     async def _reindex(self, file_path: Path) -> None:
+        from memtomem.indexing.engine import PrivacyRejection
+
         try:
             stats = await self._engine.index_file(file_path)
             logger.info(
@@ -234,6 +243,14 @@ class FileWatcher:
                 stats.indexed_chunks,
                 stats.skipped_chunks,
                 stats.deleted_chunks,
+            )
+        except PrivacyRejection as exc:
+            # ADR-0006 PR-A: a watched file gained secret-class content; it is
+            # left un-indexed (not a failure — the boundary is doing its job).
+            logger.warning(
+                "Auto-reindex blocked by redaction guard for %s: %d hit(s)",
+                file_path.name,
+                exc.hit_count,
             )
         except Exception as exc:
             logger.error("Auto-reindex failed for %s: %s", file_path, exc)

--- a/packages/memtomem/src/memtomem/integrations/langgraph.py
+++ b/packages/memtomem/src/memtomem/integrations/langgraph.py
@@ -298,7 +298,10 @@ class MemtomemStore:
         effective_namespace = self._resolve_add_namespace(namespace)
 
         append_entry(target, content, title=title, tags=tags)
-        stats = await comp.index_engine.index_file(target, namespace=effective_namespace)
+        # Guarded above (``enforce_write_guard``); skip the engine gate (ADR-0006 PR-A).
+        stats = await comp.index_engine.index_file(
+            target, namespace=effective_namespace, already_scanned=True
+        )
 
         return {
             "file": str(target),

--- a/packages/memtomem/src/memtomem/models.py
+++ b/packages/memtomem/src/memtomem/models.py
@@ -241,3 +241,13 @@ class IndexingStats:
     # can echo what was *actually* applied — important when policy rules
     # split a folder into multiple namespaces.
     resolved_namespaces: tuple[str | None, ...] = ()
+    # ADR-0006 PR-A: files skipped by the secret-redaction gate during
+    # un-adjudicated bulk indexing (each such file raised ``PrivacyRejection``,
+    # was recorded here, and the run continued). ``blocked_files`` is the count;
+    # ``blocked_paths`` are the absolute paths so surfaces can list them.
+    blocked_files: int = 0
+    blocked_paths: tuple[str, ...] = ()
+    # Subset of ``blocked_files`` whose scope is ``project_shared`` — those are
+    # hard-refused even with ``force_unsafe`` (ADR-0011 §5), so surfaces must
+    # not tell the user to retry with ``--force-unsafe`` for them.
+    blocked_project_shared_files: int = 0

--- a/packages/memtomem/src/memtomem/server/tools/importers.py
+++ b/packages/memtomem/src/memtomem/server/tools/importers.py
@@ -47,11 +47,20 @@ async def mem_import_notion(
     if not imported:
         return "No markdown files found in the Notion export."
 
-    # Index all imported files
+    # Index all imported files. ADR-0006 PR-A: imported content is
+    # un-adjudicated, so the engine redaction gate is active; skip + count
+    # secret-bearing files rather than aborting the whole import.
+    from memtomem.indexing.engine import PrivacyRejection
+
     effective_ns = namespace or "notion"
     total_chunks = 0
+    blocked = 0
     for f in imported:
-        stats = await app.index_engine.index_file(f, namespace=effective_ns)
+        try:
+            stats = await app.index_engine.index_file(f, namespace=effective_ns)
+        except PrivacyRejection:
+            blocked += 1
+            continue
         total_chunks += stats.indexed_chunks
 
     # Apply tags
@@ -79,6 +88,7 @@ async def mem_import_notion(
         f"Notion import complete:\n"
         f"- Files imported: {len(imported)}\n"
         f"- Chunks indexed: {total_chunks}\n"
+        f"- Blocked (redaction): {blocked}\n"
         f"- Namespace: {effective_ns}\n"
         f"- Output: {output_dir}"
     )
@@ -121,11 +131,20 @@ async def mem_import_obsidian(
     if not imported:
         return "No markdown files found in the Obsidian vault."
 
-    # Index all imported files
+    # Index all imported files. ADR-0006 PR-A: imported content is
+    # un-adjudicated, so the engine redaction gate is active; skip + count
+    # secret-bearing files rather than aborting the whole import.
+    from memtomem.indexing.engine import PrivacyRejection
+
     effective_ns = namespace or "obsidian"
     total_chunks = 0
+    blocked = 0
     for f in imported:
-        stats = await app.index_engine.index_file(f, namespace=effective_ns)
+        try:
+            stats = await app.index_engine.index_file(f, namespace=effective_ns)
+        except PrivacyRejection:
+            blocked += 1
+            continue
         total_chunks += stats.indexed_chunks
 
     # Apply tags
@@ -153,6 +172,7 @@ async def mem_import_obsidian(
         f"Obsidian import complete:\n"
         f"- Files imported: {len(imported)}\n"
         f"- Chunks indexed: {total_chunks}\n"
+        f"- Blocked (redaction): {blocked}\n"
         f"- Namespace: {effective_ns}\n"
         f"- Output: {output_dir}"
     )

--- a/packages/memtomem/src/memtomem/server/tools/indexing.py
+++ b/packages/memtomem/src/memtomem/server/tools/indexing.py
@@ -54,8 +54,17 @@ async def mem_index(
         f"- Indexed: {stats.indexed_chunks}\n"
         f"- Skipped (unchanged): {stats.skipped_chunks}\n"
         f"- Deleted (stale): {stats.deleted_chunks}\n"
+        f"- Blocked (redaction): {stats.blocked_files}\n"
         f"- Duration: {stats.duration_ms:.0f}ms"
     )
+    if stats.blocked_files:
+        # ADR-0006 PR-A: name the skipped files so an operator can review them.
+        result += "\n- Blocked files:\n" + "\n".join(f"    {p}" for p in stats.blocked_paths)
+        if stats.blocked_project_shared_files:
+            result += (
+                f"\n- {stats.blocked_project_shared_files} of these are project_shared"
+                " (hard-refused; force_unsafe does not apply)."
+            )
 
     if auto_tag and stats.indexed_chunks > 0:
         from memtomem.tools.auto_tag import auto_tag_storage

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -310,7 +310,7 @@ async def _mem_add_core(
 
     # Re-index the whole file via the standard pipeline so the watcher
     # (which also calls index_file) produces identical hashes → no duplicates.
-    stats = await app.index_engine.index_file(target, namespace=effective_ns)
+    stats = await app.index_engine.index_file(target, namespace=effective_ns, already_scanned=True)
     app.search_pipeline.invalidate_cache()
 
     display_ns = effective_ns or app.config.namespace.default_namespace
@@ -523,12 +523,14 @@ async def mem_edit(
         await asyncio.to_thread(
             replace_chunk_body, meta.source_file, meta.start_line, meta.end_line, new_content
         )
-        stats = await app.index_engine.index_file(meta.source_file, force=True)
+        stats = await app.index_engine.index_file(
+            meta.source_file, force=True, already_scanned=True
+        )
         app.search_pipeline.invalidate_cache()
     except Exception as exc:
         await asyncio.to_thread(meta.source_file.write_text, original, encoding="utf-8")
         try:
-            await app.index_engine.index_file(meta.source_file, force=True)
+            await app.index_engine.index_file(meta.source_file, force=True, already_scanned=True)
         except Exception:
             logger.warning("Rollback re-index also failed", exc_info=True)
         app.search_pipeline.invalidate_cache()
@@ -598,12 +600,16 @@ async def mem_delete(
         original = await asyncio.to_thread(meta.source_file.read_text, encoding="utf-8")
         try:
             await asyncio.to_thread(remove_lines, meta.source_file, meta.start_line, meta.end_line)
-            stats = await app.index_engine.index_file(meta.source_file, force=True)
+            stats = await app.index_engine.index_file(
+                meta.source_file, force=True, already_scanned=True
+            )
             app.search_pipeline.invalidate_cache()
         except Exception as exc:
             await asyncio.to_thread(meta.source_file.write_text, original, encoding="utf-8")
             try:
-                await app.index_engine.index_file(meta.source_file, force=True)
+                await app.index_engine.index_file(
+                    meta.source_file, force=True, already_scanned=True
+                )
             except Exception:
                 logger.warning("Rollback re-index also failed", exc_info=True)
             app.search_pipeline.invalidate_cache()
@@ -893,7 +899,7 @@ async def mem_batch_add(
         append_entry(target, value, title=key or None, tags=entry_tags)
 
     effective_ns = namespace or _resolve_agent_namespace(app, None)
-    stats = await app.index_engine.index_file(target, namespace=effective_ns)
+    stats = await app.index_engine.index_file(target, namespace=effective_ns, already_scanned=True)
     app.search_pipeline.invalidate_cache()
 
     display_ns = effective_ns or app.config.namespace.default_namespace

--- a/packages/memtomem/src/memtomem/server/tools/session.py
+++ b/packages/memtomem/src/memtomem/server/tools/session.py
@@ -420,7 +420,24 @@ async def _persist_session_summary_chunk(
     target.parent.mkdir(parents=True, exist_ok=True)
     await asyncio.to_thread(target.write_text, content, "utf-8")
 
-    stats = await app.index_engine.index_file(target, namespace=namespace)
+    # ADR-0006 PR-A: the session summary is un-adjudicated content, so the
+    # engine redaction gate is active. If it trips, the file is written but not
+    # indexed; surface that instead of reporting success.
+    from memtomem.indexing.engine import PrivacyRejection
+
+    try:
+        stats = await app.index_engine.index_file(target, namespace=namespace)
+    except PrivacyRejection as exc:
+        app.search_pipeline.invalidate_cache()
+        # Return the contracted (status_line, chunk_id) tuple — a bare string
+        # here would make the caller's ``line, id = await …`` unpack raise
+        # ValueError, swallowing this message under the generic except.
+        return (
+            f"Session summary written to {target} but NOT indexed — blocked by the "
+            f"redaction guard ({exc.hit_count} secret-pattern hit(s)). Review the "
+            f"file; re-index with 'mm index --force-unsafe' if intended.",
+            None,
+        )
     app.search_pipeline.invalidate_cache()
 
     if not stats.indexed_chunks:

--- a/packages/memtomem/src/memtomem/server/tools/url_index.py
+++ b/packages/memtomem/src/memtomem/server/tools/url_index.py
@@ -47,9 +47,22 @@ async def mem_fetch(
     except Exception as exc:
         return f"Error fetching URL: {exc}"
 
-    # Index the fetched file
+    # Index the fetched file. ADR-0006 PR-A: fetched content is un-adjudicated,
+    # so the engine redaction gate is active — a secret-bearing page is saved
+    # but not indexed, and surfaced here instead of silently reporting success.
+    from memtomem.indexing.engine import PrivacyRejection
+
     effective_ns = namespace or _resolve_agent_namespace(app, None)
-    stats = await app.index_engine.index_file(file_path, namespace=effective_ns)
+    try:
+        stats = await app.index_engine.index_file(file_path, namespace=effective_ns)
+    except PrivacyRejection as exc:
+        app.search_pipeline.invalidate_cache()
+        return (
+            f"Fetched but NOT indexed — blocked by the redaction guard: {url}\n"
+            f"- Saved to: {file_path}\n"
+            f"- Secret-pattern hits: {exc.hit_count}. Review the file; re-index "
+            f"with 'mm index --force-unsafe' if it is a false positive."
+        )
 
     # Apply tags if provided
     if tags and stats.indexed_chunks > 0:

--- a/packages/memtomem/src/memtomem/web/routes/chunks.py
+++ b/packages/memtomem/src/memtomem/web/routes/chunks.py
@@ -118,7 +118,10 @@ async def edit_chunk(
         # the metadata header on disk. Prefix ``new_content`` with ``## ``
         # to override the heading explicitly.
         replace_chunk_body(meta.source_file, meta.start_line, meta.end_line, body.new_content)
-        await index_engine.index_file(meta.source_file, force=True)
+        # Guarded above (``enforce_write_guard``); skip the engine gate so the
+        # whole-file reindex doesn't re-litigate already-adjudicated content and
+        # the existing rollback contract stays intact (ADR-0006 PR-A).
+        await index_engine.index_file(meta.source_file, force=True, already_scanned=True)
     except Exception as exc:
         logger.error("Chunk edit failed for %s: %s", chunk_id, exc, exc_info=True)
         raise HTTPException(status_code=500, detail="Edit failed. Check server logs.") from exc
@@ -176,7 +179,10 @@ async def delete_chunk(
     if source.exists() and meta.start_line and meta.end_line:
         try:
             remove_lines(source, meta.start_line, meta.end_line)
-            await index_engine.index_file(source, force=True)
+            # Delete (removal) of an already-adjudicated file — skip the engine
+            # gate; the ``except`` fallback below still relies on real indexing
+            # failures raising (ADR-0006 PR-A).
+            await index_engine.index_file(source, force=True, already_scanned=True)
         except Exception as exc:
             logger.warning("Source file edit failed for %s: %s", chunk_id, exc)
             # Fall back to index-only delete

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -670,6 +670,9 @@ async def add_memory_dir(
                 "deleted_chunks": stats.deleted_chunks,
                 "duration_ms": stats.duration_ms,
                 "errors": list(stats.errors) if stats.errors else [],
+                "blocked_files": stats.blocked_files,
+                "blocked_paths": list(stats.blocked_paths),
+                "blocked_project_shared_files": stats.blocked_project_shared_files,
             }
         except Exception as err:  # pragma: no cover — surface partial result
             indexed = {"error": str(err)}
@@ -890,12 +893,29 @@ async def reindex_all(
             "skipped_chunks": stats.skipped_chunks,
             "deleted_chunks": stats.deleted_chunks,
             "duration_ms": stats.duration_ms,
+            "blocked_files": stats.blocked_files,
+            "blocked_project_shared_files": stats.blocked_project_shared_files,
         }
+        if stats.blocked_files:
+            entry["blocked_paths"] = list(stats.blocked_paths)
         if stats.errors:
             entry["errors"] = list(stats.errors)
         results.append(entry)
     all_errors = [e for r in results for e in r.get("errors", [])]
-    return {"ok": len(all_errors) == 0, "results": results, "errors": all_errors}
+    total_blocked = 0
+    total_blocked_ps = 0
+    for r in results:
+        b = r.get("blocked_files", 0)
+        total_blocked += b if isinstance(b, int) else 0
+        bps = r.get("blocked_project_shared_files", 0)
+        total_blocked_ps += bps if isinstance(bps, int) else 0
+    return {
+        "ok": len(all_errors) == 0,
+        "results": results,
+        "errors": all_errors,
+        "blocked_files": total_blocked,
+        "blocked_project_shared_files": total_blocked_ps,
+    }
 
 
 @router.get("/embedding-status", response_model=EmbeddingStatusResponse)
@@ -1294,6 +1314,9 @@ async def trigger_index(
         duration_ms=stats.duration_ms,
         errors=list(stats.errors) if stats.errors else [],
         resolved_namespaces=list(stats.resolved_namespaces),
+        blocked_files=stats.blocked_files,
+        blocked_paths=list(stats.blocked_paths),
+        blocked_project_shared_files=stats.blocked_project_shared_files,
     )
 
 
@@ -1425,7 +1448,9 @@ async def upload_files(
                 continue
 
             dest.write_bytes(content)
-            stats = await index_engine.index_file(dest)
+            # Route-layer guard above already adjudicated this content
+            # (``enforce_write_guard``); skip the engine gate (ADR-0006 PR-A).
+            stats = await index_engine.index_file(dest, already_scanned=True)
             results.append(
                 UploadFileResult(
                     filename=fname,
@@ -1634,7 +1659,9 @@ async def add_memory(
     target.parent.mkdir(parents=True, exist_ok=True)
     tags = req.tags or []
     append_entry(target, req.content, title=req.title, tags=tags)
-    stats = await index_engine.index_file(target, namespace=req.namespace)
+    # Compose/add route guarded this content above (``enforce_write_guard``);
+    # skip the engine gate (ADR-0006 PR-A).
+    stats = await index_engine.index_file(target, namespace=req.namespace, already_scanned=True)
 
     # Apply tags to indexed chunks (the chunker doesn't parse tag text from content)
     if tags and stats.indexed_chunks > 0:

--- a/packages/memtomem/src/memtomem/web/schemas/memory.py
+++ b/packages/memtomem/src/memtomem/web/schemas/memory.py
@@ -115,6 +115,12 @@ class IndexResponse(BaseModel):
     duration_ms: float
     errors: list[str] = []
     resolved_namespaces: list[str | None] = []
+    # ADR-0006 PR-A: files skipped by the secret-redaction gate during bulk
+    # indexing (count + paths). Zero/empty on the common path.
+    blocked_files: int = 0
+    blocked_paths: list[str] = []
+    # Subset that is project_shared — hard-refused even with force_unsafe.
+    blocked_project_shared_files: int = 0
 
 
 class PreviewNamespaceResponse(BaseModel):

--- a/packages/memtomem/tests/test_cli_index_noop_e2e.py
+++ b/packages/memtomem/tests/test_cli_index_noop_e2e.py
@@ -185,3 +185,15 @@ class TestFreshNoopIndexSubprocess:
         r = _run("search", "hello")
         assert r.returncode == 0, f"search failed:\nstdout={r.stdout}\nstderr={r.stderr}"
         assert "hello world" in r.stdout
+
+
+def test_force_unsafe_rejected_with_debounce_modes():
+    """ADR-0006 PR-A: ``--force-unsafe`` only applies to direct indexing; the
+    debounce queue does not thread it, so combining it with
+    ``--flush`` / ``--status`` / ``--debounce-window`` must error rather than
+    silently ignore the flag.
+    """
+    runner = CliRunner()
+    r = runner.invoke(cli, ["index", "--force-unsafe", "--flush"])
+    assert r.exit_code != 0
+    assert "only applies to direct indexing" in r.output

--- a/packages/memtomem/tests/test_index_privacy_block_surfaces.py
+++ b/packages/memtomem/tests/test_index_privacy_block_surfaces.py
@@ -1,0 +1,161 @@
+"""ADR-0006 PR-A — the folder-index redaction gate.
+
+Bulk / un-adjudicated indexing (``index_path`` / ``index_file`` /
+``index_path_stream``) scans each file's content and refuses to index
+secret-bearing files unless ``force_unsafe`` — closing the gap where
+``mm reindex`` / the watcher / ``mem_index`` / ``mem_fetch`` pulled arbitrary
+secrets into the store, bypassing the trust boundary the write ingresses
+already enforce. Ingress-guarded callers pass ``already_scanned=True`` so the
+whole-file reindex neither re-litigates already-adjudicated content nor breaks
+their exception-based rollback.
+
+Pins:
+- bulk ``index_path`` skips a secret file (raise → aggregated) and still
+  indexes the clean sibling; ``blocked_files`` / ``blocked_paths`` surface it.
+- ``force_unsafe=True`` bypasses (bulk indexes the secret anyway).
+- single-file ``index_file`` propagates ``PrivacyRejection`` (so callers can
+  roll back / surface, rather than silently succeeding).
+- ``already_scanned=True`` skips the gate (regression guard for the
+  ingress-guarded mutation callers).
+- ``project_shared`` + ``force_unsafe=True`` is still hard-refused
+  (ADR-0011 §5 — the bypass valve never applies to the git-tracked tier).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memtomem import privacy
+from memtomem.indexing.engine import PrivacyRejection
+
+
+@pytest.fixture(autouse=True)
+def _reset_privacy_counters():
+    # The gate calls ``privacy.record(...)`` (record_outcome=True) on the
+    # process-global counters; reset around each test so we don't leak state
+    # into counter-asserting tests elsewhere in the suite.
+    privacy.reset_for_tests()
+    yield
+    privacy.reset_for_tests()
+
+
+# HuggingFace-token shape assembled at runtime so GitHub push-protection does
+# not flag this file (mirrors tests/test_privacy.py:90).
+_SECRET = "hf" + "_FAKEfake0123456789FAKEfake01234567"
+
+_CLEAN = "# Notes\n\nJust some ordinary prose with nothing sensitive in it.\n"
+_LEAK = f"# Leak\n\napi token: {_SECRET}\n"
+
+
+class TestBulkIndexRedactionGate:
+    async def test_secret_file_blocked_clean_indexed(self, bm25_only_components):
+        comp, mem_dir = bm25_only_components
+        (mem_dir / "clean.md").write_text(_CLEAN)
+        (mem_dir / "leak.md").write_text(_LEAK)
+
+        stats = await comp.index_engine.index_path(mem_dir, recursive=True)
+
+        assert stats.blocked_files == 1
+        assert any("leak.md" in p for p in stats.blocked_paths)
+        assert any("redaction_blocked" in e for e in stats.errors)
+        # The clean sibling was still indexed — one flagged file does not abort
+        # the whole run.
+        assert stats.indexed_chunks > 0
+
+    async def test_force_unsafe_bypasses_bulk(self, bm25_only_components):
+        comp, mem_dir = bm25_only_components
+        (mem_dir / "leak.md").write_text(_LEAK)
+
+        stats = await comp.index_engine.index_path(mem_dir, recursive=True, force_unsafe=True)
+
+        assert stats.blocked_files == 0
+        assert stats.indexed_chunks > 0
+
+    async def test_stream_reports_blocked(self, bm25_only_components):
+        comp, mem_dir = bm25_only_components
+        (mem_dir / "clean.md").write_text(_CLEAN)
+        (mem_dir / "leak.md").write_text(_LEAK)
+
+        events = [ev async for ev in comp.index_engine.index_path_stream(mem_dir, recursive=True)]
+        complete = next(ev for ev in events if ev["type"] == "complete")
+
+        assert complete["blocked_files"] == 1
+        assert any("leak.md" in p for p in complete["blocked_paths"])
+
+    async def test_single_file_index_raises(self, bm25_only_components):
+        comp, mem_dir = bm25_only_components
+        leak = mem_dir / "leak.md"
+        leak.write_text(_LEAK)
+
+        with pytest.raises(PrivacyRejection) as ei:
+            await comp.index_engine.index_file(leak)
+
+        assert ei.value.hit_count >= 1
+        assert ei.value.decision == "blocked"
+        # The exception message must not echo the matched secret bytes.
+        assert _SECRET not in str(ei.value)
+
+    async def test_already_scanned_skips_gate(self, bm25_only_components):
+        # Ingress-guarded callers (mem_add / mem_edit / upload / chunk edit)
+        # already adjudicated the content upstream; the whole-file reindex must
+        # NOT re-block it — else their rollback fires and storage goes stale.
+        comp, mem_dir = bm25_only_components
+        leak = mem_dir / "leak.md"
+        leak.write_text(_LEAK)
+
+        stats = await comp.index_engine.index_file(leak, already_scanned=True)
+
+        assert stats.blocked_files == 0
+        assert stats.indexed_chunks > 0  # indexed despite the secret
+
+    async def test_project_shared_force_unsafe_hard_refused(
+        self, bm25_only_components, monkeypatch
+    ):
+        # ADR-0011 §5: the force_unsafe bypass valve never applies to the
+        # git-tracked project_shared tier — a hit there is hard-refused even
+        # with force_unsafe=True.
+        comp, mem_dir = bm25_only_components
+        leak = mem_dir / "leak.md"
+        leak.write_text(_LEAK)
+
+        engine = comp.index_engine
+        monkeypatch.setattr(engine, "_resolve_scope", lambda p: ("project_shared", mem_dir))
+
+        with pytest.raises(PrivacyRejection) as ei:
+            await engine.index_file(leak, force_unsafe=True)
+
+        assert ei.value.decision == "blocked_project_shared"
+
+    async def test_bulk_project_shared_counted_distinctly(self, bm25_only_components, monkeypatch):
+        # A project_shared block is counted in blocked_project_shared_files so
+        # surfaces can give scope-correct guidance (force_unsafe never applies).
+        comp, mem_dir = bm25_only_components
+        (mem_dir / "leak.md").write_text(_LEAK)
+        engine = comp.index_engine
+        monkeypatch.setattr(engine, "_resolve_scope", lambda p: ("project_shared", mem_dir))
+
+        stats = await engine.index_path(mem_dir, recursive=True)
+
+        assert stats.blocked_files == 1
+        assert stats.blocked_project_shared_files == 1
+
+    async def test_stream_project_shared_force_unsafe_flagged(
+        self, bm25_only_components, monkeypatch
+    ):
+        # Codex-requested: index_path_stream(force_unsafe=True) on project_shared
+        # is still hard-refused; the complete event flags it distinctly (and the
+        # decision is preserved in the error) so the CLI does not tell the user
+        # to retry with --force-unsafe.
+        comp, mem_dir = bm25_only_components
+        (mem_dir / "leak.md").write_text(_LEAK)
+        engine = comp.index_engine
+        monkeypatch.setattr(engine, "_resolve_scope", lambda p: ("project_shared", mem_dir))
+
+        events = [
+            ev async for ev in engine.index_path_stream(mem_dir, recursive=True, force_unsafe=True)
+        ]
+        complete = next(ev for ev in events if ev["type"] == "complete")
+
+        assert complete["blocked_files"] == 1
+        assert complete["blocked_project_shared_files"] == 1
+        assert any("blocked_project_shared" in e for e in complete["errors"])

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -5203,7 +5203,9 @@ class TestInitialSeedThreshold:
         memory_dir.mkdir()
 
         class _FakeEngine:
-            async def index_path_stream(self, path, recursive=True, force=False, namespace=None):
+            async def index_path_stream(
+                self, path, recursive=True, force=False, namespace=None, force_unsafe=False
+            ):
                 yield {"type": "discovery", "files_total": 1}
                 yield {
                     "type": "progress",
@@ -5259,7 +5261,9 @@ class TestInitialSeedThreshold:
         memory_dir.mkdir()
 
         class _FakeEngine:
-            async def index_path_stream(self, path, recursive=True, force=False, namespace=None):
+            async def index_path_stream(
+                self, path, recursive=True, force=False, namespace=None, force_unsafe=False
+            ):
                 yield {"type": "discovery", "files_total": 1}
                 yield {
                     "type": "progress",
@@ -5461,7 +5465,9 @@ class TestInitialSeedThreshold:
         }
 
         class _FakeEngine:
-            async def index_path_stream(self, path, recursive=True, force=False, namespace=None):
+            async def index_path_stream(
+                self, path, recursive=True, force=False, namespace=None, force_unsafe=False
+            ):
                 key = str(path)
                 counts = path_counts[key]
                 yield {"type": "discovery", "files_total": counts["total_files"]}
@@ -5560,7 +5566,9 @@ class TestInitialSeedThreshold:
         captured: dict[str, object] = {}
 
         class _FakeEngine:
-            async def index_path_stream(self, path, recursive=True, force=False, namespace=None):
+            async def index_path_stream(
+                self, path, recursive=True, force=False, namespace=None, force_unsafe=False
+            ):
                 yield {"type": "discovery", "files_total": 1}
                 file = str(memory_dir / "big.md")
                 # Server only emits chunk_progress when the file exceeds the
@@ -5642,7 +5650,9 @@ class TestInitialSeedThreshold:
         captured: dict[str, object] = {}
 
         class _FakeEngine:
-            async def index_path_stream(self, path, recursive=True, force=False, namespace=None):
+            async def index_path_stream(
+                self, path, recursive=True, force=False, namespace=None, force_unsafe=False
+            ):
                 yield {"type": "discovery", "files_total": 2}
                 for name in ("a.md", "b.md"):
                     yield {

--- a/packages/memtomem/tests/test_memory_crud_redaction.py
+++ b/packages/memtomem/tests/test_memory_crud_redaction.py
@@ -92,6 +92,31 @@ class TestMemAddRedactionGuard:
         assert target.exists()
 
     @pytest.mark.asyncio
+    async def test_force_unsafe_content_is_actually_indexed(self, bm25_only_components):
+        """ADR-0006 PR-A regression: ``mem_add(force_unsafe=True)`` writes AND
+        indexes the content. The new engine-layer redaction gate must NOT
+        silently re-block the post-write reindex — ``mem_add`` passes
+        ``already_scanned=True`` because it already adjudicated the content at
+        ingress. Without that thread the file would exist on disk but never
+        make it into the store.
+        """
+        comp, mem_dir = bm25_only_components
+        app = AppContext.from_components(comp)
+        ctx = StubCtx(app)
+        target = mem_dir / "bypass_indexed.md"
+
+        result = await mem_add(  # type: ignore[arg-type]
+            content=_SECRET_SAMPLE,
+            file=str(target),
+            force_unsafe=True,
+            ctx=ctx,
+        )
+
+        assert "Memory added" in result, f"Expected success, got: {result!r}"
+        chunks = await comp.storage.list_chunks_by_source(target)
+        assert chunks, "force-allowed content must be indexed, not silently re-blocked"
+
+    @pytest.mark.asyncio
     async def test_clean_content_records_pass(self, bm25_only_components):
         comp, mem_dir = bm25_only_components
         app = AppContext.from_components(comp)

--- a/packages/memtomem/tests/test_sessions.py
+++ b/packages/memtomem/tests/test_sessions.py
@@ -604,3 +604,34 @@ class TestSessionSummaryPhaseB:
                 continue
             link = await app.storage.get_chunk_link(c.id, link_type="summarizes")
             assert link is None, "manual summary path must not write summarizes links"
+
+
+class TestSessionSummaryRedactionGate:
+    """ADR-0006 PR-A: a secret in the session summary makes the engine redaction
+    gate raise ``PrivacyRejection``. The blocked branch of
+    ``_persist_session_summary_chunk`` must return the contracted
+    ``(status_line, chunk_id)`` tuple — a bare string would make the caller's
+    ``line, id = await …`` unpack raise ``ValueError``, which the generic
+    ``except`` swallows, so the user never sees the "written but NOT indexed"
+    message.
+    """
+
+    @pytest.mark.asyncio
+    async def test_blocked_summary_returns_tuple_with_message(self, bm25_only_components):
+        from memtomem.server.tools.session import _persist_session_summary_chunk
+
+        comp, _ = bm25_only_components
+        app = AppContext.from_components(comp)
+        secret = "hf" + "_FAKEfake0123456789FAKEfake01234567"
+
+        line, chunk_id = await _persist_session_summary_chunk(
+            app,
+            session_id="redactiontest",
+            agent_id="tester",
+            summary=f"api token: {secret}",
+            event_counts={"note": 1},
+        )
+
+        assert chunk_id is None
+        assert line is not None and "NOT indexed" in line
+        assert secret not in line  # no matched bytes echoed


### PR DESCRIPTION
## Summary

Closes the last unbuilt half of **ADR-0006** (Axes A.3/B.2 — folder-index): bulk
and un-adjudicated indexing bypassed the secret-redaction trust boundary that
single-file upload, `mem_add`/`mem_edit`, and JSON import already enforce.
`IndexEngine` had **zero** `enforce_write_guard` calls, so `mm reindex`, the Web
UI Index/Sources flows (`trigger_index`, `reindex_all`, `memory-dirs/add`
auto-index, `index_stream`), the file watcher, `mem_index`, `mem_fetch`, and file
import all pulled arbitrary secret-bearing files straight into the store — the
gap CLAUDE.md calls out as "STM-bypass must not be safety-bypass." The ADR marks
this **Accepted** with the trigger already fired (2026-06-11); this is PR-A.

## Design

- **Gate at the `IndexEngine._index_file` chokepoint** every entrypoint funnels
  through. It resolves scope, then scans the raw content via
  `privacy.enforce_write_guard(surface="index", scope=…, force_unsafe=…)` and
  **raises `PrivacyRejection`** on a hit without `force_unsafe`. The bypass is
  hard-refused for the git-tracked `project_shared` tier (ADR-0011 §5).
- **Bulk entrypoints catch + aggregate.** `index_path` / `index_path_stream`
  catch it per file into `IndexingStats.blocked_files` / `blocked_paths`, so one
  flagged file doesn't abort the run. Surfaced on `IndexResponse`, the SSE
  `complete` event, `reindex_all` / `memory-dirs/add` JSON, the `mem_index`
  result, and the `mm index` summary.
- **Single-file callers propagate.** Ingress-guarded callers pass
  `already_scanned=True` to **skip** the gate (they already adjudicated the new
  content upstream; a whole-file re-scan would re-litigate already-stored
  content, double-count, and break their exception-based rollback). The rest
  catch `PrivacyRejection` and surface an error instead of reporting false
  success.
- **`mm index --force-unsafe`** ships the bulk escape hatch (audit-logged).

## Why raise-not-return / skip-not-thread

A **Codex design gate** on the first draft (return-marker + `force_unsafe`
threading) flagged that it would break `mem_edit` / web chunk-edit/delete, which
rely on `index_file()` **raising** to trigger rollback / stale-chunk cleanup — a
silent blocked-marker would let them report success while storage went
inconsistent. The raise + `already_scanned` model resolves all of that
structurally (guarded callers get no new exception, no double-count). A second
Codex review of the diff returned **SHIP**.

## Scope / follow-up

- **In:** engine gate, all caller wiring, `blocked_files` surfacing, CLI
  `--force-unsafe`, tests, ADR-0006 status + CHANGELOG.
- **Deferred:** the Web UI `force_unsafe` toggle (ADR-0006 **PR-B**) — this PR
  surfaces `blocked_files` so a later UI can render it.

## Testing

- New `test_index_privacy_block_surfaces.py` — 6 engine pins (block, bypass,
  stream aggregation, single-file raise, `already_scanned` skip, `project_shared`
  hard-refusal). Plus a `mem_add(force_unsafe)` no-reblock regression in
  `test_memory_crud_redaction.py`. Both **mutation-validated** to fail without
  the fix.
- Full suite green (`uv run pytest -m "not ollama"`), `ruff` clean (src+tests),
  `mypy` clean. (The 7 local failures are pre-existing environment artifacts —
  a local `~/.memtomem-wiki` + cross-test ordering — and `main`'s CI is green.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
