### PR TITLE
docs(guides): fix tier/fan-out accuracy in context-gateway + data-config-cli

### DIFF
--- a/docs/guides/context-gateway.md
+++ b/docs/guides/context-gateway.md
@@ -13,7 +13,7 @@ runtime's copy is overwritten on the next Sync.
 
 This guide walks through that model and the first task most people want — getting
 a project's skills into their AI tools — from both the Web UI and the CLI. It
-links out to [`reference.md`](reference/data-config-cli.md#cli-reference) for the full command matrix and to
+links out to [the CLI reference](reference/data-config-cli.md#cli-reference) for the full command matrix and to
 [`configuration.md#context-gateway`](configuration.md#context-gateway) for the
 environment variables; it does not re-document those here.
 
@@ -120,7 +120,7 @@ runtimes like any other.
 
 In the Web UI the wiki panel is **read-only** (browse + Install); authoring
 canonical or vendor-override files is done with the `mm wiki …` CLI (or the
-in-browser editor in dev mode). See [`reference.md`](reference/data-config-cli.md#cli-reference)
+in-browser editor in dev mode). See [the CLI reference](reference/data-config-cli.md#cli-reference)
 for the full `mm wiki` / `mm context install` command matrix.
 
 ## Walkthrough — get this project's skills into your AI tools
@@ -223,7 +223,7 @@ mm context diff        # show in-sync / out-of-sync state
 mm context sync        # send the Store out to every detected runtime
 ```
 
-Useful flags (see [`reference.md`](reference/data-config-cli.md#cli-reference) for the full
+Useful flags (see [the CLI reference](reference/data-config-cli.md#cli-reference) for the full
 list):
 
 - `--include=<kind>` — narrow to `skills`, `agents`, `commands`, or `settings`.
@@ -263,9 +263,12 @@ them out:
 - **Project (shared)** writes hard-refuse on a detected secret and **cannot** be
   overridden — `--force-unsafe` is rejected for `project_shared` because git
   history is permanent. Remove the flagged line, then re-run.
-- **User** and **Project (local)** writes can be overridden with
-  `--force-unsafe` (CLI) or *Sync anyway* (Web) after you've reviewed a false
-  positive — e.g. a type annotation like `api_key: str`.
+- **User** writes can be overridden with `--force-unsafe` (CLI) or *Sync
+  anyway* (Web) after you've reviewed a false positive — e.g. a type
+  annotation like `api_key: str`.
+- **Project (local)** writes can be overridden with `--force-unsafe`, CLI
+  only — the Web UI has no Project (local) write surface (its write routes
+  reject that tier before any privacy check).
 
 See [`configuration.md#context-gateway`](configuration.md#context-gateway) for
 the related environment variables.

--- a/docs/guides/reference/data-config-cli.md
+++ b/docs/guides/reference/data-config-cli.md
@@ -321,7 +321,7 @@ mm context diff                        # check sync status
 mm context status                      # installed wiki assets + their drift state (read-only)
 mm context status --all-projects       # aggregated drift across enrolled on-disk projects (read-only; same data as GET /api/context/status-all)
 mm context sync                        # sync context.md → agent files (project_shared default)
-mm context sync --scope user           # fan out from ~/.memtomem/... → ~/.{claude,gemini,codex,kimi}/...
+mm context sync --scope user           # fan out from ~/.memtomem/... → ~/.{claude,gemini,codex,kimi}/... (Codex: skills → ~/.agents/skills, commands → ~/.codex/prompts)
 mm context sync --include=skills --scope user --force-unsafe   # bypass Gate A on a reviewed false positive (user/project_local only; project_shared hard-refuses)
 mm context sync --include=skills --scope project_local   # NO_FANOUT skip (no runtime per ADR §3)
 mm context sync --include=agents,commands --label production # sync using the 'production' labeled version (agents/commands only)


### PR DESCRIPTION
## What

Three verified inaccuracies in the guides (2026-07-02 review, docs-parity dimension), each checked against source before editing:

1. **context-gateway.md privacy section** claimed Project (local) writes can be overridden via "*Sync anyway* (Web)" — but the web sync routes reject project_local outright before any force check (`_reject_project_local_write`, context_skills.py:69 + agents/commands mirrors) and web force-unsafe is user-tier-only (in-source comments pin this). Split into two bullets: User = CLI or Web; Project (local) = CLI-only (the web has no project_local write surface).
2. **data-config-cli.md `--scope user` fan-out shorthand** said `~/.{claude,gemini,codex,kimi}/...` — per `_runtime_targets.py`, Codex skills fan out to `~/.agents/skills` ("NOT .codex/skills") and commands to `~/.codex/prompts`. Added the two exceptions as a compact parenthetical (agents genuinely live under `~/.codex/agents`), matching context-gateway.md:168.
3. **Link labels** at context-gateway.md:16/123/226 displayed `reference.md` while linking to `reference/data-config-cli.md` — labels renamed to "the CLI reference", hrefs unchanged (255/275/276 were already correct).

`test_docs_guards.py` (docs CLI-line/link walker) = 16 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
