### PR TITLE
test: stop lifespan tests from sourcing the developer's .env into the suite

### DIFF
--- a/packages/memtomem/tests/conftest.py
+++ b/packages/memtomem/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -19,6 +20,52 @@ from memtomem.server.component_factory import Components, create_components, clo
 # Keeping the definitions in ``_wiki_fixtures.py`` avoids bloating this
 # already-heavy conftest with unrelated git-env plumbing.
 from _wiki_fixtures import git_identity, wiki_root  # noqa: F401
+
+
+# Bare (unprefixed) env names that pydantic-settings binds onto
+# ``SessionTraceConfig`` fields case-insensitively — the sub-configs carry no
+# ``model_config``, so these bypass the documented ``MEMTOMEM_`` surface
+# entirely (#1522). A developer shell or a sourced repo-root ``.env``
+# exporting them defeats the langfuse keys-missing validator in any test
+# that constructs the config (#1508).
+_BARE_LANGFUSE_ENV_VARS = (
+    "LANGFUSE_PUBLIC_KEY",
+    "LANGFUSE_SECRET_KEY",
+    "LANGFUSE_HOST",
+    "LANGFUSE_ENABLED",
+)
+
+# The documented nested surface for the same fields. Scrubbed by prefix, not a
+# hand-list, so future SessionTraceConfig fields are covered automatically.
+_SESSION_TRACE_ENV_PREFIX = "MEMTOMEM_SESSION_TRACE__"
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_dotenv(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the developer's shell and repo-root ``.env`` out of every test.
+
+    ``app_lifespan`` sources ``.env`` via ``_load_dotenv()``; python-dotenv
+    resolves the file from the *calling frame's* location (walking up from
+    ``server/lifespan.py`` to the repo root), so neither ``monkeypatch`` nor
+    ``chdir`` contains it — one lifespan-driving test loads the developer's
+    real credentials into ``os.environ`` for the rest of the pytest process
+    (#1508). Tests that need the real loader opt out with
+    ``@pytest.mark.real_dotenv``; the env scrub always applies.
+
+    The scrub is case-insensitive (pydantic-settings binds env names
+    case-insensitively, so lowercase ``langfuse_public_key`` leaks the same
+    way) and also covers the documented ``MEMTOMEM_SESSION_TRACE__*`` surface
+    a developer shell may export. Tests that need any of these set them via
+    ``monkeypatch.setenv`` in their own body, which runs after this fixture.
+    """
+    for key in list(os.environ):
+        upper = key.upper()
+        if upper in _BARE_LANGFUSE_ENV_VARS or upper.startswith(_SESSION_TRACE_ENV_PREFIX):
+            monkeypatch.delenv(key, raising=False)
+    if request.node.get_closest_marker("real_dotenv") is None:
+        from memtomem.server import lifespan as lifespan_mod
+
+        monkeypatch.setattr(lifespan_mod, "_load_dotenv", lambda: None)
 
 
 def _ollama_available() -> bool:

--- a/packages/memtomem/tests/test_server_lifespan.py
+++ b/packages/memtomem/tests/test_server_lifespan.py
@@ -16,6 +16,7 @@ are covered in ``test_server_app_context.py``.
 
 from __future__ import annotations
 
+import os
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -217,3 +218,65 @@ async def test_lifespan_cleans_up_webhook_when_appcontext_init_fails(
             pytest.fail("yield should not be reached")
 
     assert closed, "webhook must be closed when AppContext construction fails"
+
+
+# ── dotenv loading (#1508) ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_lifespan_invokes_dotenv_loader(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Startup must call ``_load_dotenv()`` exactly once. The suite-wide
+    conftest fixture no-ops the loader (#1508), so this spy — layered on
+    top of that no-op — is the only remaining coverage that the production
+    startup path still wires it."""
+    monkeypatch.delenv("MEMTOMEM_WEBHOOK__ENABLED", raising=False)
+    monkeypatch.delenv("MEMTOMEM_WEBHOOK__URL", raising=False)
+
+    calls: list[None] = []
+    monkeypatch.setattr(lifespan_mod, "_load_dotenv", lambda: calls.append(None))
+
+    async with lifespan_mod.app_lifespan(MagicMock()):
+        pass
+
+    assert len(calls) == 1, f"_load_dotenv must run once at startup; ran {len(calls)}×"
+
+
+@pytest.mark.asyncio
+async def test_lifespan_under_test_does_not_source_repo_dotenv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end wiring pin for #1508: with the conftest hermeticity
+    fixture active, entering the *real* lifespan must leave the bare
+    langfuse env absent — even on a dev machine whose repo-root ``.env``
+    defines it. Before the fix, this test polluted ``os.environ`` for
+    every later test in the run (the four ``test_session_tracing``
+    validator failures)."""
+    monkeypatch.delenv("MEMTOMEM_WEBHOOK__ENABLED", raising=False)
+    monkeypatch.delenv("MEMTOMEM_WEBHOOK__URL", raising=False)
+
+    async with lifespan_mod.app_lifespan(MagicMock()):
+        pass
+
+    assert "LANGFUSE_PUBLIC_KEY" not in os.environ
+    assert "LANGFUSE_SECRET_KEY" not in os.environ
+
+
+@pytest.mark.real_dotenv
+def test_load_dotenv_does_not_override_existing_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real loader must keep already-exported env vars (python-dotenv's
+    ``override=False`` default): a repo-root ``.env`` may *add* to the
+    environment but never replace explicit configuration. Marked
+    ``real_dotenv`` to opt out of the conftest no-op; the loader resolves
+    ``.env`` upward from the source tree, so on a dev machine it may add
+    that file's other keys — the snapshot/restore keeps this test from
+    becoming the very polluter #1508 fixed."""
+    snapshot = dict(os.environ)
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "sentinel-keep-me")
+    try:
+        lifespan_mod._load_dotenv()
+        assert os.environ["LANGFUSE_PUBLIC_KEY"] == "sentinel-keep-me"
+    finally:
+        os.environ.clear()
+        os.environ.update(snapshot)

--- a/packages/memtomem/tests/test_session_cli.py
+++ b/packages/memtomem/tests/test_session_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from contextlib import asynccontextmanager
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -12,6 +13,8 @@ import pytest
 from click.testing import CliRunner
 
 from memtomem.cli import cli
+
+from .helpers import set_home
 
 
 def _mock_components(*, sessions=None, events=None, add_event=None):
@@ -51,7 +54,12 @@ def _create_session_call_args(mock: AsyncMock) -> tuple:
 
 
 @pytest.fixture
-def runner() -> CliRunner:
+def runner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> CliRunner:
+    """CliRunner with HOME isolated. The CLI bootstrap otherwise reads the
+    developer's real ``~/.memtomem/config.json``; one that enables langfuse
+    tracing (keys expected from env) makes the client's auth warning bleed
+    into ``result.output`` and break the ``--json`` contract (#1508)."""
+    set_home(monkeypatch, tmp_path)
     return CliRunner()
 
 

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -1751,8 +1751,15 @@ class TestConfigPatch:
         assert any("nonexistent" in r for r in data["rejected"])
 
     async def test_save_config(self, client: AsyncClient):
-        """POST /api/config/save persists config."""
-        with patch("memtomem.config.save_config_overrides"):
+        """POST /api/config/save persists config.
+
+        Patch the *route module's* binding, like ``test_patch_namespace_rules``
+        below — patching ``memtomem.config.save_config_overrides`` misses the
+        ``from memtomem.config import ...`` binding in ``routes/system.py``, so
+        the real saver ran against the developer's ``~/.memtomem/config.json``
+        (masked while leaked langfuse env kept its validation green, #1508).
+        """
+        with patch("memtomem.web.routes.system.save_config_overrides"):
             resp = await client.post("/api/config/save")
             assert resp.status_code == 200
             data = resp.json()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ markers = [
     "multilingual: multilingual/large-corpus regression tests (runs in the test-golden-path CI job)",
     "requires_symlinks: needs a filesystem that can create symlinks (auto-skipped on Windows without Developer Mode/admin)",
     "browser: requires pytest-playwright + a Chromium install (auto-skipped when unavailable)",
+    "real_dotenv: opt out of the suite-wide _load_dotenv no-op and run the real dotenv loader (#1508)",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
## Summary

Makes the test suite hermetic against the developer's shell and repo-root `.env` (#1508). Any test driving the real `app_lifespan` was loading the developer's `.env` into `os.environ` process-wide via `_load_dotenv()`; leaked bare `LANGFUSE_*` keys then bound onto `SessionTraceConfig` (unprefixed `BaseSettings`, tracked separately as #1522) and defeated the langfuse keys-missing validator in four `test_session_tracing` tests — red in local full runs, green solo and on CI.

## Changes

- **`tests/conftest.py`** — autouse `_hermetic_dotenv` fixture:
  - no-ops `memtomem.server.lifespan._load_dotenv` (python-dotenv resolves `.env` from the calling frame's location, so neither `monkeypatch` nor `chdir` can contain it); opt back in with the new `@pytest.mark.real_dotenv`;
  - scrubs the langfuse env surface **case-insensitively** — bare `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` / `LANGFUSE_HOST` / `LANGFUSE_ENABLED` in any casing, plus the documented `MEMTOMEM_SESSION_TRACE__*` prefix — so parent-shell exports can't reach the validator either.
- **`pyproject.toml`** — registers the `real_dotenv` marker.
- **`tests/test_server_lifespan.py`** — pins the loader wiring the suite-wide no-op would otherwise leave uncovered: an invocation spy (mutation-validated: deleting the production `_load_dotenv()` call turns it red), an end-to-end pin that entering the real lifespan leaves no bare langfuse env behind, and a `real_dotenv`-marked pin of the loader's `override=False` semantics with env snapshot/restore.
- **Two tests that only ever passed via the leaked env**, unmasked by the hermeticity fix:
  - `test_web_routes_extended.py::TestConfigPatch::test_save_config` patched `memtomem.config.save_config_overrides` instead of the route module's binding, so the real saver ran — validating (and on success **writing**) the developer's real `~/.memtomem/config.json` from a test. Now patches `memtomem.web.routes.system.save_config_overrides`, matching the sibling test.
  - `test_session_cli.py` ran `CliRunner` against the real HOME; a dev config enabling langfuse tracing bled the client's auth warning into `result.output`, breaking the `--json` contract. The `runner` fixture now isolates HOME via `set_home`.

## Verification

- On a machine with a repo-root `.env` containing langfuse keys: polluter pairs (`test_lazy_init_acceptance.py` / `test_server_lifespan.py` + `test_session_tracing.py`) go red → green with this change.
- Leak scenarios from review all pass now: uppercase shell exports, lowercase `langfuse_public_key` exports, and `MEMTOMEM_SESSION_TRACE__ENABLED/LANGFUSE_ENABLED=true`.
- Full suite (`-m "not ollama"`): only the three known #1506 wiki-absent failures remain (fixed by #1507, not in this branch); the four session-tracing failures and both unmasked tests are green.
- `ruff check` + `ruff format --check` clean.

Review: two Codex passes — first pass (on the plan) required the parent-shell scrub, ruled out chdir isolation, and required loader coverage; second pass (on the diff) required case-insensitive scrubbing and the `MEMTOMEM_SESSION_TRACE__*` surface. All applied and re-verified.

Closes #1508

🤖 Generated with [Claude Code](https://claude.com/claude-code)
