### PR TITLE
fix(wiki): resolve default wiki path at call time, not import time

### DIFF
--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -22,7 +22,13 @@ from pathlib import Path, PurePosixPath
 logger = logging.getLogger(__name__)
 
 DEFAULT_WIKI_PATH: Path = Path.home() / ".memtomem-wiki"
-"""Default wiki location — overridable via ``MEMTOMEM_WIKI_PATH`` env."""
+"""Default wiki location — overridable via ``MEMTOMEM_WIKI_PATH`` env.
+
+Documentation-only: frozen under the importing process's home at import
+time. Runtime resolution goes through :func:`_wiki_path_from_env`, which
+re-reads ``Path.home()`` at call time so a ``HOME`` override applied after
+import (e.g. a test sandbox) is honored (#1506).
+"""
 
 WIKI_ASSET_TYPES: tuple[str, ...] = ("skills", "agents", "commands")
 """Asset directory names at the wiki root. Order is significant for listing."""
@@ -118,7 +124,9 @@ def _wiki_path_from_env() -> Path:
     env = os.environ.get("MEMTOMEM_WIKI_PATH")
     if env:
         return Path(env).expanduser()
-    return DEFAULT_WIKI_PATH
+    # Call-time Path.home(), not DEFAULT_WIKI_PATH — the constant is frozen
+    # at import and would ignore a HOME override applied afterwards (#1506).
+    return Path.home() / ".memtomem-wiki"
 
 
 # Match the ``userinfo@`` segment of a ``scheme://userinfo@host`` URL. The

--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -17,7 +17,10 @@ from memtomem.wiki.store import (
     WikiNotFoundError,
     WikiNothingToCommitError,
     WikiStore,
+    _wiki_path_from_env,
 )
+
+from .helpers import set_home
 
 
 class TestDefaultPath:
@@ -36,6 +39,19 @@ class TestDefaultPath:
         monkeypatch.delenv("MEMTOMEM_WIKI_PATH", raising=False)
         store = WikiStore.at_default()
         assert store.root == Path.home() / ".memtomem-wiki"
+
+    def test_fallback_follows_home_set_after_import(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Regression pin for #1506 — the fallback must re-read ``Path.home()``
+        at call time. The import-time-frozen ``DEFAULT_WIKI_PATH`` made
+        wiki-absent tests leak the real ``~/.memtomem-wiki`` on dev machines
+        despite their ``set_home`` sandbox.
+        """
+        monkeypatch.delenv("MEMTOMEM_WIKI_PATH", raising=False)
+        sandbox_home = tmp_path / "sandbox-home"
+        set_home(monkeypatch, sandbox_home)
+        assert _wiki_path_from_env() == sandbox_home / ".memtomem-wiki"
 
 
 class TestInitScratch:


### PR DESCRIPTION
## Summary

Fixes the non-hermetic wiki-absent degradation tests (#1506, option A): `_wiki_path_from_env()` now computes the `~/.memtomem-wiki` fallback with a call-time `Path.home()` instead of returning the import-time-frozen `DEFAULT_WIKI_PATH`.

## Root cause

`DEFAULT_WIKI_PATH` evaluates `Path.home() / ".memtomem-wiki"` when `wiki/store.py` is imported — i.e. under the *real* `HOME` during pytest collection. The wiki-absent tests sandbox `HOME`/`USERPROFILE` via `set_home` *after* import and `delenv("MEMTOMEM_WIKI_PATH")` for hermeticity, which together pinned resolution to the frozen real-home constant. On any dev box with a real `~/.memtomem-wiki`, the real wiki's HEAD leaked into the "absent" scenario and three tests failed (CI stayed green — runners have no wiki).

## Changes

- `wiki/store.py` — `_wiki_path_from_env()` fallback is now lazy (call-time `Path.home()`). `DEFAULT_WIKI_PATH` stays exported as a documentation-only default; its docstring now notes the import-time-freeze caveat.
- `tests/test_wiki_store.py` — regression pin per the issue: override `HOME` after import (`set_home`) and assert the resolver follows it. The existing pins on the constant's value and the `at_default` home fallback pass unmodified.

## Verification

- The three previously failing tests (`test_collect_wiki_absent_degrades_to_stale_pin`, `test_wiki_absent_degradation_note`, `test_wiki_absent_degrades_to_stale_pin_rows`) now pass on a machine with a real `~/.memtomem-wiki`; reproduced red on `origin/main @ cd0ae767` first.
- Full suite (`-m "not ollama"`): main = 7 failed, this branch = 4 failed. The remaining 4 (`test_session_tracing.py` config-validation tests) are pre-existing on main, full-run-only (pass in isolation both before and after this change), and unrelated — will be triaged separately.
- `ruff check` + `ruff format --check` clean on `src` and `tests`.

Closes #1506

🤖 Generated with [Claude Code](https://claude.com/claude-code)
