### PR TITLE
fix(context): lock + mtime-guard the .mcp.json read-merge-write

### DIFF
--- a/packages/memtomem/src/memtomem/context/mcp_servers.py
+++ b/packages/memtomem/src/memtomem/context/mcp_servers.py
@@ -24,7 +24,7 @@ from typing import Any
 
 from memtomem import privacy
 from memtomem.context import _skip_reasons as skip_codes
-from memtomem.context._atomic import atomic_write_text
+from memtomem.context._atomic import _file_lock, _lock_path_for, atomic_write_text
 from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context._runtime_targets import DiffRow
 
@@ -33,6 +33,13 @@ logger = logging.getLogger(__name__)
 CANONICAL_MCP_SERVER_ROOT = ".memtomem/mcp-servers"
 PROJECT_MCP_CONFIG = ".mcp.json"
 MCP_RUNTIME = "project_mcp"
+
+# Sidecar-lock acquisition budget for the ``.mcp.json`` read-merge-write
+# (the ``settings._SETTINGS_LOCK_BUDGET_S`` twin, #1145 review shape): a
+# bounded wait keeps a (possibly thread-offloaded) caller from blocking
+# indefinitely on a lock another process holds; on exhaustion the sync
+# self-aborts with a typed skip instead of hanging or orphaning a late write.
+_MCP_LOCK_BUDGET_S = 30.0
 
 
 class McpServerParseError(ValueError):
@@ -322,39 +329,85 @@ def generate_all_mcp_servers(
         definitions[parsed.name] = parsed.definition
 
     target = _project_mcp_path(project_root)
-    current_text = target.read_text(encoding="utf-8") if target.exists() else None
-    config = _parse_project_mcp_text(current_text) if current_text is not None else {}
-    mcp_servers = dict(config.get("mcpServers") or {})
-    for name, definition in definitions.items():
-        mcp_servers[name] = definition
-    config["mcpServers"] = mcp_servers
-    merged_text = json.dumps(config, indent=2, sort_keys=False) + "\n"
+    # Cross-process guard (the settings #1123 twin): ``.mcp.json`` is a SHARED
+    # file merged read-modify-write with foreign ``mcpServers`` entries
+    # preserved verbatim, so two unsynchronized writers (a CLI sync racing the
+    # web sync, or two ``mm`` processes) could silently drop each other's
+    # entries. The canonical scan/parse above stays OUTSIDE the lock (slow
+    # work out, invariant in); the sidecar lock spans read → merge → write.
+    # The ``st_mtime_ns`` recheck is kept as a second layer for writers that
+    # take no lock (a direct editor save mid-merge), matching
+    # ``generate_all_settings``.
+    try:
+        with _file_lock(_lock_path_for(target), timeout=_MCP_LOCK_BUDGET_S):
+            current_text = target.read_text(encoding="utf-8") if target.exists() else None
+            existing_mtime_ns = target.stat().st_mtime_ns if target.is_file() else 0
+            config = _parse_project_mcp_text(current_text) if current_text is not None else {}
+            mcp_servers = dict(config.get("mcpServers") or {})
+            for name, definition in definitions.items():
+                mcp_servers[name] = definition
+            config["mcpServers"] = mcp_servers
+            merged_text = json.dumps(config, indent=2, sort_keys=False) + "\n"
 
-    if merged_text == current_text:
-        # Nothing to change — rewriting anyway churned mtime, reflowed user
-        # formatting, and chmodded the file every run (#1247 id 43). Typed
-        # skip, not silent: an MCP-only project that is fully in sync must
-        # not read as "nothing to sync" in the Sync All no-op detection.
+            if merged_text == current_text:
+                # Nothing to change — rewriting anyway churned mtime, reflowed
+                # user formatting, and chmodded the file every run (#1247 id
+                # 43). Typed skip, not silent: an MCP-only project that is
+                # fully in sync must not read as "nothing to sync" in the Sync
+                # All no-op detection.
+                return McpServerSyncResult(
+                    generated=[],
+                    skipped=[
+                        (
+                            MCP_RUNTIME,
+                            f"all {len(definitions)} canonical server(s) already in sync "
+                            f"with {PROJECT_MCP_CONFIG}",
+                            skip_codes.IN_SYNC,
+                        )
+                    ],
+                )
+
+            # Concurrent-write guard, 0-sentinel form (a delete is as much an
+            # external change as an edit — the settings-copy #1382 lesson).
+            if (target.stat().st_mtime_ns if target.is_file() else 0) != existing_mtime_ns:
+                return McpServerSyncResult(
+                    generated=[],
+                    skipped=[
+                        (
+                            MCP_RUNTIME,
+                            f"{PROJECT_MCP_CONFIG} was modified by another process "
+                            f"during merge; nothing was written. Re-run "
+                            f"`mm context sync --include=mcp-servers` to retry.",
+                            skip_codes.TARGET_CONFLICT,
+                        )
+                    ],
+                )
+
+            # Mode policy (Codex design gate): a NEW file holds only
+            # Gate-A-scanned canonical content → 0o644 like every other
+            # fan-out target. A REWRITE preserves the existing mode in both
+            # directions — the merge carries foreign ``mcpServers`` entries
+            # verbatim without scanning them, so widening a user's 0600 file
+            # could expose unscanned secret env values, and forcing 0600 onto
+            # a 0644 file was the original id 43 complaint.
+            mode = 0o644 if current_text is None else stat.S_IMODE(target.stat().st_mode)
+            atomic_write_text(target, merged_text, mode=mode)
+    except TimeoutError:
+        # Another process held the lock past the budget. Abort cleanly so a
+        # (possibly thread-offloaded) caller never blocks indefinitely and
+        # never orphans a late writer (#1145 review shape).
         return McpServerSyncResult(
             generated=[],
             skipped=[
                 (
                     MCP_RUNTIME,
-                    f"all {len(definitions)} canonical server(s) already in sync "
-                    f"with {PROJECT_MCP_CONFIG}",
-                    skip_codes.IN_SYNC,
+                    f"{PROJECT_MCP_CONFIG}: another process held the lock past "
+                    f"the {_MCP_LOCK_BUDGET_S:g}s acquisition budget. Re-run "
+                    f"`mm context sync --include=mcp-servers` to retry.",
+                    skip_codes.LOCK_TIMEOUT,
                 )
             ],
         )
-
-    # Mode policy (Codex design gate): a NEW file holds only Gate-A-scanned
-    # canonical content → 0o644 like every other fan-out target. A REWRITE
-    # preserves the existing mode in both directions — the merge carries
-    # foreign ``mcpServers`` entries verbatim without scanning them, so
-    # widening a user's 0600 file could expose unscanned secret env values,
-    # and forcing 0600 onto a 0644 file was the original id 43 complaint.
-    mode = 0o644 if current_text is None else stat.S_IMODE(target.stat().st_mode)
-    atomic_write_text(target, merged_text, mode=mode)
 
     return McpServerSyncResult(
         generated=[(MCP_RUNTIME, name, target) for name in definitions],

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -472,7 +472,8 @@ def generate_all_skills(
     Args:
         project_root: project root containing ``.memtomem/skills/``.
         runtimes: list of generator names. ``None`` means all registered
-            runtimes (currently ``claude_skills`` + ``gemini_skills``).
+            runtimes (``claude_skills`` / ``gemini_skills`` / ``codex_skills``
+            / ``kimi_skills`` — a default sync fans out to all four).
         scope: ADR-0011 PR-E3 — selects canonical root and runtime
             fan-out destination. Default ``project_shared`` preserves
             pre-PR-E3 behavior.

--- a/packages/memtomem/tests/test_context_mcp_servers.py
+++ b/packages/memtomem/tests/test_context_mcp_servers.py
@@ -264,3 +264,69 @@ def test_runtime_only_enumeration_tolerates_broken_mcp_json(tmp_path: Path) -> N
     (tmp_path / ".mcp.json").write_text("{broken", encoding="utf-8")
     rows = diff_mcp_servers(tmp_path)
     assert [(r[0], r[1], r[2]) for r in rows] == [("project_mcp", "demo", "parse error")]
+
+
+# ── T1-5: .mcp.json read-merge-write is cross-process guarded ────────────────
+
+
+def test_sync_aborts_when_sidecar_lock_held(tmp_path: Path) -> None:
+    """A concurrent holder of the .mcp.json sidecar lock makes the merge
+    self-abort with a typed LOCK_TIMEOUT skip (bounded budget) instead of
+    blocking forever — the settings #1123 twin. Expiry-direction timing: a
+    slow runner only delays the abort, it can never produce a false pass."""
+    from memtomem.context import _skip_reasons as skip_codes
+    from memtomem.context import mcp_servers as mod
+    from memtomem.context._atomic import _file_lock, _lock_path_for
+
+    _canonical(tmp_path, "demo", {"command": "uvx"})
+    target = tmp_path / ".mcp.json"
+    monkeypatch_budget = mod._MCP_LOCK_BUDGET_S
+    try:
+        mod._MCP_LOCK_BUDGET_S = 0.2
+        with _file_lock(_lock_path_for(target)):
+            result = mod.generate_all_mcp_servers(tmp_path)
+    finally:
+        mod._MCP_LOCK_BUDGET_S = monkeypatch_budget
+
+    assert result.generated == []
+    assert [(r[0], r[2]) for r in result.skipped] == [("project_mcp", skip_codes.LOCK_TIMEOUT)]
+    # The lock protected the file: nothing was written under contention.
+    assert not target.exists()
+
+
+def test_sync_aborts_when_target_mtime_changes_mid_merge(tmp_path: Path) -> None:
+    """The st_mtime_ns recheck (second layer, for a non-locking direct editor
+    save mid-merge) aborts with a TARGET_CONFLICT skip and writes nothing."""
+    from memtomem.context import _skip_reasons as skip_codes
+    from memtomem.context import mcp_servers as mod
+
+    _canonical(tmp_path, "demo", {"command": "uvx"})
+    target = tmp_path / ".mcp.json"
+    target.write_text(
+        json.dumps({"mcpServers": {"other": {"command": "node"}}}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    real_dumps = json.dumps
+    state = {"bumped": False}
+
+    def _dumps_then_touch(*args: object, **kwargs: object) -> str:
+        # Simulate a concurrent write landing after the in-lock read but
+        # before the mtime recheck: bump the file's mtime once.
+        out = real_dumps(*args, **kwargs)
+        if not state["bumped"]:
+            state["bumped"] = True
+            st = target.stat()
+            os.utime(target, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+        return out
+
+    import unittest.mock as _mock
+
+    with _mock.patch.object(mod.json, "dumps", _dumps_then_touch):
+        result = mod.generate_all_mcp_servers(tmp_path)
+
+    assert result.generated == []
+    assert [(r[0], r[2]) for r in result.skipped] == [("project_mcp", skip_codes.TARGET_CONFLICT)]
+    # Untouched: still only the pre-existing entry, demo NOT merged in.
+    written = json.loads(target.read_text(encoding="utf-8"))
+    assert written["mcpServers"] == {"other": {"command": "node"}}


### PR DESCRIPTION
## Problem

`generate_all_mcp_servers` did a read → merge (foreign `mcpServers` entries preserved verbatim) → write of the **shared** project `.mcp.json` with **no cross-process lock** and **no concurrent-write guard**. Its structural twin `generate_all_settings` wraps the identical read-merge-write of a shared config in a per-target `_file_lock` + `st_mtime_ns` recheck (the #1123 lost-update fix); the mcp path never got it. The web route serializes with the in-process `_gateway_lock` only, so a CLI `mm context sync --include=mcp-servers` racing the web sync (or two `mm` processes) could silently drop each other's entries.

Found by the 2026-07-02 context/wiki review (sync-engines dimension), adversarially CONFIRMED.

## Fix

- Wrap the read-merge-write in `_file_lock(_lock_path_for(target))` with a bounded 30s budget (`_MCP_LOCK_BUDGET_S`, the settings `_SETTINGS_LOCK_BUDGET_S` twin, #1145 shape). The canonical scan/parse stays **outside** the lock (slow work out, invariant in). On budget exhaustion the sync self-aborts with a typed `LOCK_TIMEOUT` skip instead of blocking a thread-offloaded caller.
- Keep an `st_mtime_ns` recheck inside the lock (0-sentinel form, #1382) as a second layer catching a non-locking direct editor save mid-merge → `TARGET_CONFLICT` skip, writes nothing.
- Ride-along: `generate_all_skills`' `runtimes=None` docstring claimed claude+gemini, but four generators are registered (claude/gemini/codex/kimi) — corrected.

## Tests

Two regressions, **mutation-validated** (both RED against the unfixed engine, green after): sidecar lock held → `LOCK_TIMEOUT` skip + nothing written (expiry-direction timing, no false-pass); concurrent mtime bump mid-merge → `TARGET_CONFLICT` skip + file untouched. mcp engine/CLI/web/copy/privacy suites = 79 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
