### PR TITLE
security(mcp): redact absolute paths in context tool errors

### DIFF
--- a/packages/memtomem/src/memtomem/context/_runtime_targets.py
+++ b/packages/memtomem/src/memtomem/context/_runtime_targets.py
@@ -188,8 +188,11 @@ class DiffRow(tuple):
     field with the ``validate_name`` message).
 
     ``reason`` is raw, unsanitized engine text (exception messages embed
-    absolute source paths) — web routes sanitize at the wire boundary,
-    CLI/MCP print it for the local operator verbatim.
+    absolute source paths) — the web routes AND the MCP context tools sanitize
+    it at their wire boundary (``web/routes/context_gateway.sanitize_diff_reason``
+    / ``context.error_redact.redact_engine_reason``), since both surface the
+    reason beyond the host; only the CLI prints it for the local operator
+    verbatim.
     """
 
     reason: str | None

--- a/packages/memtomem/src/memtomem/context/error_redact.py
+++ b/packages/memtomem/src/memtomem/context/error_redact.py
@@ -1,0 +1,90 @@
+"""Neutral engine-reason / error-message redactors for the MCP context tools.
+
+The web wire boundary already display-sanitizes raw engine exception text
+before it leaves the loopback dashboard:
+
+* ``web/routes/_errors._redact_message`` — collapse ``$HOME`` → ``~``, drop
+  secret-shape messages whole, then truncate to 200 chars.
+* ``web/routes/context_gateway.sanitize_diff_reason`` — strip the project root
+  (both the given and the ``.resolve()``'d form) wherever it appears inside the
+  message, then apply ``_redact_message``.
+
+The MCP context tools in ``server/tools/context.py`` are a *second* wire
+boundary for the SAME engine reasons: their string results flow into the
+calling agent's transcript and on to the model provider / any telemetry, so an
+absolute host path leaks ``$HOME`` (and the OS username) just as it would on
+the dashboard. The MCP layer cannot import from ``memtomem.web.*`` (the web
+depends on the server tools' package, not the reverse, and MCP↔web coupling is
+disallowed), so these functions mirror the web contract in a neutral
+``memtomem.context`` leaf both layers can reach.
+
+These are kept in lock-step with the two web twins named above; a later PR can
+collapse the duplication by having those web functions delegate here. The
+remediation-critical ``privacy block: …`` message is deliberately NOT routed
+through here — it round-trips the full canonical path so the agent can act on
+it (``test_sync_privacy_block_surfaces``), matching the web privacy 422 that
+keeps its own fixed, path-free detail.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from memtomem.privacy import scan as _privacy_scan
+
+# Frozen at import time (cross-platform #1506 discipline): a process that
+# rewrites ``$HOME`` after startup keeps the original collapse anchor, matching
+# the ``web/routes/_errors`` constant this mirrors.
+_HOME = str(Path.home())
+_ERROR_MESSAGE_LIMIT = 200
+_SECRET_REDACTED_MARKER = "<redacted: secret-shape>"
+
+
+def redact_message(message: str) -> str:
+    """Collapse ``$HOME`` → ``~``, drop secret-shape messages, then truncate.
+
+    Mirror of ``web/routes/_errors._redact_message``: a catch-all / ``OSError``
+    ``str(exc)`` may incidentally carry provider tokens or ``api_key=…``
+    fragments pulled from a config parse or a third-party library, so
+    truncation alone is not enough at this trust boundary. We reuse the LTM
+    secret-class scanner; any hit replaces the *whole* message with a fixed
+    marker (span-splicing was rejected because assignment-anchored patterns
+    like ``api_key=…`` would leave the secret value behind).
+    """
+    redacted = message.replace(_HOME, "~") if _HOME else message
+    if _privacy_scan(redacted):
+        return _SECRET_REDACTED_MARKER
+    if len(redacted) > _ERROR_MESSAGE_LIMIT:
+        redacted = redacted[:_ERROR_MESSAGE_LIMIT]
+    return redacted
+
+
+def redact_engine_reason(message: str | None, *project_roots: Path) -> str | None:
+    """Display-sanitize a raw engine reason / error string for the MCP wire.
+
+    Mirror of ``web/routes/context_gateway.sanitize_diff_reason`` generalized to
+    accept more than one root (a transfer straddles a source and a destination
+    project). Engine reasons embed absolute source paths inside arbitrary
+    message text, so ``Path.relative_to`` doesn't apply: strip each root prefix
+    — both the given form and its ``.resolve()``'d form (macOS ``/tmp`` →
+    ``/private/tmp``, a symlinked home, a case-variant mount) — wherever it
+    appears, longest-first so a root that contains another as a prefix can't be
+    half-stripped, then apply :func:`redact_message`.
+
+    Returns ``None`` for an empty/absent message so callers can keep their
+    ``if reason`` truthiness checks.
+    """
+    if not message:
+        return None
+    roots: set[str] = set()
+    for project_root in project_roots:
+        roots.add(str(project_root))
+        try:
+            roots.add(str(project_root.resolve()))
+        except (AttributeError, OSError):
+            pass  # PurePath / unresolvable root — the bare form still strips
+    cleaned = message
+    for root in sorted(roots, key=len, reverse=True):
+        cleaned = cleaned.replace(root + os.sep, "").replace(root, ".")
+    return redact_message(cleaned)

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -10,6 +10,7 @@ import click
 
 from memtomem.config import TargetScope
 from memtomem.context import versioning
+from memtomem.context.error_redact import redact_engine_reason
 from memtomem.context.scope_resolver import find_project_root
 from memtomem.server import mcp
 from memtomem.server.context import CtxType
@@ -36,6 +37,20 @@ def _find_project_root() -> Path:
     MCP context tools, the CLI, and the web app share one definition.
     """
     return find_project_root()
+
+
+def _redact_reason(reason: str | None, *roots: Path) -> str:
+    """Strip absolute host paths from a raw engine diff/skip ``reason``.
+
+    Thin wrapper over ``context.error_redact.redact_engine_reason`` (the neutral
+    twin of the web ``sanitize_diff_reason``) that coalesces the ``None``
+    (empty-reason) return to ``""`` so a skip line renders ``skipped x: ``
+    rather than ``skipped x: None``; diff-row callers keep their ``if reason``
+    suffix guard on the returned string. The MCP tool result flows to the
+    calling agent's transcript / model provider, so it gets the same wire-
+    boundary sanitization the loopback dashboard applies.
+    """
+    return redact_engine_reason(reason, *roots) or ""
 
 
 def _resolve_mcp_scope(override: str | None = None) -> str:
@@ -631,7 +646,7 @@ async def mem_context_generate(
                 rel = path.relative_to(root) if path.is_relative_to(root) else path
                 results.append(f"  {runtime}: {rel}")
         for runtime, reason, _code in skill_result.skipped:
-            results.append(f"  skipped {runtime}: {reason}")
+            results.append(f"  skipped {runtime}: {_redact_reason(reason, root)}")
 
     if "agents" in inc:
         try:
@@ -657,7 +672,7 @@ async def mem_context_generate(
                     rel = path
                 results.append(f"  {runtime}: {rel}")
         for runtime, reason, _code in agent_result.skipped:
-            results.append(f"  skipped {runtime}: {reason}")
+            results.append(f"  skipped {runtime}: {_redact_reason(reason, root)}")
         for runtime, agent_name, dropped in agent_result.dropped:
             results.append(f"  {runtime} dropped {dropped} from '{agent_name}'")
 
@@ -685,7 +700,7 @@ async def mem_context_generate(
                     rel = path
                 results.append(f"  {runtime}: {rel}")
         for runtime, reason, _code in command_result.skipped:
-            results.append(f"  skipped {runtime}: {reason}")
+            results.append(f"  skipped {runtime}: {_redact_reason(reason, root)}")
         for runtime, cmd_name, dropped in command_result.dropped:
             results.append(f"  {runtime} dropped {dropped} from '{cmd_name}'")
 
@@ -785,7 +800,7 @@ async def mem_context_diff(
             lines.append("Skills:")
             for row in rows:
                 runtime, name, status = row
-                reason = getattr(row, "reason", None)
+                reason = _redact_reason(getattr(row, "reason", None), root)
                 suffix = f" — {reason}" if reason else ""
                 lines.append(f"  {runtime}: {name} [{status}]{suffix}")
         else:
@@ -799,7 +814,7 @@ async def mem_context_diff(
             lines.append("Sub-agents:")
             for row in rows:
                 runtime, name, status = row
-                reason = getattr(row, "reason", None)
+                reason = _redact_reason(getattr(row, "reason", None), root)
                 suffix = f" — {reason}" if reason else ""
                 lines.append(f"  {runtime}: {name} [{status}]{suffix}")
         else:
@@ -813,7 +828,7 @@ async def mem_context_diff(
             lines.append("Commands:")
             for row in rows:
                 runtime, name, status = row
-                reason = getattr(row, "reason", None)
+                reason = _redact_reason(getattr(row, "reason", None), root)
                 suffix = f" — {reason}" if reason else ""
                 lines.append(f"  {runtime}: {name} [{status}]{suffix}")
         else:
@@ -970,7 +985,7 @@ async def mem_context_sync(
                 rel = path.relative_to(root) if path.is_relative_to(root) else path
                 results.append(f"  {runtime}: {rel}")
         for runtime, reason, _code in skill_result.skipped:
-            results.append(f"  skipped {runtime}: {reason}")
+            results.append(f"  skipped {runtime}: {_redact_reason(reason, root)}")
 
     if "agents" in inc:
         try:
@@ -997,7 +1012,7 @@ async def mem_context_sync(
                     rel = path
                 results.append(f"  {runtime}: {rel}")
         for runtime, reason, _code in agent_result.skipped:
-            results.append(f"  skipped {runtime}: {reason}")
+            results.append(f"  skipped {runtime}: {_redact_reason(reason, root)}")
         for runtime, agent_name, dropped in agent_result.dropped:
             results.append(f"  {runtime} dropped {dropped} from '{agent_name}'")
 
@@ -1026,7 +1041,7 @@ async def mem_context_sync(
                     rel = path
                 results.append(f"  {runtime}: {rel}")
         for runtime, reason, _code in command_result.skipped:
-            results.append(f"  skipped {runtime}: {reason}")
+            results.append(f"  skipped {runtime}: {_redact_reason(reason, root)}")
         for runtime, cmd_name, dropped in command_result.dropped:
             results.append(f"  {runtime} dropped {dropped} from '{cmd_name}'")
 
@@ -1477,7 +1492,9 @@ async def mem_context_artifact_migrate(
                 surface="mcp_context_artifact_migrate",
             )
         except (FileNotFoundError, ValueError) as exc:
-            return f"error: {exc}"
+            # Engine FileNotFoundError embeds project_root / flat paths
+            # (context/migrate.py) — strip the root before it leaves the tool.
+            return f"error: {_redact_reason(str(exc), project_root)}"
         except PrivacyScanError as exc:
             return f"privacy block: {exc.message}"
         except MigratePartialError as exc:
@@ -1522,7 +1539,8 @@ async def mem_context_artifact_migrate(
     try:
         rows = await asyncio.to_thread(classify_migrate, project_root, asset, nm)
     except (FileNotFoundError, ValueError) as exc:
-        return f"error: {exc}"
+        # Same path-embedding types as the scope-tier leg above.
+        return f"error: {_redact_reason(str(exc), project_root)}"
 
     skills_section = asset is None
     if not rows:
@@ -2002,9 +2020,14 @@ async def mem_context_artifact_transfer(
     except MigratePartialError as exc:
         return f"error: {exc.message}"
     except McpServerParseError as exc:
-        return f"error: {exc}"
+        # Web twin renders ``exc.safe_message`` (basename + the JSON problem),
+        # never the resolved canonical host path (context_transfer.py). Mirror
+        # it so the path never reaches the calling agent's transcript.
+        return f"error: {exc.safe_message}"
     except (FileNotFoundError, InvalidNameError, ValueError) as exc:
-        return f"error: {exc}"
+        # ``FileNotFoundError`` from the engine embeds absolute src/dst paths
+        # (context/migrate.py) — strip both project roots + ``$HOME`` first.
+        return f"error: {_redact_reason(str(exc), src_root, dst_root)}"
     except click.ClickException as exc:
         return f"error: {exc.message}"
 
@@ -2233,7 +2256,11 @@ async def mem_context_version(
     try:
         snapshot_bytes = await asyncio.to_thread(working_file.read_bytes)
     except OSError as exc:
-        return f"error: cannot read working canonical {working_file}: {exc}"
+        # ``working_file`` and ``str(OSError)`` both embed the absolute canonical
+        # path (the web twin never echoes it). Echo the basename only and strip
+        # the errno message's path.
+        detail = _redact_reason(str(exc), root)
+        return f"error: cannot read working canonical {working_file.name}: {detail}"
     file_scan = await asyncio.to_thread(
         lambda: scan_text_content(
             snapshot_bytes.decode("utf-8", errors="replace"),

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -260,9 +260,11 @@ async def mem_context_init(
     results: list[str] = []
 
     if not scope_explicit and not has_project_signal:
+        # No absolute root echo — the MCP result crosses the wire (the caller
+        # already knows its own cwd; the path only adds ``$HOME``/username).
         results.append(
-            f"warning: no .git or pyproject.toml in {root} — creating .memtomem/ here. "
-            "Use scope='user' for cross-project artifacts."
+            "warning: no .git or pyproject.toml at the project root — creating "
+            ".memtomem/ here. Use scope='user' for cross-project artifacts."
         )
 
     artifact_only_scope = scope_explicit and artifact_scope in ("user", "project_local")
@@ -322,7 +324,9 @@ async def mem_context_init(
     for kind in ("agents", "skills", "commands"):
         d = canonical_artifact_dir(kind, artifact_scope, root)
         d.mkdir(parents=True, exist_ok=True)
-        results.append(f"Created {d}")
+        # Project-relative for project scopes, ``~``-collapsed for user scope —
+        # the absolute canonical dir embeds ``$HOME``/username on the MCP wire.
+        results.append(f"Created {_redact_reason(str(d), root)}")
 
     if artifact_scope == "project_local":
         wrote, msg = _append_gitignore_marker(root)
@@ -348,7 +352,13 @@ async def mem_context_init(
             )
             else "skipped"
         )
-        return f"  {prefix} {name}: {reason}"
+        # Import-engine skip reasons carry raw ``OSError`` text with the
+        # absolute source path (agents/commands/skills importers) — same MCP
+        # wire boundary as the generate/sync skip lines. The remediation
+        # full-path channel stays the ``privacy block:`` exception returns;
+        # a redacted reason keeps the project-relative remainder, so blocked
+        # rows stay actionable.
+        return f"  {prefix} {name}: {_redact_reason(reason, root)}"
 
     if "skills" in inc:
         try:
@@ -718,17 +728,22 @@ async def mem_context_generate(
         settings_results = generate_all_settings(
             root, scope=settings_scope, allow_host_writes=allow_host_writes
         )
+        # Settings reasons embed absolute ``canonical_path`` / ``target_path``
+        # values (context/settings.py f-strings), and the ok-row target is an
+        # absolute path (``$HOME`` for user scope) — same MCP wire boundary as
+        # the artifact skip lines above. Warnings are label/event prose, no
+        # paths.
         for sname, sr in settings_results.items():
             if sr.status == "ok":
-                results.append(f"\nSettings: {sname} → {sr.target}")
+                results.append(f"\nSettings: {sname} → {_redact_reason(str(sr.target), root)}")
                 for w in sr.warnings:
                     results.append(f"  warning: {w}")
             elif sr.status == "skipped":
-                results.append(f"  skipped {sname}: {sr.reason}")
+                results.append(f"  skipped {sname}: {_redact_reason(sr.reason, root)}")
             elif sr.status == "needs_confirmation":
-                results.append(f"  needs confirmation {sname}: {sr.reason}")
+                results.append(f"  needs confirmation {sname}: {_redact_reason(sr.reason, root)}")
             elif sr.status in ("error", "aborted"):
-                results.append(f"  {sr.status} {sname}: {sr.reason}")
+                results.append(f"  {sr.status} {sname}: {_redact_reason(sr.reason, root)}")
 
     return "Generated:\n" + "\n".join(results)
 
@@ -853,15 +868,17 @@ async def mem_context_diff(
                 lines.append("")
             lines.append("Settings:")
             lines.extend(dup_warnings)
+            # Same MCP wire-boundary redaction as the generate/sync settings
+            # loops — reasons embed absolute canonical/target paths.
             for sname, sr in settings_results.items():
                 if sr.status in ("in sync", "out of sync", "missing target"):
                     lines.append(f"  {sname} [{sr.status}]")
                     for w in sr.warnings:
                         lines.append(f"    warning: {w}")
                 elif sr.status == "skipped":
-                    lines.append(f"  skipped {sname}: {sr.reason}")
+                    lines.append(f"  skipped {sname}: {_redact_reason(sr.reason, root)}")
                 elif sr.status == "error":
-                    lines.append(f"  error {sname}: {sr.reason}")
+                    lines.append(f"  error {sname}: {_redact_reason(sr.reason, root)}")
 
     return "\n".join(lines) if lines else "Nothing to compare."
 
@@ -1059,21 +1076,24 @@ async def mem_context_sync(
         settings_results = generate_all_settings(
             root, scope=settings_scope, allow_host_writes=allow_host_writes
         )
+        # Same MCP wire-boundary redaction as the generate settings loop —
+        # reasons embed absolute canonical/target paths, the ok-row target is
+        # absolute (``$HOME`` for user scope).
         for sname, sr in settings_results.items():
             if sr.status == "ok":
                 if results:
                     results.append("")
-                results.append(f"Settings: {sname} → {sr.target}")
+                results.append(f"Settings: {sname} → {_redact_reason(str(sr.target), root)}")
                 for w in sr.warnings:
                     results.append(f"  warning: {w}")
             elif sr.status == "skipped":
-                results.append(f"  skipped {sname}: {sr.reason}")
+                results.append(f"  skipped {sname}: {_redact_reason(sr.reason, root)}")
             elif sr.status == "needs_confirmation":
                 if results:
                     results.append("")
-                results.append(f"  needs confirmation {sname}: {sr.reason}")
+                results.append(f"  needs confirmation {sname}: {_redact_reason(sr.reason, root)}")
             elif sr.status in ("error", "aborted"):
-                results.append(f"  {sr.status} {sname}: {sr.reason}")
+                results.append(f"  {sr.status} {sname}: {_redact_reason(sr.reason, root)}")
 
     return "Synced:\n" + "\n".join(results) if results else "Nothing to sync."
 

--- a/packages/memtomem/tests/test_server_tools_context_redaction.py
+++ b/packages/memtomem/tests/test_server_tools_context_redaction.py
@@ -132,7 +132,9 @@ async def test_diff_row_reason_redacts_absolute_path(
     _assert_no_abs_path(out, root)
     assert "parse error" in out
     assert "missing YAML frontmatter" in out  # the diagnostic survives, path-stripped
-    assert ".memtomem/agents/foo/agent.md" in out  # relative remainder
+    # ``abs_path`` renders with ``os.sep``, so the surviving remainder does too
+    # (Windows: ``.memtomem\agents\…``) — compare via ``Path`` (#838 discipline).
+    assert str(Path(".memtomem/agents/foo/agent.md")) in out  # relative remainder
 
 
 def _skip_result(reason: str):
@@ -398,7 +400,8 @@ async def test_generate_settings_reasons_and_target_redact_absolute_paths(
     out = await mem_context_generate(include="settings")
 
     _assert_no_abs_path(out, root)
-    assert "Settings: claude_settings → .claude/settings.json" in out  # target relativized
+    # The relativized target renders with ``os.sep`` — compare via ``Path``.
+    assert f"Settings: claude_settings → {Path('.claude/settings.json')}" in out
     assert "skipped codex_settings:" in out
     assert "needs confirmation kimi_settings:" in out
     assert "error gemini_settings:" in out
@@ -420,7 +423,8 @@ async def test_sync_settings_reasons_and_target_redact_absolute_paths(
     out = await mem_context_sync(include="settings")
 
     _assert_no_abs_path(out, root)
-    assert "Settings: claude_settings → .claude/settings.json" in out
+    # Same ``os.sep`` rendering as the generate twin above.
+    assert f"Settings: claude_settings → {Path('.claude/settings.json')}" in out
     assert "skipped codex_settings:" in out
     assert "needs confirmation kimi_settings:" in out
     assert "error gemini_settings:" in out

--- a/packages/memtomem/tests/test_server_tools_context_redaction.py
+++ b/packages/memtomem/tests/test_server_tools_context_redaction.py
@@ -19,6 +19,21 @@ audit found unredacted:
 4. ``mem_context_version`` create — the working-canonical read ``OSError`` echoes
    only the basename with a path-stripped errno message.
 
+The #1539 review round (Codex gate) found two more legs the audit's four-leg
+list missed, pinned here as well:
+
+5. ``mem_context_init`` — the import-engine ``_skip_line`` rows echo raw
+   ``OSError`` reasons with the absolute source path;
+6. the settings loops in ``mem_context_generate`` / ``mem_context_diff`` /
+   ``mem_context_sync`` — ``SettingsSyncResult.reason`` embeds absolute
+   canonical/target paths (``context/settings.py`` f-strings) and the ok-row
+   ``target`` echo is an absolute path (``$HOME`` for user scope).
+
+A parity guard (``TestWebParityGuard``) additionally pins the neutral
+``context.error_redact`` twins against the web originals on representative
+inputs so the two copies of this security boundary cannot silently drift
+before the planned delegation refactor.
+
 The remediation-critical ``privacy block: …`` message is intentionally left
 round-tripping the full path (``test_sync_privacy_block_surfaces``) and is not
 exercised here.
@@ -293,3 +308,208 @@ async def test_version_create_oserror_echoes_basename_only(
     _assert_no_abs_path(out, root)
     assert out.startswith("error: cannot read working canonical agent.md:")
     assert "Permission denied" in out
+
+
+# ── leg 5 (#1539 review round): init import-engine skip lines ────────────────
+
+
+@pytest.mark.anyio
+async def test_init_skipped_reason_redacts_absolute_path(
+    layout, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from memtomem.context import agents as ctx_agents
+    from memtomem.context.agents import ExtractResult
+    from memtomem.server.tools.context import mem_context_init
+
+    root = layout["project_root"]
+    reason = f"unreadable: [Errno 13] Permission denied: '{root}/.claude/agents/foo.md'"
+    result = ExtractResult(imported=[], skipped=[("foo", reason, "parse_error")])
+    monkeypatch.setattr(ctx_agents, "extract_agents_to_canonical", lambda *a, **k: result)
+
+    out = await mem_context_init(include="agents")
+
+    _assert_no_abs_path(out, root)
+    assert "skipped foo:" in out
+    assert "Permission denied" in out  # errno text survives, path-stripped
+
+
+@pytest.mark.anyio
+async def test_init_privacy_blocked_skip_keeps_relative_remainder(
+    layout, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Blocked rows redact like skips — the remediation full-path channel is
+    the ``privacy block:`` exception return, not the per-item row."""
+    from memtomem.context import _skip_reasons as skip_codes
+    from memtomem.context import agents as ctx_agents
+    from memtomem.context.agents import ExtractResult
+    from memtomem.server.tools.context import mem_context_init
+
+    root = layout["project_root"]
+    reason = f"privacy hits in {root}/.claude/agents/foo.md (1 finding)"
+    result = ExtractResult(imported=[], skipped=[("foo", reason, skip_codes.PRIVACY_BLOCKED)])
+    monkeypatch.setattr(ctx_agents, "extract_agents_to_canonical", lambda *a, **k: result)
+
+    out = await mem_context_init(include="agents")
+
+    _assert_no_abs_path(out, root)
+    assert "blocked foo:" in out
+    assert ".claude/agents/foo.md" in out  # relative remainder stays actionable
+
+
+# ── leg 6 (#1539 review round): settings reasons + ok-row target ─────────────
+
+
+def _settings_results(root: Path) -> dict[str, object]:
+    """One result per settings branch that renders a reason or a target."""
+    from memtomem.context.settings import SettingsSyncResult
+
+    return {
+        "claude_settings": SettingsSyncResult(
+            status="ok", target=root / ".claude" / "settings.json"
+        ),
+        "codex_settings": SettingsSyncResult(
+            status="skipped",
+            reason=f"{root}/.memtomem/settings.json is not valid JSON (or not a JSON object).",
+        ),
+        "kimi_settings": SettingsSyncResult(
+            status="needs_confirmation",
+            reason=f"{root}/.kimi/settings.json is outside the project root; pass "
+            "allow_host_writes=True.",
+        ),
+        "gemini_settings": SettingsSyncResult(
+            status="error",
+            reason=f"{root}/.gemini/settings.json: boom. Fix the file manually.",
+        ),
+    }
+
+
+@pytest.mark.anyio
+async def test_generate_settings_reasons_and_target_redact_absolute_paths(
+    layout, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from memtomem.context import settings as ctx_settings
+    from memtomem.server.tools.context import mem_context_generate
+
+    root = layout["project_root"]
+    monkeypatch.setattr(
+        ctx_settings, "generate_all_settings", lambda *a, **k: _settings_results(root)
+    )
+
+    out = await mem_context_generate(include="settings")
+
+    _assert_no_abs_path(out, root)
+    assert "Settings: claude_settings → .claude/settings.json" in out  # target relativized
+    assert "skipped codex_settings:" in out
+    assert "needs confirmation kimi_settings:" in out
+    assert "error gemini_settings:" in out
+    assert "is not valid JSON" in out  # diagnostics survive, path-stripped
+
+
+@pytest.mark.anyio
+async def test_sync_settings_reasons_and_target_redact_absolute_paths(
+    layout, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from memtomem.context import settings as ctx_settings
+    from memtomem.server.tools.context import mem_context_sync
+
+    root = layout["project_root"]
+    monkeypatch.setattr(
+        ctx_settings, "generate_all_settings", lambda *a, **k: _settings_results(root)
+    )
+
+    out = await mem_context_sync(include="settings")
+
+    _assert_no_abs_path(out, root)
+    assert "Settings: claude_settings → .claude/settings.json" in out
+    assert "skipped codex_settings:" in out
+    assert "needs confirmation kimi_settings:" in out
+    assert "error gemini_settings:" in out
+
+
+@pytest.mark.anyio
+async def test_diff_settings_reasons_redact_absolute_paths(
+    layout, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from memtomem.context import settings as ctx_settings
+    from memtomem.context.settings import SettingsSyncResult
+    from memtomem.server.tools.context import mem_context_diff
+
+    root = layout["project_root"]
+    results = {
+        "claude_settings": SettingsSyncResult(
+            status="skipped",
+            reason=f"{root}/.memtomem/settings.json is not valid JSON (or not a JSON object).",
+        ),
+        "codex_settings": SettingsSyncResult(
+            status="error",
+            reason=f"{root}/.codex/settings.json: boom. Fix the file manually.",
+        ),
+    }
+    monkeypatch.setattr(ctx_settings, "diff_settings", lambda *a, **k: results)
+
+    out = await mem_context_diff(include="settings")
+
+    _assert_no_abs_path(out, root)
+    assert "skipped claude_settings:" in out
+    assert "error codex_settings:" in out
+
+
+# ── parity guard: the neutral leaf must not drift from the web twins ─────────
+
+
+class TestWebParityGuard:
+    """Pin ``context.error_redact`` byte-for-byte against the web originals.
+
+    The neutral leaf duplicates ``web/routes/_errors._redact_message`` and
+    ``context_gateway.sanitize_diff_reason`` (the MCP layer may not import
+    ``memtomem.web.*``). This is a security boundary — a silent drift between
+    the twins reopens the leak on whichever surface got the stale copy — so
+    representative inputs are compared against BOTH implementations until the
+    planned delegation refactor collapses them.
+    """
+
+    def test_frozen_constants_match_web(self) -> None:
+        from memtomem.context import error_redact
+        from memtomem.web.routes import _errors as web_errors
+
+        assert error_redact._HOME == web_errors._HOME
+        assert error_redact._ERROR_MESSAGE_LIMIT == web_errors._ERROR_MESSAGE_LIMIT
+        assert error_redact._SECRET_REDACTED_MARKER == web_errors._SECRET_REDACTED_MARKER
+
+    def test_redact_message_matches_web(self) -> None:
+        from memtomem.context import error_redact
+        from memtomem.web.routes._errors import _redact_message as web_redact
+
+        home = error_redact._HOME
+        cases = [
+            "plain diagnostic, no path",
+            f"unreadable: [Errno 13] Permission denied: '{home}/proj/agent.md'",
+            "x" * 500,  # truncation
+            "token AKIA1234567890ABCDEF leaked",  # secret-shape → whole-replace
+            "",
+        ]
+        for msg in cases:
+            assert error_redact.redact_message(msg) == web_redact(msg), msg
+
+    def test_engine_reason_matches_web_single_root(self, tmp_path: Path) -> None:
+        from memtomem.context.error_redact import redact_engine_reason
+        from memtomem.web.routes.context_gateway import sanitize_diff_reason
+
+        real = (tmp_path / "real").resolve()
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real)
+        cases = [
+            None,
+            "",
+            "no path at all",
+            f"missing YAML frontmatter: {real}/.memtomem/agents/foo/agent.md",
+            f"{real}: [Errno 2] No such file or directory",
+            f"{real}{real}/nested repeat",
+        ]
+        for root in (real, link, tmp_path):
+            for msg in cases:
+                assert redact_engine_reason(msg, root) == sanitize_diff_reason(msg, root), (
+                    msg,
+                    root,
+                )

--- a/packages/memtomem/tests/test_server_tools_context_redaction.py
+++ b/packages/memtomem/tests/test_server_tools_context_redaction.py
@@ -1,0 +1,295 @@
+"""Path-redaction pins for the MCP context tool error/reason surfaces.
+
+The web wire boundary sanitizes raw engine exception text before it leaves the
+loopback dashboard (``web/routes/_errors._redact_message`` +
+``context_gateway.sanitize_diff_reason``). The MCP context tools in
+``server/tools/context.py`` are a second wire boundary for the same reasons —
+their string results flow into the calling agent's transcript and on to the
+model provider — so they must strip the absolute host path (``$HOME`` / the OS
+username) the same way. These tests pin the four legs the dedicated MCP-surface
+audit found unredacted:
+
+1. ``mem_context_diff`` diff-row ``reason`` and the generate / sync ``skipped``
+   lines (a ``DiffRow.reason`` / skip tuple embeds the absolute source path);
+2. ``mem_context_artifact_transfer`` — ``McpServerParseError`` → ``safe_message``
+   (basename, not the resolved canonical path) and the adjacent
+   ``FileNotFoundError`` → path-stripped;
+3. ``mem_context_artifact_migrate`` — both ``FileNotFoundError`` legs
+   (scope-tier ``migrate_scope`` + flat ``classify_migrate``);
+4. ``mem_context_version`` create — the working-canonical read ``OSError`` echoes
+   only the basename with a path-stripped errno message.
+
+The remediation-critical ``privacy block: …`` message is intentionally left
+round-tripping the full path (``test_sync_privacy_block_surfaces``) and is not
+exercised here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memtomem.context.error_redact import redact_engine_reason, redact_message
+
+
+@pytest.fixture
+def layout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    """A project root (``.git`` so ``_find_project_root`` terminates) + isolated
+    HOME + cwd at the project (mirrors the sibling MCP context tool tests)."""
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    (project_root / ".git").mkdir()
+    user_home = tmp_path / "home"
+    user_home.mkdir()
+    monkeypatch.setenv("HOME", str(user_home))
+    monkeypatch.setenv("USERPROFILE", str(user_home))
+    monkeypatch.chdir(project_root)
+    return {"project_root": project_root.resolve(), "user_home": user_home.resolve()}
+
+
+def _assert_no_abs_path(out: str, project_root: Path) -> None:
+    """The absolute project root (both forms) must never reach the wire."""
+    assert str(project_root) not in out, out
+    assert str(project_root.resolve()) not in out, out
+
+
+# ── neutral redactor contract (mirror of the web twins) ──────────────────────
+
+
+class TestNeutralRedactor:
+    def test_reason_strips_both_root_forms(self, tmp_path: Path) -> None:
+        real = (tmp_path / "real").resolve()
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real)
+        # A reason built from the RESOLVED path but redacted with the UNRESOLVED
+        # (symlinked) root — the single-form strip left the resolved path behind
+        # pre-fix (the #1412 canonical-path-leak shape).
+        reason = f"missing YAML frontmatter: {real}/.memtomem/agents/foo/agent.md"
+        out = redact_engine_reason(reason, link)
+        assert out is not None
+        assert str(real) not in out
+        assert str(link) not in out
+        assert "missing YAML frontmatter" in out
+        assert ".memtomem/agents/foo/agent.md" in out  # relative remainder survives
+
+    def test_empty_reason_is_none(self) -> None:
+        assert redact_engine_reason(None, Path("/x")) is None
+        assert redact_engine_reason("", Path("/x")) is None
+
+    def test_message_collapses_home_and_truncates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # ``_HOME`` is frozen at import — patch the module constant to assert the
+        # collapse without depending on the test runner's real home.
+        from memtomem.context import error_redact
+
+        monkeypatch.setattr(error_redact, "_HOME", "/Users/alice")
+        assert error_redact.redact_message("boom at /Users/alice/x") == "boom at ~/x"
+        assert len(error_redact.redact_message("x" * 500)) == 200
+
+    def test_message_drops_secret_shape_whole(self) -> None:
+        # AWS access-key shape trips the LTM secret-class scanner → whole-replace.
+        assert redact_message("token AKIA1234567890ABCDEF leaked") == "<redacted: secret-shape>"
+
+
+# ── leg 1: diff-row reason + generate/sync skipped lines ─────────────────────
+
+
+@pytest.mark.anyio
+async def test_diff_row_reason_redacts_absolute_path(
+    layout, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from memtomem.context import agents as ctx_agents
+    from memtomem.context._runtime_targets import DiffRow
+    from memtomem.server.tools.context import mem_context_diff
+
+    root = layout["project_root"]
+    abs_path = root / ".memtomem" / "agents" / "foo" / "agent.md"
+    reason = f"missing YAML frontmatter: {abs_path}"
+
+    def fake_diff_agents(project_root, *, scope="project_shared"):
+        return [DiffRow("claude", "foo", "parse error", reason)]
+
+    monkeypatch.setattr(ctx_agents, "diff_agents", fake_diff_agents)
+
+    out = await mem_context_diff(include="agents", scope="project_shared")
+
+    _assert_no_abs_path(out, root)
+    assert "parse error" in out
+    assert "missing YAML frontmatter" in out  # the diagnostic survives, path-stripped
+    assert ".memtomem/agents/foo/agent.md" in out  # relative remainder
+
+
+def _skip_result(reason: str):
+    """An ``AgentSyncResult`` whose only outcome is one path-bearing skip."""
+    from memtomem.context.agents import AgentSyncResult
+
+    return AgentSyncResult(generated=[], dropped=[], skipped=[("claude", reason, "parse_error")])
+
+
+@pytest.mark.anyio
+async def test_generate_skipped_reason_redacts_absolute_path(
+    layout, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from memtomem.context import agents as ctx_agents
+    from memtomem.server.tools.context import mem_context_generate
+
+    root = layout["project_root"]
+    reason = f"unreadable: [Errno 13] Permission denied: '{root}/.memtomem/agents/foo/agent.md'"
+    monkeypatch.setattr(ctx_agents, "generate_all_agents", lambda *a, **k: _skip_result(reason))
+
+    out = await mem_context_generate(include="agents", scope="project_shared")
+
+    _assert_no_abs_path(out, root)
+    assert "skipped claude:" in out
+    assert "Permission denied" in out  # errno text survives, path-stripped
+
+
+@pytest.mark.anyio
+async def test_sync_skipped_reason_redacts_absolute_path(
+    layout, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from memtomem.context import agents as ctx_agents
+    from memtomem.server.tools.context import mem_context_sync
+
+    root = layout["project_root"]
+    reason = f"unreadable: [Errno 13] Permission denied: '{root}/.memtomem/agents/foo/agent.md'"
+    monkeypatch.setattr(ctx_agents, "generate_all_agents", lambda *a, **k: _skip_result(reason))
+
+    out = await mem_context_sync(include="agents", scope="project_shared")
+
+    _assert_no_abs_path(out, root)
+    assert "skipped claude:" in out
+    assert "Permission denied" in out
+
+
+# ── leg 2: artifact_transfer parse error + FileNotFoundError ─────────────────
+
+
+@pytest.mark.anyio
+async def test_transfer_parse_error_uses_safe_message(
+    layout, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from memtomem.context import transfer as ctx_transfer
+    from memtomem.context.mcp_servers import McpServerParseError
+    from memtomem.server.tools.context import mem_context_artifact_transfer
+
+    root = layout["project_root"]
+    abs_path = root / ".memtomem" / "mcp-servers" / "x.json"
+
+    def boom(*a, **k):
+        raise McpServerParseError(
+            f"invalid JSON in {abs_path}: Expecting value",
+            safe_message="invalid JSON in x.json: Expecting value",
+        )
+
+    monkeypatch.setattr(ctx_transfer, "transfer_artifact", boom)
+
+    out = await mem_context_artifact_transfer(
+        asset_type="agents", name="foo", mode="copy", to_scope="project_local"
+    )
+
+    _assert_no_abs_path(out, root)
+    assert out == "error: invalid JSON in x.json: Expecting value"
+
+
+@pytest.mark.anyio
+async def test_transfer_filenotfound_redacts_absolute_path(
+    layout, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from memtomem.context import transfer as ctx_transfer
+    from memtomem.server.tools.context import mem_context_artifact_transfer
+
+    root = layout["project_root"]
+    abs_path = root / ".memtomem" / "agents" / "foo" / "agent.md"
+
+    def boom(*a, **k):
+        raise FileNotFoundError(2, "No such file or directory", str(abs_path))
+
+    monkeypatch.setattr(ctx_transfer, "transfer_artifact", boom)
+
+    out = await mem_context_artifact_transfer(
+        asset_type="agents", name="foo", mode="copy", to_scope="project_local"
+    )
+
+    _assert_no_abs_path(out, root)
+    assert out.startswith("error:")
+    assert "No such file or directory" in out
+
+
+# ── leg 3: artifact_migrate FileNotFoundError (both legs) ─────────────────────
+
+
+@pytest.mark.anyio
+async def test_migrate_scope_filenotfound_redacts_absolute_path(
+    layout, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from memtomem.context import migrate as ctx_migrate
+    from memtomem.server.tools.context import mem_context_artifact_migrate
+
+    root = layout["project_root"]
+
+    def boom(*a, **k):
+        raise FileNotFoundError(f"project_root {root} is not a directory")
+
+    monkeypatch.setattr(ctx_migrate, "migrate_scope", boom)
+
+    out = await mem_context_artifact_migrate(
+        asset_type="agents", name="foo", to_scope="project_local"
+    )
+
+    _assert_no_abs_path(out, root)
+    assert out.startswith("error:")
+    assert "is not a directory" in out
+
+
+@pytest.mark.anyio
+async def test_migrate_flat_filenotfound_redacts_absolute_path(
+    layout, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from memtomem.context import migrate as ctx_migrate
+    from memtomem.server.tools.context import mem_context_artifact_migrate
+
+    root = layout["project_root"]
+
+    def boom(*a, **k):
+        raise FileNotFoundError(f"no flat canonical to adopt at {root}/.memtomem/agents/foo.md")
+
+    monkeypatch.setattr(ctx_migrate, "classify_migrate", boom)
+
+    out = await mem_context_artifact_migrate(asset_type="agents", name="foo")
+
+    _assert_no_abs_path(out, root)
+    assert out.startswith("error:")
+    assert "no flat canonical to adopt" in out
+
+
+# ── leg 4: version create working-canonical read OSError ─────────────────────
+
+
+@pytest.mark.anyio
+async def test_version_create_oserror_echoes_basename_only(
+    layout, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from memtomem.server.tools.context import mem_context_version
+
+    root = layout["project_root"]
+    artifact_dir = root / ".memtomem" / "agents" / "foo"
+    artifact_dir.mkdir(parents=True)
+    working_file = artifact_dir / "agent.md"
+    working_file.write_text("---\nname: foo\ndescription: d\n---\n\nbody\n", encoding="utf-8")
+
+    real_read_bytes = Path.read_bytes
+
+    def boom(self: Path):
+        if self == working_file:
+            raise OSError(13, "Permission denied", str(working_file))
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", boom)
+
+    out = await mem_context_version("agents", "foo", action="create")
+
+    _assert_no_abs_path(out, root)
+    assert out.startswith("error: cannot read working canonical agent.md:")
+    assert "Permission denied" in out

--- a/packages/memtomem/tests/test_sync_privacy_block_surfaces.py
+++ b/packages/memtomem/tests/test_sync_privacy_block_surfaces.py
@@ -32,8 +32,10 @@ _LEAK_PATH = "/tmp/p/.memtomem/agents/leak.md"
 _FAKE_BLOCKED = FileScan(Path(_LEAK_PATH), "blocked", 1)
 # Mirror the real engine remediation, which ends with the absolute canonical
 # path (``privacy_scan.py``). The web 422 must NOT echo it (#1385 finding 1);
-# the MCP tool surface (a different trust boundary — the result goes to the
-# calling agent, not a loopback browser) still round-trips the full message.
+# the MCP tool surface deliberately still round-trips the full message — not
+# because MCP is a weaker boundary (#1539 redacts its incidental error/reason
+# paths), but because this message IS the remediation: the caller must know
+# exactly which file to fix.
 _FAKE_MSG = (
     "Gate A: leak.md contains 1 privacy pattern hit(s); fan-out rejected. "
     f"Or remove the secret from {_LEAK_PATH} before re-running sync."
@@ -323,8 +325,9 @@ class TestMcpServersParseBranchPathFree:
 
     def test_safe_message_is_basename_only(self) -> None:
         # The core contract every web catch site relies on: ``safe_message``
-        # names only the basename while ``str(exc)`` keeps the full path the CLI
-        # / MCP surfaces want. Driven through the real parser (no hand-built
+        # names only the basename while ``str(exc)`` keeps the full path for
+        # the local-operator CLI (the MCP tool renders ``safe_message`` too
+        # since #1539). Driven through the real parser (no hand-built
         # exception) so the raise site and the twin stay in lockstep.
         from memtomem.context.mcp_servers import McpServerParseError, parse_mcp_server_text
 
@@ -332,7 +335,7 @@ class TestMcpServersParseBranchPathFree:
         with pytest.raises(McpServerParseError) as ei:
             parse_mcp_server_text(self._MALFORMED, name="x", source=src)
         exc = ei.value
-        assert str(src) in str(exc)  # CLI / MCP keep the full path
+        assert str(src) in str(exc)  # the CLI keeps the full path
         assert str(src) not in exc.safe_message  # web boundary stays path-free
         assert str(src.parent) not in exc.safe_message
         assert exc.safe_message.startswith("invalid JSON in x.json:")  # names the artifact


### PR DESCRIPTION
> [!NOTE]
> **Design decision resolved — ACCEPT** (maintainer + independent Codex gate, 2026-07-02): MCP tool results are serialized into the calling agent's transcript and sent to the model provider — a stronger egress than the loopback dashboard the web boundary already redacts. #1229 U7 conflated the CLI (the operator's own terminal, no disclosure) with MCP (third-party egress); this PR corrects that category split. **CLI stays verbatim.**

## What it does

Ports the web trust boundary's error redaction to the MCP context tools (`server/tools/context.py`), which re-implement error formatting inline and skip the redaction the web routes apply. New neutral leaf `context/error_redact.py` (`redact_message` mirrors `web/routes/_errors._redact_message`; `redact_engine_reason` mirrors `context_gateway.sanitize_diff_reason`) — imports only `memtomem.privacy` (acyclic), so no server→web coupling.

**Commit 1 — the four legs the MCP-surface audit found:**

1. **Diff reasons + generate/sync skip lines** (9 sites) → redacted (engine reasons embed absolute source paths).
2. **`artifact_transfer`** → `McpServerParseError.safe_message`; FNF/ValueError → redacted (migrate raises embed project/flat paths).
3. **`artifact_migrate`** → both FNF/ValueError legs redacted.
4. **`version create` OSError** → `working_file.name` (basename) + redacted message.

**Commit 2 — the legs the Codex review round found beyond the audit** (the four-leg list was a lower bound):

5. **`mem_context_init`** — `_skip_line()` import skip reasons (raw engine `OSError` text), plus two more init echoes surfaced while testing: the `Created {dir}` absolute-canonical-dir lines and the no-project-signal warning embedding the absolute root.
6. **Settings loops in generate/diff/sync** — `SettingsSyncResult.reason` (absolute canonical/target paths from `context/settings.py`) and the ok-row `Settings: name → target` absolute-target echo (`$HOME` for user scope).

The remediation-critical `privacy block:` full-path round-trip is **preserved** on every leg — that message IS the remediation, so the caller must see the exact file. Blocked (privacy) skip *rows* redact like plain skips; the project-relative remainder keeps them actionable.

## Parity guard (Codex major finding)

`context.error_redact` duplicates the two web functions (MCP may not import `memtomem.web.*`). `TestWebParityGuard` pins the twins against each other — frozen constants (`_HOME` anchor, truncation limit, secret marker) plus representative message/reason inputs including the #1412 symlinked-root shape — so silent drift fails a test until a later PR collapses the duplication by having the web delegate here.

## Posture docs updated

- `DiffRow` docstring: web AND MCP sanitize at their wire boundary; only the CLI prints verbatim.
- The two test comments written against the pre-#1539 "CLI/MCP print verbatim" stance are reworded (`test_safe_message_is_basename_only`, `test_sync_privacy_block_surfaces`) — full-path retention is CLI-only; the privacy-block round-trip is justified by remediation-criticality, not by MCP being a weaker boundary.

## Known follow-ups (out of scope)

- **Web sibling gap**: `web/routes/settings_sync.py` renders raw `r.reason` on one surface (`settings_sync.py:528`) — same class of leak on the *web* settings axis, needs its own sweep.
- **Sibling-prefix nit** (Codex minor): the bare-root `.replace(root, ".")` can mangle a sibling like `/tmp/project2` into `.2/…` — mirrors the current web helper, no absolute path survives; fold a boundary-aware replacement into the delegation refactor.

## Tests

Commit 1: 12 RED-first (pre-fix 8 failed / 4 passed → 12 passed). Commit 2: +8 (init skip + blocked rows, settings reasons/targets ×3 tools, 3-case parity guard) — the init test's whole-output assert is what surfaced the two extra init echoes. Full related suites: 814 passed; `ruff check` + `format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
