### PR TITLE
fix(context): verify pin ancestry before reporting a wiki 'behind' update

### DIFF
--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -734,6 +734,15 @@ def _update_asset(
     new_commit = wiki.current_commit()
     dest = project_root / ".memtomem" / asset_type / validated
 
+    # RESIDUAL (follow-up): update moves the pin to HEAD whenever it differs
+    # from the recorded pin, WITHOUT checking that HEAD descends from it. After
+    # a wiki reset / force-pull to older-or-divergent history HEAD is behind (or
+    # off to the side of) the pin, so this would move the pin BACKWARD — a
+    # silent downgrade, the same forward-only gap `classify_status` now guards
+    # against via `WikiStore.commit_is_ancestor`. Fixing it here (and in
+    # `_classify_for_all_update`'s preview parity) needs a new refuse verdict
+    # threaded through both the single-asset and `--all` state machines, so it
+    # is deliberately left out of the status-classification change.
     if lock_entry.get("wiki_commit") == new_commit:
         # True no-op: lockfile bytes untouched, installed_at echoed.
         return UpdateResult(

--- a/packages/memtomem/src/memtomem/context/status.py
+++ b/packages/memtomem/src/memtomem/context/status.py
@@ -9,7 +9,11 @@ run in cron pipes (``mm context status && mm context update --all``).
 State semantics for each lockfile entry:
 
 - ``ok`` — dest clean, lockfile pin reachable in wiki, pin == HEAD
-- ``behind`` — dest clean, pin reachable, pin != HEAD ("update available")
+- ``behind`` — dest clean, pin reachable AND an ancestor of HEAD, pin !=
+  HEAD ("update available"). Ancestry is required, not just reachability:
+  after a wiki reset / force-pull to older history the pin is reachable but
+  NEWER than (or divergent from) HEAD, so ``mm context update`` would move
+  the pin BACKWARD — that case is ``stale-pin``, not ``behind``
 - ``dirty`` — dest has local edits since ``installed_at``
 - ``missing`` — lockfile entry exists but ``<project>/.memtomem/<type>/<name>/``
   is gone (collapses :data:`memtomem.context.dirty.DirtyReport.reason`
@@ -18,7 +22,10 @@ State semantics for each lockfile entry:
   asset, the row's reason points at ``mm context migrate`` instead of
   claiming "dest missing" (#1247)
 - ``stale-pin`` — wiki absent or unusable, OR pin not reachable in the
-  wiki repo (history rewrite, force-push past the pin, etc.)
+  wiki repo (history rewrite, force-push past the pin, etc.), OR pin
+  reachable but NOT an ancestor of HEAD (wiki reset / force-pull to
+  older/divergent history — the pin is newer/divergent, so "updating"
+  would silently downgrade it)
 - ``untracked`` — project_shared canonical on disk with no lockfile entry
   (reverse-imported via ``mm context init`` or moved in via ``mm context
   migrate --to project_shared``); actively served by sync fan-out, just
@@ -144,8 +151,11 @@ def classify_status(
     well-formed entries; the corrupt case is the caller's to surface.
 
     Wiki reachability: probed once per entry via
-    :meth:`WikiStore.commit_is_reachable`. When the wiki is absent,
-    that method isn't called.
+    :meth:`WikiStore.commit_is_reachable`, then — only for a reachable pin
+    that differs from HEAD — :meth:`WikiStore.commit_is_ancestor` decides
+    ``behind`` (pin is an ancestor of HEAD, update available) vs ``stale-pin``
+    (pin reachable but diverged; "updating" would downgrade). When the wiki is
+    absent, neither method is called.
     """
     project_root_path = Path(project_root).expanduser()
     lockfile = Lockfile.at(project_root_path)
@@ -229,12 +239,25 @@ def classify_status(
                 reason = "lockfile entry missing wiki_commit"
             elif pin_commit == wiki_head:
                 state = "ok"
-            elif wiki.commit_is_reachable(pin_commit):
+            elif not wiki.commit_is_reachable(pin_commit):
+                state = "stale-pin"
+                reason = f"pin {pin_commit[:12]} not reachable"
+            elif wiki.commit_is_ancestor(pin_commit):
+                # Reachable AND an ancestor of HEAD → HEAD genuinely advanced
+                # past the pin; an update is available.
                 state = "behind"
                 reason = "wiki advanced past pin"
             else:
+                # Reachable but NOT an ancestor of HEAD: the wiki was reset or
+                # force-pulled to older/divergent history, so the pin is
+                # newer/divergent and `mm context update` would move it BACKWARD
+                # (a silent downgrade). Not "behind" — surface it as drift so
+                # the user investigates instead of "updating" into a downgrade.
+                # Folds into stale-pin ("history rewrite, force-push past the
+                # pin, etc.") rather than a new state — keeps the 7-key
+                # state-count conservation contract intact (#1280).
                 state = "stale-pin"
-                reason = f"pin {pin_commit[:12]} not reachable"
+                reason = "wiki history diverged from pin (reset or force-pull?)"
 
         rows.append(
             StatusRow(

--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -527,6 +527,42 @@ class WikiStore:
         )
         return result.returncode == 0
 
+    def commit_is_ancestor(self, commit: str, of: str = "HEAD") -> bool:
+        """``True`` when *commit* is an ancestor of *of* (default wiki HEAD).
+
+        Uses ``git merge-base --is-ancestor <commit> <of>``: exit 0 means
+        *commit* is reachable from *of* along the commit graph (a commit is
+        its own ancestor, so ``commit == of`` also returns ``True``), exit 1
+        means it is not. Any OTHER exit code — 128 for a bad/unknown object or
+        a broken repo, or anything git may return in future — is treated as
+        "not an ancestor" (``False``), mirroring :meth:`commit_is_reachable`'s
+        conservatism so ``mm context status`` degrades instead of crashing on
+        garbage input.
+
+        This is the forward-only guard :meth:`commit_is_reachable` does NOT
+        provide: reachability only proves the pin's object still EXISTS, not
+        that HEAD descends from it. After a wiki reset / force-pull to older
+        or divergent history the pin is newer/divergent — still reachable, but
+        not an ancestor of HEAD — and advancing the pin to HEAD would be a
+        downgrade, not an update. ``mm context status`` uses this to keep such
+        an entry out of the ``behind`` ("update available") bucket.
+
+        *commit* must be a full 40-hex object id for the same pin-contract
+        reason as :meth:`commit_is_reachable`: a symbolic ref (``main``) or an
+        abbreviated SHA must not silently satisfy the ancestry check. *of*
+        defaults to the symbolic ``HEAD`` and is passed through unvalidated —
+        it is the repo's own ref, not a stored pin.
+
+        Raises :class:`WikiNotFoundError` if the wiki itself is missing — the
+        caller decides whether that's a hard error or a graceful-degradation
+        path, exactly as :meth:`commit_is_reachable` does.
+        """
+        self.require_exists()
+        if not commit or _FULL_SHA_RE.fullmatch(commit) is None:
+            return False
+        result = _git_query(["merge-base", "--is-ancestor", commit, of], self.root)
+        return result.returncode == 0
+
     def is_dirty(self) -> bool:
         """``True`` when the wiki working tree has uncommitted modifications.
 

--- a/packages/memtomem/tests/test_context_status.py
+++ b/packages/memtomem/tests/test_context_status.py
@@ -256,6 +256,67 @@ def test_stale_pin_when_history_rewritten(wiki_root: Path, tmp_path: Path) -> No
     assert "not reachable" in (rows[0].reason or "")
 
 
+def test_diverged_pin_reachable_but_not_ancestor_is_not_behind(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """Pin reachable but NOT an ancestor of HEAD → NOT ``behind``.
+
+    After a wiki reset / force-pull to older (or divergent) history the pin
+    is newer than HEAD and no longer an ancestor of it. ``commit_is_reachable``
+    still finds the object, so the pre-fix classifier labelled the row
+    ``behind`` ("update available") — but ``mm context update`` would move the
+    pin BACKWARD to HEAD, a silent downgrade. Status must instead flag it as
+    an attention state (``stale-pin``, history diverged), never ``behind``.
+    """
+    _initialized_wiki(wiki_root)
+    # Baseline commit becomes HEAD after the reset below (== pin~1).
+    base_pin = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    # Advance the wiki and install pinned at the NEWER commit.
+    pin = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    _setup_installed_at_pin(tmp_path, "skills", "foo", {"SKILL.md": b"v2\n"}, pin)
+
+    # Wiki reset/force-pull BACKWARD: HEAD is now an ancestor of the pin, so
+    # the pin is NOT an ancestor of HEAD. No gc → the pin object is still
+    # reachable (this is the reachable-but-diverged case, distinct from the
+    # unreachable force-push-past case above).
+    subprocess.run(
+        ["git", "-C", str(wiki_root), "reset", "--hard", base_pin],
+        check=True,
+        capture_output=True,
+    )
+    wiki = WikiStore.at_default()
+    assert wiki.current_commit() == base_pin
+    assert wiki.commit_is_reachable(pin) is True  # object still present
+
+    head, rows = classify_status(tmp_path)
+
+    assert head == base_pin
+    assert len(rows) == 1
+    assert rows[0].pin_commit == pin
+    assert rows[0].state != "behind"  # RED pre-fix: labelled "behind"
+    assert rows[0].state == "stale-pin"
+    assert "diverg" in (rows[0].reason or "").lower()
+
+
+def test_behind_requires_pin_ancestor_of_head(wiki_root: Path, tmp_path: Path) -> None:
+    """Companion to the divergence test: a normal forward advance (pin IS an
+    ancestor of HEAD) still classifies ``behind`` (update available)."""
+    _initialized_wiki(wiki_root)
+    old_pin = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    _setup_installed_at_pin(tmp_path, "skills", "foo", {"SKILL.md": b"v1\n"}, old_pin)
+    new_head = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    wiki = WikiStore.at_default()
+    assert wiki.commit_is_ancestor(old_pin) is True  # pin is behind HEAD
+
+    head, rows = classify_status(tmp_path)
+
+    assert head == new_head
+    assert len(rows) == 1
+    assert rows[0].state == "behind"
+    assert rows[0].pin_commit == old_pin
+
+
 def test_dirty_takes_priority_over_behind(wiki_root: Path, tmp_path: Path) -> None:
     """If both dirty and pin != HEAD, dirty wins (single state per row)."""
     _initialized_wiki(wiki_root)

--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -373,6 +373,72 @@ class TestCommitIsReachable:
             store.commit_is_reachable("0" * 40)
 
 
+class TestCommitIsAncestor:
+    """``commit_is_ancestor`` — the forward-only guard that distinguishes a
+    genuinely-behind pin (ancestor of HEAD → an update is available) from a
+    pin that is reachable but NOT an ancestor (wiki reset / force-pull to
+    older or divergent history → moving the pin to HEAD would downgrade)."""
+
+    @staticmethod
+    def _commit(root: Path, marker: str) -> str:
+        (root / "marker.txt").write_text(marker, encoding="utf-8")
+        subprocess.run(["git", "-C", str(root), "add", "."], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(root), "commit", "-m", marker],
+            check=True,
+            capture_output=True,
+        )
+        return WikiStore.at_default().current_commit()
+
+    def test_ancestor_of_head_is_true(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        old = self._commit(wiki_root, "c1")
+        self._commit(wiki_root, "c2")  # HEAD advances
+        assert store.commit_is_ancestor(old) is True
+
+    def test_head_is_its_own_ancestor(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        head = self._commit(wiki_root, "c1")
+        # git treats a commit as its own ancestor (rc 0).
+        assert store.commit_is_ancestor(head) is True
+
+    def test_descendant_is_not_ancestor(self, wiki_root: Path) -> None:
+        """The downgrade case: a newer commit is NOT an ancestor of an older
+        ``of`` — moving the pin there would move it backward."""
+        store = WikiStore.at_default()
+        store.init()
+        old = self._commit(wiki_root, "c1")
+        new = self._commit(wiki_root, "c2")
+        assert store.commit_is_ancestor(new, of=old) is False
+
+    def test_unknown_sha_is_not_ancestor(self, wiki_root: Path) -> None:
+        """Bad/unknown object → git exits 128; we degrade to False, not crash."""
+        store = WikiStore.at_default()
+        store.init()
+        assert store.commit_is_ancestor("0" * 40) is False
+
+    def test_empty_string_is_not_ancestor(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        assert store.commit_is_ancestor("") is False
+
+    def test_symbolic_ref_is_not_ancestor(self, wiki_root: Path) -> None:
+        """A symbolic ref / abbreviation must not silently satisfy the pin
+        contract — same conservatism as ``commit_is_reachable``."""
+        store = WikiStore.at_default()
+        store.init()
+        head = store.current_commit()
+        assert store.commit_is_ancestor("main") is False
+        assert store.commit_is_ancestor(head[:12]) is False
+
+    def test_raises_when_wiki_absent(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        with pytest.raises(WikiNotFoundError):
+            store.commit_is_ancestor("0" * 40)
+
+
 class TestCopyAssetAtCommit:
     def test_copies_files_at_pin(self, wiki_root: Path, tmp_path: Path) -> None:
         """Bytes at the pin land in dest, even after wiki HEAD advances."""


### PR DESCRIPTION
## Problem
`classify_status` labelled any clean entry whose pin != wiki HEAD but still *reachable* as `behind` ("update available"). `commit_is_reachable` (`git cat-file -e`) only proves the object exists — not that HEAD descends from it. After a wiki reset/force-pull to older/divergent history the pin is newer/divergent yet still reachable, so status falsely claimed an update and `mm context update` would move the pin **backward** (silent downgrade). Found by the 2026-07-02 review (install-lockfile dimension), CONFIRMED.

## Fix
- `wiki/store.py`: new `commit_is_ancestor(commit, of="HEAD")` via `git merge-base --is-ancestor` (non-raising `_git_query`; rc 0 = ancestor incl. self, rc 1 = not, any other rc / 128 = False so garbage input degrades instead of crashing).
- `context/status.py`: `behind` now requires pin reachable **AND** ancestor-of-HEAD (and != HEAD); reachable-but-not-ancestor reuses the existing **`stale-pin`** bucket with reason "wiki history diverged from pin (reset or force-pull?)". Reusing an existing `DRIFT_STATES` member keeps the 7-key `state_counts` count-conservation contract intact (zero blast radius into renderers/i18n/pins). Forward-only docstring claims updated.

## Residual (documented, not fixed here)
`mm context update` does not gate on `classify_status`; a proper refuse-on-divergence needs a new verdict threaded through the single + `--all` state machines with preview parity (#1247 id 13) — left as a documented comment at the pin-movement site for a follow-up, not a half-fix.

## Tests
RED-first: `TestCommitIsAncestor` (7 cases) + diverged-pin-not-behind + normal-advance-still-behind. status+wiki_store+status-all = 129 passed; update/install = 112; web/cli status = 123. ruff + advisory mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
