### PR TITLE
security(web): thread the Gate-A audit surface through wiki install/update

### DIFF
--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -214,6 +214,7 @@ def install_skill(
     *,
     wiki: WikiStore | None = None,
     lock_timeout: float | None = None,
+    surface: str = "cli_context_install",
 ) -> InstallResult:
     """Snapshot ``<wiki>/skills/<name>/`` into ``<project>/.memtomem/skills/<name>/``.
 
@@ -221,8 +222,15 @@ def install_skill(
     ``git pull`` in the wiki cannot make the recorded ``wiki_commit`` drift
     from the bytes that were copied. Refuses if either the lockfile entry
     or the destination directory already exists — see module docstring.
+
+    ``surface`` names the ingress in the Gate-A privacy audit log
+    (#1246/#1248 real-ingress rule): the CLI keeps the default, the web
+    route passes ``"web_context_install"`` so a browser-triggered block is
+    not misattributed to a CLI event.
     """
-    return _install_asset(project_root, "skills", name, wiki=wiki, lock_timeout=lock_timeout)
+    return _install_asset(
+        project_root, "skills", name, wiki=wiki, lock_timeout=lock_timeout, surface=surface
+    )
 
 
 def install_agent(
@@ -231,9 +239,12 @@ def install_agent(
     *,
     wiki: WikiStore | None = None,
     lock_timeout: float | None = None,
+    surface: str = "cli_context_install",
 ) -> InstallResult:
     """Snapshot ``<wiki>/agents/<name>/`` into ``<project>/.memtomem/agents/<name>/``."""
-    return _install_asset(project_root, "agents", name, wiki=wiki, lock_timeout=lock_timeout)
+    return _install_asset(
+        project_root, "agents", name, wiki=wiki, lock_timeout=lock_timeout, surface=surface
+    )
 
 
 def install_command(
@@ -242,9 +253,12 @@ def install_command(
     *,
     wiki: WikiStore | None = None,
     lock_timeout: float | None = None,
+    surface: str = "cli_context_install",
 ) -> InstallResult:
     """Snapshot ``<wiki>/commands/<name>/`` into ``<project>/.memtomem/commands/<name>/``."""
-    return _install_asset(project_root, "commands", name, wiki=wiki, lock_timeout=lock_timeout)
+    return _install_asset(
+        project_root, "commands", name, wiki=wiki, lock_timeout=lock_timeout, surface=surface
+    )
 
 
 def _installed_at_epoch(lock_entry: dict[str, Any]) -> float | None:
@@ -524,6 +538,7 @@ def _install_asset(
     *,
     wiki: WikiStore | None,
     lock_timeout: float | None = None,
+    surface: str = "cli_context_install",
 ) -> InstallResult:
     """Internal: install a single asset of any type.
 
@@ -596,7 +611,7 @@ def _install_asset(
     # no dest bytes, no lockfile entry).
     _gate_a_scan_src_tree(
         src,
-        surface="cli_context_install",
+        surface=surface,
         project_root=project_root,
         asset_type=asset_type,
         name=validated,
@@ -637,15 +652,27 @@ def update_skill(
     wiki: WikiStore | None = None,
     force: bool = False,
     lock_timeout: float | None = None,
+    surface: str = "cli_context_update",
 ) -> UpdateResult:
     """Refresh ``<wiki>/skills/<name>/`` snapshot at ``<project>/.memtomem/skills/<name>/``.
 
     No-op when wiki HEAD already matches the lockfile pin. Refuses when
     local edits would be clobbered, unless ``force=True`` (which preserves
     each dirty file as ``<file>.bak`` before overwriting).
+
+    ``surface`` names the ingress in the Gate-A privacy audit log
+    (#1246/#1248 real-ingress rule): the CLI keeps the default, the web
+    route passes ``"web_context_update"`` so a browser-triggered block is
+    not misattributed to a CLI event.
     """
     return _update_asset(
-        project_root, "skills", name, wiki=wiki, force=force, lock_timeout=lock_timeout
+        project_root,
+        "skills",
+        name,
+        wiki=wiki,
+        force=force,
+        lock_timeout=lock_timeout,
+        surface=surface,
     )
 
 
@@ -656,10 +683,17 @@ def update_agent(
     wiki: WikiStore | None = None,
     force: bool = False,
     lock_timeout: float | None = None,
+    surface: str = "cli_context_update",
 ) -> UpdateResult:
     """Refresh ``<wiki>/agents/<name>/`` snapshot at ``<project>/.memtomem/agents/<name>/``."""
     return _update_asset(
-        project_root, "agents", name, wiki=wiki, force=force, lock_timeout=lock_timeout
+        project_root,
+        "agents",
+        name,
+        wiki=wiki,
+        force=force,
+        lock_timeout=lock_timeout,
+        surface=surface,
     )
 
 
@@ -670,10 +704,17 @@ def update_command(
     wiki: WikiStore | None = None,
     force: bool = False,
     lock_timeout: float | None = None,
+    surface: str = "cli_context_update",
 ) -> UpdateResult:
     """Refresh ``<wiki>/commands/<name>/`` snapshot at ``<project>/.memtomem/commands/<name>/``."""
     return _update_asset(
-        project_root, "commands", name, wiki=wiki, force=force, lock_timeout=lock_timeout
+        project_root,
+        "commands",
+        name,
+        wiki=wiki,
+        force=force,
+        lock_timeout=lock_timeout,
+        surface=surface,
     )
 
 
@@ -685,6 +726,7 @@ def _update_asset(
     wiki: WikiStore | None,
     force: bool = False,
     lock_timeout: float | None = None,
+    surface: str = "cli_context_update",
 ) -> UpdateResult:
     """Internal: refresh a single installed asset of any type.
 
@@ -757,6 +799,7 @@ def _update_asset(
         wiki_commit=new_commit,
         lock_entry=lock_entry,
         force=force,
+        surface=surface,
         lock_timeout=lock_timeout,
     )
 

--- a/packages/memtomem/src/memtomem/web/routes/context_mutations.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mutations.py
@@ -123,8 +123,17 @@ async def install_asset(
     installer = _INSTALLERS[asset_type]
 
     def _run() -> InstallResult:
+        # surface= attributes a Gate-A privacy block to THIS browser ingress in
+        # the audit log — without it the engine default logs the block as a
+        # cli_context_install event (audit misattribution). Kind-agnostic like
+        # its CLI analog (one dispatcher for all three asset types), matching
+        # the web_context_transfer / web_context_sync_all precedent.
         return installer(
-            project_root, name, wiki=WikiStore.at_default(), lock_timeout=_INSTALL_LOCK_BUDGET_S
+            project_root,
+            name,
+            wiki=WikiStore.at_default(),
+            lock_timeout=_INSTALL_LOCK_BUDGET_S,
+            surface="web_context_install",
         )
 
     try:
@@ -198,12 +207,15 @@ async def update_asset(
     updater = _UPDATERS[asset_type]
 
     def _run() -> UpdateResult:
+        # surface= — see install_asset._run: audit attribution of Gate-A
+        # blocks to the browser ingress, not the CLI default.
         return updater(
             project_root,
             name,
             wiki=WikiStore.at_default(),
             force=force,
             lock_timeout=_INSTALL_LOCK_BUDGET_S,
+            surface="web_context_update",
         )
 
     try:

--- a/packages/memtomem/tests/test_context_install.py
+++ b/packages/memtomem/tests/test_context_install.py
@@ -25,6 +25,8 @@ from memtomem.context._names import InvalidNameError
 from memtomem.context.install import (
     AlreadyInstalledError,
     AssetNotFoundError,
+    install_agent,
+    install_command,
     install_skill,
 )
 from memtomem.context.lockfile import LOCKFILE_VERSION, Lockfile, LockfileCorruptError
@@ -524,6 +526,38 @@ def test_install_blocks_secret_in_wiki_src_zero_residue(wiki_root: Path, tmp_pat
     by_tool = privacy.snapshot()["by_tool"]
     assert by_tool.get("cli_context_install", {}).get("blocked", 0) == 1
     assert "cli_context_sync" not in by_tool
+
+
+@pytest.mark.parametrize(
+    ("asset_type", "verb"),
+    [("skills", install_skill), ("agents", install_agent), ("commands", install_command)],
+)
+def test_install_surface_kwarg_threads_to_audit(
+    wiki_root: Path, tmp_path: Path, asset_type: str, verb
+) -> None:
+    """A caller-supplied ``surface=`` reaches the Gate-A audit record on all
+    three install wrappers — the web route relies on this so a browser-
+    triggered block is not logged as ``cli_context_install`` (audit
+    misattribution). Parametrized because the route dispatches per asset
+    type; a wrapper that silently drops the kwarg would only misattribute
+    that one kind."""
+    _initialized_wiki(wiki_root)
+    asset_dir = wiki_root / asset_type / "leak"
+    asset_dir.mkdir(parents=True)
+    (asset_dir / "main.md").write_bytes(b"# leak\n" + SECRET.encode() + b"\n")
+    subprocess.run(["git", "-C", str(wiki_root), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root), "commit", "-m", "add leak"],
+        check=True,
+        capture_output=True,
+    )
+
+    with pytest.raises(PrivacyBlockedError):
+        verb(tmp_path, "leak", surface="web_context_install")
+
+    by_tool = privacy.snapshot()["by_tool"]
+    assert by_tool["web_context_install"]["blocked"] >= 1
+    assert "cli_context_install" not in by_tool
 
 
 def test_install_no_false_block_on_wiki_shipped_bak(wiki_root: Path, tmp_path: Path) -> None:

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -409,6 +409,7 @@ def test_update_agent_command_wrappers_dispatch(monkeypatch: pytest.MonkeyPatch)
     must keep the 3-wrapper API stable for downstream Python callers."""
     seen: list[str] = []
     timeouts: list[float | None] = []
+    surfaces: list[str] = []
 
     def _fake_update_asset(
         project_root: object,
@@ -418,9 +419,14 @@ def test_update_agent_command_wrappers_dispatch(monkeypatch: pytest.MonkeyPatch)
         wiki: object,
         force: bool,
         lock_timeout: float | None = None,
+        # Sentinel default (NOT "cli_context_update") so a wrapper that stops
+        # forwarding surface= fails the assertions below instead of the fake's
+        # own default masking the dropped kwarg (mutation-style pin).
+        surface: str = "<surface-not-forwarded>",
     ) -> object:
         seen.append(asset_type)
         timeouts.append(lock_timeout)
+        surfaces.append(surface)
         from memtomem.context.install import UpdateResult
 
         return UpdateResult(
@@ -440,11 +446,20 @@ def test_update_agent_command_wrappers_dispatch(monkeypatch: pytest.MonkeyPatch)
     update_agent(Path("/tmp/p"), "a")
     update_command(Path("/tmp/p"), "c")
     update_skill(Path("/tmp/p"), "s")
+    update_skill(Path("/tmp/p"), "s", surface="web_context_update")
 
-    assert seen == ["agents", "commands", "skills"]
+    assert seen == ["agents", "commands", "skills", "skills"]
     # The wrappers forward lock_timeout verbatim; callers that omit it (the
     # CLI / direct Python use) get the unbounded default (None).
-    assert timeouts == [None, None, None]
+    assert timeouts == [None, None, None, None]
+    # surface= forwards verbatim: the CLI default when omitted, the caller's
+    # audit surface (e.g. the web route's) when given.
+    assert surfaces == [
+        "cli_context_update",
+        "cli_context_update",
+        "cli_context_update",
+        "web_context_update",
+    ]
 
 
 # ════════════════════════════════════════════════════════════════════════
@@ -1491,6 +1506,24 @@ class TestUpdatePrivacyGate:
         assert lock_path.read_bytes() == pre_lock_bytes
         # No .bak anywhere under dest (no preservation pass ran).
         assert list(dest.rglob("*.bak")) == []
+
+    def test_update_surface_kwarg_threads_to_audit(self, wiki_root: Path, tmp_path: Path) -> None:
+        """A caller-supplied ``surface=`` reaches the Gate-A audit record —
+        the web route relies on this so a browser-triggered block is not
+        logged as a ``cli_context_update`` event (audit misattribution)."""
+        _initialized_wiki(wiki_root)
+        _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+        project = tmp_path
+        install_skill(project, "foo")
+        _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": f"v2\n{SECRET}\n".encode()})
+        privacy.reset_for_tests()  # drop the clean install's audit rows
+
+        with pytest.raises(PrivacyBlockedError):
+            update_skill(project, "foo", surface="web_context_update")
+
+        by_tool = privacy.snapshot()["by_tool"]
+        assert by_tool["web_context_update"]["blocked"] >= 1
+        assert "cli_context_update" not in by_tool
 
     def test_force_update_blocks_on_secret_in_dirty_dest_file(
         self, wiki_root: Path, tmp_path: Path

--- a/packages/memtomem/tests/test_web_routes_context_mutations.py
+++ b/packages/memtomem/tests/test_web_routes_context_mutations.py
@@ -27,6 +27,7 @@ from unittest.mock import AsyncMock
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from memtomem import privacy
 from memtomem.config import ContextGatewayConfig, Mem2MemConfig
 from memtomem.context.lockfile import Lockfile
 from memtomem.web.app import create_app
@@ -70,6 +71,14 @@ def _advance_wiki(root: Path) -> None:
 
 
 # ── fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_privacy_counters():
+    """Zeroed counters so surface-attribution asserts see only their own test."""
+    privacy.reset_for_tests()
+    yield
+    privacy.reset_for_tests()
 
 
 @pytest.fixture
@@ -401,6 +410,55 @@ async def test_install_privacy_block_is_422_no_path_leak(
     assert _SECRET not in resp.text
     # Refusal left no residue in the project tree.
     assert not (project_root / ".memtomem" / "skills" / "leaky").exists()
+
+
+@pytest.mark.asyncio
+async def test_install_privacy_block_audits_web_surface(
+    client,
+    wiki_root: Path,  # noqa: F811 — wiki_root from conftest
+    project_root: Path,
+) -> None:
+    # Audit attribution (backlog item b, 2026-06-29): a Gate-A block triggered
+    # from the BROWSER must be recorded under the web ingress surface, not the
+    # engine's CLI default — otherwise the privacy audit log claims a CLI event
+    # that never happened. End-to-end pin of the route's ``surface=`` kwarg
+    # through the engine into the audit counters.
+    WikiStore.at_default().init()
+    secret_dir = wiki_root / "skills" / "leaky"
+    secret_dir.mkdir(parents=True)
+    (secret_dir / "SKILL.md").write_text(f"# Leaky\n\naccess key {_SECRET}\n", encoding="utf-8")
+    _commit(wiki_root, "seed leaky")
+
+    resp = await client.post("/api/context/skills/leaky/install")
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["reason_code"] == "privacy_blocked"
+    by_tool = privacy.snapshot()["by_tool"]
+    assert by_tool["web_context_install"]["blocked"] >= 1
+    assert "cli_context_install" not in by_tool
+
+
+@pytest.mark.asyncio
+async def test_update_privacy_block_audits_web_surface(
+    client, seeded_wiki: Path, project_root: Path
+) -> None:
+    # Update twin of the install attribution pin: install clean, poison the
+    # wiki, then a browser-triggered update block must audit as
+    # web_context_update — never the CLI default.
+    assert (await client.post("/api/context/skills/alpha/install")).status_code == 200
+    (seeded_wiki / "skills" / "alpha" / "SKILL.md").write_text(
+        f"{_SKILL_BODY}\naccess key {_SECRET}\n", encoding="utf-8"
+    )
+    _commit(seeded_wiki, "poison alpha")
+    privacy.reset_for_tests()  # drop the clean install's audit rows
+
+    resp = await client.post("/api/context/skills/alpha/update")
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["reason_code"] == "privacy_blocked"
+    by_tool = privacy.snapshot()["by_tool"]
+    assert by_tool["web_context_update"]["blocked"] >= 1
+    assert "cli_context_update" not in by_tool
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Every other web mutation threads a distinct `web_context_*` audit surface into its Gate-A privacy scan, and the privacy audit log records that surface per outcome. The wiki install/update path was the sole exception: `_install_asset` hardcoded `surface="cli_context_install"` and the update path defaulted likewise, with no parameter for the web route to thread — so a Gate-A privacy block triggered from the **browser** was logged as a **CLI** event. (2026-06-29 backlog item (b); re-confirmed by the 2026-07-02 review.)

## Fix

- `context/install.py`: the three install verbs gain kw-only `surface: str = "cli_context_install"`, the three update verbs `surface: str = "cli_context_update"`, threaded through `_install_asset` / `_update_asset` / `_apply_update` into every scan site. Defaults preserve CLI behavior exactly; the batch surfaces (`cli_context_install_all` / `cli_context_update_all`) were already parameterized and are untouched.
- `web/routes/context_mutations.py`: install/update handlers pass `surface="web_context_install"` / `"web_context_update"` — kind-agnostic because this router is one dispatcher for all three asset types (the `web_context_transfer` / `web_context_sync_all` precedent).
- MCP: verified `server/tools/context.py` never calls the install/update engines — nothing to thread.

## Tests

- End-to-end route pins: a privacy-blocked web install/update 422 records `web_context_*` in the audit `by_tool` (CLI surface absent).
- Engine pins: parametrized surface-kwarg threading over all three install verbs + the update twin; existing tests keep the CLI defaults pinned.
- **Mutation-validated twice**: dropping the route kwargs → both route pins RED; dropping `surface=surface` in `update_skill` → dispatch + audit tests RED (restored). The wrapper-dispatch test now records surface with a non-default sentinel so a dropped pass-through can't be masked.
- 133 tests across the 4 affected suites; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
