### PR TITLE
fix(web): close two non-UTF-8 parity gaps in the context_skills routes

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -34,7 +34,11 @@ from memtomem.web.routes._confirm import host_write_gate
 from memtomem.web.routes._errors import PRIVACY_BLOCK_DETAIL, PRIVACY_BLOCK_IMPORT_DETAIL, _error
 from memtomem.web.routes._locks import _gateway_lock
 from memtomem.web.routes._sync_phase import SyncPhaseError
-from memtomem.web.routes.context_gateway import delete_skip_entry, sanitize_diff_reason
+from memtomem.web.routes.context_gateway import (
+    delete_skip_entry,
+    read_text_lenient,
+    sanitize_diff_reason,
+)
 from memtomem.web.routes.context_projects import (
     resolve_scope_root,
     resolve_scope_root_cascade_gated,
@@ -371,9 +375,30 @@ async def create_skill(
                         f"Skill '{body.name}' already exists",
                         reason_code="already_exists",
                     )
+                # Validate the submitted content encodes as UTF-8 before
+                # anything touches disk. A lone-surrogate body can't be UTF-8
+                # encoded, so ``atomic_write_text`` (which does ``text.encode``)
+                # would raise UnicodeEncodeError AFTER ``mkdir``, leaving an
+                # orphan directory that wedges every retry on the 409 above.
+                # Mirrors create_command / create_agent, which pre-encode for
+                # the same reason (they reuse the bytes as create_version's
+                # source_bytes; skills have no versioning layer, so the encoded
+                # bytes are discarded and only the validation matters here).
+                try:
+                    body.content.encode("utf-8")
+                except UnicodeEncodeError as exc:
+                    raise _error(400, "validation", "Skill content is not valid UTF-8") from exc
                 skill_dir.mkdir(parents=True)
                 manifest = skill_dir / SKILL_MANIFEST
-                atomic_write_text(manifest, body.content)
+                try:
+                    atomic_write_text(manifest, body.content)
+                except BaseException:
+                    # Roll back the partial skill dir so a transient failure
+                    # doesn't leave an empty directory that wedges every future
+                    # create of this name on the orphan-dir 409 above. Mirrors
+                    # create_command / create_agent.
+                    shutil.rmtree(skill_dir, ignore_errors=True)
+                    raise
     except TimeoutError:
         raise _error(503, "busy", "Skill create timed out — another sync may be in progress")
     return {"name": body.name, "canonical_path": _safe_rel(skill_dir, project_root)}
@@ -573,9 +598,19 @@ async def diff_skill(
     canonical_manifest = skill_dir / SKILL_MANIFEST
     canonical_content = None
     if canonical_manifest.is_file():
-        canonical_content = canonical_manifest.read_text(encoding="utf-8")
+        # Lenient read for the display pane — a stray non-UTF-8 byte in the
+        # canonical SKILL.md must not abort the whole diff with an uncaught
+        # UnicodeDecodeError (the app maps it to a 400, not a diff). The engine
+        # ``diff_skills`` reads bytes with errors="replace" and stays the
+        # byte-wise authority for the list badge; this pane just mirrors it so
+        # the detail panel diagnoses instead of erroring (parity with
+        # diff_command / diff_agent — this route never got #1229/#1233's
+        # lenient read). ``None`` here means missing OR unreadable canonical.
+        canonical_content = read_text_lenient(canonical_manifest)
 
-    runtimes = []
+    # ``object`` values (not ``str``) — ``runtime_content`` may be ``None`` when
+    # the lenient read hits an OSError; mirrors context_commands / context_agents.
+    runtimes: list[dict[str, object]] = []
     for gen_name, gen in SKILL_GENERATORS.items():
         # Resolve the runtime side at the same tier as the canonical side —
         # the engine diff (diff_skills) already does; without scope= this
@@ -595,11 +630,13 @@ async def diff_skill(
                 {
                     "runtime": gen_name,
                     "status": "missing canonical",
-                    "runtime_content": target_manifest.read_text(encoding="utf-8"),
+                    # Lenient read — see the canonical read above; a non-UTF-8
+                    # runtime copy is drift to display, not a diff-wide abort.
+                    "runtime_content": read_text_lenient(target_manifest),
                 }
             )
         else:
-            runtime_content = target_manifest.read_text(encoding="utf-8")
+            runtime_content = read_text_lenient(target_manifest)
             if runtime_content == canonical_content:
                 runtimes.append({"runtime": gen_name, "status": "in sync"})
             else:

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -77,7 +77,7 @@ def _make_skill(tmp_path: Path, name: str, content: str = "# Test skill\n") -> P
     """Create a canonical skill directory with SKILL.md."""
     skill_dir = tmp_path / ".memtomem" / "skills" / name
     skill_dir.mkdir(parents=True, exist_ok=True)
-    (skill_dir / SKILL_MANIFEST).write_text(content, encoding="utf-8")
+    _write_text_lf(skill_dir / SKILL_MANIFEST, content)
     return skill_dir
 
 
@@ -90,7 +90,7 @@ def _make_runtime_skill(
     """Create a runtime skill directory."""
     skill_dir = tmp_path / runtime_dir / name
     skill_dir.mkdir(parents=True, exist_ok=True)
-    (skill_dir / SKILL_MANIFEST).write_text(content, encoding="utf-8")
+    _write_text_lf(skill_dir / SKILL_MANIFEST, content)
     return skill_dir
 
 
@@ -177,7 +177,7 @@ class TestOverview:
         # .gemini/skills/foo/SKILL.md → gemini detected via skill dir
         gem_skill = tmp_path / ".gemini" / "skills" / "foo"
         gem_skill.mkdir(parents=True)
-        (gem_skill / SKILL_MANIFEST).write_text("# g\n", encoding="utf-8")
+        _write_text_lf(gem_skill / SKILL_MANIFEST, "# g\n")
 
         r = await client.get("/api/context/overview")
         runtimes = {r["name"]: r["available"] for r in r.json()["detected_runtimes"]}
@@ -206,7 +206,7 @@ class TestOverview:
     ):
         local = tmp_path / ".memtomem" / "skills.local" / "draft"
         local.mkdir(parents=True)
-        (local / SKILL_MANIFEST).write_text("# Draft\n", encoding="utf-8")
+        _write_text_lf(local / SKILL_MANIFEST, "# Draft\n")
 
         default = await client.get("/api/context/overview")
         assert default.json()["target_scope"] == "project_shared"
@@ -716,7 +716,7 @@ class TestListSkills:
     ):
         local = tmp_path / ".memtomem" / "skills.local" / "draft"
         local.mkdir(parents=True)
-        (local / SKILL_MANIFEST).write_text("# Draft\n", encoding="utf-8")
+        _write_text_lf(local / SKILL_MANIFEST, "# Draft\n")
 
         default = await client.get("/api/context/skills")
         assert all(s["name"] != "draft" for s in default.json()["skills"])
@@ -998,10 +998,10 @@ class TestDiffSkill:
         content = "# User skill\n"
         skill_dir = home / ".memtomem" / "skills" / "scoped"
         skill_dir.mkdir(parents=True)
-        (skill_dir / SKILL_MANIFEST).write_text(content, encoding="utf-8")
+        _write_text_lf(skill_dir / SKILL_MANIFEST, content)
         rt_dir = home / ".claude" / "skills" / "scoped"
         rt_dir.mkdir(parents=True)
-        (rt_dir / SKILL_MANIFEST).write_text(content, encoding="utf-8")
+        _write_text_lf(rt_dir / SKILL_MANIFEST, content)
 
         r = await client.get("/api/context/skills/scoped/diff", params={"target_scope": "user"})
         assert r.status_code == 200
@@ -1017,7 +1017,7 @@ class TestDiffSkill:
         must not fabricate runtime rows against project_shared paths (#1229)."""
         local_dir = tmp_path / ".memtomem" / "skills.local" / "draft"
         local_dir.mkdir(parents=True)
-        (local_dir / SKILL_MANIFEST).write_text("# Draft\n", encoding="utf-8")
+        _write_text_lf(local_dir / SKILL_MANIFEST, "# Draft\n")
 
         r = await client.get(
             "/api/context/skills/draft/diff", params={"target_scope": "project_local"}
@@ -2114,7 +2114,7 @@ class TestImportOneAgent:
 def _make_local_skill(tmp_path: Path, name: str, content: str = "# Local\n") -> Path:
     skill_dir = tmp_path / ".memtomem" / "skills.local" / name
     skill_dir.mkdir(parents=True, exist_ok=True)
-    (skill_dir / SKILL_MANIFEST).write_text(content, encoding="utf-8")
+    _write_text_lf(skill_dir / SKILL_MANIFEST, content)
     return skill_dir
 
 

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -21,6 +21,7 @@ Diff-payload contract pinned by ``TestDiffCommand`` / ``TestDiffAgent`` (#1256):
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path, PureWindowsPath
 from unittest.mock import AsyncMock
@@ -836,6 +837,40 @@ class TestCreateSkill:
         )
         assert r.status_code == 400
 
+    @pytest.mark.anyio
+    async def test_create_lone_surrogate_no_orphan_dir_wedge(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """A lone-surrogate body can't be UTF-8 encoded, so ``atomic_write_text``
+        raises ``UnicodeEncodeError`` *after* ``skill_dir.mkdir()`` — pre-fix
+        that left an orphan directory behind, wedging every retry on the 409
+        "already exists" conflict. ``create_command`` / ``create_agent``
+        pre-encode the body (clean 400 before mkdir) and roll the partial dir
+        back on any failure; this route now mirrors that shape.
+
+        httpx 0.28 encodes ``json=`` with ``ensure_ascii=False`` and would raise
+        on the lone surrogate client-side, so the escaped ASCII JSON body is
+        sent directly (stdlib json decodes the escape back to a lone surrogate
+        server-side).
+        """
+        skill_dir = tmp_path / ".memtomem" / "skills" / "surrogate"
+        body = json.dumps({"name": "surrogate", "content": "# bad \ud800\n"})
+        r = await client.post(
+            "/api/context/skills",
+            content=body,
+            headers={"Content-Type": "application/json"},
+        )
+        assert r.status_code == 400, r.text
+        # No orphan directory left behind — the wedge source.
+        assert not skill_dir.exists()
+        # Wedge regression: a retry with valid content must succeed, not 409.
+        r2 = await client.post(
+            "/api/context/skills",
+            json={"name": "surrogate", "content": "# good\n"},
+        )
+        assert r2.status_code == 200, r2.text
+        assert (skill_dir / SKILL_MANIFEST).is_file()
+
 
 # ---------------------------------------------------------------------------
 # Skills — Update
@@ -990,6 +1025,61 @@ class TestDiffSkill:
         data = r.json()
         assert data["canonical_content"] == "# Draft\n"
         assert data["runtimes"] == []
+
+    @pytest.mark.anyio
+    async def test_diff_non_utf8_canonical_does_not_abort(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """A stray non-UTF-8 byte in the canonical SKILL.md must not abort the
+        per-name diff (pre-fix ``read_text(encoding="utf-8")`` raised
+        ``UnicodeDecodeError`` → the app's ValueError handler turned it into a
+        400 error, not a diff). The engine ``diff_skills`` reads bytes with
+        ``errors="replace"``, so the detail pane must read leniently too —
+        parity with ``diff_command`` / ``diff_agent`` (#1229/#1233), which this
+        route never received."""
+        skill_dir = tmp_path / ".memtomem" / "skills" / "cafe"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / SKILL_MANIFEST).write_bytes(b"# caf\xe9 skill\n")
+        r = await client.get("/api/context/skills/cafe/diff")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["canonical_content"] is not None
+        assert "�" in data["canonical_content"]  # U+FFFD replacement
+
+    @pytest.mark.anyio
+    async def test_diff_non_utf8_runtime_reports_drift_not_abort(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """A non-UTF-8 byte in a *runtime* copy is drift to display, not a
+        diff-wide abort — the ``out of sync`` runtime read must go through the
+        lenient reader (#1229/#1233)."""
+        _make_skill(tmp_path, "diverged", "# clean\n")
+        rt_dir = tmp_path / ".claude" / "skills" / "diverged"
+        rt_dir.mkdir(parents=True)
+        (rt_dir / SKILL_MANIFEST).write_bytes(b"# caf\xe9 drift\n")
+        r = await client.get("/api/context/skills/diverged/diff")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        claude_rt = [rt for rt in data["runtimes"] if rt["runtime"] == "claude_skills"][0]
+        assert claude_rt["status"] == "out of sync"
+        assert "�" in claude_rt["runtime_content"]
+
+    @pytest.mark.anyio
+    async def test_diff_non_utf8_runtime_missing_canonical_does_not_abort(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """A runtime-only skill whose SKILL.md carries a non-UTF-8 byte surfaces
+        as ``missing canonical`` with a lenient runtime preview, not an abort
+        (the third read site in ``diff_skill``)."""
+        rt_dir = tmp_path / ".claude" / "skills" / "runtime-only"
+        rt_dir.mkdir(parents=True)
+        (rt_dir / SKILL_MANIFEST).write_bytes(b"# caf\xe9 only\n")
+        r = await client.get("/api/context/skills/runtime-only/diff")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        claude_rt = [rt for rt in data["runtimes"] if rt["runtime"] == "claude_skills"][0]
+        assert claude_rt["status"] == "missing canonical"
+        assert "�" in claude_rt["runtime_content"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
Two sibling-parity gaps in `web/routes/context_skills.py` (2026-07-02 review, verified):
1. `diff_skill` read the canonical/runtime SKILL.md with strict `read_text(utf-8)` while commands/agents/mcp got `read_text_lenient` (#1229/#1233) — a non-UTF-8 canonical made the diff error instead of diagnosing.
2. `create_skill` did `mkdir` then write with no rollback — a write failure (lone surrogate → UnicodeEncodeError) left an orphan dir that wedged retries on the 409, while `create_command`/`create_agent` pre-encode (clean 400 before mkdir) + `try/except BaseException: rmtree`.

## Fix
- `diff_skill`'s three reads use `read_text_lenient`; `read_skill` left strict to match the sibling detail reads (`read_command`/`read_agent` are strict). Engine `diff_skills` compares byte-wise, so lenient display doesn't change diff semantics.
- `create_skill` pre-encodes `body.content` to UTF-8 (validation → clean 400 before mkdir) and wraps mkdir+write in `try/except BaseException: shutil.rmtree; raise`, mirroring the siblings.

## Tests
RED-first (4 failed → passed): non-UTF-8 canonical/runtime diff returns 200 + U+FFFD (not error); create with a lone surrogate → clean 400, no orphan dir, retry with valid content succeeds. Skills-route suites = 380 passed; broader skills-touching sweep = 426; ruff + advisory mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
