### PR TITLE
fix(wiki): preserve the executable bit when committing wiki edits

### DIFF
--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -570,7 +570,9 @@ class WikiStore:
         2. Each target's bytes are stored byte-exact (``hash-object -w
            --no-filters``, so override Invariant 4 holds despite any repo
            ``.gitattributes`` eol/clean filters) and staged via
-           ``update-index --add --cacheinfo``.
+           ``update-index --add --cacheinfo`` under a mode resolved by
+           :meth:`_commit_blob_mode` (the exec bit is preserved, not
+           hardcoded to 100644 — see that method).
         3. ``write-tree`` + ``commit-tree`` build the commit using the wiki
            repo's own git identity (memtomem injects none).
         4. ``update-ref <branch> <new> <expected_head>`` is a compare-and-swap:
@@ -608,13 +610,14 @@ class WikiStore:
             blob_file = tmpdir / "blob"
             for rel, data in files.items():
                 _require_clean_rel(rel)
+                mode = self._commit_blob_mode(rel, head)
                 blob_file.write_bytes(data)
                 blob = _git(
                     ["hash-object", "-w", "--no-filters", str(blob_file)],
                     cwd=self.root,
                 ).stdout.strip()
                 _git(
-                    ["update-index", "--add", "--cacheinfo", f"100644,{blob},{rel}"],
+                    ["update-index", "--add", "--cacheinfo", f"{mode},{blob},{rel}"],
                     cwd=self.root,
                     env=env,
                 )
@@ -647,6 +650,57 @@ class WikiStore:
             return new
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def _commit_blob_mode(self, rel: str, head: str) -> str:
+        """Resolve the git blob mode to stage for *rel* — ``100644`` or ``100755``.
+
+        The temp index is seeded from HEAD, but ``update-index --cacheinfo``
+        overwrites the entry's mode, so a hardcoded ``100644`` silently strips
+        the exec bit from an executable script (e.g. ``skills/<n>/scripts/run.sh``
+        at ``100755`` in HEAD) — it extracts non-runnable on the next
+        ``mm context install`` (ADR-0027 commits the SAVED bytes of a resolved
+        target; the mode must ride along with them).
+
+        Semantics — **disk-first**, mirroring ``git add`` / ``core.filemode``:
+
+        * On POSIX, take the exec bit from the on-disk file (``self.root / rel``
+          — the exact file the caller read the saved bytes from; both callers
+          build ``rel`` as ``path.relative_to(store.root)``). This picks up a
+          ``chmod +x`` the same way ``git add`` would. ``os.access(_, X_OK)`` is
+          umask-independent and reflects the real bit.
+        * On Windows the filesystem carries no exec bit (git's ``core.filemode``
+          is false there), so fall back to HEAD's recorded mode — committing an
+          edit to a ``100755`` file from Windows must not flip it to ``100644``.
+        * A path not tracked at HEAD (brand-new file) with no usable on-disk
+          mode defaults to ``100644``.
+
+        Only regular-file blobs (``100644`` / ``100755``) are in scope. A
+        ``120000`` (symlink) or ``160000`` (gitlink) entry at HEAD is refused
+        loudly — ``commit_paths`` stages saved *regular-file* bytes (the editor
+        writes plain files; Save targets are server-resolved regular paths), so
+        committing those bytes under a symlink/gitlink mode would corrupt the
+        entry. Silent-rewrite is worse than a hard failure here.
+        """
+        head_mode = self._head_blob_mode(rel, head)
+        if head_mode is not None and head_mode not in ("100644", "100755"):
+            raise ValueError(
+                f"refusing to commit {rel!r}: HEAD mode {head_mode} is not a "
+                "regular file (only 100644/100755 blobs are committable)"
+            )
+        disk = self.root / PurePosixPath(rel)
+        if os.name != "nt" and disk.is_file() and not disk.is_symlink():
+            return "100755" if os.access(disk, os.X_OK) else "100644"
+        return head_mode or "100644"
+
+    def _head_blob_mode(self, rel: str, head: str) -> str | None:
+        """Git file mode recorded for *rel* at *head*, or ``None`` if untracked.
+
+        Parses the mode column of ``git ls-tree <head> -- <rel>`` (empty output
+        means the path is absent at that commit — a brand-new file)."""
+        out = _git(["ls-tree", head, "--", rel], cwd=self.root).stdout
+        if not out.strip():
+            return None
+        return out.split(maxsplit=1)[0]
 
     def copy_asset_at_commit(
         self,

--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import subprocess
 from pathlib import Path
 
@@ -658,3 +659,90 @@ class TestCommitPaths:
         head = store.current_commit()
         with pytest.raises(ValueError):
             store.commit_paths({"../evil": b"x\n"}, message="e", expected_head=head)
+
+    # ── file-mode preservation (exec bit) ──────────────────────────────────
+    # commit_paths must not hardcode 100644: an edit to a script that is
+    # executable in HEAD would silently lose its +x, so ``mm context install``
+    # extracts a non-runnable script.
+
+    def _mode_at(self, wiki_root: Path, commit: str, rel: str) -> str:
+        """Git file mode recorded for *rel* at *commit* (e.g. ``100755``)."""
+        out = subprocess.run(
+            ["git", "-C", str(wiki_root), "ls-tree", commit, "--", rel],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert out.strip(), f"{rel} not tracked at {commit[:12]}"
+        return out.split(maxsplit=1)[0]
+
+    def _seed_exec_script(self, wiki_root: Path, rel: str, body: bytes) -> tuple[WikiStore, str]:
+        """Seed + commit an executable (0755) file so HEAD records 100755."""
+        store = self._seed(wiki_root)
+        path = wiki_root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(body)
+        path.chmod(0o755)
+        # ``--chmod=+x`` forces the 100755 index entry regardless of the repo's
+        # core.filemode, so HEAD reliably records the exec bit on any host.
+        subprocess.run(["git", "-C", str(wiki_root), "add", rel], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(wiki_root), "update-index", "--chmod=+x", rel],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(wiki_root), "commit", "-m", "add exec script"],
+            check=True,
+            capture_output=True,
+        )
+        return store, store.current_commit()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX exec bit is not modelled on Windows")
+    def test_edit_preserves_exec_bit(self, wiki_root: Path) -> None:
+        """Editing a file that is 100755 in HEAD keeps 100755 (regression)."""
+        rel = "skills/foo/scripts/run.sh"
+        store, head = self._seed_exec_script(wiki_root, rel, b"#!/bin/sh\necho v1\n")
+        assert self._mode_at(wiki_root, head, rel) == "100755"  # precondition
+        new = store.commit_paths({rel: b"#!/bin/sh\necho v2\n"}, message="edit", expected_head=head)
+        assert self._mode_at(wiki_root, new, rel) == "100755"
+
+    def test_new_path_defaults_to_regular_mode(self, wiki_root: Path) -> None:
+        """A brand-new (untracked-at-HEAD) path is committed as 100644."""
+        store = self._seed(wiki_root)
+        head = store.current_commit()
+        rel = "agents/beta/overrides/gemini.md"
+        (wiki_root / "agents" / "beta" / "overrides").mkdir()
+        (wiki_root / rel).write_text("ov\n", encoding="utf-8")
+        new = store.commit_paths({rel: b"ov\n"}, message="add override", expected_head=head)
+        assert self._mode_at(wiki_root, new, rel) == "100644"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX exec bit is not modelled on Windows")
+    def test_chmod_plus_x_on_disk_gains_exec_bit(self, wiki_root: Path) -> None:
+        """A 100644 file chmod'd +x on disk before commit is committed as 100755
+        (disk-first, mirroring ``git add`` / ``core.filemode``)."""
+        store = self._seed(wiki_root)  # agents/beta/agent.md is 100644 in HEAD
+        head = store.current_commit()
+        rel = "agents/beta/agent.md"
+        assert self._mode_at(wiki_root, head, rel) == "100644"  # precondition
+        (wiki_root / rel).chmod(0o755)
+        new = store.commit_paths({rel: b"v2\n"}, message="edit", expected_head=head)
+        assert self._mode_at(wiki_root, new, rel) == "100755"
+
+    @pytest.mark.skipif(os.name == "nt", reason="symlink modes are not modelled on Windows")
+    def test_refuses_symlink_head_mode(self, wiki_root: Path) -> None:
+        """A 120000 (symlink) entry at HEAD is refused loudly, never silently
+        rewritten into a regular blob."""
+        store = self._seed(wiki_root)
+        rel = "agents/beta/link.md"
+        (wiki_root / rel).symlink_to("agent.md")
+        subprocess.run(["git", "-C", str(wiki_root), "add", rel], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(wiki_root), "commit", "-m", "add symlink"],
+            check=True,
+            capture_output=True,
+        )
+        head = store.current_commit()
+        assert self._mode_at(wiki_root, head, rel) == "120000"  # precondition
+        with pytest.raises(ValueError, match="regular file"):
+            store.commit_paths({rel: b"clobber\n"}, message="edit", expected_head=head)


### PR DESCRIPTION
## Problem
`WikiStore.commit_paths` seeds its temp index from HEAD (`read-tree`) but then stages every target with a hardcoded `update-index --cacheinfo 100644,<blob>,<rel>`, overwriting the HEAD mode. Committing an edit to a file that is executable in HEAD (e.g. `skills/<name>/scripts/run.sh` at 100755) silently drops it to 100644 — the script loses its exec bit on the next `mm context install` extraction. Found by the 2026-07-02 review (wiki-engine dimension).

## Fix
New `_commit_blob_mode` / `_head_blob_mode` helpers resolve the mode per target, **disk-first with HEAD fallback** (mirrors `git add` / `core.filemode`): POSIX reads the exec bit from the on-disk file (provably the same file whose saved bytes the caller read — both callers build `rel` as `path.relative_to(store.root)`); Windows (no fs exec bit) falls back to HEAD's recorded mode so a 100755 file doesn't flip when committed there; a new path defaults to 100644. A `120000`/`160000` (symlink/gitlink) HEAD entry raises `ValueError` rather than committing regular bytes under a special mode (defense-in-depth; Save targets are server-resolved regular files).

## Tests
RED-first in `TestCommitPaths`: edit preserves 100755; `chmod +x` on disk gains it; symlink HEAD mode refused; new path defaults 100644. POSIX-gated per suite convention. Pre-fix 3 failed/1 passed → 9 passed. wiki commit/store/cmd/mutations suites = 137 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
