### PR TITLE
fix(web): bound the version-route sidecar lock and offload the engine

### DIFF
--- a/packages/memtomem/src/memtomem/context/versioning.py
+++ b/packages/memtomem/src/memtomem/context/versioning.py
@@ -280,6 +280,7 @@ def create_version(
     note: str = "",
     *,
     source_bytes: bytes | None = None,
+    lock_timeout: float | None = None,
 ) -> VersionRecord:
     """Snapshot *working_file* into ``versions/<tag>.md`` and record it.
 
@@ -288,6 +289,12 @@ def create_version(
     so two concurrent callers cannot both allocate the same tag. The version
     file is write-once: if ``versions/<tag>.md`` already exists the call raises
     :class:`InvalidTagError` rather than overwriting.
+
+    ``lock_timeout``: bound (seconds) on the sidecar-lock wait; ``None``
+    blocks indefinitely (CLI default — Ctrl-C-able). Callers that must not
+    block forever (an async web handler offloading to a worker thread) pass a
+    budget; on expiry :func:`memtomem.context._atomic._file_lock` raises the
+    builtin ``TimeoutError`` having acquired nothing (#1145 shape).
 
     ``source_bytes``: pass the bytes the caller already read (and privacy-
     scanned) to snapshot *exactly* those, closing the scan→write TOCTOU window —
@@ -310,7 +317,7 @@ def create_version(
             raise VersionError(f"cannot read working canonical {working_file}: {exc}") from exc
 
     lock = _lock_path_for(versions_json_path(artifact_dir))
-    with _file_lock(lock):
+    with _file_lock(lock, timeout=lock_timeout):
         manifest = load_manifest(artifact_dir)
         # Allocate against BOTH the manifest and any on-disk ``vN.md`` files.
         # A crash between the version-file write and the manifest save (below)
@@ -348,18 +355,21 @@ def _next_version_tag_reconciled(artifact_dir: Path, manifest: VersionsManifest)
     return f"v{max(nums) + 1}" if nums else "v1"
 
 
-def promote_label(artifact_dir: Path, label: str, version: str) -> None:
+def promote_label(
+    artifact_dir: Path, label: str, version: str, *, lock_timeout: float | None = None
+) -> None:
     """Point *label* at *version* (create-or-move). Rollout == rollback.
 
     Raises :class:`ReservedLabelError` for ``latest``, :class:`InvalidLabelError`
     for a version-shaped label name, :class:`InvalidTagError` for a malformed
     tag, and :class:`VersionNotFoundError` if the tag is not in the manifest.
-    Holds ``_file_lock`` across ``load → validate → mutate → save``.
+    Holds ``_file_lock`` across ``load → validate → mutate → save``;
+    ``lock_timeout`` bounds the wait as in :func:`create_version`.
     """
     _validate_label_name(label)
     _validate_tag(version)
     lock = _lock_path_for(versions_json_path(artifact_dir))
-    with _file_lock(lock):
+    with _file_lock(lock, timeout=lock_timeout):
         manifest = load_manifest(artifact_dir)
         if version not in manifest.versions:
             raise VersionNotFoundError(f"version {version!r} does not exist")
@@ -367,13 +377,14 @@ def promote_label(artifact_dir: Path, label: str, version: str) -> None:
         _save_manifest(artifact_dir, manifest)
 
 
-def delete_label(artifact_dir: Path, label: str) -> None:
+def delete_label(artifact_dir: Path, label: str, *, lock_timeout: float | None = None) -> None:
     """Remove *label* from the manifest. No-op if absent. Raises
-    :class:`ReservedLabelError` for ``latest``. Holds ``_file_lock``."""
+    :class:`ReservedLabelError` for ``latest``. Holds ``_file_lock``;
+    ``lock_timeout`` bounds the wait as in :func:`create_version`."""
     if label in RESERVED_LABELS:
         raise ReservedLabelError(f"{label!r} is a reserved label and cannot be deleted")
     lock = _lock_path_for(versions_json_path(artifact_dir))
-    with _file_lock(lock):
+    with _file_lock(lock, timeout=lock_timeout):
         manifest = load_manifest(artifact_dir)
         if label in manifest.labels:
             del manifest.labels[label]

--- a/packages/memtomem/src/memtomem/web/routes/_locks.py
+++ b/packages/memtomem/src/memtomem/web/routes/_locks.py
@@ -11,13 +11,17 @@ Two independent locks serialize different write paths:
   interleave.
 
 * ``_gateway_lock`` — guards every context-gateway write path that touches
-  ``.memtomem/{settings,agents,commands,skills}/`` or fans out to runtime
-  targets like ``~/.claude/settings.json``. Wraps POST / PUT / DELETE
-  handlers in :mod:`memtomem.web.routes.settings_sync`,
-  :mod:`memtomem.web.routes.context_agents`,
-  :mod:`memtomem.web.routes.context_commands`, and
-  :mod:`memtomem.web.routes.context_skills` (each handler runs the engine
-  call synchronously inside ``async with _gateway_lock``).
+  ``.memtomem/{settings,agents,commands,skills,mcp-servers}/``, the wiki, or
+  fans out to runtime targets like ``~/.claude/settings.json``. Wraps
+  POST / PUT / DELETE handlers in :mod:`memtomem.web.routes.settings_sync`,
+  the four per-kind route modules (``context_agents`` / ``context_commands``
+  / ``context_skills`` / ``context_mcp_servers``), ``context_sync_all``,
+  ``context_transfer``, ``context_versions``, ``context_mutations``, and
+  ``wiki_mutations``. Handler shape varies: the per-kind CRUD handlers run
+  their engine call synchronously inside ``async with _gateway_lock``, while
+  handlers whose engines block on a cross-process file lock (install/update,
+  transfer, versions, wiki commit) offload to ``asyncio.to_thread`` inside
+  the lock with a bounded engine ``lock_timeout`` (#1145 shape).
 
   This is an **in-process** ``asyncio.Lock`` — layer 1 of a two-layer model.
   It fully serializes concurrent async mutators in *this* server process, so

--- a/packages/memtomem/src/memtomem/web/routes/context_versions.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_versions.py
@@ -59,6 +59,13 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["context-versions"])
 
+# Engine-side bound on the versions.json sidecar-lock wait, kept under the
+# routes' outer ``asyncio.timeout(60)`` so the worker thread self-aborts
+# in-window — an unbounded ``portalocker`` wait is uncancellable and would
+# keep writing after the handler already returned 503 (#1145 shape;
+# 30s < 60s mirrors context_mutations/context_transfer/wiki-commit).
+_VERSIONS_LOCK_BUDGET_S = 30.0
+
 # Artifact types eligible for versioning → (resolver, validate_name kind).
 # Skills are excluded by design (ADR-0022 invariant 7); any other type 404s.
 _Resolver = Callable[[Path, str, TargetScope], "tuple[Path, Layout] | None"]
@@ -318,9 +325,20 @@ async def create_artifact_version(
         async with asyncio.timeout(60):
             # Hold the gateway lock so a concurrent update to the working file
             # cannot tear the snapshot; create_version also takes its own
-            # non-reentrant file lock on the versions.json sidecar.
+            # non-reentrant file lock on the versions.json sidecar. The engine
+            # call is offloaded — it blocks on that cross-process lock, and
+            # running it on the loop would stall every concurrent request AND
+            # make the outer timeout unable to fire (the loop never yields).
+            # The builtin TimeoutError from an expired lock budget lands in
+            # the same 503 arm as the outer asyncio.timeout.
             async with _gateway_lock:
-                record = versioning.create_version(artifact_dir, working_file, note=note)
+                record = await asyncio.to_thread(
+                    versioning.create_version,
+                    artifact_dir,
+                    working_file,
+                    note=note,
+                    lock_timeout=_VERSIONS_LOCK_BUDGET_S,
+                )
     except TimeoutError:
         raise _error(503, "busy", "Version create timed out — another sync may be in progress")
     except VersionError as exc:
@@ -491,8 +509,19 @@ async def promote_artifact_label(
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
-                versioning.promote_label(artifact_dir, label, body.version)
-                manifest = versioning.load_manifest(artifact_dir)
+                # Offloaded + lock-budgeted like create (the engine blocks on
+                # the cross-process sidecar lock); the follow-up manifest read
+                # rides the same worker thread.
+                def _promote_and_load() -> versioning.VersionsManifest:
+                    versioning.promote_label(
+                        artifact_dir,
+                        label,
+                        body.version,
+                        lock_timeout=_VERSIONS_LOCK_BUDGET_S,
+                    )
+                    return versioning.load_manifest(artifact_dir)
+
+                manifest = await asyncio.to_thread(_promote_and_load)
     except TimeoutError:
         raise _error(503, "busy", "Label promote timed out — another sync may be in progress")
     except VersionError as exc:
@@ -531,8 +560,14 @@ async def delete_artifact_label(
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
-                versioning.delete_label(artifact_dir, label)
-                manifest = versioning.load_manifest(artifact_dir)
+                # Same offload + lock budget as create/promote.
+                def _delete_and_load() -> versioning.VersionsManifest:
+                    versioning.delete_label(
+                        artifact_dir, label, lock_timeout=_VERSIONS_LOCK_BUDGET_S
+                    )
+                    return versioning.load_manifest(artifact_dir)
+
+                manifest = await asyncio.to_thread(_delete_and_load)
     except TimeoutError:
         raise _error(503, "busy", "Label delete timed out — another sync may be in progress")
     except VersionError as exc:

--- a/packages/memtomem/tests/test_context_versioning.py
+++ b/packages/memtomem/tests/test_context_versioning.py
@@ -321,6 +321,32 @@ class TestConcurrency:
         assert (artifact_dir / "versions" / "v2.md").is_file()
         assert set(v.load_manifest(artifact_dir).versions) == {"v1", "v2"}
 
+    def test_lock_timeout_expires_when_sidecar_lock_held(self, tmp_path):
+        """``lock_timeout`` bounds the sidecar-lock wait: with the lock held by
+        another holder, every mutator raises the builtin ``TimeoutError``
+        (the #1145 shape the web routes map to 503) instead of blocking
+        forever. Expiry-direction timing: a slow runner only makes the
+        expiry later, never a false pass."""
+        from memtomem.context._atomic import _file_lock, _lock_path_for
+
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        v.create_version(artifact_dir, working)  # so promote has a v1 to point at
+        lock = _lock_path_for(v.versions_json_path(artifact_dir))
+        with _file_lock(lock):
+            with pytest.raises(TimeoutError):
+                v.create_version(artifact_dir, working, lock_timeout=0.1)
+            with pytest.raises(TimeoutError):
+                v.promote_label(artifact_dir, "staging", "v1", lock_timeout=0.1)
+            with pytest.raises(TimeoutError):
+                v.delete_label(artifact_dir, "staging", lock_timeout=0.1)
+
+    def test_lock_timeout_none_still_blocks_and_succeeds(self, tmp_path):
+        """Default ``lock_timeout=None`` keeps the blocking CLI semantics —
+        an uncontended call just succeeds."""
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        record = v.create_version(artifact_dir, working, lock_timeout=None)
+        assert record.tag == "v1"
+
 
 # ── Label-aware sync integration (generate_all_agents) ───────────────
 

--- a/packages/memtomem/tests/test_web_routes_context_versions.py
+++ b/packages/memtomem/tests/test_web_routes_context_versions.py
@@ -524,6 +524,71 @@ class TestPrivacyAndTimeout:
         assert r.json()["detail"]["error_kind"] == "busy"
 
 
+class TestLockBudgetOffload:
+    """The three version mutators offload the engine to a worker thread with a
+    bounded sidecar-lock budget (#1145 shape) — pin the kwarg pass-through and
+    the contention → 503 mapping."""
+
+    @pytest.mark.anyio
+    async def test_create_threads_lock_budget_kwarg(self, client, tmp_path, monkeypatch):
+        _make_dir_agent(tmp_path, "reviewer")
+        seen: dict = {}
+
+        def _spy(artifact_dir, working_file, note="", *, source_bytes=None, lock_timeout=None):
+            seen["lock_timeout"] = lock_timeout
+            return versioning.VersionRecord(tag="v1", created_at="2026-01-01T00:00:00+00:00")
+
+        monkeypatch.setattr(versioning, "create_version", _spy)
+        r = await client.post("/api/context/agents/reviewer/versions", json={})
+        assert r.status_code == 200
+        assert seen["lock_timeout"] == 30.0
+
+    @pytest.mark.anyio
+    async def test_promote_threads_lock_budget_kwarg(self, client, tmp_path, monkeypatch):
+        _make_dir_agent(tmp_path, "reviewer")
+        seen: dict = {}
+
+        def _spy(artifact_dir, label, version, *, lock_timeout=None):
+            seen["lock_timeout"] = lock_timeout
+
+        monkeypatch.setattr(versioning, "promote_label", _spy)
+        r = await client.put("/api/context/agents/reviewer/labels/staging", json={"version": "v1"})
+        assert r.status_code == 200
+        assert seen["lock_timeout"] == 30.0
+
+    @pytest.mark.anyio
+    async def test_delete_threads_lock_budget_kwarg(self, client, tmp_path, monkeypatch):
+        _make_dir_agent(tmp_path, "reviewer")
+        seen: dict = {}
+
+        def _spy(artifact_dir, label, *, lock_timeout=None):
+            seen["lock_timeout"] = lock_timeout
+
+        monkeypatch.setattr(versioning, "delete_label", _spy)
+        r = await client.delete("/api/context/agents/reviewer/labels/staging")
+        assert r.status_code == 200
+        assert seen["lock_timeout"] == 30.0
+
+    @pytest.mark.anyio
+    async def test_held_sidecar_lock_expires_budget_to_503(self, client, tmp_path, monkeypatch):
+        """End-to-end: with the versions.json sidecar lock HELD by the test,
+        the offloaded engine call must exhaust its (shrunken) budget and map
+        the builtin ``TimeoutError`` to the same 503 as the outer timeout —
+        pre-fix, the engine ran unbudgeted ON the event loop and this request
+        would hang forever. Expiry-direction timing: runner slowness delays
+        the 503, it can never produce a false pass."""
+        from memtomem.context._atomic import _file_lock, _lock_path_for
+        from memtomem.web.routes import context_versions as cv
+
+        adir = _make_dir_agent(tmp_path, "reviewer")
+        monkeypatch.setattr(cv, "_VERSIONS_LOCK_BUDGET_S", 0.2)
+        lock_path = _lock_path_for(versioning.versions_json_path(adir))
+        with _file_lock(lock_path):
+            r = await client.post("/api/context/agents/reviewer/versions", json={})
+        assert r.status_code == 503
+        assert r.json()["detail"]["error_kind"] == "busy"
+
+
 # ---------------------------------------------------------------------------
 # Enable versioning (adopt flat → dir, ADR-0022 rank 6)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The version-route mutators (`POST .../versions`, `PUT/DELETE .../labels/{label}`) were the one set of gateway writers that ran their engine **synchronously on the event loop** while the engine takes an **unbounded** cross-process `_file_lock` on the `versions.json` sidecar (`portalocker` `LOCK_EX` — a blocking C call, `timeout=None`).

Consequences under cross-process contention (e.g. a CLI `mm context version create` holding the sidecar):

- the entire event loop stalls — every concurrent dashboard request hangs;
- the routes' own `asyncio.timeout(60)` **can never fire** (the loop never yields inside the blocking call), so the documented 60s → 503 was unreachable.

Every sibling writer (`context_mutations` install/update, `context_transfer`, wiki commit) already follows the #1145 pattern; these three routes were the stragglers. Found by the 2026-07-02 context/wiki review (web-routes-infra dimension), adversarially CONFIRMED.

## Fix

- `context/versioning.py`: `create_version` / `promote_label` / `delete_label` gain a keyword-only `lock_timeout: float | None = None` threaded into `_file_lock(timeout=...)`. Default `None` keeps the blocking, Ctrl-C-able CLI semantics — CLI/MCP callers unchanged.
- `web/routes/context_versions.py`: the three mutators offload the engine call (plus the follow-up `load_manifest` read) to `asyncio.to_thread` **inside** `_gateway_lock`, passing `_VERSIONS_LOCK_BUDGET_S = 30.0` (< the 60s outer timeout, mirroring `context_mutations`/`context_transfer`/wiki-commit). The builtin `TimeoutError` from an expired lock budget lands in the same 503 "busy" arm as the outer `asyncio.timeout`.
- Ride-along: the `_locks.py` module docstring understated `_gateway_lock`'s users (4 of the actual 10 modules) and claimed every handler runs its engine synchronously — corrected to the real user list and the two handler shapes.

## Tests

- Engine (`test_context_versioning.py`): with the sidecar lock held, all three mutators raise `TimeoutError` at `lock_timeout=0.1`; default `None` still succeeds uncontended.
- Routes (`test_web_routes_context_versions.py::TestLockBudgetOffload`):
  - kwarg pass-through pins for all three mutators (`lock_timeout == 30.0`) — **mutation-validated**: dropping the `lock_timeout` kwarg from the create route turns the pin RED (verified, then restored);
  - end-to-end contention pin: test holds the real sidecar `_file_lock`, budget shrunk to 0.2s → POST returns 503 `busy`. Pre-fix this request hung forever. Expiry-direction timing — a slow runner delays the 503 but can never produce a false pass (the #1305 windows-CI lesson shape).

135 version-related tests green; ruff check/format clean.

## Notes

- The MCP version tools already offload via `to_thread`; whether they should also pass a bound is tracked with the other MCP event-loop items in #1518.
- `POST .../versions/enable` (`adopt_flat_to_dir`) takes no `_file_lock` (pure renames), so it is deliberately not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
