### PR TITLE
fix(cli): exit non-zero when generate/sync refuse on a missing context.md

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -1187,7 +1187,11 @@ def generate_cmd(
                 click.echo(f"  {name:10s}  {gen.output_path}")
     elif not inc:
         click.secho(f"{CONTEXT_FILENAME} not found. Run 'mm context init' first.", fg="red")
-        return
+        # Exit non-zero so a script / CI wrapping `mm context generate` can
+        # detect the refusal — this used to `return` and still exit 0. Raise
+        # SystemExit (not ClickException) to keep the red guidance text exactly
+        # as printed, matching the `seed-validation` scan leg's convention.
+        raise SystemExit(1)
     else:
         click.secho(f"  ({CONTEXT_FILENAME} missing — skipping project memory)", fg="yellow")
 
@@ -1359,7 +1363,16 @@ def sync_cmd(
     label: str | None,
     force_unsafe: bool,
 ) -> None:
-    """Sync context.md to all detected agent files."""
+    """Sync context.md + included artifacts to detected agent files.
+
+    Regenerates the detected project-memory files (CLAUDE.md / GEMINI.md /
+    .cursorrules / …) from ``.memtomem/context.md``. For every kind passed via
+    ``--include`` it also fans out the canonical artifacts: skills, agents,
+    commands, settings, and (opt-in) mcp-servers. ``--all-projects`` syncs
+    every enrolled/discovered project (project_shared tier only); ``--scope`` /
+    ``--label`` pick the artifact tier; ``--force-unsafe`` bypasses Gate A on a
+    reviewed false positive (user / project_local destinations only).
+    """
     # sync accepts mcp-servers on top of the shared kinds (#1311); the other
     # context commands keep the default _KNOWN_INCLUDES set.
     inc = _parse_include(include, allowed=_SYNC_INCLUDES)
@@ -1389,7 +1402,7 @@ def sync_cmd(
         return
 
     root = _find_project_root()
-    if _run_sync_legs(
+    if not _run_sync_legs(
         root,
         inc=inc,
         strict=strict,
@@ -1399,7 +1412,13 @@ def sync_cmd(
         label=label,
         force_unsafe=force_unsafe,
     ):
-        click.secho("Synced.", fg="green")
+        # _run_sync_legs returns False only on the single-project
+        # missing-context.md refusal (red note already printed, no legs ran).
+        # Exit non-zero so a script / CI wrapping `mm context sync` can detect
+        # it — this used to just skip `Synced.` and still exit 0. Mirrors
+        # generate_cmd; batch mode never reaches the False leg.
+        raise SystemExit(1)
+    click.secho("Synced.", fg="green")
 
 
 def _run_sync_legs(
@@ -1419,8 +1438,9 @@ def _run_sync_legs(
 
     Returns False only on the single-project missing-``context.md`` early
     refusal (no legs ran — the caller must not print ``Synced.``, the
-    historical behavior Codex impl review caught a regression on); True
-    on every path that ran the legs.
+    historical behavior Codex impl review caught a regression on, and now
+    exits non-zero so a script/CI can detect the refusal); True on every
+    path that ran the legs.
 
     The extracted body of ``mm context sync`` — the single-project path
     calls it once with ``batch=False`` and keeps its historical behavior
@@ -5243,7 +5263,7 @@ def projects_resume_cmd(selector: str) -> None:
     "--force",
     is_flag=True,
     default=False,
-    help="Re-seed even if DIRECTORY already contains a .memtomem/ Store.",
+    help="Seed even if DIRECTORY is non-empty (a real project is otherwise never overwritten).",
 )
 @click.option(
     "--json",

--- a/packages/memtomem/tests/test_cli_context_sync_all_projects.py
+++ b/packages/memtomem/tests/test_cli_context_sync_all_projects.py
@@ -402,13 +402,19 @@ def test_single_sync_missing_context_prints_no_false_success(
     """Codex impl-review regression: plain ``mm context sync`` in a project
     with no ``context.md`` and no ``--include`` refuses with the init hint
     and must NOT also print ``Synced.`` — the extracted ``_run_sync_legs``
-    early-return has to keep suppressing the caller's success line."""
+    early-return has to keep suppressing the caller's success line.
+
+    The refusal now also exits non-zero (2026-07-02 cli-surface fix): the
+    single-project ``sync`` used to print the red line and still exit 0, so a
+    script/CI wrapping it could not detect the failure. ``_run_sync_legs``
+    still returns False on this leg; ``sync_cmd`` turns that into
+    ``SystemExit(1)``."""
     a = _project(tmp_path, "proj-a")  # .memtomem exists, no context.md
     _seed_known_projects(known_projects_path, [])
     monkeypatch.chdir(a)
 
     result = CliRunner().invoke(context_group, ["sync"])
-    assert result.exit_code == 0, result.output
+    assert result.exit_code != 0, result.output
     assert "not found. Run 'mm context init' first." in result.output
     assert "Synced." not in result.output
 

--- a/packages/memtomem/tests/test_context_cli_exit_scope.py
+++ b/packages/memtomem/tests/test_context_cli_exit_scope.py
@@ -10,6 +10,15 @@ Each test maps to one audit finding:
   (the code hard-rejects that combination).
 - B2-5: ``memory-migrate`` must reject an explicit non-``.md`` source, matching
   the glob branch's filter and the documented ``.md files`` contract.
+
+Later additions (2026-07-02 cli-surface review):
+
+- A missing ``.memtomem/context.md`` refusal in the *mutating* commands
+  (``generate`` / single-project ``sync``) must exit non-zero — it used to
+  print a red line and still exit 0, so a script/CI wrapping the command
+  could not detect the failure.
+- The ``sync`` one-line summary and the ``seed-validation --force`` help must
+  match what the code actually does (artifact fan-out; any-non-empty guard).
 """
 
 from __future__ import annotations
@@ -79,6 +88,36 @@ class TestGenerateUnknownAgentExitCode:
 
         r = runner.invoke(cli, ["context", "generate", "--agent", "all"])
         assert r.exit_code == 0, f"--agent all should succeed: {r.output}"
+
+
+class TestMissingContextRefusalExitCode:
+    """A missing ``.memtomem/context.md`` refusal in the mutating context
+    commands must exit non-zero, not exit 0 after a red line.
+
+    ``mm context generate`` / single-project ``mm context sync`` with no
+    ``context.md`` and no ``--include`` print
+    ``context.md not found. Run 'mm context init' first.`` in red and used to
+    ``return`` / ``return False`` — leaving exit code 0, so a script or CI
+    wrapping the command saw success. The fix raises ``SystemExit(1)`` after
+    the existing ``secho`` (matching the ``seed-validation`` scan leg), so the
+    exact red guidance text is preserved but the process exits non-zero.
+    """
+
+    def test_generate_missing_context_exits_nonzero(self, tmp_path, monkeypatch):
+        runner, project = _runner_in_project(tmp_path, monkeypatch)
+        # No .memtomem/context.md written (and no --include artifact leg).
+        r = runner.invoke(cli, ["context", "generate"])
+        assert r.exit_code != 0, f"expected failure, got 0: {r.output}"
+        assert "not found. Run 'mm context init' first." in r.output
+
+    def test_sync_missing_context_exits_nonzero(self, tmp_path, monkeypatch):
+        runner, project = _runner_in_project(tmp_path, monkeypatch)
+        # No .memtomem/context.md written (and no --include artifact leg).
+        r = runner.invoke(cli, ["context", "sync"])
+        assert r.exit_code != 0, f"expected failure, got 0: {r.output}"
+        assert "not found. Run 'mm context init' first." in r.output
+        # The refusal must not also print the success line.
+        assert "Synced." not in r.output
 
 
 class TestDiffSettingsHonoursScope:
@@ -171,6 +210,44 @@ class TestMigrateForceHelp:
         help_text = (force_opt.help or "").lower()
         assert "no effect" not in help_text
         assert "--to" in (force_opt.help or "")
+
+
+class TestSyncHelpDocumentsFanout:
+    def test_sync_help_mentions_artifact_kinds(self):
+        """The ``mm context sync`` help used to claim only
+        "Sync context.md to all detected agent files" — stale now that sync
+        also fans out skills / agents / commands / settings (+ opt-in
+        mcp-servers) via ``--include`` and honours --all-projects/--scope/
+        --label/--force-unsafe."""
+        from memtomem.cli.context_cmd import sync_cmd
+
+        help_text = sync_cmd.help or ""
+        assert help_text.strip() != "Sync context.md to all detected agent files."
+        low = help_text.lower()
+        for token in ("skills", "agents", "commands", "settings", "mcp-servers", "--include"):
+            assert token in low, f"sync help should mention {token!r}: {help_text!r}"
+
+    def test_sync_short_help_signals_fanout(self):
+        """The short help (first docstring line — what Click shows in the
+        ``mm context --help`` command list) must mention the artifact fan-out,
+        not just agent files."""
+        from memtomem.cli.context_cmd import sync_cmd
+
+        short = sync_cmd.get_short_help_str(limit=200).lower()
+        assert "artifact" in short, f"sync short help should signal fan-out: {short!r}"
+
+
+class TestSeedValidationForceHelp:
+    def test_force_help_matches_non_empty_guard(self):
+        """The ``seed-validation --force`` help said it re-seeds only when the
+        dir "already contains a .memtomem/ Store", but the guard refuses ANY
+        non-empty directory. The help must match the code."""
+        from memtomem.cli.context_cmd import seed_validation_cmd
+
+        force_opt = next(p for p in seed_validation_cmd.params if p.name == "force")
+        help_text = (force_opt.help or "").lower()
+        assert "already contains a .memtomem" not in help_text
+        assert "non-empty" in help_text
 
 
 class TestMemoryMigrateRejectsNonMarkdownSource:


### PR DESCRIPTION
## Problem
With no context.md, `mm context generate`/`sync` printed a red refusal but exited 0, so a script/CI wrapping them couldn't detect the failure. Found by the 2026-07-02 review (cli-surface dimension), CONFIRMED.

## Fix
Both exact refusal sites now exit non-zero via `raise SystemExit(1)` (the file's existing convention at the seed-validation scan leg — preserves the exact red `secho` text, where a ClickException would reformat to `Error: ...` and break message pins): `generate_cmd` inline, and `sync_cmd` when `_run_sync_legs` returns False (helper's `bool` contract kept; `--all-projects` batch never hits the False leg so it still exits 0 on a per-project missing-context note). The yellow "skipping project memory" warn-then-continue branches stay exit 0. A read-only `diff_cmd` near-match (different, shorter message) was left untouched and reported.

## Ride-alongs
- `mm context sync` one-line help expanded to signal the `--include` artifact fan-out + `--all-projects`/`--scope`/`--label`/`--force-unsafe` (was Phase-1-only, stale).
- seed-validation `--force` help corrected to match the any-non-empty-dir guard.

## Tests
RED-first (6 failed → passed): generate/sync exit non-zero + red text preserved; sync help mentions fan-out; force-help matches guard. Flipped one stale pin (exit 0 → non-zero). CLI context + `test_docs_guards.py` = 80 passed; end-to-end verified in an isolated project; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
