### PR TITLE
docs(claude-md): point the STM privacy-sync invariant at CREDENTIAL_PATTERNS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,11 @@ for `memtomem` and both resolve to `memtomem.cli:cli`.
   `import memtomem_stm` from `packages/memtomem/src/`, and don't hand-roll an
   in-process STM client — cross-repo coupling is explicitly forbidden.
 - **`memtomem/privacy.py` syncs from STM, asymmetrically.** The redaction
-  patterns in `packages/memtomem/src/memtomem/privacy.py` are copied from
-  `memtomem-stm/proxy/privacy.py:DEFAULT_PATTERNS` (the SHA pin lives in the
-  module docstring). The trust boundary is here, not there — STM-bypass must
+  patterns in `packages/memtomem/src/memtomem/privacy.py` are kept in sync with
+  memtomem-stm's `src/memtomem_stm/proxy/privacy.py:CREDENTIAL_PATTERNS` —
+  secret-class only; do **not** sync from STM's `DEFAULT_PATTERNS`, which folds
+  in `PII_PATTERNS` (the SHA pin lives in the module docstring). The trust
+  boundary is here, not there — STM-bypass must
   not be safety-bypass. When STM adds a **secret-class** pattern, sync it
   here in the same release window and bump the SHA. **PII-class** patterns
   (email, phone, name, address, etc.) do not auto-sync — they would force


### PR DESCRIPTION
## Summary

Fixes the STM privacy-sync invariant pointer in `CLAUDE.md`. It said the redaction patterns are copied from `memtomem-stm/proxy/privacy.py:DEFAULT_PATTERNS`, which is wrong on both parts:

- **Path**: the STM module lives at `src/memtomem_stm/proxy/privacy.py`.
- **Constant**: STM's `DEFAULT_PATTERNS` is `[*CREDENTIAL_PATTERNS, *PII_PATTERNS]` — following the pointer literally would mirror the PII-class patterns that the *same paragraph* forbids auto-syncing. The secret-class sync target is `CREDENTIAL_PATTERNS`.

`privacy.py`'s own module docstring already tracks the right constant (byte-identical to STM `CREDENTIAL_PATTERNS` as of STM `8c884cb`, verified against STM `origin/main`); this brings the CLAUDE.md instruction in line so a future sync pass doesn't mirror the wrong list.

Also rewords "are copied from" → "are kept in sync with": since #1488/#1491 the flow is bidirectional (LTM-origin secret-class additions reverse-mirrored into STM).

Doc-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
