### PR TITLE
fix(context): emit plural asset type in `mm context migrate` hints

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -1711,7 +1711,7 @@ def version_create_cmd(artifact_type: str, name: str, note: str, scope_flag: str
     if not working_file.is_file():
         raise click.ClickException(
             f"No working canonical at {working_file}. The artifact must exist in "
-            f"directory layout — run `mm context migrate {artifact_type[:-1]} {name}` first."
+            f"directory layout — run `mm context migrate {artifact_type} {name}` first."
         )
     # Gate A on the snapshot bytes (ADR-0011 trust boundary): creating a version
     # is a new write into a git-tracked tree for project_shared, so a privacy

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -860,14 +860,17 @@ def _apply_update(
     if dirty_report.reason in ("missing_dest", "never_installed"):
         flat_path, flat_dirty = _flat_layout_probe(dest, asset_type, name, lock_entry)
         if flat_path is not None:
-            kind = asset_type.removesuffix("s")
+            # The migrate CLI's asset-type argument is a plural Choice
+            # ("agents", ...) — embed the plural verbatim so the hint is
+            # runnable as-is (the singular trips Click's invalid-choice
+            # error, same shape as the #895 privacy_scan fix).
             if flat_dirty and not force:
                 raise StaleInstallError(
                     f"{asset_type}/{name}: flat-layout file {flat_path.name} has local "
                     f"edits (or no provable install time) and the dir-layout install "
-                    f"would stop it being served; run `mm context migrate {kind} {name}` "
-                    f"first, or pass --force to write the dir layout anyway (the flat "
-                    f"file is kept on disk but stops being served)"
+                    f"would stop it being served; run `mm context migrate {asset_type} "
+                    f"{name}` first, or pass --force to write the dir layout anyway "
+                    f"(the flat file is kept on disk but stops being served)"
                 )
             logger.warning(
                 "%s/%s: dir layout will shadow flat file %s (dir wins at fan-out); "
@@ -875,7 +878,7 @@ def _apply_update(
                 asset_type,
                 name,
                 flat_path,
-                kind,
+                asset_type,
                 name,
             )
 
@@ -1092,8 +1095,7 @@ def _classify_for_all_update(
             # execute phase would raise.
             state = "refuse"
             reason = (
-                f"flat layout with local edits; run "
-                f"`mm context migrate {asset_type.removesuffix('s')} {name}` first"
+                f"flat layout with local edits; run `mm context migrate {asset_type} {name}` first"
             )
         elif report.reason == "never_installed" and dest.is_dir():
             # Unprovable install record over an existing dest — preview
@@ -1306,7 +1308,7 @@ def _classify_for_install_all(
                         state="refuse",
                         reason=(
                             f"flat layout with local edits; run `mm context migrate "
-                            f"{asset_type.removesuffix('s')} {name}` first"
+                            f"{asset_type} {name}` first"
                         ),
                         lock_entry=entry,
                         dirty_report=is_asset_dirty(
@@ -1514,14 +1516,17 @@ def _apply_pinned_install(
             dest, asset_type, name, classification.lock_entry
         )
         if flat_path is not None:
-            kind = asset_type.removesuffix("s")
+            # The migrate CLI's asset-type argument is a plural Choice
+            # ("agents", ...) — embed the plural verbatim so the hint is
+            # runnable as-is (the singular trips Click's invalid-choice
+            # error, same shape as the #895 privacy_scan fix).
             if flat_dirty and not force:
                 raise StaleInstallError(
                     f"{asset_type}/{name}: flat-layout file {flat_path.name} has local "
                     f"edits (or no provable install time) and the dir-layout install "
-                    f"would stop it being served; run `mm context migrate {kind} {name}` "
-                    f"first, or pass --force to write the dir layout anyway (the flat "
-                    f"file is kept on disk but stops being served)"
+                    f"would stop it being served; run `mm context migrate {asset_type} "
+                    f"{name}` first, or pass --force to write the dir layout anyway "
+                    f"(the flat file is kept on disk but stops being served)"
                 )
             logger.warning(
                 "%s/%s: dir layout will shadow flat file %s (dir wins at fan-out); "
@@ -1529,7 +1534,7 @@ def _apply_pinned_install(
                 asset_type,
                 name,
                 flat_path,
-                kind,
+                asset_type,
                 name,
             )
 

--- a/packages/memtomem/src/memtomem/context/status.py
+++ b/packages/memtomem/src/memtomem/context/status.py
@@ -208,9 +208,7 @@ def classify_status(
             dest = project_root_path / ".memtomem" / asset_type / name
             flat = project_root_path / ".memtomem" / asset_type / f"{name}.md"
             if asset_type in ("agents", "commands") and not dest.is_dir() and flat.is_file():
-                reason = (
-                    f"flat layout; run `mm context migrate {asset_type.removesuffix('s')} {name}`"
-                )
+                reason = f"flat layout; run `mm context migrate {asset_type} {name}`"
             elif report.reason == "never_installed" and dest.is_dir():
                 # Entry present but unusable installed_at over an existing
                 # dest — "dest missing" would be flatly wrong. Mirrors the

--- a/packages/memtomem/tests/test_context_cli_subprocess_e2e.py
+++ b/packages/memtomem/tests/test_context_cli_subprocess_e2e.py
@@ -218,7 +218,9 @@ class TestContextVersionCliInline:
 
         r = runner.invoke(cli, ["context", "version", "create", "agents", "flat-agent"])
         assert r.exit_code != 0
-        assert "migrate" in r.output.lower()
+        # The hint must embed the runnable (plural) migrate command — the
+        # singular form trips Click's invalid-choice error when pasted.
+        assert "mm context migrate agents flat-agent" in r.output
 
     def test_version_create_blocks_secret_in_project_shared(self, tmp_path, monkeypatch):
         # Gate A: creating a version is a new git-tracked write for the default

--- a/packages/memtomem/tests/test_context_install_all.py
+++ b/packages/memtomem/tests/test_context_install_all.py
@@ -972,11 +972,13 @@ def test_install_all_refuses_dirty_flat_sibling(wiki_root: Path, tmp_path: Path)
     [row] = rows
     assert row.state == "refuse"
     assert "flat layout" in (row.reason or "")
-    assert "migrate" in (row.reason or "")
+    assert "mm context migrate agents foo" in (row.reason or "")
     assert row.dirty_report is not None
 
 
-def test_install_all_force_extracts_dir_and_preserves_flat(wiki_root: Path, tmp_path: Path) -> None:
+def test_install_all_force_extracts_dir_and_preserves_flat(
+    wiki_root: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     """--force on the flat-refuse row extracts the dir; the flat file stays
     on disk with no .bak (nothing was overwritten)."""
     from memtomem.context.install import _apply_pinned_install, _classify_for_install_all
@@ -992,12 +994,17 @@ def test_install_all_force_extracts_dir_and_preserves_flat(wiki_root: Path, tmp_
     [row] = _classify_for_install_all(tmp_path, wiki=WikiStore.at_default())
     assert row.state == "refuse"
 
-    result = _apply_pinned_install(tmp_path, row, wiki=WikiStore.at_default(), force=True)
+    with caplog.at_level("WARNING", logger="memtomem.context.install"):
+        result = _apply_pinned_install(tmp_path, row, wiki=WikiStore.at_default(), force=True)
 
     assert result.files_written >= 1
     assert (tmp_path / ".memtomem" / "agents" / "foo" / "agent.md").read_bytes() == b"wiki\n"
     assert flat.read_bytes() == b"# local flat\n"
     assert not flat.with_suffix(".md.bak").exists()
+    # The shadowing warning must embed the runnable (plural) migrate command
+    # — the singular form trips Click's invalid-choice error when pasted.
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any("mm context migrate agents foo" in m for m in messages)
 
 
 # ── unprovable install record (#1247 impl gate) ──────────────────────────
@@ -1108,6 +1115,6 @@ def test_cli_install_all_refuses_flat_sibling_appearing_during_confirm_prompt(
 
     assert result.exit_code == 1, result.output
     assert "flat-layout" in result.output
-    assert "migrate" in result.output
+    assert "mm context migrate agents foo" in result.output
     assert flat.read_bytes() == b"# local flat\n"
     assert not (tmp_path / ".memtomem" / "agents" / "foo").exists()

--- a/packages/memtomem/tests/test_context_status.py
+++ b/packages/memtomem/tests/test_context_status.py
@@ -859,7 +859,7 @@ def test_status_flat_layout_row_points_at_migrate(wiki_root: Path, tmp_path: Pat
     [row] = [r for r in rows if r.asset_type == "agents" and r.name == "foo"]
     assert row.state == "missing"
     assert row.tier == "project_shared"
-    assert "migrate agent foo" in (row.reason or "")
+    assert "mm context migrate agents foo" in (row.reason or "")
     assert "dest missing" not in (row.reason or "")
 
 

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -1614,7 +1614,7 @@ def test_update_refuses_dirty_flat_layout(wiki_root: Path, tmp_path: Path) -> No
 
     msg = str(excinfo.value)
     assert "flat-layout" in msg
-    assert "mm context migrate agent foo" in msg
+    assert "mm context migrate agents foo" in msg
     assert "--force" in msg
     # Refusal left zero residue: no dir layout, flat bytes untouched.
     assert not (tmp_path / ".memtomem" / "agents" / "foo").exists()
@@ -1661,7 +1661,7 @@ def test_update_clean_flat_proceeds_and_warns(
     assert flat.is_file()
     messages = [rec.getMessage() for rec in caplog.records]
     assert any("shadow" in m for m in messages)
-    assert any("mm context migrate" in m for m in messages)
+    assert any("mm context migrate agents foo" in m for m in messages)
 
 
 def test_update_refuses_flat_with_unprovable_installed_at(wiki_root: Path, tmp_path: Path) -> None:
@@ -1697,7 +1697,7 @@ def test_classify_for_all_update_flat_dirty_is_refuse(wiki_root: Path, tmp_path:
     [c] = classifications
     assert c.state == "refuse"
     assert "flat layout" in (c.reason or "")
-    assert "migrate" in (c.reason or "")
+    assert "mm context migrate agents foo" in (c.reason or "")
 
 
 # ── unprovable install record (#1247 impl gate) ──────────────────────────


### PR DESCRIPTION
## Problem

Remediation hints across the install/status/version surfaces told users to run `mm context migrate <singular> <name>`, but the migrate command's asset-type argument is a **plural-only** `click.Choice(["agents", "commands", "skills", "memory"])` — pasting the hint exits 2 with Click's invalid-choice error. The identical shape was already fixed once for `privacy_scan` (#895; its test even pins the singular's absence) but the sweep never reached these sites — two of them were **test-pinned in the broken form**.

Verified by hand during the 2026-07-02 review.

## Fix

Emit the plural verbatim in every runnable `mm context migrate ...` command string:

- `cli/context_cmd.py:1714` (version-create hint)
- `context/install.py` — `_classify_for_all_update`, `_classify_for_install_all`, plus two sweep-found extra sites in `_apply_update` / `_apply_pinned_install` (StaleInstallError + shadow warning pairs)
- `context/status.py:211` (flat-layout status reason)

Display-noun uses of the singular (`validate_name kind=...` labels) are untouched. Post-fix sweep: no singular interpolation remains in any `context migrate` command string.

## Tests

Flipped the two broken-form pins (test_context_status.py:862, test_context_update.py:1617) and strengthened weak `"migrate"`-substring asserts to pin the full plural command across 5 test files — 8 targeted tests RED against unfixed source, then green. 255 passed under isolated HOME; ruff clean. (`test_context_status.py::test_collect_wiki_absent_degrades_to_stale_pin` fails with a real `~/.memtomem-wiki` on unmodified main too — machine-env, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
