### PR TITLE
fix(context): abort settings copy when a destination file is deleted mid-apply

### DIFF
--- a/packages/memtomem/src/memtomem/context/settings_copy.py
+++ b/packages/memtomem/src/memtomem/context/settings_copy.py
@@ -594,10 +594,18 @@ def apply_hook_copy(
             if state == "exact":
                 result.canonical_already = True
             else:
-                if (
-                    plan.dst_canonical_path.is_file()
-                    and plan.dst_canonical_path.stat().st_mtime_ns != canonical_mtime_ns
-                ):
+                # Compare against the missing-file sentinel ``0`` (the
+                # ``_read_with_mtime`` convention), NOT a bare ``is_file()``
+                # guard: a concurrent DELETE (mtime → 0) is just as much an
+                # external change as an edit, and a bare guard would skip the
+                # abort and resurrect the deleted file (settings-migrate
+                # precedent, #1382).
+                current_canonical_mtime_ns = (
+                    plan.dst_canonical_path.stat().st_mtime_ns
+                    if plan.dst_canonical_path.is_file()
+                    else 0
+                )
+                if current_canonical_mtime_ns != canonical_mtime_ns:
                     result.warnings.append(
                         f"{plan.dst_canonical_path} was modified by another "
                         f"process during apply; nothing was written. {retry_hint}"
@@ -640,10 +648,12 @@ def apply_hook_copy(
             if state == "exact":
                 result.target_already = True
                 return result
-            if (
-                plan.dst_target_path.is_file()
-                and plan.dst_target_path.stat().st_mtime_ns != target_mtime_ns
-            ):
+            # 0-sentinel compare for the same delete-race reason as the
+            # canonical leg above (#1382).
+            current_target_mtime_ns = (
+                plan.dst_target_path.stat().st_mtime_ns if plan.dst_target_path.is_file() else 0
+            )
+            if current_target_mtime_ns != target_mtime_ns:
                 result.warnings.append(
                     f"{plan.dst_target_path} was modified by another process "
                     f"during apply; the canonical entry was written but the "

--- a/packages/memtomem/tests/test_settings_copy.py
+++ b/packages/memtomem/tests/test_settings_copy.py
@@ -400,6 +400,54 @@ class TestApplyConcurrency:
         assert result.canonical_written and not result.target_written
         assert any("tier was not" in w for w in result.warnings)
 
+    def test_canonical_delete_race_aborts_and_does_not_recreate(
+        self, src_project, dst_project, monkeypatch
+    ):
+        """A concurrent DELETE of the destination canonical between read and
+        write must abort like an edit — not resurrect the deleted file with
+        its pre-delete hooks (the settings-migrate #1382 shape)."""
+        from memtomem.context import settings_copy as mod
+
+        canonical_path = dst_project / CANONICAL_SETTINGS_FILE
+        _write_doc(canonical_path, {"hooks": {}})
+        real = mod._read_with_mtime
+
+        def read_then_delete(path):
+            doc, mtime = real(path)
+            if path == canonical_path:
+                canonical_path.unlink()
+            return doc, mtime
+
+        monkeypatch.setattr(mod, "_read_with_mtime", read_then_delete)
+        result = apply_hook_copy(_plan(src_project, dst_project))
+        assert not result.canonical_written and not result.target_written
+        assert any("modified by another process" in w for w in result.warnings)
+        assert not canonical_path.exists()
+        assert not (dst_project / ".claude" / "settings.json").exists()
+
+    def test_tier_delete_race_keeps_canonical_and_does_not_recreate(
+        self, src_project, dst_project, monkeypatch
+    ):
+        """Same delete race on the tier leg: the canonical write stands, the
+        deleted tier file must NOT be recreated."""
+        from memtomem.context import settings_copy as mod
+
+        tier_path = dst_project / ".claude" / "settings.json"
+        _write_doc(tier_path, {"hooks": {}})
+        real = mod._read_with_mtime
+
+        def read_then_delete(path):
+            doc, mtime = real(path)
+            if path == tier_path:
+                tier_path.unlink()
+            return doc, mtime
+
+        monkeypatch.setattr(mod, "_read_with_mtime", read_then_delete)
+        result = apply_hook_copy(_plan(src_project, dst_project))
+        assert result.canonical_written and not result.target_written
+        assert any("tier was not" in w for w in result.warnings)
+        assert not tier_path.exists()
+
     def test_lock_budget_exhaustion_writes_nothing(self, src_project, dst_project, monkeypatch):
         import contextlib
 


### PR DESCRIPTION
## Problem

Both apply legs in `settings_copy.apply_hook_copy` re-checked freshness with `path.is_file() and path.stat().st_mtime_ns != mtime_ns`. A concurrent DELETE between the plan read and the apply write makes `is_file()` False, short-circuiting the abort — the copy then **recreates the just-deleted file** with its pre-delete content plus the new rule, resurrecting hooks the user deliberately removed. Same shape #1382 fixed in `settings_migrate`.

Found by the 2026-07-02 context/wiki review (transfer-migrate dimension), adversarially CONFIRMED.

## Fix

Mirror the #1382 0-sentinel idiom on both legs: `(stat().st_mtime_ns if is_file() else 0) != mtime_ns` → the existing per-leg abort pathway. The symmetric create-race (absent at read, created concurrently) still aborts; absent-at-read → still-absent still writes.

## Tests

`TestApplyConcurrency` gains two RED-verified regressions (monkeypatched `_read_with_mtime` unlinks the destination right after the real read): canonical-leg delete → nothing written; tier-leg delete → canonical written, tier aborted, file NOT recreated. Full settings sweep (settings_copy/cli/web/migrate/settings/locked-CAS) = 227 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
