### PR TITLE
security(web): finish the #1412 canonical-path disclosure sweep across kind routes

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -38,6 +38,7 @@ from memtomem.context.agents import (
 from memtomem.context.detector import AGENT_DIRS
 from memtomem.context.privacy_scan import PrivacyScanError
 from memtomem.web.routes.context_gateway import (
+    _safe_rel,
     delete_skip_entry,
     expected_vs_runtime_row,
     read_text_lenient,
@@ -300,9 +301,15 @@ async def rendered_agent(
     try:
         parsed = parse_canonical_agent(agent_path, layout=layout)
     except AgentParseError as exc:
+        # ``str(exc)`` embeds the absolute canonical source path (the parser
+        # raises ``missing YAML frontmatter: {path}`` / ``... (source: {path})``);
+        # route it through the shared display-sanitize boundary so the loopback
+        # 422 detail stays path-free — the #1412 fix class the mcp-servers
+        # parse-422 already applies.
+        detail = sanitize_diff_reason(str(exc), project_root) or ""
         return JSONResponse(
             status_code=422,
-            content={"detail": {"error_kind": "parse", "message": f"Parse error: {exc}"}},
+            content={"detail": {"error_kind": "parse", "message": f"Parse error: {detail}"}},
         )
 
     diffs = diff_agents(project_root, scope=target_scope)
@@ -535,20 +542,6 @@ async def update_agent(
 
 
 # ── Delete ───────────────────────────────────────────────────────────────
-
-
-def _safe_rel(p: Path, project_root: Path) -> str:
-    """Project-relative path as a POSIX string for API payloads.
-
-    ``.as_posix()`` (not ``str``) so canonical/runtime paths come back
-    ``/``-separated on every platform — the Web UI and diff payloads pin POSIX
-    separators (#1256). Falls back to the absolute POSIX path for user-tier
-    locations outside ``project_root``.
-    """
-    try:
-        return p.relative_to(project_root).as_posix()
-    except ValueError:
-        return p.as_posix()
 
 
 @router.delete("/context/agents/{name}")

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -37,6 +37,7 @@ from memtomem.context.commands import (
 from memtomem.context.detector import COMMAND_DIRS
 from memtomem.context.privacy_scan import PrivacyScanError
 from memtomem.web.routes.context_gateway import (
+    _safe_rel,
     delete_skip_entry,
     expected_vs_runtime_row,
     read_text_lenient,
@@ -98,20 +99,6 @@ def _reject_project_local_write(target_scope: TargetScope, action: str) -> None:
             ),
             reason_code="project_local_unsupported",
         )
-
-
-def _safe_rel(p: Path, project_root: Path) -> str:
-    """Project-relative path as a POSIX string for API payloads.
-
-    ``.as_posix()`` (not ``str``) so canonical/runtime paths come back
-    ``/``-separated on every platform — the Web UI and diff payloads pin POSIX
-    separators (#1256). Falls back to the absolute POSIX path for user-tier
-    locations outside ``project_root``.
-    """
-    try:
-        return p.relative_to(project_root).as_posix()
-    except ValueError:
-        return p.as_posix()
 
 
 def _user_scan_dirs() -> list[str]:
@@ -307,9 +294,14 @@ async def rendered_command(
     try:
         parsed = parse_canonical_command(cmd_path, layout=layout)
     except CommandParseError as exc:
+        # ``str(exc)`` embeds the absolute canonical source path (the parser
+        # raises ``... (source: {path})``); route it through the shared
+        # display-sanitize boundary so the loopback 422 detail stays path-free
+        # — the #1412 fix class the mcp-servers parse-422 already applies.
+        detail = sanitize_diff_reason(str(exc), project_root) or ""
         return JSONResponse(
             status_code=422,
-            content={"detail": {"error_kind": "parse", "message": f"Parse error: {exc}"}},
+            content={"detail": {"error_kind": "parse", "message": f"Parse error: {detail}"}},
         )
 
     runtimes = []

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -74,6 +74,43 @@ def sanitize_diff_reason(message: str | None, project_root: Path) -> str | None:
     return _redact_message(cleaned)
 
 
+def _safe_rel(p: Path, project_root: Path) -> str:
+    """Project-relative path as a POSIX string for API payloads.
+
+    ``.as_posix()`` (not ``str``) so ``canonical_path`` / ``path`` fields come
+    back ``/``-separated on every platform — the Web UI and diff payloads pin
+    POSIX separators (#1256; the ``PureWindowsPath`` guard is #1325). Falls back
+    to the absolute POSIX path for user-tier locations outside ``project_root``.
+    Shared by the skills / commands / agents / mcp-servers routes so the
+    path-sanitization boundary cannot drift per kind (same rationale as
+    ``sanitize_diff_reason``) — the per-kind copies DID drift: #1412 hardened
+    only the mcp-servers variant, leaving the others latent (#1264 parity).
+
+    ``p`` is a ``.resolve()``'d canonical/runtime path (``canonical_artifact_dir``
+    resolves), but the route may receive an unresolved/symlinked ``project_root``
+    (macOS ``/tmp``→``/private/tmp``, a symlinked home, a case-variant mount),
+    so ``relative_to`` against the bare root raises ``ValueError`` and the
+    fallback would emit the ABSOLUTE resolved path to the loopback dashboard
+    (#1412, the same disclosure as the parse-error reason). Try the resolved
+    root too before falling back. ``resolve()`` lives only on concrete ``Path``
+    objects — the cross-platform ``PureWindowsPath`` tests (#1325) drive this
+    with a pure path, so the resolved attempt is guarded and skipped there.
+    """
+    roots = [project_root]
+    try:
+        resolved_root = project_root.resolve()
+    except (AttributeError, OSError):
+        resolved_root = project_root
+    if resolved_root != project_root:
+        roots.append(resolved_root)
+    for root in roots:
+        try:
+            return p.relative_to(root).as_posix()
+        except ValueError:
+            continue
+    return p.as_posix()
+
+
 def read_text_lenient(path: Path) -> str | None:
     """Best-effort text read for diff payload previews (#1229 U7).
 

--- a/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
@@ -30,7 +30,7 @@ from memtomem.context.mcp_servers import (
 from memtomem.web.routes._errors import _error
 from memtomem.web.routes._locks import _gateway_lock
 from memtomem.web.routes._sync_phase import SyncPhaseError
-from memtomem.web.routes.context_gateway import read_text_lenient, sanitize_diff_reason
+from memtomem.web.routes.context_gateway import _safe_rel, read_text_lenient, sanitize_diff_reason
 from memtomem.web.routes.context_projects import (
     resolve_scope_root,
     resolve_writable_scope_root,
@@ -39,40 +39,6 @@ from memtomem.web.routes.context_projects import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["context-mcp-servers"])
-
-
-def _safe_rel(p: Path, project_root: Path) -> str:
-    """Project-relative path as a POSIX string for API payloads.
-
-    ``.as_posix()`` (not ``str``) so ``canonical_path`` / ``path`` fields come
-    back ``/``-separated on every platform — the Web UI and diff payloads pin
-    POSIX separators (#1256). Falls back to the absolute POSIX path outside
-    ``project_root``. Parity with ``context_agents`` / ``context_commands``
-    (#1264); this route was never covered by #1256's diff tests, so the
-    ``str()`` form lingered latent (#1325).
-
-    ``p`` is a ``.resolve()``'d canonical/runtime path, but the route may receive
-    an unresolved/symlinked ``project_root`` (macOS ``/tmp``→``/private/tmp``),
-    so ``relative_to`` against the bare root raises ``ValueError`` and the
-    fallback would emit the ABSOLUTE resolved path to the loopback dashboard
-    (#1412, the same disclosure as the parse-error reason). Try the resolved
-    root too before falling back. ``resolve()`` lives only on concrete ``Path``
-    objects — the cross-platform ``PureWindowsPath`` tests (#1325) drive this
-    with a pure path, so the resolved attempt is guarded and skipped there.
-    """
-    roots = [project_root]
-    try:
-        resolved_root = project_root.resolve()
-    except (AttributeError, OSError):
-        resolved_root = project_root
-    if resolved_root != project_root:
-        roots.append(resolved_root)
-    for root in roots:
-        try:
-            return p.relative_to(root).as_posix()
-        except ValueError:
-            continue
-    return p.as_posix()
 
 
 def _reject_non_shared_write(target_scope: TargetScope, action: str) -> None:
@@ -362,7 +328,16 @@ async def delete_mcp_server(
                         path.unlink()
                         removed.append(_safe_rel(path, project_root))
                     except OSError as exc:
-                        skipped.append({"path": _safe_rel(path, project_root), "reason": str(exc)})
+                        # ``str(exc)`` embeds the absolute canonical path
+                        # (``OSError`` carries ``.filename``); sanitize it like
+                        # the skills/commands/agents delete legs so the skip
+                        # reason never leaks it to the loopback dashboard (#1412).
+                        skipped.append(
+                            {
+                                "path": _safe_rel(path, project_root),
+                                "reason": sanitize_diff_reason(str(exc), project_root) or "",
+                            }
+                        )
                 if cascade:
                     mcp_path = project_root / ".mcp.json"
                     if mcp_path.is_file():

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -34,7 +34,11 @@ from memtomem.web.routes._confirm import host_write_gate
 from memtomem.web.routes._errors import PRIVACY_BLOCK_DETAIL, PRIVACY_BLOCK_IMPORT_DETAIL, _error
 from memtomem.web.routes._locks import _gateway_lock
 from memtomem.web.routes._sync_phase import SyncPhaseError
-from memtomem.web.routes.context_gateway import delete_skip_entry, sanitize_diff_reason
+from memtomem.web.routes.context_gateway import (
+    _safe_rel,
+    delete_skip_entry,
+    sanitize_diff_reason,
+)
 from memtomem.web.routes.context_projects import (
     resolve_scope_root,
     resolve_scope_root_cascade_gated,
@@ -135,22 +139,6 @@ def _user_sync_host_targets(project_root: Path) -> list[str]:
             if dst is not None:
                 targets.append(str(dst))
     return sorted(targets)
-
-
-def _safe_rel(p: Path, project_root: Path) -> str:
-    """Project-relative path as a POSIX string for API payloads.
-
-    ``.as_posix()`` (not ``str``) so canonical/runtime paths come back
-    ``/``-separated on every platform — the Web UI and diff payloads pin POSIX
-    separators (#1256). Falls back to the absolute POSIX path for user-tier
-    locations outside ``project_root``. Parity with ``context_agents`` /
-    ``context_commands`` (#1264); this route was just never covered by #1256's
-    diff tests, so the ``str()`` form lingered latent (#1325).
-    """
-    try:
-        return p.relative_to(project_root).as_posix()
-    except ValueError:
-        return p.as_posix()
 
 
 # ── List ─────────────────────────────────────────────────────────────────

--- a/packages/memtomem/tests/test_context_kind_routes_path_free.py
+++ b/packages/memtomem/tests/test_context_kind_routes_path_free.py
@@ -1,0 +1,175 @@
+"""Path-disclosure regression pins for the skills / commands / agents context
+routes — the #1412 sweep that never finished (dde6fd33 hardened only
+mcp-servers).
+
+Two legs, both already fixed for mcp-servers, previously drifted here:
+
+(a) ``_safe_rel`` under a symlinked / case-variant ``project_root`` emitted the
+    ABSOLUTE resolved canonical path in ``canonical_path``: the naive per-kind
+    copies only tried ``relative_to`` against the bare (unresolved) root, so a
+    resolved canonical (``canonical_artifact_dir`` calls ``.resolve()``) fell
+    through to the absolute fallback and leaked ``$HOME`` + the OS username to
+    the loopback dashboard. Mirrors
+    ``TestMcpServersParseBranchPathFree.test_list_symlinked_root_is_path_free``.
+
+(c) The ``rendered_command`` / ``rendered_agent`` parse-error 422 embedded the
+    raw ``str(exc)`` whose message carries the absolute source ``Path`` (the
+    parsers raise ``... (source: {path})`` / ``missing YAML frontmatter:
+    {path}``). Now routed through ``sanitize_diff_reason`` — the #1412 fix class
+    for the mcp parse-error 422, here for commands + agents.
+
+(Leg (b) — the mcp delete-skip raw ``str(exc)`` — lives next to the other mcp
+delete tests in ``test_web_routes_context_mcp_servers.py``.)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+from memtomem.web.routes import context_agents, context_commands, context_skills
+
+
+def _client_for(router: APIRouter, project_root: Path) -> TestClient:
+    """Minimal app exposing one context router with ``project_root`` pinned.
+
+    Mirrors ``TestMcpServersParseBranchPathFree._build_app`` — override
+    ``resolve_scope_root`` so the route runs against a real (possibly
+    symlinked) root without the selector / eligibility machinery.
+    """
+    from memtomem.web.routes.context_projects import resolve_scope_root
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[resolve_scope_root] = lambda: project_root
+    return TestClient(app)
+
+
+def _assert_path_free(body: dict, *leaky: Path) -> None:
+    """Whole-body assertion: no absolute path (resolved or not) nor ``$HOME``.
+
+    Serializes the entire response so a future shape change that echoes the
+    path under a new key is still caught (mirrors the mcp whole-body check).
+    """
+    blob = json.dumps(body)
+    for p in leaky:
+        assert str(p) not in blob, body
+        assert str(p.resolve()) not in blob, body
+    assert str(Path.home()) not in blob, body
+
+
+# ── (a) symlinked-root ``_safe_rel`` fallback ────────────────────────────
+
+
+def _seed_skill(root: Path, name: str = "demo") -> None:
+    from memtomem.context.skills import SKILL_MANIFEST
+
+    d = root / ".memtomem" / "skills" / name
+    d.mkdir(parents=True)
+    (d / SKILL_MANIFEST).write_text("# demo skill\n", encoding="utf-8")
+
+
+def _seed_command(root: Path, name: str = "demo") -> None:
+    p = root / ".memtomem" / "commands" / f"{name}.md"
+    p.parent.mkdir(parents=True)
+    p.write_text("---\nname: demo\ndescription: d\n---\nbody\n", encoding="utf-8")
+
+
+def _seed_agent(root: Path, name: str = "demo") -> None:
+    p = root / ".memtomem" / "agents" / f"{name}.md"
+    p.parent.mkdir(parents=True)
+    p.write_text("---\nname: demo\ndescription: d\n---\nbody\n", encoding="utf-8")
+
+
+# kind → (router, list URL, container key, seeder, expected relative path)
+_LIST_SPECS: dict[str, tuple[APIRouter, str, str, object, str]] = {
+    "skills": (
+        context_skills.router,
+        "/context/skills",
+        "skills",
+        _seed_skill,
+        ".memtomem/skills/demo",
+    ),
+    "commands": (
+        context_commands.router,
+        "/context/commands",
+        "commands",
+        _seed_command,
+        ".memtomem/commands/demo.md",
+    ),
+    "agents": (
+        context_agents.router,
+        "/context/agents",
+        "agents",
+        _seed_agent,
+        ".memtomem/agents/demo.md",
+    ),
+}
+
+
+@pytest.mark.requires_symlinks
+@pytest.mark.parametrize("kind", ["skills", "commands", "agents"])
+def test_list_symlinked_root_canonical_path_is_relative(kind: str, tmp_path: Path) -> None:
+    router, url, container, seed, expected = _LIST_SPECS[kind]
+    real = (tmp_path / "real").resolve()
+    real.mkdir()
+    seed(real)  # type: ignore[operator]
+    link = tmp_path / "link"
+    link.symlink_to(real)
+
+    # The route receives the UNRESOLVED symlink as project_root; the engine
+    # canonical is ``.resolve()``'d (→ under ``real``), so a bare
+    # ``relative_to(link)`` raises ValueError and the naive fallback leaked the
+    # absolute resolved path.
+    res = _client_for(router, link).get(url)
+
+    assert res.status_code == 200, res.text
+    body = res.json()
+    item = next(i for i in body[container] if i.get("canonical_path") is not None)
+    assert item["canonical_path"] == expected, item
+    _assert_path_free(body, real, real / ".memtomem")
+
+
+# ── (c) rendered parse-error 422 ─────────────────────────────────────────
+
+
+def test_rendered_command_parse_error_422_is_path_free(tmp_path: Path) -> None:
+    from memtomem.context.scope_resolver import canonical_artifact_dir
+
+    p = tmp_path / ".memtomem" / "commands" / "broken.md"
+    p.parent.mkdir(parents=True)
+    # A path-separator name fails ``validate_name`` → ``CommandParseError`` whose
+    # message ends with ``(source: {absolute canonical path})``.
+    p.write_text("---\nname: bad/name\ndescription: d\n---\nbody\n", encoding="utf-8")
+
+    res = _client_for(context_commands.router, tmp_path).get("/context/commands/broken/rendered")
+
+    assert res.status_code == 422, res.text
+    body = res.json()
+    assert body["detail"]["error_kind"] == "parse", body
+    canon = canonical_artifact_dir("commands", "project_shared", tmp_path) / "broken.md"
+    _assert_path_free(body, canon, canon.parent, tmp_path)
+    assert "Parse error" in body["detail"]["message"], body
+
+
+def test_rendered_agent_parse_error_422_is_path_free(tmp_path: Path) -> None:
+    from memtomem.context.scope_resolver import canonical_artifact_dir
+
+    p = tmp_path / ".memtomem" / "agents" / "broken.md"
+    p.parent.mkdir(parents=True)
+    # Agents REQUIRE frontmatter → ``AgentParseError("missing YAML frontmatter:
+    # {absolute canonical path}")``.
+    p.write_text("no frontmatter, just a body\n", encoding="utf-8")
+
+    res = _client_for(context_agents.router, tmp_path).get("/context/agents/broken/rendered")
+
+    assert res.status_code == 422, res.text
+    body = res.json()
+    assert body["detail"]["error_kind"] == "parse", body
+    canon = canonical_artifact_dir("agents", "project_shared", tmp_path) / "broken.md"
+    _assert_path_free(body, canon, canon.parent, tmp_path)
+    assert "Parse error" in body["detail"]["message"], body

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -2,10 +2,11 @@
 
 Diff-payload contract pinned by ``TestDiffCommand`` / ``TestDiffAgent`` (#1256):
 
-- **Paths** are normalized to POSIX separators on every platform. The route
-  helpers ``_safe_rel`` in ``context_commands`` / ``context_agents`` /
-  ``context_skills`` return ``.as_posix()`` so the Web UI receives stable
-  ``/``-separated paths; the diff tests assert literal POSIX strings (e.g.
+- **Paths** are normalized to POSIX separators on every platform. The shared
+  ``_safe_rel`` helper in ``context_gateway`` (imported by
+  ``context_commands`` / ``context_agents`` / ``context_skills`` /
+  ``context_mcp_servers``) returns ``.as_posix()`` so the Web UI receives
+  stable ``/``-separated paths; the diff tests assert literal POSIX strings (e.g.
   ``.claude/commands/ghost.md``) rather than ``str(Path(...))``, which would be
   backslash-joined on Windows. The literal-POSIX route assertions only fail on
   ``windows-latest`` (``str(PosixPath)`` already ``/``-joins on macOS/Linux);
@@ -107,7 +108,7 @@ def test_safe_rel_joins_with_posix_separators() -> None:
     every host) makes the assertion fail on any platform if ``.as_posix()``
     reverts to ``str()`` — the exact gap that let this bug slip past #1256.
     """
-    from memtomem.web.routes.context_skills import _safe_rel
+    from memtomem.web.routes.context_gateway import _safe_rel
 
     root = PureWindowsPath(r"C:\proj")
     nested = PureWindowsPath(r"C:\proj\.memtomem\skills\demo\SKILL.md")

--- a/packages/memtomem/tests/test_web_routes_context_mcp_servers.py
+++ b/packages/memtomem/tests/test_web_routes_context_mcp_servers.py
@@ -23,7 +23,7 @@ from httpx import ASGITransport, AsyncClient
 
 from memtomem.config import Mem2MemConfig
 from memtomem.web.app import create_app
-from memtomem.web.routes.context_mcp_servers import _safe_rel
+from memtomem.web.routes.context_gateway import _safe_rel
 
 
 @pytest.fixture
@@ -383,6 +383,38 @@ async def test_delete_removed_entry_is_posix(client: AsyncClient, tmp_path: Path
     data = r.json()
     assert data["deleted"] == [".memtomem/mcp-servers/gone.json"]
     assert data["skipped"] == []
+
+
+@pytest.mark.anyio
+async def test_delete_skip_reason_is_path_free(
+    client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed ``path.unlink()`` builds a ``skipped[]`` row whose ``reason``
+    must not echo the absolute canonical path (#1412 sweep, leg b).
+
+    ``str(OSError)`` from ``unlink`` embeds ``self`` (the resolved canonical
+    ``Path``) — the disclosure the skills/commands/agents delete legs already
+    close by routing the reason through ``sanitize_diff_reason``; the mcp route
+    surfaced the raw ``str(exc)`` verbatim to the loopback dashboard.
+    """
+    path = _seed_canonical(tmp_path, "gone")
+
+    def _boom(self: Path, *args: object, **kwargs: object) -> None:
+        raise OSError(f"[Errno 13] Permission denied: '{self}'")
+
+    monkeypatch.setattr(Path, "unlink", _boom)
+    r = await client.delete("/api/context/mcp-servers/gone")
+
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["deleted"] == []
+    assert len(data["skipped"]) == 1, data
+    reason = data["skipped"][0]["reason"]
+    assert str(path) not in reason, data
+    assert str(path.resolve()) not in reason, data
+    # Whole-body sweep so a future shape change can't reintroduce the leak.
+    assert str(tmp_path) not in json.dumps(data), data
+    assert str(tmp_path.resolve()) not in json.dumps(data), data
 
 
 def test_safe_rel_joins_with_posix_separators() -> None:


### PR DESCRIPTION
## Problem
Commit `dde6fd33` (#1412) hardened canonical-path disclosure on the mcp-servers route but never finished the sweep across the sibling kind routes (2026-07-02 review, CONFIRMED). Three legs:
- (a) `_safe_rel` in skills/commands/agents was the naive pre-#1412 form → emits the ABSOLUTE resolved canonical path when `project_root` is a symlink (macOS /tmp→/private/tmp).
- (b) mcp delete-skip row used raw `str(exc)` (absolute path in the OSError).
- (c) `rendered_command`/`rendered_agent` parse-error 422 embedded unsanitized `str(exc)` (absolute source path).

## Fix
- Hoisted the one hardened `_safe_rel` (tries `project_root.resolve()` before fallback, guarded for PurePath/OSError) into `context_gateway.py` next to `sanitize_diff_reason`; imported it in all four route files and deleted the four local copies.
- (b) delete-skip reason → `sanitize_diff_reason(str(exc), project_root)`.
- (c) parse-error 422 message → `sanitize_diff_reason`, keeping the `{error_kind:"parse", message}` shape (no test pinned the detail; reused the established display-sanitize boundary rather than adding an engine-side `safe_message` twin, keeping the change confined to web/routes).

## Tests
RED-first: symlinked-root `canonical_path` relative for skills/commands/agents; commands/agents parse-error 422 path-free; mcp delete-skip path-free. Existing per-file `_safe_rel` POSIX/PureWindowsPath unit tests repointed at `context_gateway`, assertions unchanged. Route suite = 375 passed; ruff clean (2 advisory mypy lambda notes pre-exist on main).

## Follow-up noted
A 5th naive `_safe_rel` lives in the dev-tier `context_mutations.py` (used for install/copy/move result paths). It carries an explicit "never import a prod router" isolation rationale, so importing the prod-router helper would violate it — left unchanged; hoisting to a neutral leaf is a separate architectural call (candidate for the #1520 small-batch issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
