### PR TITLE
docs(adr): record the project→wiki one-way rejection + complete the wiki cheat-sheet

### DIFF
--- a/docs/adr/0008-wiki-layer.md
+++ b/docs/adr/0008-wiki-layer.md
@@ -127,6 +127,9 @@ a single mental group of "manipulate this artifact":
 ```
 mm wiki init [--from <git-url>]
 mm wiki list
+mm wiki remote [<url>]
+mm wiki push
+mm wiki pull
 
 mm wiki skill   {override, diff, lint, commit} <name> [--vendor <vendor>]
 mm wiki agent   {override, diff, lint, commit} <name> [--vendor <vendor>]
@@ -326,6 +329,15 @@ override slots. They can be added in v2 if their runtime surface grows.
 - **Cursor / Copilot override slots.** Deferred — runtime surface too
   thin in v1.
 - **Settings in wiki.** Rejected — host-scope mutation trust boundary.
+- **Project→wiki "contribute back" verb.** Rejected: the layer is
+  intentionally one-way — the project is the authoritative, git-tracked
+  copy (Invariant 3), and every wiki-write primitive sources bytes from
+  the wiki's own canonical or an editor, never a project file.
+  Project→project reuse is `mm context {move, copy}` (ADR-0023), which
+  deliberately refuses to bless locally-edited bytes as pristine wiki
+  state; and promoting `project_shared` content into host-global git
+  would be the highest-stakes privacy ingress (ADR-0011 Gate A guards
+  only the wiki→project direction).
 
 ## References
 


### PR DESCRIPTION
## What

Two accuracy gaps in ADR-0008 from the 2026-07-02 review (docs-parity + backlog dimensions):

1. **"Considered & rejected" now records the project→wiki one-way decision** (maintainer call, 2026-06-29): no contribute-back verb — the project is the authoritative git-tracked copy (Invariant 3); every wiki-write primitive sources bytes from the wiki's own canonical or an editor; project↔project reuse is `mm context {move, copy}` (ADR-0023), which deliberately refuses to bless locally-edited bytes as pristine wiki state; and project_shared → host-global git would be the highest-stakes privacy ingress (Gate A guards only wiki→project). Previously this rationale lived only in review history.
2. **The Subcommands cheat-sheet gains the shipped `mm wiki remote [<url>]` / `push` / `pull` verbs** (#1419) — they were described in the git-remotes decision text but missing from the at-a-glance list. Verb spellings verified against `cli/wiki_cmd.py` (remote takes one optional positional; push/pull take none).

Note: the plan named the verb "mm context transfer", which does not exist — the shipped verbs are `mm context move`/`copy` (docs-as-tests catch during writing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
