### PR TITLE
security(privacy): forward-sync the AWS secret-material label rule from memtomem-stm#553

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Security
 
+- **AWS secret material is redacted by label (`SECRET_ACCESS_KEY` /
+  `SESSION_TOKEN`) — forward-sync of memtomem-stm#553.** The redaction guard
+  caught AWS key **IDs** (`AKIA`/`ASIA`) but not the secret **material** those
+  IDs unlock: `secret[_-]?key` needs its two words adjacent
+  (`secret_access_key` splits them) and `access[_-]?token` needs the literal
+  `access` (`session_token` has neither), so an STS AssumeRole JSON or an
+  `env`-dump note could cross the write boundary unredacted. One new
+  `DEFAULT_PATTERNS` rule (STM-origin, mirrored forward — the inverse of the
+  #1488→#1491 reverse-sync) with two alternatives: a quoted-key form
+  (`"SessionToken": "…"` — STS JSON / dict repr / kebab-case serialized
+  headers; the quote must sit directly on both sides of the label and the
+  value must open as a string, so JSON-Schema properties and prefixed keys
+  never fire) and an unquoted label form (`AWS_SECRET_ACCESS_KEY=`,
+  `aws_session_token =`, TOML `aws.secret_access_key =`, namespaced
+  `TF_VAR_aws_secret_access_key=`) carrying a left boundary so identifiers
+  that merely embed the label (`get_session_token:`,
+  `supports_session_token:`, `rotateSecretAccessKey:`) don't trip the guard.
+  The two sides are byte-identical again at 17 patterns (STM pin
+  memtomem-stm@`5ab5467`); the pattern translates cleanly to the Web UI's
+  client-side JS scan (fixed-width lookbehinds, ES2018+).
+
 - **Bulk folder indexing now enforces the secret-redaction trust boundary
   (ADR-0006 PR-A).** Previously `mm reindex`, the Web UI Index / Sources flows
   (`trigger_index`, `reindex_all`, `memory-dirs/add` auto-index, `index_stream`),

--- a/packages/memtomem/src/memtomem/privacy.py
+++ b/packages/memtomem/src/memtomem/privacy.py
@@ -1,17 +1,19 @@
 """Content redaction guard at the LTM trust boundary.
 
 The pattern set has two provenance tiers, both secret-class only. As of
-STM commit ``8c884cb`` the two sides are in sync: this module's 16
+STM commit ``5ab5467`` the two sides are in sync: this module's 17
 secret-class patterns are byte-identical to memtomem-stm
 ``proxy/privacy.py:CREDENTIAL_PATTERNS``.
 
-1. **STM-synced subset** (9 patterns) — originally mirrored from
-   memtomem-stm. The SHA above tracks the STM commit this module is
+1. **STM-synced subset** (10 patterns) — originally mirrored from
+   memtomem-stm; the AWS secret-material label rule (memtomem-stm#553)
+   is the first STM-origin addition forward-synced after the #1491
+   reverse mirror. The SHA above tracks the STM commit this module is
    audited-consistent with (history: ``a98636e`` -> ``3e585b5`` ->
-   ``8c884cb``). STM's full set also carries PII patterns (email, etc.);
-   those are excluded here by design because PII false positives on prose
-   ingress would be unworkable — they live in STM's separate
-   ``PII_PATTERNS`` list.
+   ``8c884cb`` -> ``5ab5467``). STM's full set also carries PII patterns
+   (email, etc.); those are excluded here by design because PII false
+   positives on prose ingress would be unworkable — they live in STM's
+   separate ``PII_PATTERNS`` list.
 
 2. **LTM-origin additions** (7 patterns, issue #1488) — secret-class
    provider-token patterns added at this trust boundary first, ahead of
@@ -69,6 +71,35 @@ logger = logging.getLogger(__name__)
 DEFAULT_PATTERNS: tuple[str, ...] = (
     r"(?i)(api[_-]?key|secret[_-]?key|access[_-]?token)\s*[:=]",
     r"(?i)(password|passwd|pwd)\s*[:=]",
+    # AWS secret material by label (STM-origin; forward-synced from
+    # memtomem-stm#553). The generic label rule above misses both spellings
+    # the AWS toolchain actually emits: ``secret[_-]?key`` needs its two
+    # words adjacent (``secret_access_key`` splits them) and
+    # ``access[_-]?token`` needs the literal ``access`` (``session_token``
+    # has neither). Two alternatives in one rule:
+    #
+    # - quoted form — ``"SessionToken": "…"`` / ``"SecretAccessKey": "…"``
+    #   (STS JSON, python-dict repr, kebab-case serialized headers). The
+    #   quote must sit DIRECTLY on both sides of the label and the value
+    #   must open as a string, so a JSON-Schema property
+    #   (``"session_token": {"type"…`` — object value) and a prefixed key
+    #   (``"aws.get_session_token": "unhealthy"``) never fire.
+    # - unquoted form — ``AWS_SECRET_ACCESS_KEY=`` / ``aws_session_token =``
+    #   (env output, ~/.aws/credentials INI, TOML dotted keys). Carries a
+    #   LEFT boundary — token start (``SESSION_TOKEN=``, namespaced
+    #   ``TF_VAR_aws_secret_access_key=``) or a directly preceding ``aws``
+    #   separator (``aws.secret_access_key =``) — so identifiers that
+    #   merely EMBED the label (``get_session_token: unhealthy``,
+    #   ``supports_session_token: true``, ``rotateSecretAccessKey: done``)
+    #   don't fire. A plain optional ``(?:aws[_-])?`` prefix instead of
+    #   the lookbehind pair would drop the namespaced env-var forms, so
+    #   don't "simplify" it that way.
+    #
+    # The AKIA/ASIA rule below catches the key *IDs*; this one catches the
+    # *material* those IDs unlock.
+    r"(?i)(?:[\"'](?:secret[_-]?access[_-]?key|session[_-]?token)[\"']\s*:\s*[\"']"
+    r"|(?:(?<![A-Za-z0-9_.-])|(?<=aws[._-]))"
+    r"(?:secret[_-]?access[_-]?key|session[_-]?token)\s*[:=])",
     # Provider-prefixed token formats. Anchored by prefix so false positives
     # on arbitrary high-entropy strings are rare.
     r"(?i)(sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|xox[bps]-[0-9A-Za-z-]+)",

--- a/packages/memtomem/tests/test_privacy.py
+++ b/packages/memtomem/tests/test_privacy.py
@@ -40,10 +40,11 @@ def _reset_counters():
 
 class TestPatternSurface:
     def test_pattern_count_pinned(self):
-        # 9 STM-synced secret-class patterns + 7 LTM-origin additions
-        # (#1488). Bump deliberately when adding a pattern so a silent
-        # add/drop surfaces here.
-        assert len(privacy.DEFAULT_PATTERNS) == 16
+        # 10 STM-synced secret-class patterns (incl. the memtomem-stm#553
+        # AWS-label forward-sync) + 7 LTM-origin additions (#1488). Bump
+        # deliberately when adding a pattern so a silent add/drop surfaces
+        # here.
+        assert len(privacy.DEFAULT_PATTERNS) == 17
 
     @pytest.mark.parametrize(
         "clean_input",
@@ -363,46 +364,50 @@ _PATTERN_FIXTURES: tuple[tuple[str, str], ...] = (
     ("API_KEY: abc123", "api keys are documented separately"),
     # 1: password/passwd/pwd
     ("Password = hunter2", "passport renewal next month"),
-    # 2: sk-/ghp_/xox prefix
+    # 2: AWS secret-material label (memtomem-stm#553 forward-sync).
+    #    Negative: an identifier that embeds the label — the unquoted
+    #    branch's left boundary must reject it.
+    ('"SessionToken": "FAKEFwoGZXIvYXdzFAKE"', "supports_session_token: true"),
+    # 3: sk-/ghp_/xox prefix
     ("token=sk-" + "a" * 30, "Sky color today is blue"),
-    # 3: github_pat_
+    # 4: github_pat_
     ("github_pat_" + "x" * 30, "github_user joined the org"),
-    # 4: stripe-style sk_live_, pk_test_, whsec_
+    # 5: stripe-style sk_live_, pk_test_, whsec_
     ("sk_live_" + "a" * 25, "sk_live_short"),
-    # 5: npm_
+    # 6: npm_
     ("npm_" + "a" * 30, "npm install foo"),
-    # 6: AWS access key id (AKIA/ASIA)
+    # 7: AWS access key id (AKIA/ASIA)
     ("AKIAIOSFODNN7EXAMPLE", "AKIA-no-good"),
-    # 7: JWT
+    # 8: JWT
     ("eyJhbGciOiJIUzI1NiJ9.eyJzdWIicm9vdA.SflKxwRJSMeK", "eyJ-not-a-jwt"),
-    # 8: PEM private key header
+    # 9: PEM private key header
     ("-----BEGIN RSA PRIVATE KEY-----", "RSA public key"),
-    # 9: OpenAI modern (sk-proj-/svcacct-/admin-, T3BlbkFJ-anchored).
-    #    Negative: a kebab slug with the prefix but no marker.
+    # 10: OpenAI modern (sk-proj-/svcacct-/admin-, T3BlbkFJ-anchored).
+    #     Negative: a kebab slug with the prefix but no marker.
     (
         "sk-proj-FAKE0aaaa1111bbbb2222cccc3333T3Blbk" + "FJEXAMPLE0dddd4444eeee5555ffff6666",
         "sk-project-management-tool",
     ),
-    # 10: Anthropic (sk-ant-NN-, exact 93-char body + AA). Negative: a
+    # 11: Anthropic (sk-ant-NN-, exact 93-char body + AA). Negative: a
     #     digit-bearing kebab slug carrying the infix (a loose body matched
     #     it; the exact length + AA terminal rejects it).
     (
         "sk-ant-api03-" + ("FAKEfake0123456789" * 6)[:93] + "AA",
         "sk-ant-api03-release-notes-2026-migration-guide",
     ),
-    # 11: GitHub gh*_ family completion. Negative: an English word that
+    # 12: GitHub gh*_ family completion. Negative: an English word that
     #     starts "gho" but is not a gho_ token.
     ("ghs_FAKEfake0123456789FAKEfake0123456789", "ghost_writer_mode_enabled"),
-    # 12: Google API key (AIza + exactly 35). Negative: too short.
+    # 13: Google API key (AIza + exactly 35). Negative: too short.
     ("AIzaSy0_-BcdSy0_-BcdSy0_-BcdSy0_-BcdSy0", "AIzaShortKey"),
-    # 13: GitLab PAT (glpat-, exact 20-char body). Negative: a digit-bearing
+    # 14: GitLab PAT (glpat-, exact 20-char body). Negative: a digit-bearing
     #     "glpat-" kebab slug (a {20,} superset matched it; exact length
     #     rejects it).
     ("glpat-" + ("FAKEfake0123456789" * 2)[:20], "glpat-form-builder-component-name-2026"),
-    # 14: Hugging Face (hf_ + exactly 34, digit-guarded). Negative: a
+    # 15: Hugging Face (hf_ + exactly 34, digit-guarded). Negative: a
     #     34-char letter-only run (no digit) directly after hf_.
     ("hf" + "_FAKEfake0123456789FAKEfake01234567", "hf" + "_abcdefghijklmnopqrstuvwxyzabcdefgh"),
-    # 15: PyPI / TestPyPI macaroon token. Negative: the prefix without the
+    # 16: PyPI / TestPyPI macaroon token. Negative: the prefix without the
     #     fixed base64 header.
     (
         "pypi-AgEIcHlwaS5vcmcFAKEfake0123456789FAKEfake0123456789FAKEfake0123456789",
@@ -621,18 +626,20 @@ class TestNewSecretPatterns1488:
     @pytest.mark.parametrize("text", _NEW_PATTERN_NEAR_MISSES)
     def test_new_pattern_near_miss_does_not_hit(self, text):
         # The contract is "no false positive from the #1488 additions"
-        # (indices >= 9). A near-miss may legitimately stay clean of the
-        # legacy 0-8 rules too, but those are pinned elsewhere; here we
+        # (indices >= 10 since the memtomem-stm#553 forward-sync inserted
+        # at index 2). A near-miss may legitimately stay clean of the
+        # earlier 0-9 rules too, but those are pinned elsewhere; here we
         # isolate the new set so a future loosening surfaces precisely.
-        offending = [h.pattern_index for h in privacy.scan(text) if h.pattern_index >= 9]
+        offending = [h.pattern_index for h in privacy.scan(text) if h.pattern_index >= 10]
         assert not offending, f"#1488 pattern(s) {offending} false-positived on {text[:50]!r}"
 
     def test_ghp_still_covered_by_legacy_not_duplicated(self):
-        # ghp_ stays the legacy index-2 rule's job; the new gh[ousr]_
-        # pattern (index 11) deliberately excludes 'p' to avoid a
+        # ghp_ stays the legacy sk-/ghp_/xox rule's job (index 3 since the
+        # memtomem-stm#553 forward-sync inserted at index 2); the new
+        # gh[ousr]_ pattern (index 12) deliberately excludes 'p' to avoid a
         # duplicate hit. Locks the dedup intent + guards against the
         # change accidentally dropping ghp_ coverage.
         ghp = "ghp_" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"  # ghp_ + 36 base62
         idxs = {h.pattern_index for h in privacy.scan(ghp)}
-        assert 2 in idxs, "ghp_ must still be caught by the legacy index-2 rule"
-        assert 11 not in idxs, "gh[ousr]_ (index 11) must exclude 'p' — no duplication"
+        assert 3 in idxs, "ghp_ must still be caught by the legacy sk-/ghp_/xox rule"
+        assert 12 not in idxs, "gh[ousr]_ (index 12) must exclude 'p' — no duplication"

--- a/packages/memtomem/tests/test_privacy_long_content.py
+++ b/packages/memtomem/tests/test_privacy_long_content.py
@@ -110,10 +110,11 @@ class TestLongContentScan:
     def test_one_megabyte_scan_under_perf_ceiling(self):
         # Soft ceiling — not a microbenchmark, just a non-linear-regression
         # guard. ``scan()`` runs one ``re.finditer`` pass per pattern, so cost
-        # grows linearly with the pattern count: the 16 short prefix-anchored
+        # grows linearly with the pattern count: the 17 short prefix-anchored
         # ``DEFAULT_PATTERNS`` take ~100 ms locally and ~200 ms on a loaded CI
         # runner for a 1 MB input (#1488 grew the set 9 -> 16, each added
-        # secret class a linear pass — no single hot spot). The 500 ms ceiling
+        # secret class a linear pass — no single hot spot; the
+        # memtomem-stm#553 forward-sync makes it 17). The 500 ms ceiling
         # — matching ``test_crafted_repetition_scans_linearly`` below — keeps
         # ~2x headroom over that worst case while still catching a genuine
         # non-linear rewrite (e.g. a naive overlap-window scan that re-reads


### PR DESCRIPTION
## Summary

First STM-origin secret-class addition since the #1488→#1491 reverse mirror, flowing the other way per the module's asymmetric sync rule: the redaction guard caught AWS key **IDs** (`AKIA`/`ASIA`) but not the secret **material** those IDs unlock — `secret[_-]?key` needs its two words adjacent (`secret_access_key` splits them) and `access[_-]?token` needs the literal `access` (`session_token` has neither) — so an STS AssumeRole JSON or an env-dump note crossed the write boundary unredacted.

## Change

- **`privacy.py`**: the memtomem-stm#553 rule inserted at **index 2, matching STM's order**, so the two sets are byte-identical again — 17 patterns, STM pin `5ab5467` (verified by an elementwise import-level comparison of both modules). Docstring: tier-1 subset 9→10, SHA-pin history `a98636e → 3e585b5 → 8c884cb → 5ab5467`.
- **Rule shape** (final post-review form from the STM side): a quoted-key branch (STS JSON / dict repr / kebab serialized headers; quote directly on both sides + string-opening value, so JSON-Schema properties and prefixed telemetry keys never fire) and an unquoted label branch with a **left boundary** — token start or a directly preceding `aws` separator — so identifiers embedding the label (`get_session_token:`, `supports_session_token:`, `rotateSecretAccessKey:`) don't trip the guard, while namespaced env forms (`TF_VAR_aws_secret_access_key=`) still do.
- **Index shift fallout**: #1488 additions move to indices ≥ 10, the legacy `sk-/ghp_/xox` rule to index 3 — the index-pinned tests (`test_ghp_still_covered…`, the ≥ 9 isolation filter) and the `_PATTERN_FIXTURES` numbering are updated, and the new pattern gets its JS-translation parity fixture.
- **JS client scan**: the pattern uses fixed-width lookbehinds — `to_js_pattern` passes it through and the parity test covers it (ES2018+ in the browser).
- **CHANGELOG**: Unreleased Security entry.

## Verification

- Byte-identical: `tuple(ltm.DEFAULT_PATTERNS) == tuple(stm.CREDENTIAL_PATTERNS)` → `True` (17 = 17, no elementwise mismatch).
- Full suite: 7472+ passed; the only failures during bring-up were the pre-existing wiki home-fallback class — resolved by rebasing onto #1507 — plus 4 order-dependent flakes that pass in isolation, none touching privacy.
- `ruff check` / `ruff format --check` clean on changed files.

Closes the divergence window opened by memtomem-stm#553; the content-hash pin proposed in memtomem-stm#559 can now land with the sets equal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)