### PR TITLE
fix(index): surface redaction-blocked files from the remaining bulk-caller gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,24 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   (Runtime group) now render the outcome totals plus a per-write-surface
   breakdown, so an operator can audit redaction activity without an MCP client.
 
+- **The interactive shell `index` command, the watcher startup backfill, and the
+  `mm init` wizard seed now name redaction-blocked files (ADR-0006 PR-A
+  follow-up).** A sweep of the remaining `IndexEngine` bulk callers found three
+  surfaces still swallowing the PR-A `blocked_files` aggregates: the shell and
+  the backfill reported only a count — no paths, no scope guidance, and
+  non-redaction per-file errors (too-large / binary / backend failures) not at
+  all — and the `mm init` seed dropped the signal entirely, so a secret-bearing
+  file in a seeded folder vanished behind the green "Seeded initial index" line
+  (or, with every file blocked, behind a misleading "check logs for upsert
+  errors" + embedding-reset hint). The shell and the seed now print the same
+  blocked-file summary `mm index` shows — paths, `--force-unsafe` guidance where
+  it applies, the `project_shared` hard-refusal note — plus the non-redaction
+  ERROR lines, via reporters shared by all three CLI surfaces
+  (`cli/_index_progress.py`) so that messaging cannot drift; the watcher
+  backfill (a log surface, not a terminal one) now names the blocked paths in
+  its warning and aggregates non-redaction errors to one line per directory.
+  `mm index` output is unchanged.
+
 ## [0.3.2] — 2026-06-30
 
 A security release. The Web UI now validates `Host`/`Origin` on every `/api/*`

--- a/docs/adr/0006-web-ui-folder-upload-redaction.md
+++ b/docs/adr/0006-web-ui-folder-upload-redaction.md
@@ -541,14 +541,23 @@ In rough order, all in `packages/memtomem/src/memtomem/`:
       `index()` tool had the identical reporting gap (no return value at all
       for `blocked_files` / `blocked_paths` / `errors`) and was fixed the
       same way.
-    - **Known, lower-severity partial gap — tracked, not fixed in this
-      pass.** `cli/shell.py`'s interactive `index` command and
-      `indexing/watcher.py`'s startup backfill both log `stats.blocked_files`
-      as a count, but neither logs `blocked_paths` (which files) nor
-      inspects generic `stats.errors` (non-redaction per-file failures).
-      Some signal already exists here — unlike the debounce/flush and
-      LangGraph gaps above — so this is deferred alongside PR-B rather than
-      bundled into this fix.
+    - **Known, lower-severity partial gap — closed in the follow-up sweep
+      (#1505).** `cli/shell.py`'s interactive `index` command and
+      `indexing/watcher.py`'s startup backfill logged `stats.blocked_files`
+      only as a count — no `blocked_paths` (which files), no generic
+      `stats.errors` (non-redaction per-file failures). The close-out sweep
+      also found a third, fully-silent caller the original enumeration
+      missed: the `mm init` wizard seed read only total/indexed/skipped
+      from the stream aggregate, so blocked files vanished behind the green
+      "Seeded initial index" line (and a fully-blocked seed printed the
+      unrelated upsert/embedder diagnosis). The shell and the seed now print
+      the blocked summary (paths, bypass hint, `project_shared` hard-refuse
+      note) plus non-redaction ERROR lines via reporters extracted into
+      `cli/_index_progress.py` (`print_blocked_summary` /
+      `print_index_errors`; `mm index` calls the same reporters, output
+      byte-identical), so the CLI messaging cannot drift per surface. The
+      backfill — a log surface — names the blocked paths in its warning and
+      aggregates non-redaction errors to one line per dir.
 - **PR-B — Web UI override toggle + audit surface (both shipped
   2026-07-01).**
   - **Toggle — built.** An "Index without privacy gate" checkbox on the Index

--- a/packages/memtomem/src/memtomem/cli/_index_progress.py
+++ b/packages/memtomem/src/memtomem/cli/_index_progress.py
@@ -25,7 +25,15 @@ their distinct UX):
 Helper guarantees: bar is always closed on exit (including raise), stream
 runs serially over the supplied ``paths``, returned aggregate dict has
 stable keys ``total_files``, ``indexed``, ``skipped``, ``deleted``,
-``total_chunks``, ``duration_ms``, ``errors``, ``bar_rendered``."""
+``total_chunks``, ``duration_ms``, ``errors``, ``bar_rendered``,
+``blocked``, ``blocked_paths``, ``blocked_project_shared`` (ADR-0006 PR-A).
+
+:func:`print_blocked_summary` / :func:`print_index_errors` are the shared
+post-run reporters for those counters — every CLI bulk-index surface
+(``mm index``, the wizard seed, the interactive shell) prints the same
+blocked-files block so the trust-boundary messaging can't drift per
+surface; only the bypass hint differs (each surface names the command its
+user can actually run)."""
 
 from __future__ import annotations
 
@@ -253,6 +261,57 @@ async def run_with_progress(
     return agg
 
 
+def print_blocked_summary(
+    *,
+    blocked: int,
+    blocked_paths: Sequence[str],
+    blocked_project_shared: int,
+    bypass_hint: str,
+) -> None:
+    """Print the redaction-blocked summary shared by the CLI bulk surfaces.
+
+    ADR-0006 PR-A: name the secret-bearing files the gate skipped, with
+    scope-correct guidance — ``project_shared`` is hard-refused even with
+    ``--force-unsafe``, so the bypass hint covers only the bypassable rest.
+    ``bypass_hint`` is surface-specific (``mm index`` says "re-run with
+    --force-unsafe"; surfaces without their own flag name the command to
+    run instead) and is printed after an arrow prefix. No-op when nothing
+    was blocked.
+    """
+    if not blocked:
+        return
+    bypassable = blocked - blocked_project_shared
+    click.secho(f"  {blocked} file(s) blocked by redaction guard:", fg="yellow")
+    for p in blocked_paths:
+        click.secho(f"    {p}", fg="yellow")
+    if bypassable:
+        click.secho(f"  → {bypass_hint}", fg="yellow")
+    if blocked_project_shared:
+        click.secho(
+            f"  → {blocked_project_shared} file(s) are in the project_shared tier — "
+            "hard-refused; --force-unsafe does not apply. Move them to "
+            "user/project_local or remove the secret.",
+            fg="yellow",
+        )
+
+
+def print_index_errors(errors: Sequence[str]) -> None:
+    """Print non-redaction per-file errors from a bulk index run.
+
+    ``redaction_blocked`` entries are skipped — :func:`print_blocked_summary`
+    already surfaced those files with a clearer message and hint.
+    """
+    for err in errors:
+        if "redaction_blocked" in err:
+            continue
+        click.echo(click.style(f"  ERROR: {err}", fg="red"))
+
+
 # Re-exported asyncio.run wrapper kept thin: callers want the surface-specific
 # error handling around the await, so they manage ``asyncio.run`` themselves.
-__all__ = ["run_with_progress", "_collect_seed_scale"]
+__all__ = [
+    "print_blocked_summary",
+    "print_index_errors",
+    "run_with_progress",
+    "_collect_seed_scale",
+]

--- a/packages/memtomem/src/memtomem/cli/indexing.py
+++ b/packages/memtomem/src/memtomem/cli/indexing.py
@@ -144,7 +144,11 @@ async def _index(
     pre-stream implementation since scripts may grep it; the helper
     aggregates ``deleted`` and ``duration_ms`` from the stream's
     ``complete`` events so the format is preserved verbatim."""
-    from memtomem.cli._index_progress import run_with_progress
+    from memtomem.cli._index_progress import (
+        print_blocked_summary,
+        print_index_errors,
+        run_with_progress,
+    )
 
     resolved = Path(path).resolve()
 
@@ -179,33 +183,18 @@ async def _index(
         f"{agg['indexed']} new, {agg['skipped']} unchanged, "
         f"{agg['deleted']} deleted ({agg['duration_ms']:.0f}ms)"
     )
-    if agg["blocked"]:
-        # ADR-0006 PR-A: name the secret-bearing files that were skipped. Give
-        # scope-correct guidance — project_shared is hard-refused even with
-        # --force-unsafe, so don't tell the user to retry it there.
-        ps = agg["blocked_project_shared"]
-        bypassable = agg["blocked"] - ps
-        click.secho(f"  {agg['blocked']} file(s) blocked by redaction guard:", fg="yellow")
-        for p in agg["blocked_paths"]:
-            click.secho(f"    {p}", fg="yellow")
-        if bypassable:
-            click.secho(
-                "  → re-run with --force-unsafe to index the non-project_shared "
-                "files anyway (audit-logged).",
-                fg="yellow",
-            )
-        if ps:
-            click.secho(
-                f"  → {ps} file(s) are in the project_shared tier — hard-refused; "
-                "--force-unsafe does not apply. Move them to user/project_local "
-                "or remove the secret.",
-                fg="yellow",
-            )
-    for err in agg["errors"]:
-        if "redaction_blocked" in err:
-            # Already surfaced above with a clearer message + hint.
-            continue
-        click.echo(click.style(f"  ERROR: {err}", fg="red"))
+    # ADR-0006 PR-A: shared reporters keep the blocked-files block and the
+    # non-redaction error lines byte-identical across the CLI bulk surfaces.
+    print_blocked_summary(
+        blocked=agg["blocked"],
+        blocked_paths=agg["blocked_paths"],
+        blocked_project_shared=agg["blocked_project_shared"],
+        bypass_hint=(
+            "re-run with --force-unsafe to index the non-project_shared "
+            "files anyway (audit-logged)."
+        ),
+    )
+    print_index_errors(agg["errors"])
 
 
 def _print_status(*, as_json: bool) -> None:

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -21,6 +21,10 @@ from memtomem.cli._index_progress import (
     _collect_seed_scale as _collect_seed_scale,
 )
 from memtomem.cli._index_progress import (
+    print_blocked_summary,
+    print_index_errors,
+)
+from memtomem.cli._index_progress import (
     run_with_progress as _run_index_with_progress,
 )
 from memtomem.cli.init_presets import PRESETS, _VALID_PRESETS, get_preset
@@ -1773,6 +1777,29 @@ def _seed_with_progress(paths: list[Path]) -> bool:
         return False
 
     click.echo()
+    # ADR-0006 PR-A: surface the redaction-blocked files and non-redaction
+    # per-file errors the seed run aggregated — previously both were
+    # swallowed, so a secret-bearing file vanished behind a green summary
+    # (or, fully blocked, behind the wrong "upsert errors" diagnosis below).
+    if len(paths) == 1:
+        bypass_hint = (
+            f"re-run `mm index --force-unsafe {paths[0]}` after setup to "
+            "index the non-project_shared files anyway (audit-logged)."
+        )
+    else:
+        bypass_hint = (
+            "re-run `mm index --force-unsafe <dir>` on the affected dir(s) "
+            "after setup to index the non-project_shared files anyway "
+            "(audit-logged)."
+        )
+    print_blocked_summary(
+        blocked=agg["blocked"],
+        blocked_paths=agg["blocked_paths"],
+        blocked_project_shared=agg["blocked_project_shared"],
+        bypass_hint=bypass_hint,
+    )
+    print_index_errors(agg["errors"])
+
     # Defensive: if the stream processed files but landed zero chunks
     # (neither new nor skipped-as-unchanged), something went wrong
     # silently — per-file errors are logged but the `complete` event
@@ -1783,6 +1810,11 @@ def _seed_with_progress(paths: list[Path]) -> bool:
     # Next-steps step 1 stays unmarked and the user knows to investigate
     # rather than seeing a false green success.
     if agg["indexed"] == 0 and agg["skipped"] == 0:
+        if agg["blocked"] == agg["total_files"]:
+            # Fully explained by the redaction gate — the blocked summary
+            # above is the diagnosis; the upsert/embedder hints would point
+            # the wrong way.
+            return False
         click.secho(
             f"  Seeded {agg['total_files']} file(s) but 0 chunks were indexed — "
             "check logs for upsert errors.",

--- a/packages/memtomem/src/memtomem/cli/shell.py
+++ b/packages/memtomem/src/memtomem/cli/shell.py
@@ -302,6 +302,19 @@ async def _cmd_index(comp, args: list[str]) -> None:
         f"Done: {stats.total_files} files, {stats.indexed_chunks} chunks ({stats.duration_ms}ms)",
         fg="green",
     )
-    if stats.blocked_files:
-        # ADR-0006 PR-A: secret-bearing files skipped by the redaction gate.
-        click.secho(f"  {stats.blocked_files} file(s) blocked by redaction guard", fg="yellow")
+    # ADR-0006 PR-A: name the secret-bearing files the redaction gate skipped
+    # and surface non-redaction per-file errors (previously count-only /
+    # silent). The shell deliberately has no inline force-unsafe syntax
+    # (mirrors _cmd_add), so the bypass hint names the CLI command to run.
+    from memtomem.cli._index_progress import print_blocked_summary, print_index_errors
+
+    print_blocked_summary(
+        blocked=stats.blocked_files,
+        blocked_paths=stats.blocked_paths,
+        blocked_project_shared=stats.blocked_project_shared_files,
+        bypass_hint=(
+            f"run `mm index --force-unsafe {path}` (outside the shell) to "
+            "index the non-project_shared files anyway (audit-logged)."
+        ),
+    )
+    print_index_errors(stats.errors)

--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -179,11 +179,24 @@ class FileWatcher:
                 stats = await self._engine.index_path(d, recursive=True)
                 total_indexed += stats.indexed_chunks
                 if stats.blocked_files:
-                    # ADR-0006 PR-A: secret-bearing files skipped during backfill.
+                    # ADR-0006 PR-A: secret-bearing files skipped during
+                    # backfill — name them so the log is actionable.
                     logger.warning(
-                        "Startup backfill %s: %d file(s) blocked by redaction guard",
+                        "Startup backfill %s: %d file(s) blocked by redaction guard: %s",
                         d,
                         stats.blocked_files,
+                        ", ".join(stats.blocked_paths),
+                    )
+                other_errors = [e for e in stats.errors if "redaction_blocked" not in e]
+                if other_errors:
+                    # Non-redaction per-file failures/skips (too-large, binary,
+                    # backend errors) — previously dropped. One aggregated line
+                    # per dir bounds the per-restart log noise.
+                    logger.warning(
+                        "Startup backfill %s: %d file(s) skipped or failed: %s",
+                        d,
+                        len(other_errors),
+                        "; ".join(other_errors),
                     )
                 if stats.indexed_chunks or stats.deleted_chunks:
                     logger.info(

--- a/packages/memtomem/tests/test_index_privacy_block_surfaces.py
+++ b/packages/memtomem/tests/test_index_privacy_block_surfaces.py
@@ -159,3 +159,64 @@ class TestBulkIndexRedactionGate:
         assert complete["blocked_files"] == 1
         assert complete["blocked_project_shared_files"] == 1
         assert any("blocked_project_shared" in e for e in complete["errors"])
+
+
+class TestShellIndexBlockedSurfacing:
+    """The interactive shell's ``index`` command (``cli/shell.py:_cmd_index``)
+    previously printed only a blocked-files count — no paths, no scope
+    guidance, and ``stats.errors`` not at all (the ADR-0006 "known,
+    lower-severity partial gap"). It now prints the shared blocked summary
+    and the non-redaction error lines, mirroring ``mm index``."""
+
+    async def test_blocked_paths_and_bypass_hint_printed(self, bm25_only_components, capsys):
+        from memtomem.cli.shell import _cmd_index
+
+        comp, mem_dir = bm25_only_components
+        (mem_dir / "clean.md").write_text(_CLEAN)
+        (mem_dir / "leak.md").write_text(_LEAK)
+
+        await _cmd_index(comp, [str(mem_dir)])
+
+        out = capsys.readouterr().out
+        assert "1 file(s) blocked by redaction guard:" in out
+        assert "leak.md" in out
+        # The shell has no inline force-unsafe syntax (mirrors _cmd_add) —
+        # the hint names the CLI command the user can actually run.
+        assert "mm index --force-unsafe" in out
+        # The matched secret bytes never echo to the terminal.
+        assert _SECRET not in out
+        # The redaction_blocked stats.errors entry is folded into the blocked
+        # summary, not double-printed as a raw ERROR line.
+        assert "ERROR:" not in out
+
+    async def test_project_shared_block_messaged_as_hard_refused(
+        self, bm25_only_components, capsys, monkeypatch
+    ):
+        from memtomem.cli.shell import _cmd_index
+
+        comp, mem_dir = bm25_only_components
+        (mem_dir / "leak.md").write_text(_LEAK)
+        monkeypatch.setattr(
+            comp.index_engine, "_resolve_scope", lambda p: ("project_shared", mem_dir)
+        )
+
+        await _cmd_index(comp, [str(mem_dir)])
+
+        out = capsys.readouterr().out
+        assert "project_shared tier" in out
+        assert "hard-refused" in out
+        # Scope-correct guidance: no bypass hint — force_unsafe never
+        # applies to the git-tracked tier (ADR-0011 §5).
+        assert "mm index --force-unsafe" not in out
+
+    async def test_non_redaction_errors_printed(self, bm25_only_components, capsys):
+        from memtomem.cli.shell import _cmd_index
+
+        comp, mem_dir = bm25_only_components
+        (mem_dir / "note.md").write_text(_CLEAN)
+        (mem_dir / "blob.md").write_bytes(b"\x00\x01binary")
+
+        await _cmd_index(comp, [str(mem_dir)])
+
+        out = capsys.readouterr().out
+        assert "ERROR: blob.md: binary file detected, skipping" in out

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -2427,6 +2427,80 @@ class TestFileWatcher:
         assert first > 0
         assert first == second, f"expected backfill idempotent, got {first} -> {second}"
 
+    async def test_startup_backfill_logs_blocked_paths(self, components, memory_dir, caplog):
+        """ADR-0006 PR-A follow-up: the backfill's redaction-blocked warning
+        logged only a count — ops can't act on a count. It now names the
+        blocked file(s) (paths only, never the matched bytes)."""
+        import logging
+
+        from memtomem import privacy
+        from memtomem.indexing.watcher import FileWatcher
+
+        # Runtime-assembled token shape (mirrors test_index_privacy_block_surfaces).
+        secret = "hf" + "_FAKEfake0123456789FAKEfake01234567"
+        (memory_dir / "leak.md").write_text(f"# Leak\n\napi token: {secret}\n", encoding="utf-8")
+        components.config.indexing.startup_backfill = True
+
+        privacy.reset_for_tests()
+        try:
+            watcher = FileWatcher(
+                index_engine=components.index_engine,
+                config=components.config.indexing,
+                debounce_ms=100,
+            )
+            try:
+                with caplog.at_level(logging.WARNING, logger="memtomem.indexing.watcher"):
+                    await watcher.start()
+                    assert watcher._backfill_task is not None
+                    await watcher._backfill_task
+            finally:
+                await watcher.stop()
+        finally:
+            privacy.reset_for_tests()
+
+        # Filter to the watcher's own backfill line: caplog captures ALL
+        # loggers, and the engine emits its own per-file "Indexing blocked by
+        # redaction guard for <path>" warning that would satisfy a bare
+        # message-substring match even without the watcher change.
+        blocked = [
+            r.message
+            for r in caplog.records
+            if r.name == "memtomem.indexing.watcher"
+            and r.message.startswith("Startup backfill")
+            and "blocked by redaction guard" in r.message
+        ]
+        assert blocked, [r.message for r in caplog.records]
+        assert any("leak.md" in m for m in blocked)
+        assert all(secret not in m for m in blocked)
+
+    async def test_startup_backfill_logs_non_redaction_errors(self, components, memory_dir, caplog):
+        """Non-redaction per-file failures/skips (binary, too-large) vanished
+        from the backfill logs entirely — a walk that skipped files looked
+        identical to one that indexed everything. One aggregated warning per
+        dir now names them."""
+        import logging
+
+        from memtomem.indexing.watcher import FileWatcher
+
+        (memory_dir / "blob.md").write_bytes(b"\x00\x01binary")
+        components.config.indexing.startup_backfill = True
+
+        watcher = FileWatcher(
+            index_engine=components.index_engine,
+            config=components.config.indexing,
+            debounce_ms=100,
+        )
+        try:
+            with caplog.at_level(logging.WARNING, logger="memtomem.indexing.watcher"):
+                await watcher.start()
+                assert watcher._backfill_task is not None
+                await watcher._backfill_task
+        finally:
+            await watcher.stop()
+
+        msgs = [r.message for r in caplog.records]
+        assert any("skipped or failed" in m and "binary file detected" in m for m in msgs), msgs
+
 
 # ===========================================================================
 # 11. memory_dir_stats — per-dir index status for the web widget

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -5300,6 +5300,127 @@ class TestInitialSeedThreshold:
         assert "0 chunks were indexed" not in out
         assert "embedding-reset" not in out
 
+    def test_seed_with_progress_surfaces_blocked_files(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """ADR-0006 PR-A follow-up: the seed read only total/indexed/skipped
+        from the aggregate, so a secret-bearing file skipped by the redaction
+        gate vanished behind the green "Seeded initial index" line. A partial
+        block now prints the shared blocked summary (paths + bypass hint)
+        while the clean rest still seeds successfully."""
+        from contextlib import asynccontextmanager
+
+        from memtomem.cli import init_cmd
+
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        leak = memory_dir / "leak.md"
+
+        class _FakeEngine:
+            async def index_path_stream(
+                self, path, recursive=True, force=False, namespace=None, force_unsafe=False
+            ):
+                yield {"type": "discovery", "files_total": 2}
+                yield {
+                    "type": "progress",
+                    "file": str(memory_dir / "a.md"),
+                    "files_done": 1,
+                    "files_total": 2,
+                    "indexed": 3,
+                    "skipped": 0,
+                }
+                yield {
+                    "type": "complete",
+                    "total_files": 2,
+                    "total_chunks": 3,
+                    "indexed_chunks": 3,
+                    "skipped_chunks": 0,
+                    "deleted_chunks": 0,
+                    "duration_ms": 1.0,
+                    "blocked_files": 1,
+                    "blocked_paths": [str(leak)],
+                    "blocked_project_shared_files": 0,
+                    "errors": ["leak.md: redaction_blocked (hits=1, scope=user, decision=blocked)"],
+                }
+
+        class _FakeComp:
+            index_engine = _FakeEngine()
+
+        @asynccontextmanager  # type: ignore[misc]
+        async def _fake_components():
+            yield _FakeComp()
+
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _fake_components)
+
+        assert init_cmd._seed_with_progress([memory_dir]) is True
+        out = capsys.readouterr().out
+        assert "1 file(s) blocked by redaction guard:" in out
+        assert str(leak) in out
+        assert f"mm index --force-unsafe {memory_dir}" in out
+        assert "Seeded initial index" in out
+        # The redaction_blocked errors entry is folded into the blocked
+        # summary, not double-printed as a raw ERROR line.
+        assert "ERROR:" not in out
+
+    def test_seed_with_progress_fully_blocked_skips_upsert_misdiagnosis(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When every seeded file is redaction-blocked, indexed==skipped==0
+        used to fall into the zero-chunks branch and print "check logs for
+        upsert errors" + the embedding-reset hint — the wrong diagnosis for
+        a redaction block. The blocked summary is the diagnosis now; the
+        seed still returns False so Next-steps step 1 stays unmarked."""
+        from contextlib import asynccontextmanager
+
+        from memtomem.cli import init_cmd
+
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        leak = memory_dir / "leak.md"
+
+        class _FakeEngine:
+            async def index_path_stream(
+                self, path, recursive=True, force=False, namespace=None, force_unsafe=False
+            ):
+                yield {"type": "discovery", "files_total": 1}
+                yield {
+                    "type": "complete",
+                    "total_files": 1,
+                    "total_chunks": 0,
+                    "indexed_chunks": 0,
+                    "skipped_chunks": 0,
+                    "deleted_chunks": 0,
+                    "duration_ms": 1.0,
+                    "blocked_files": 1,
+                    "blocked_paths": [str(leak)],
+                    "blocked_project_shared_files": 0,
+                    "errors": ["leak.md: redaction_blocked (hits=1, scope=user, decision=blocked)"],
+                }
+
+        class _FakeComp:
+            index_engine = _FakeEngine()
+
+        @asynccontextmanager  # type: ignore[misc]
+        async def _fake_components():
+            yield _FakeComp()
+
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _fake_components)
+
+        assert init_cmd._seed_with_progress([memory_dir]) is False
+        out = capsys.readouterr().out
+        assert "1 file(s) blocked by redaction guard:" in out
+        assert str(leak) in out
+        # The misdiagnosis hints must NOT fire when the block explains it.
+        assert "0 chunks were indexed" not in out
+        assert "embedding-reset" not in out
+        assert "Seeded initial index" not in out
+
     def test_seed_with_progress_keyboard_interrupt_is_graceful(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary

Closes the ADR-0006 "known, lower-severity partial gap" — and a third, fully-silent gap a full-tree caller sweep found on the way. Three bulk-index surfaces still swallowed the PR-A (#1499) `blocked_files` aggregates:

- **Interactive shell `index`** printed only a blocked-files count — no paths, no scope guidance, and `stats.errors` (too-large / binary / backend failures) not at all.
- **Watcher startup backfill** logged the same count-only warning and dropped non-redaction per-file errors entirely — a walk that skipped files looked identical to one that indexed everything.
- **`mm init` wizard seed** (the sweep's find — not in the ADR's original enumeration) read only total/indexed/skipped from the stream aggregate, so a secret-bearing file vanished behind the green "Seeded initial index" line; with *every* file blocked, the zero-chunks branch printed "check logs for upsert errors" + the embedding-reset hint — the wrong diagnosis for a redaction block.

## Changes

- Extracted `mm index`'s blocked-summary + error-line printing into shared reporters (`cli/_index_progress.py`: `print_blocked_summary` / `print_index_errors`); `mm index` output stays **byte-identical** (execution-verified across 6 input cases). The shell and the seed print the same summary; surfaces without their own `--force-unsafe` flag name the CLI command to run instead (the shell mirrors `_cmd_add`'s no-inline-bypass precedent). `project_shared` blocks never show a bypass hint.
- The backfill warning now names the blocked paths (never the matched bytes) and aggregates non-redaction errors to one line per dir to bound per-restart log noise.
- The fully-blocked seed (`blocked == total_files`) skips the upsert/embedder misdiagnosis and lets the blocked summary be the diagnosis; still returns `False` so Next-steps step 1 stays unmarked.
- ADR-0006 gap paragraph updated to closed; CHANGELOG entry under `[Unreleased]` → Security.

## Tests

Seven new tests (shell ×3 real-engine + capsys, watcher backfill ×2 caplog, seed ×2 fake-stream), each verified to fail on the pre-fix code. Review gates: Codex SHIP (0 findings); a 4-lens adversarial verify pass (byte-parity / regressions / test-mutation / trust-boundary messaging) — its one FAIL (a caplog filter that also matched the engine's per-file warning, un-pinning the watcher change) and two doc-precision CONCERNs are fixed in this diff. Full suite: 7419 passed; the 7 failures are pre-existing on `origin/main` (3 wiki-absent hermeticity failures from a real `~/.memtomem-wiki` leaking into local runs, 4 known `test_session_tracing` parallel flakes that pass in isolation) — none touch this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
