### PR TITLE
security(web): redact engine exceptions in the index SSE error event

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -46,6 +46,7 @@ from memtomem.web.deps import (
     get_storage,
     require_configured,
 )
+from memtomem.web.routes._errors import _redact_message
 from memtomem.web.routes._locks import _config_lock
 from memtomem.web.schemas.config import (
     BuiltinExcludePatternsResponse,
@@ -1310,7 +1311,13 @@ async def index_stream(
             ):
                 yield f"data: {json.dumps(event)}\n\n"
         except Exception as exc:
-            error_event = {"type": "error", "message": str(exc)}
+            # Engine-level failures escape to this handler (per-file errors
+            # are caught inside the engine and reported as basenames in the
+            # "complete" event). A raw ``str(exc)`` here can embed absolute
+            # paths — leaking ``$HOME``/username — or secret-shaped fragments
+            # to the client, so route it through the same redactor every
+            # other error surface at this trust boundary uses.
+            error_event = {"type": "error", "message": _redact_message(str(exc))}
             yield f"data: {json.dumps(error_event)}\n\n"
 
     return StreamingResponse(

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -3221,6 +3221,51 @@ class TestBulkIndexForceUnsafe:
 
 
 # ---------------------------------------------------------------------------
+# GET /api/index/stream — SSE error-event redaction
+# ---------------------------------------------------------------------------
+
+
+class TestIndexStreamErrorRedaction:
+    """Engine-level exceptions that escape to the SSE generator must pass
+    through ``_redact_message`` before serialization. Per-file read/permission
+    errors never reach this handler — the engine catches them internally and
+    reports basenames in the ``complete`` event — but an *engine-level*
+    failure (e.g. a storage error) propagates to the route's ``except`` and a
+    raw ``str(exc)`` embedding an absolute path would leak ``$HOME`` (and the
+    OS username) to the client. Every other error surface at this trust
+    boundary routes through ``_redact_message`` or a fixed string; the SSE
+    error event must not be the exception."""
+
+    async def test_index_stream_error_event_redacts_home_path(
+        self, app, client: AsyncClient, tmp_path, monkeypatch
+    ):
+        app.state.config.indexing.memory_dirs = [tmp_path]
+        # ``_errors._HOME`` is captured at import time from ``Path.home()``,
+        # so pin it to a fake home rather than patching the env.
+        fake_home = "/home/leaky-user"
+        monkeypatch.setattr("memtomem.web.routes._errors._HOME", fake_home)
+
+        async def _boom(*args, **kwargs):
+            raise RuntimeError(f"database is locked: {fake_home}/.memtomem/index.db")
+            yield  # pragma: no cover — makes this an async generator function
+
+        app.state.index_engine.index_path_stream = _boom
+
+        resp = await client.get("/api/index/stream", params={"path": str(tmp_path)})
+        assert resp.status_code == 200, resp.text
+        events = [
+            json.loads(line.removeprefix("data: "))
+            for line in resp.text.splitlines()
+            if line.startswith("data: ")
+        ]
+        error_events = [e for e in events if e.get("type") == "error"]
+        assert error_events, f"no error event in stream: {resp.text!r}"
+        message = error_events[0]["message"]
+        assert fake_home not in message, f"raw $HOME path leaked to the client: {message!r}"
+        assert "~/.memtomem/index.db" in message, f"expected redacted form, got: {message!r}"
+
+
+# ---------------------------------------------------------------------------
 # GET /api/memory-dirs/status
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

The `/api/index/stream` SSE handler serialized a raw `str(exc)` into the error event. Engine-level exceptions escaping to this handler can embed absolute paths ($HOME/username) or secret-shaped fragments; every other error surface at this trust boundary routes through `_redact_message`. (Per-file read errors never reach here — the engine reports those as basenames in the "complete" event — so the exposure is engine-level failures only.)

Found by the 2026-07-02 review (trust-boundary dimension), adversarially verified with the narrowed trigger.

## Fix

Route the message through `_redact_message(str(exc))` ($HOME→~ collapse + secret-shape drop), event shape unchanged. Sweep of the other `str(exc)` sites in system.py judged each: `/index/stream` is the file's only streaming route; `/api/upload`'s per-file `error=str(exc)` shares the exposure class but is a POST JSON surface — left for a follow-up note on #1520.

## Tests

`TestIndexStreamErrorRedaction` pins a fake-$HOME-embedding engine exception: raw path absent from the SSE event, `~`-collapsed form present (RED before the fix). test_web_routes.py + exclude-guard suites = 201 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
