### PR TITLE
fix(wiki): classify detached-HEAD commit as WikiDetachedHeadError

### DIFF
--- a/packages/memtomem/src/memtomem/cli/wiki_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/wiki_cmd.py
@@ -316,8 +316,10 @@ def _run_commit(
             "wiki commit timed out — another wiki operation may be in progress; retry shortly"
         ) from exc
     except RuntimeError as exc:
-        # git failure (e.g. missing git identity) — surface the git error the way
-        # the sibling ``mm wiki init`` does. The embedded wiki path is the user's
+        # Covers WikiDetachedHeadError (its str() IS the friendly, actionable
+        # "check out a branch" message — the push/pull precedent) and any git
+        # failure (e.g. missing git identity) — surface the error the way the
+        # sibling ``mm wiki init`` does. The embedded wiki path is the user's
         # own local path, not a secret as it would be in the web route's HTTP
         # response (which uses a fixed, path-free message instead).
         raise click.ClickException(str(exc)) from exc

--- a/packages/memtomem/src/memtomem/web/routes/wiki_mutations.py
+++ b/packages/memtomem/src/memtomem/web/routes/wiki_mutations.py
@@ -69,6 +69,7 @@ from memtomem.wiki.override import (
     write_override,
 )
 from memtomem.wiki.store import (
+    WikiDetachedHeadError,
     WikiHeadMovedError,
     WikiNotFoundError,
     WikiStore,
@@ -668,9 +669,11 @@ async def commit_wiki(asset_type: AssetType, name: str, body: WikiCommitRequest)
     Responses: ``{committed: true, wiki_head, wiki_dirty, privacy_warning}`` on
     success; ``committed: false`` (200) when the saved bytes already match HEAD
     (no new history, ``.bak`` still cleaned); 409 ``stale_head`` (HEAD moved) /
-    ``stale_target`` (a file changed since Save); 503 ``busy`` on lock timeout;
-    500 ``commit_failed`` with a **fixed** message (raw git stderr — which embeds
-    ``$HOME`` — is logged server-side only, never returned).
+    ``stale_target`` (a file changed since Save) / ``detached_head`` (no branch
+    checked out — a wiki-state conflict, not a git failure); 503 ``busy`` on
+    lock timeout; 500 ``commit_failed`` with a **fixed** message (raw git
+    stderr — which embeds ``$HOME`` — is logged server-side only, never
+    returned).
 
     Privacy (§D-E): the commit *message* is new persisted user text, so it is
     scanned with the soft, scope-less ``privacy.scan`` and a non-blocking
@@ -731,6 +734,13 @@ async def commit_wiki(asset_type: AssetType, name: str, body: WikiCommitRequest)
         return _commit_head_conflict(fresh)
     except WikiNotFoundError as exc:
         raise _wiki_absent(exc) from exc
+    except WikiDetachedHeadError as exc:
+        # Wiki-state precondition, not a git failure: a detached HEAD has no
+        # branch ref to CAS-advance, so the 500 ``commit_failed`` catch-all
+        # would misclassify it. 409 conflict like the sibling wiki-state
+        # envelopes (``override_exists``); the engine message is fixed and
+        # deliberately path-free (see WikiDetachedHeadError in wiki/store.py).
+        raise _error(409, "conflict", str(exc), reason_code="detached_head") from exc
     except TimeoutError as exc:
         raise _error(
             503, "busy", "wiki commit timed out — another wiki operation may be in progress"

--- a/packages/memtomem/src/memtomem/wiki/commit.py
+++ b/packages/memtomem/src/memtomem/wiki/commit.py
@@ -143,6 +143,8 @@ def commit_targets(
 
     Raises :class:`WikiTargetChangedError` (a target moved — caller → conflict),
     :class:`~memtomem.wiki.store.WikiHeadMovedError` (HEAD advanced — propagated),
+    :class:`~memtomem.wiki.store.WikiDetachedHeadError` (no branch to commit
+    onto — propagated; the message is fixed and path-free),
     :class:`TimeoutError` (the cross-process lock is held past
     ``_COMMIT_LOCK_TIMEOUT`` by a concurrent committer — the web route maps it to
     a 503, the CLI to a retry hint), or :class:`RuntimeError` (git failure — the

--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -97,11 +97,13 @@ class WikiNothingToCommitError(RuntimeError):
 class WikiDetachedHeadError(RuntimeError):
     """Raised when a branch operation runs on a detached-HEAD wiki.
 
-    ``mm wiki push`` / ``pull`` push or pull a *branch* (``origin <branch>``);
-    a detached HEAD has no branch to name, so :meth:`WikiStore.current_branch`
-    refuses rather than let git emit a cryptic refspec error. The message is
-    deliberately path- and SHA-free so it stays safe if a future web surface
-    ever reuses it (CLI surfaces it as a classified ``ClickException``).
+    ``mm wiki push`` / ``pull`` push or pull a *branch* (``origin <branch>``),
+    and :meth:`WikiStore.commit_paths` CAS-advances a *branch ref*; a detached
+    HEAD has no branch to name, so :meth:`WikiStore.current_branch` and
+    :meth:`WikiStore.commit_paths` refuse rather than let git emit a cryptic
+    refspec / symbolic-ref error. The message is deliberately path- and
+    SHA-free so the web commit route can return it verbatim in its 409
+    envelope (the CLI surfaces it as a classified ``ClickException``).
     """
 
 
@@ -549,9 +551,11 @@ class WikiStore:
            the new HEAD — best-effort, since the commit has already landed.
 
         Raises :class:`WikiHeadMovedError` (HEAD advanced — caller → 409),
-        :class:`WikiNothingToCommitError` (bytes identical to HEAD), or
-        :class:`RuntimeError` (git failure — the caller MUST surface a fixed
-        message; the raw stderr embeds the absolute repo path).
+        :class:`WikiNothingToCommitError` (bytes identical to HEAD),
+        :class:`WikiDetachedHeadError` (no branch to CAS-advance — the message
+        is fixed and path-free, safe to surface), or :class:`RuntimeError`
+        (git failure — the caller MUST surface a fixed message; the raw stderr
+        embeds the absolute repo path).
         """
         self.require_exists()
         head = self.current_commit()
@@ -562,9 +566,22 @@ class WikiStore:
             )
 
         # Resolve the actual branch ref dynamically — never hardcode
-        # ``refs/heads/main`` (a clone may be on another branch); a detached
-        # HEAD has no symbolic ref and cannot be safely CAS-advanced.
-        branch_ref = _git(["symbolic-ref", "HEAD"], cwd=self.root).stdout.strip()
+        # ``refs/heads/main`` (a clone may be on another branch). A detached
+        # HEAD has no symbolic ref (rc != 0) and cannot be safely CAS-advanced,
+        # so classify it the way :meth:`current_branch` does for push/pull
+        # (#1419) instead of leaking git's raw "ref HEAD is not a symbolic ref"
+        # RuntimeError. This runs BEFORE the temp index is created, so there is
+        # nothing to roll back.
+        ref_result = _git_query(["symbolic-ref", "HEAD"], self.root)
+        if ref_result.returncode != 0:
+            raise WikiDetachedHeadError(
+                "wiki is in detached HEAD state; check out a branch before committing"
+            )
+        branch_ref = ref_result.stdout.strip()
+        if not branch_ref:
+            # rc 0 with empty output should never happen (mirrors the
+            # current_branch guard) — but never run ``git update-ref "" …``.
+            raise RuntimeError("could not determine the wiki's current branch")
 
         tmpdir = Path(tempfile.mkdtemp(prefix="mm-wiki-commit-"))
         try:

--- a/packages/memtomem/tests/test_web_routes_wiki_mutations.py
+++ b/packages/memtomem/tests/test_web_routes_wiki_mutations.py
@@ -1089,6 +1089,31 @@ async def test_commit_git_failure_is_fixed_message_no_path_leak(
 
 
 @pytest.mark.asyncio
+async def test_commit_detached_head_is_409_not_500(dev_client, seeded_wiki: Path) -> None:
+    # A detached-HEAD wiki has no branch ref to CAS-advance — a wiki-state
+    # precondition, not a git failure. It must map to a 409 conflict envelope
+    # (reason_code=detached_head) with the engine's fixed path-free message,
+    # never the generic 500 commit_failed.
+    mtime = await _save_canonical(dev_client, _EDITED)
+    head = await _wiki_head(dev_client)
+    subprocess.run(
+        ["git", "-C", str(seeded_wiki), "checkout", "--detach"],
+        check=True,
+        capture_output=True,
+    )
+    resp = await dev_client.post(
+        "/api/wiki/agents/beta/commit",
+        json={"expected_head": head, "targets": [{"kind": "canonical", "mtime_ns": mtime}]},
+    )
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["error_kind"] == "conflict"
+    assert detail["reason_code"] == "detached_head"
+    assert "detached HEAD" in detail["message"]
+    assert str(seeded_wiki) not in resp.text  # fixed, path-free message
+
+
+@pytest.mark.asyncio
 async def test_commit_is_dev_tier_only(prod_client, seeded_wiki: Path) -> None:
     resp = await prod_client.post(
         "/api/wiki/agents/beta/commit",

--- a/packages/memtomem/tests/test_wiki_cmd_commit.py
+++ b/packages/memtomem/tests/test_wiki_cmd_commit.py
@@ -215,6 +215,25 @@ def test_invalid_name_errors(wiki_root: Path) -> None:
     assert "invalid skill name" in result.output
 
 
+def test_detached_head_is_friendly(wiki_root: Path) -> None:
+    # A detached-HEAD wiki has no branch to commit onto. The engine's classified
+    # WikiDetachedHeadError must surface as a clean, actionable message (the
+    # push/pull precedent) — never git's raw "symbolic-ref … failed" string.
+    _init_wiki()
+    _seed_skill(wiki_root)
+    (wiki_root / "skills/demo/SKILL.md").write_bytes(b"# edited\n")
+    _git(wiki_root, "checkout", "--detach")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "commit", "demo", "-c"])
+
+    assert result.exit_code != 0
+    out = _combined(result)
+    assert "detached HEAD" in out
+    assert "check out a branch" in out
+    assert "symbolic-ref" not in out  # no raw git gibberish
+
+
 def test_busy_lock_is_classified(wiki_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # A concurrent committer holding the shared cross-process wiki lock makes
     # ``_file_lock`` raise the builtin ``TimeoutError`` (an OSError, NOT a

--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -13,6 +13,7 @@ from memtomem.wiki.store import (
     WIKI_ASSET_TYPES,
     CommitNotFoundError,
     WikiAlreadyExistsError,
+    WikiDetachedHeadError,
     WikiHeadMovedError,
     WikiNotFoundError,
     WikiNothingToCommitError,
@@ -602,3 +603,18 @@ class TestCommitPaths:
         head = store.current_commit()
         with pytest.raises(ValueError):
             store.commit_paths({"../evil": b"x\n"}, message="e", expected_head=head)
+
+    def test_detached_head_raises_classified(self, wiki_root: Path) -> None:
+        # A detached HEAD has no branch ref to CAS-advance. That must surface as
+        # the friendly WikiDetachedHeadError (the current_branch / #1419 push-pull
+        # precedent), NOT the raw `git symbolic-ref HEAD failed: …` RuntimeError.
+        store = self._seed(wiki_root)
+        head = store.current_commit()
+        subprocess.run(
+            ["git", "-C", str(wiki_root), "checkout", "--detach"],
+            check=True,
+            capture_output=True,
+        )
+        with pytest.raises(WikiDetachedHeadError, match="detached HEAD"):
+            store.commit_paths({"agents/beta/agent.md": b"v2\n"}, message="e", expected_head=head)
+        assert store.current_commit() == head  # nothing was committed


### PR DESCRIPTION
## Problem

`WikiStore.commit_paths` resolved the branch ref with a raising `_git(["symbolic-ref", "HEAD"])`. On a detached-HEAD wiki this surfaced the raw `git symbolic-ref HEAD failed: fatal: ref HEAD is not a symbolic ref` string on the CLI and a generic 500 `commit_failed` on the web — indistinguishable from a real git failure, and inconsistent with push/pull, which classify the identical condition as the friendly `WikiDetachedHeadError` (#1419, `current_branch`).

Found by the 2026-07-02 review (wiki-engine dimension).

## Fix

- `store.commit_paths` resolves the ref via the non-raising `_git_query` and classifies rc != 0 as `WikiDetachedHeadError` ("check out a branch before committing"), mirroring `current_branch` — before the temp index exists, so nothing to roll back. Kept the rc-0-empty-output guard (never `update-ref ""`).
- CLI: the existing `except RuntimeError → ClickException` arm surfaces the friendly message (push/pull precedent); comment updated, behavior pinned by a new test.
- Web commit route: new `except WikiDetachedHeadError → _error(409, "conflict", reason_code="detached_head")` before the 500 catch-all (the `override_exists` wiki-state-conflict precedent; message is fixed/path-free by the error class's contract).

## Tests

Three RED-verified: engine raise classification (`test_wiki_store.py`), CLI friendly message with no `symbolic-ref` gibberish (`test_wiki_cmd_commit.py`), web 409-not-500 with `reason_code=detached_head` and no path leak (`test_web_routes_wiki_mutations.py`). Full wiki suites 191 + 86 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
