### PR TITLE
fix(wiki): preserve non-ASCII asset paths in ls-tree parsing

### DIFF
--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -189,6 +189,31 @@ def _git(
         raise RuntimeError(_redact_url_userinfo(f"git {' '.join(args)} failed: {exc}")) from exc
 
 
+def _git_bytes(args: list[str], cwd: Path) -> subprocess.CompletedProcess[bytes]:
+    """Run ``git <args>`` in ``cwd`` returning raw *bytes* stdout.
+
+    Twin of :func:`_git` for path-carrying porcelain output (``ls-tree -z``):
+    ``text=True`` decodes with the host's preferred locale encoding, which
+    corrupts non-ASCII pathnames on non-UTF-8 hosts — the caller decodes
+    explicitly instead. Failure classification and credential redaction
+    mirror :func:`_git`.
+    """
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or b"").decode("utf-8", errors="replace").strip()
+        raise RuntimeError(_redact_url_userinfo(f"git {' '.join(args)} failed: {detail}")) from exc
+    except OSError as exc:
+        # Same classification as _git: a raw OSError never escapes a caller's
+        # (or the CLI's) RuntimeError handler.
+        raise RuntimeError(_redact_url_userinfo(f"git {' '.join(args)} failed: {exc}")) from exc
+
+
 def _git_query(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
     """Run ``git <args>`` allowing a non-zero exit; normalize only ``OSError``.
 
@@ -628,7 +653,7 @@ class WikiStore:
 
         1. ``commit_is_reachable`` precheck — :class:`CommitNotFoundError`
            if the SHA is not in the object database.
-        2. ``git ls-tree -r --name-only <commit> -- <asset_type>/<name>/``
+        2. ``git ls-tree -r -z --name-only <commit> -- <asset_type>/<name>/``
            enumerates the files at that commit. An empty result means
            the asset path didn't exist at that revision — raises
            :class:`memtomem.context.install.AssetNotFoundError` (deferred
@@ -696,8 +721,9 @@ class WikiStore:
     def asset_files_at_commit(self, commit: str, asset_type: str, name: str) -> list[str]:
         """List the asset's file relpaths (relative to the asset dir) at *commit*.
 
-        ``git ls-tree -r --name-only`` against the commit's objects — the
-        wiki working tree is never consulted. Raises
+        ``git ls-tree -r -z --name-only`` (NUL-terminated bytes, so non-ASCII
+        pathnames survive ``core.quotePath``) against the commit's objects —
+        the wiki working tree is never consulted. Raises
         :class:`CommitNotFoundError` for an unreachable SHA and
         :class:`memtomem.context.install.AssetNotFoundError` when the asset
         path has no files at that revision. Used by
@@ -712,18 +738,33 @@ class WikiStore:
             raise CommitNotFoundError(f"commit {commit[:12]} is not reachable in {self.root}")
 
         src_prefix = f"{asset_type}/{name}/"
-        ls_result = _git(
-            ["ls-tree", "-r", "--name-only", commit, "--", src_prefix],
+        # ``-z`` (NUL-terminated, verbatim pathnames) via the bytes runner:
+        # with git's default ``core.quotePath=true``, line-oriented porcelain
+        # output C-quotes any non-ASCII pathname (``"skills/\354…"`` wrapped
+        # in double quotes), which fails the prefix match below — a
+        # Korean-named file silently vanished from extraction and the digest
+        # map. NUL-terminated bytes round-trip every pathname exactly.
+        ls_result = _git_bytes(
+            ["ls-tree", "-r", "-z", "--name-only", commit, "--", src_prefix],
             cwd=self.root,
         )
-        inner_relpaths = [
-            line[len(src_prefix) :]
-            for line in ls_result.stdout.splitlines()
-            # The startswith filter guards against odd git path output; the
-            # truthiness check drops a bare prefix row (ls-tree -r shouldn't
-            # yield one, but guard against odd git versions).
-            if line.startswith(src_prefix) and line[len(src_prefix) :]
-        ]
+        prefix_bytes = src_prefix.encode("utf-8")
+        try:
+            inner_relpaths = [
+                entry[len(prefix_bytes) :].decode("utf-8")
+                for entry in ls_result.stdout.split(b"\0")
+                # The startswith filter guards against odd git path output;
+                # the truthiness check drops the empty tail after the final
+                # NUL (and a bare prefix row, which ls-tree -r shouldn't
+                # yield, but guard against odd git versions).
+                if entry.startswith(prefix_bytes) and entry[len(prefix_bytes) :]
+            ]
+        except UnicodeDecodeError as exc:
+            # Path-free by design: the web routes render RuntimeError as a
+            # clean envelope; the raw bytes stay in the chained exception.
+            raise RuntimeError(
+                f"non-UTF-8 pathname under {asset_type}/{name} at commit {commit[:12]}"
+            ) from exc
         if not inner_relpaths:
             raise AssetNotFoundError(
                 f"{asset_type}/{name} not present at commit {commit[:12]} in {self.root}"

--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -509,6 +509,46 @@ class TestCopyAssetAtCommit:
         assert not (dest / "__pycache__").exists()
 
 
+class TestAssetFilesNonAsciiPaths:
+    """Non-ASCII (e.g. Korean) pathnames must survive ``ls-tree`` parsing.
+
+    git's default ``core.quotePath=true`` C-quotes non-ASCII pathnames in
+    line-oriented porcelain output (``"skills/\\355\\225\\234…"`` wrapped in
+    double quotes), so a plain ``--name-only`` line parse fails the
+    ``startswith`` prefix match and the file silently vanishes from
+    extraction and the digest map — data loss on ``mm context install``."""
+
+    def test_non_ascii_file_survives_extraction(self, wiki_root: Path, tmp_path: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        pin = _seed_skill(
+            wiki_root,
+            "foo",
+            {
+                "SKILL.md": b"# foo\n",
+                "references/설명.md": "# 설명\n".encode(),
+            },
+        )
+
+        rels = store.asset_files_at_commit(pin, "skills", "foo")
+        assert sorted(rels) == ["SKILL.md", "references/설명.md"]
+
+        dest = tmp_path / "out" / "foo"
+        digest_map = store.copy_asset_at_commit(pin, "skills", "foo", dest)
+        assert sorted(digest_map) == ["SKILL.md", "references/설명.md"]
+        assert (dest / "references" / "설명.md").read_bytes() == "# 설명\n".encode()
+
+    def test_non_ascii_asset_name_is_found(self, wiki_root: Path) -> None:
+        """An asset whose NAME is non-ASCII must not raise a spurious
+        ``AssetNotFoundError`` (every quoted ls-tree line failed the prefix
+        match, so the old parse saw zero files)."""
+        store = WikiStore.at_default()
+        store.init()
+        pin = _seed_skill(wiki_root, "한글스킬", {"SKILL.md": b"# ko\n"})
+
+        assert store.asset_files_at_commit(pin, "skills", "한글스킬") == ["SKILL.md"]
+
+
 class TestCommitPaths:
     """``WikiStore.commit_paths`` — the isolated commit primitive (ADR-0027 §3)."""
 


### PR DESCRIPTION
## Problem

`WikiStore.asset_files_at_commit` parsed `git ls-tree -r --name-only` output line-by-line with a `startswith(src_prefix)` filter. Under git's default `core.quotePath=true`, any pathname containing non-ASCII bytes is emitted **C-quoted and wrapped in double quotes** (`"skills/\354\204\244\353\252\205.md"`), so the prefix match failed and the entry was silently filtered out.

Every consumer inherits the loss:

- `copy_asset_at_commit` (extraction) — the file's bytes never reach `dest` **or the digest map**, so `mm context install` / `update` silently install a partial asset (a Korean-named `references/설명.md` just vanishes);
- `install --all` reconciliation (#1247/#1479) — the expected-file set is wrong;
- an asset whose **name** is non-ASCII fails every prefix match → spurious `AssetNotFoundError`.

## Fix

- New module-level `_git_bytes()` runner — the bytes twin of `_git()` (same failure classification + credential redaction). `text=True` was not safe to keep: it decodes with the host's preferred locale encoding, which corrupts non-ASCII paths on non-UTF-8 hosts (Windows cp1252/cp949).
- `asset_files_at_commit` now runs `ls-tree -r -z --name-only` (NUL-terminated **verbatim** pathnames — `-z` disables quoting entirely) and splits/decodes explicitly as UTF-8.
- A genuinely non-UTF-8 pathname now raises a **path-free** `RuntimeError` (web routes render RuntimeError as a clean envelope) instead of being silently dropped.

## Tests

`TestAssetFilesNonAsciiPaths` (both RED before the fix):

- mixed asset: `references/설명.md` survives `asset_files_at_commit`, extraction, and the digest map;
- fully non-ASCII asset name (`한글스킬`) resolves instead of raising `AssetNotFoundError`.

Full `test_wiki_store.py` + `test_context_install*.py` + `test_wiki_cmd.py` suites green (109 tests); ruff check/format clean.

## Notes

- Same-shape sweep of the tree found one more line-parsed git path consumer: `cli/sync_doctor_cmd.py:_git_ls_files` — a diagnostic-only, low-stakes site (a non-ASCII-named `*.db` would evade the doctor's `endswith` check). Left out of this focused PR; recorded on the small-batch follow-up issue #1520.
- Found by the 2026-07-02 context-gateway/wiki multi-agent review (wiki-engine dimension), adversarially verified, and re-verified by hand before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
