### PR TITLE
fix(config): stop sub-configs from binding bare unprefixed env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,27 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   its warning and aggregates non-redaction errors to one line per directory.
   `mm index` output is unchanged.
 
+### Changed
+
+- **Config sections no longer bind bare, unprefixed environment variables**
+  (#1522). The 22 sub-config sections (`embedding`, `storage`, `llm`,
+  `session_trace`, …) plus `NamespacePolicyRule` were `BaseSettings` classes
+  without an `env_prefix`, so
+  generic shell exports like `API_KEY`, `ENABLED`, `MODEL`, or `HOST` silently
+  overrode memtomem configuration — including secret-bearing fields
+  (`embedding.api_key`, `session_trace.langfuse_secret_key`) and validator
+  guards — outside the documented `MEMTOMEM_` surface. They are now plain
+  pydantic models: environment binding flows exclusively through
+  `MEMTOMEM_<SECTION>__<FIELD>`.
+
+  **Migration**: if you relied on a bare name, add the documented prefix —
+  e.g. `API_KEY=sk-…` → `MEMTOMEM_EMBEDDING__API_KEY=sk-…` (or
+  `MEMTOMEM_LLM__API_KEY=sk-…`). One deliberate exception: with
+  `session_trace.langfuse_enabled=true`, the Langfuse SDK's own
+  `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` (and `LANGFUSE_HOST`) still
+  count as credentials — they are read by the SDK itself and are never copied
+  into memtomem config. `LANGFUSE_ENABLED` alone never turns tracing on.
+
 ## [0.3.2] — 2026-06-30
 
 A security release. The Web UI now validates `Host`/`Origin` on every `/api/*`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   (`embedding.api_key`, `session_trace.langfuse_secret_key`) and validator
   guards — outside the documented `MEMTOMEM_` surface. They are now plain
   pydantic models: environment binding flows exclusively through
-  `MEMTOMEM_<SECTION>__<FIELD>`.
+  `MEMTOMEM_<SECTION>__<FIELD>`. Validation strictness is unchanged — unknown
+  keys (an env typo like `MEMTOMEM_EMBEDDING__TYPO`, or a stray key in
+  `config.json`/`config.d`) still fail loudly, exactly as before.
 
   **Migration**: if you relied on a bare name, add the documented prefix —
   e.g. `API_KEY=sk-…` → `MEMTOMEM_EMBEDDING__API_KEY=sk-…` (or

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,6 +1,6 @@
 # Configuration Reference
 
-memtomem reads configuration from environment variables. All variables use the `MEMTOMEM_` prefix, with nested sections separated by `__` (double underscore).
+memtomem reads configuration from environment variables. All variables use the `MEMTOMEM_` prefix, with nested sections separated by `__` (double underscore). Unprefixed names are never read, with one documented exception: the Langfuse SDK credentials described in [Session Trace](#session-trace).
 
 ```bash
 # Example: switch from Ollama to OpenAI
@@ -829,7 +829,7 @@ gate wins.
 | `MEMTOMEM_LLM__MAX_TOKENS` | `1024` | Maximum response tokens |
 | `MEMTOMEM_LLM__TIMEOUT` | `60.0` | Request timeout in seconds |
 
-The `openai` provider works with any OpenAI-compatible endpoint (LM Studio, vLLM, OpenRouter, etc.) — set `BASE_URL` to the server's address. See [LLM Providers](llm-providers.md) for setup examples.
+The `openai` provider works with any OpenAI-compatible endpoint (LM Studio, vLLM, OpenRouter, etc.) — set `MEMTOMEM_LLM__BASE_URL` to the server's address. See [LLM Providers](llm-providers.md) for setup examples.
 
 ## Session Summary
 
@@ -857,11 +857,13 @@ Requires `MEMTOMEM_LLM__ENABLED=true` and a configured provider. Generated summa
 | `MEMTOMEM_SESSION_TRACE__LANGFUSE_PUBLIC_KEY` | _(empty)_ | Public key for your Langfuse project. |
 | `MEMTOMEM_SESSION_TRACE__LANGFUSE_SECRET_KEY` | _(empty)_ | Secret key for your Langfuse project. |
 | `MEMTOMEM_SESSION_TRACE__LANGFUSE_HOST` | _(empty)_ | Langfuse host URL (e.g. `https://cloud.langfuse.com` or self-hosted endpoint). |
-| `MEMTOMEM_SESSION_TRACE__SAMPLING_RATE` | `1.0` | Sampling rate for Langfuse spans, from `0.0` (no spans) to `1.0` (send all). Note: local JSONL logging is not affected by sampling (disable output via `ENABLED=false` or `JSONL_ENABLED=false`). |
+| `MEMTOMEM_SESSION_TRACE__SAMPLING_RATE` | `1.0` | Sampling rate for Langfuse spans, from `0.0` (no spans) to `1.0` (send all). Note: local JSONL logging is not affected by sampling (disable output via `MEMTOMEM_SESSION_TRACE__ENABLED=false` or `MEMTOMEM_SESSION_TRACE__JSONL_ENABLED=false`). |
 | `MEMTOMEM_SESSION_TRACE__PAYLOAD_MODE` | `metadata` | Payload logging mode: `metadata` (no payloads logged / None), `redacted` (replaces secret-looking fields like passwords/keys with `***` while leaving ordinary values intact), or `full` (log complete input/output). |
 | `MEMTOMEM_SESSION_TRACE__MAX_PAYLOAD_CHARS` | `10000` | Maximum character length for payload properties before truncation. |
 
 When `MEMTOMEM_SESSION_TRACE__LANGFUSE_ENABLED=true` is set, both public and secret keys must be supplied, and the `langfuse` Python package must be installed (e.g., via `pip install 'memtomem[langfuse]'` or `uv tool install 'memtomem[all]'` which includes it).
+
+The keys may come either from the config surface above or from the Langfuse SDK's own standard variables — `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and optionally `LANGFUSE_HOST`. This is the only place memtomem honours env vars without the `MEMTOMEM_` prefix, and it is credentials-only: the values are read by the Langfuse SDK itself, never copied into memtomem config, and `LANGFUSE_ENABLED` alone never turns tracing on — enabling always requires the explicit `MEMTOMEM_SESSION_TRACE__LANGFUSE_ENABLED=true` (or `config.json`) opt-in.
 
 ## Tool Mode
 

--- a/docs/guides/llm-providers.md
+++ b/docs/guides/llm-providers.md
@@ -54,7 +54,7 @@ export MEMTOMEM_LLM__API_KEY=sk-ant-...
 
 ## OpenAI-Compatible Endpoints
 
-The `openai` provider works with **any server** that implements `/v1/chat/completions` — not just OpenAI's cloud API. Set `PROVIDER=openai` and point `BASE_URL` at your server.
+The `openai` provider works with **any server** that implements `/v1/chat/completions` — not just OpenAI's cloud API. Set `MEMTOMEM_LLM__PROVIDER=openai` and point `MEMTOMEM_LLM__BASE_URL` at your server.
 
 ### LM Studio
 
@@ -91,8 +91,8 @@ export MEMTOMEM_LLM__MODEL=meta-llama/llama-3.1-8b-instruct
 
 Any server implementing `/v1/chat/completions` works:
 
-- **text-generation-webui**: enable `--api`, `BASE_URL=http://localhost:5000`
-- **LocalAI**: `BASE_URL=http://localhost:8080`
+- **text-generation-webui**: enable `--api`, `MEMTOMEM_LLM__BASE_URL=http://localhost:5000`
+- **LocalAI**: `MEMTOMEM_LLM__BASE_URL=http://localhost:8080`
 
 ### MCP Config Example
 
@@ -126,12 +126,12 @@ Code, use `claude mcp add` instead of editing a file. See
 
 ## Configuration Reference
 
-See [`configuration.md#llm`](configuration.md#llm) for the complete `MEMTOMEM_LLM__*` environment variable reference. Provider defaults when `MODEL` is empty: ollama → `gemma4:e2b`, openai → `gpt-4.1-mini`, anthropic → `claude-haiku-4-5-20251001`.
+See [`configuration.md#llm`](configuration.md#llm) for the complete `MEMTOMEM_LLM__*` environment variable reference. Provider defaults when `MEMTOMEM_LLM__MODEL` is empty: ollama → `gemma4:e2b`, openai → `gpt-4.1-mini`, anthropic → `claude-haiku-4-5-20251001`.
 
 ## Troubleshooting
 
-- **"Cannot connect to …"** — check `BASE_URL` and that the server is running
-- **"Authentication failed"** — verify `API_KEY`
+- **"Cannot connect to …"** — check `MEMTOMEM_LLM__BASE_URL` and that the server is running
+- **"Authentication failed"** — verify `MEMTOMEM_LLM__API_KEY`
 - **"Model not found" (Ollama)** — run `ollama pull <model>`
 - **Consolidation falls back to heuristic** — LLM error is logged; check provider health
 - **Query expansion adds latency** — expansion has a 3-second hard timeout; consider switching to `strategy="tags"` if LLM is consistently slow

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -9,7 +9,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Literal, cast, get_args
 
-from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from memtomem.constants import default_system_prefixes
@@ -40,7 +47,21 @@ APPEND = MergeStrategy("append")
 REPLACE = MergeStrategy("replace")
 
 
-class EmbeddingConfig(BaseModel):
+class ConfigModel(BaseModel):
+    """Base for config sections and nested config entries (#1522).
+
+    Sub-configs deliberately do not inherit ``BaseSettings`` — env binding
+    flows exclusively through ``Mem2MemConfig``'s ``MEMTOMEM_`` prefix. This
+    base preserves the strictness ``BaseSettings`` used to provide: unknown
+    keys are rejected (a typo like ``MEMTOMEM_EMBEDDING__TYPO`` or a stray
+    key in ``config.json``/``config.d`` fails loudly instead of being
+    silently dropped) and defaults run through field validators.
+    """
+
+    model_config = ConfigDict(extra="forbid", validate_default=True)
+
+
+class EmbeddingConfig(ConfigModel):
     provider: str = "none"
     model: str = ""
     dimension: int = 0
@@ -116,13 +137,13 @@ class EmbeddingConfig(BaseModel):
         return v
 
 
-class StorageConfig(BaseModel):
+class StorageConfig(ConfigModel):
     backend: str = "sqlite"
     sqlite_path: Path = Path("~/.memtomem/memtomem.db")
     collection_name: str = "memories"
 
 
-class SearchConfig(BaseModel):
+class SearchConfig(ConfigModel):
     default_top_k: int = 10
     bm25_candidates: int = 50
     dense_candidates: int = 50
@@ -190,7 +211,7 @@ def _default_memory_dirs() -> list[Path]:
     return [Path("~/.memtomem/memories")]
 
 
-class IndexingConfig(BaseModel):
+class IndexingConfig(ConfigModel):
     memory_dirs: Annotated[list[Path], APPEND] = Field(
         default_factory=lambda: _default_memory_dirs()
     )
@@ -320,7 +341,7 @@ class IndexingConfig(BaseModel):
         return [Path(d) for d in (*self.memory_dirs, *self.project_memory_dirs)]
 
 
-class DecayConfig(BaseModel):
+class DecayConfig(ConfigModel):
     enabled: bool = False
     half_life_days: float = 30.0
 
@@ -332,7 +353,7 @@ class DecayConfig(BaseModel):
         return v
 
 
-class MMRConfig(BaseModel):
+class MMRConfig(ConfigModel):
     enabled: bool = False
     lambda_param: float = 0.7  # 0.0=diversity max, 1.0=relevance max
 
@@ -344,7 +365,7 @@ class MMRConfig(BaseModel):
         return v
 
 
-class AccessConfig(BaseModel):
+class AccessConfig(ConfigModel):
     enabled: bool = False
     max_boost: float = 1.5  # maximum score multiplier for highly accessed chunks
 
@@ -360,7 +381,7 @@ _NAMESPACE_MAX_LEN = 128
 _ALLOWED_NS_PLACEHOLDERS: frozenset[str] = frozenset({"parent", "ancestor"})
 
 
-class NamespacePolicyRule(BaseModel):
+class NamespacePolicyRule(ConfigModel):
     """Maps files matching a glob pattern to a namespace label.
 
     ``path_glob`` uses gitignore-style patterns (via ``pathspec.GitIgnoreSpec``).
@@ -447,13 +468,13 @@ class NamespacePolicyRule(BaseModel):
         return v
 
 
-class NamespaceConfig(BaseModel):
+class NamespaceConfig(ConfigModel):
     default_namespace: str = "default"
     enable_auto_ns: bool = False
     rules: Annotated[list[NamespacePolicyRule], APPEND] = Field(default_factory=list)
 
 
-class RerankConfig(BaseModel):
+class RerankConfig(ConfigModel):
     """Cross-encoder reranker settings (Stage 3b in the search pipeline).
 
     Default is a lightweight English fastembed cross-encoder (~80 MB ONNX,
@@ -549,7 +570,7 @@ class RerankConfig(BaseModel):
         return self
 
 
-class QueryExpansionConfig(BaseModel):
+class QueryExpansionConfig(ConfigModel):
     enabled: bool = False
     max_terms: int = 3
     strategy: str = "tags"  # "tags" | "headings" | "both" | "llm"
@@ -562,7 +583,7 @@ class QueryExpansionConfig(BaseModel):
         return v
 
 
-class ImportanceConfig(BaseModel):
+class ImportanceConfig(ConfigModel):
     enabled: bool = False
     max_boost: float = 1.5
     weights: Annotated[list[float], REPLACE] = Field(default_factory=lambda: [0.3, 0.2, 0.3, 0.2])
@@ -575,7 +596,7 @@ class ImportanceConfig(BaseModel):
         return v
 
 
-class WebhookConfig(BaseModel):
+class WebhookConfig(ConfigModel):
     enabled: bool = False
     url: str = ""
     events: Annotated[list[str], APPEND] = Field(
@@ -585,14 +606,14 @@ class WebhookConfig(BaseModel):
     timeout_seconds: float = 10.0
 
 
-class ConsolidationScheduleConfig(BaseModel):
+class ConsolidationScheduleConfig(ConfigModel):
     enabled: bool = False
     interval_hours: float = 24.0
     min_group_size: int = 3
     max_groups: int = 10
 
 
-class PolicyConfig(BaseModel):
+class PolicyConfig(ConfigModel):
     """Memory lifecycle policies."""
 
     enabled: bool = False
@@ -603,7 +624,7 @@ class PolicyConfig(BaseModel):
 MAX_CONTEXT_WINDOW_CHUNKS = 10  # max ±N adjacent chunks around each hit
 
 
-class ContextWindowConfig(BaseModel):
+class ContextWindowConfig(ConfigModel):
     """Context window expansion for search results (small-to-big retrieval)."""
 
     enabled: bool = False
@@ -617,7 +638,7 @@ class ContextWindowConfig(BaseModel):
         return v
 
 
-class HealthWatchdogConfig(BaseModel):
+class HealthWatchdogConfig(ConfigModel):
     """Periodic health monitoring and auto-maintenance."""
 
     enabled: bool = False
@@ -629,7 +650,7 @@ class HealthWatchdogConfig(BaseModel):
     auto_maintenance: bool = True
 
 
-class SchedulerConfig(BaseModel):
+class SchedulerConfig(ConfigModel):
     """Cron scheduler for memory lifecycle jobs (P2 Phase A).
 
     Dispatch cadence is the health watchdog loop — this config has no
@@ -663,7 +684,7 @@ class SchedulerConfig(BaseModel):
         return v
 
 
-class LLMConfig(BaseModel):
+class LLMConfig(ConfigModel):
     enabled: bool = False
     provider: str = "ollama"
     model: str = ""  # empty = provider-specific default resolved in factory
@@ -687,7 +708,7 @@ class LLMConfig(BaseModel):
         return v
 
 
-class SessionSummaryConfig(BaseModel):
+class SessionSummaryConfig(ConfigModel):
     """Auto LLM summary on ``mem_session_end`` (RFC P1 Phase B).
 
     When ``auto`` is True and the closing session has at least
@@ -751,7 +772,7 @@ class SessionSummaryConfig(BaseModel):
 TargetScope = Literal["user", "project_shared", "project_local"]
 
 
-class HooksConfig(BaseModel):
+class HooksConfig(ConfigModel):
     """Settings-hooks fan-out scope (ADR-0010 §3).
 
     ``target_scope`` selects where memtomem-managed Claude Code hooks land:
@@ -764,7 +785,7 @@ class HooksConfig(BaseModel):
     target_scope: TargetScope = "user"
 
 
-class ContextGatewayConfig(BaseModel):
+class ContextGatewayConfig(ConfigModel):
     """Settings for the multi-project context UI (skills / commands / agents).
 
     See ``memtomem-docs/memtomem/planning/multi-project-context-ui-rfc.md`` —
@@ -796,7 +817,7 @@ class ContextGatewayConfig(BaseModel):
     user_tier_enabled: bool = False
 
 
-class SessionTraceConfig(BaseModel):
+class SessionTraceConfig(ConfigModel):
     """Configuration for session command execution tracing."""
 
     enabled: bool = False

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Literal, cast, get_args
 
-from pydantic import Field, ValidationInfo, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from memtomem.constants import default_system_prefixes
@@ -40,7 +40,7 @@ APPEND = MergeStrategy("append")
 REPLACE = MergeStrategy("replace")
 
 
-class EmbeddingConfig(BaseSettings):
+class EmbeddingConfig(BaseModel):
     provider: str = "none"
     model: str = ""
     dimension: int = 0
@@ -116,13 +116,13 @@ class EmbeddingConfig(BaseSettings):
         return v
 
 
-class StorageConfig(BaseSettings):
+class StorageConfig(BaseModel):
     backend: str = "sqlite"
     sqlite_path: Path = Path("~/.memtomem/memtomem.db")
     collection_name: str = "memories"
 
 
-class SearchConfig(BaseSettings):
+class SearchConfig(BaseModel):
     default_top_k: int = 10
     bm25_candidates: int = 50
     dense_candidates: int = 50
@@ -190,7 +190,7 @@ def _default_memory_dirs() -> list[Path]:
     return [Path("~/.memtomem/memories")]
 
 
-class IndexingConfig(BaseSettings):
+class IndexingConfig(BaseModel):
     memory_dirs: Annotated[list[Path], APPEND] = Field(
         default_factory=lambda: _default_memory_dirs()
     )
@@ -320,7 +320,7 @@ class IndexingConfig(BaseSettings):
         return [Path(d) for d in (*self.memory_dirs, *self.project_memory_dirs)]
 
 
-class DecayConfig(BaseSettings):
+class DecayConfig(BaseModel):
     enabled: bool = False
     half_life_days: float = 30.0
 
@@ -332,7 +332,7 @@ class DecayConfig(BaseSettings):
         return v
 
 
-class MMRConfig(BaseSettings):
+class MMRConfig(BaseModel):
     enabled: bool = False
     lambda_param: float = 0.7  # 0.0=diversity max, 1.0=relevance max
 
@@ -344,7 +344,7 @@ class MMRConfig(BaseSettings):
         return v
 
 
-class AccessConfig(BaseSettings):
+class AccessConfig(BaseModel):
     enabled: bool = False
     max_boost: float = 1.5  # maximum score multiplier for highly accessed chunks
 
@@ -360,7 +360,7 @@ _NAMESPACE_MAX_LEN = 128
 _ALLOWED_NS_PLACEHOLDERS: frozenset[str] = frozenset({"parent", "ancestor"})
 
 
-class NamespacePolicyRule(BaseSettings):
+class NamespacePolicyRule(BaseModel):
     """Maps files matching a glob pattern to a namespace label.
 
     ``path_glob`` uses gitignore-style patterns (via ``pathspec.GitIgnoreSpec``).
@@ -447,13 +447,13 @@ class NamespacePolicyRule(BaseSettings):
         return v
 
 
-class NamespaceConfig(BaseSettings):
+class NamespaceConfig(BaseModel):
     default_namespace: str = "default"
     enable_auto_ns: bool = False
     rules: Annotated[list[NamespacePolicyRule], APPEND] = Field(default_factory=list)
 
 
-class RerankConfig(BaseSettings):
+class RerankConfig(BaseModel):
     """Cross-encoder reranker settings (Stage 3b in the search pipeline).
 
     Default is a lightweight English fastembed cross-encoder (~80 MB ONNX,
@@ -549,7 +549,7 @@ class RerankConfig(BaseSettings):
         return self
 
 
-class QueryExpansionConfig(BaseSettings):
+class QueryExpansionConfig(BaseModel):
     enabled: bool = False
     max_terms: int = 3
     strategy: str = "tags"  # "tags" | "headings" | "both" | "llm"
@@ -562,7 +562,7 @@ class QueryExpansionConfig(BaseSettings):
         return v
 
 
-class ImportanceConfig(BaseSettings):
+class ImportanceConfig(BaseModel):
     enabled: bool = False
     max_boost: float = 1.5
     weights: Annotated[list[float], REPLACE] = Field(default_factory=lambda: [0.3, 0.2, 0.3, 0.2])
@@ -575,7 +575,7 @@ class ImportanceConfig(BaseSettings):
         return v
 
 
-class WebhookConfig(BaseSettings):
+class WebhookConfig(BaseModel):
     enabled: bool = False
     url: str = ""
     events: Annotated[list[str], APPEND] = Field(
@@ -585,14 +585,14 @@ class WebhookConfig(BaseSettings):
     timeout_seconds: float = 10.0
 
 
-class ConsolidationScheduleConfig(BaseSettings):
+class ConsolidationScheduleConfig(BaseModel):
     enabled: bool = False
     interval_hours: float = 24.0
     min_group_size: int = 3
     max_groups: int = 10
 
 
-class PolicyConfig(BaseSettings):
+class PolicyConfig(BaseModel):
     """Memory lifecycle policies."""
 
     enabled: bool = False
@@ -603,7 +603,7 @@ class PolicyConfig(BaseSettings):
 MAX_CONTEXT_WINDOW_CHUNKS = 10  # max ±N adjacent chunks around each hit
 
 
-class ContextWindowConfig(BaseSettings):
+class ContextWindowConfig(BaseModel):
     """Context window expansion for search results (small-to-big retrieval)."""
 
     enabled: bool = False
@@ -617,7 +617,7 @@ class ContextWindowConfig(BaseSettings):
         return v
 
 
-class HealthWatchdogConfig(BaseSettings):
+class HealthWatchdogConfig(BaseModel):
     """Periodic health monitoring and auto-maintenance."""
 
     enabled: bool = False
@@ -629,7 +629,7 @@ class HealthWatchdogConfig(BaseSettings):
     auto_maintenance: bool = True
 
 
-class SchedulerConfig(BaseSettings):
+class SchedulerConfig(BaseModel):
     """Cron scheduler for memory lifecycle jobs (P2 Phase A).
 
     Dispatch cadence is the health watchdog loop — this config has no
@@ -663,7 +663,7 @@ class SchedulerConfig(BaseSettings):
         return v
 
 
-class LLMConfig(BaseSettings):
+class LLMConfig(BaseModel):
     enabled: bool = False
     provider: str = "ollama"
     model: str = ""  # empty = provider-specific default resolved in factory
@@ -687,7 +687,7 @@ class LLMConfig(BaseSettings):
         return v
 
 
-class SessionSummaryConfig(BaseSettings):
+class SessionSummaryConfig(BaseModel):
     """Auto LLM summary on ``mem_session_end`` (RFC P1 Phase B).
 
     When ``auto`` is True and the closing session has at least
@@ -751,7 +751,7 @@ class SessionSummaryConfig(BaseSettings):
 TargetScope = Literal["user", "project_shared", "project_local"]
 
 
-class HooksConfig(BaseSettings):
+class HooksConfig(BaseModel):
     """Settings-hooks fan-out scope (ADR-0010 §3).
 
     ``target_scope`` selects where memtomem-managed Claude Code hooks land:
@@ -764,7 +764,7 @@ class HooksConfig(BaseSettings):
     target_scope: TargetScope = "user"
 
 
-class ContextGatewayConfig(BaseSettings):
+class ContextGatewayConfig(BaseModel):
     """Settings for the multi-project context UI (skills / commands / agents).
 
     See ``memtomem-docs/memtomem/planning/multi-project-context-ui-rfc.md`` —
@@ -796,7 +796,7 @@ class ContextGatewayConfig(BaseSettings):
     user_tier_enabled: bool = False
 
 
-class SessionTraceConfig(BaseSettings):
+class SessionTraceConfig(BaseModel):
     """Configuration for session command execution tracing."""
 
     enabled: bool = False
@@ -816,10 +816,25 @@ class SessionTraceConfig(BaseSettings):
             self.enabled
             and self.langfuse_enabled
             and not (self.langfuse_public_key and self.langfuse_secret_key)
+            # Deliberate, narrow exception to the MEMTOMEM_-only env surface
+            # (#1522): the Langfuse SDK's own documented variables count as
+            # credentials, so a standard Langfuse env setup keeps working.
+            # ``get_langfuse_client`` omits kwargs for empty fields and lets
+            # the SDK read these itself — the values are never copied into
+            # the config object, so they cannot leak into ``config.json``
+            # or any config-display surface. Credentials only: activation
+            # still requires the explicit ``langfuse_enabled`` opt-in above;
+            # ``LANGFUSE_ENABLED`` alone can never turn tracing on.
+            and not (
+                os.environ.get("LANGFUSE_PUBLIC_KEY") and os.environ.get("LANGFUSE_SECRET_KEY")
+            )
         ):
             raise ValueError(
-                "SessionTraceConfig.langfuse_enabled=true requires both langfuse_public_key and langfuse_secret_key "
-                "to be set (non-empty)."
+                "SessionTraceConfig.langfuse_enabled=true requires langfuse_public_key and "
+                "langfuse_secret_key — set them in config "
+                "(MEMTOMEM_SESSION_TRACE__LANGFUSE_PUBLIC_KEY / "
+                "MEMTOMEM_SESSION_TRACE__LANGFUSE_SECRET_KEY) or export the Langfuse SDK's "
+                "LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY."
             )
         return self
 
@@ -1050,12 +1065,12 @@ def coerce_and_validate(value: object, constraint: dict | None) -> object:
     elif expected_type is list:
         item_type = constraint.get("item_type", float)
         expected_len = constraint.get("length")
-        # ``list[BaseSettings]`` (e.g. ``namespace.rules``): accept a JSON
+        # ``list[BaseModel]`` (e.g. ``namespace.rules``): accept a JSON
         # string or list of dicts/model instances and validate each entry
         # via ``model_validate``. Mirrors ``load_config_d``'s APPEND
         # coercion so mutation paths (PATCH /api/config, mm config set)
         # stay in sync with the load path.
-        if isinstance(item_type, type) and issubclass(item_type, BaseSettings):
+        if isinstance(item_type, type) and issubclass(item_type, BaseModel):
             if isinstance(value, str):
                 import json as _json
 
@@ -1237,9 +1252,9 @@ def _merge_strategy_for(section_cls: type, field_name: str) -> MergeStrategy | N
 def _list_item_type(section_cls: type, field_name: str) -> type | None:
     """Return the element type of a ``list[X]`` field, or ``None`` for scalars.
 
-    Used by the fragment loader to coerce raw JSON dicts into ``BaseSettings``
+    Used by the fragment loader to coerce raw JSON dicts into ``BaseModel``
     instances before APPEND dedup, since ``setattr`` on a non-validating
-    BaseSettings won't re-validate the assigned list.
+    model won't re-validate the assigned list.
     """
     import typing
 
@@ -1258,14 +1273,14 @@ def _list_item_type(section_cls: type, field_name: str) -> type | None:
 def _dedup_key(item: object) -> object:
     """Stable equality key for APPEND dedup.
 
-    Normalises Path to its string form and dict/BaseSettings to a recursively
-    sorted tuple form so that ``list[dict]`` and ``list[BaseSettings]`` fields
+    Normalises Path to its string form and dict/BaseModel to a recursively
+    sorted tuple form so that ``list[dict]`` and ``list[BaseModel]`` fields
     (e.g. ``NamespaceConfig.rules``) can be deduped across a native default
     list and raw JSON fragment entries.
     """
     if isinstance(item, Path):
         return str(item)
-    if isinstance(item, BaseSettings):
+    if isinstance(item, BaseModel):
         return _dedup_key(item.model_dump(mode="json"))
     if isinstance(item, dict):
         return tuple(sorted((k, _dedup_key(v)) for k, v in item.items()))
@@ -1362,7 +1377,7 @@ def load_config_d(config: Mem2MemConfig, *, quiet: bool = False) -> None:
                         item_type
                         if item_type is not None
                         and isinstance(item_type, type)
-                        and issubclass(item_type, BaseSettings)
+                        and issubclass(item_type, BaseModel)
                         else None
                     )
                     seen = {_dedup_key(x) for x in current}
@@ -1950,7 +1965,7 @@ def _relativize_config_paths_in_place(data: dict) -> None:
 def _json_default(obj: object) -> object:
     """``json.dumps`` fallback for values not natively JSON-serializable.
 
-    ``BaseSettings`` entries in fields like ``namespace.rules`` must be
+    ``BaseModel`` entries in fields like ``namespace.rules`` must be
     written as dicts (via ``model_dump(mode="json")``) so the load path
     can re-validate them on startup. ``Path`` goes through
     ``_portable_path_str`` so home-rooted paths land as ``~/...``
@@ -1958,7 +1973,7 @@ def _json_default(obj: object) -> object:
     unknown types fall back to ``str()`` to preserve the original
     default=str behaviour.
     """
-    if isinstance(obj, BaseSettings):
+    if isinstance(obj, BaseModel):
         return obj.model_dump(mode="json")
     if isinstance(obj, Path):
         return _portable_path_str(obj)

--- a/packages/memtomem/tests/conftest.py
+++ b/packages/memtomem/tests/conftest.py
@@ -22,12 +22,11 @@ from memtomem.server.component_factory import Components, create_components, clo
 from _wiki_fixtures import git_identity, wiki_root  # noqa: F401
 
 
-# Bare (unprefixed) env names that pydantic-settings binds onto
-# ``SessionTraceConfig`` fields case-insensitively — the sub-configs carry no
-# ``model_config``, so these bypass the documented ``MEMTOMEM_`` surface
-# entirely (#1522). A developer shell or a sourced repo-root ``.env``
-# exporting them defeats the langfuse keys-missing validator in any test
-# that constructs the config (#1508).
+# The Langfuse SDK's own env names. Sub-configs no longer bind bare env vars
+# (#1522), but ``SessionTraceConfig``'s keys-required validator deliberately
+# accepts LANGFUSE_PUBLIC_KEY/LANGFUSE_SECRET_KEY as SDK credentials — a
+# developer shell or a sourced repo-root ``.env`` exporting them still defeats
+# the keys-missing validator in any test that constructs the config (#1508).
 _BARE_LANGFUSE_ENV_VARS = (
     "LANGFUSE_PUBLIC_KEY",
     "LANGFUSE_SECRET_KEY",

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -334,7 +334,7 @@ class TestCoerceAndValidate:
         """search.rrf_weights must be registered in FIELD_CONSTRAINTS."""
         assert "search.rrf_weights" in FIELD_CONSTRAINTS
 
-    # ── list[BaseSettings] coercion (namespace.rules) ──────────────
+    # ── list[BaseModel] coercion (namespace.rules) ─────────────────
 
     def test_namespace_rules_from_json_string(self) -> None:
         """CLI path: `mm config set namespace.rules '[{...}]'` passes a JSON string."""
@@ -352,7 +352,7 @@ class TestCoerceAndValidate:
         """Web UI path: PATCH /api/config sends a parsed list of dicts.
 
         Regression guard for PR #253: before this fix, ``coerce_and_validate``
-        did not handle ``list[BaseSettings]``, so PATCH /api/config and
+        did not handle ``list[BaseModel]``, so PATCH /api/config and
         ``mm config set namespace.rules ...`` stored raw dicts in
         ``cfg.namespace.rules``. That broke ``indexing/engine.py:121`` which
         accesses ``rule.path_glob`` on each entry — AttributeError on a dict.

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -752,20 +752,49 @@ def test_nested_prefixed_env_still_binds(monkeypatch: pytest.MonkeyPatch) -> Non
 def test_only_root_config_is_base_settings() -> None:
     """Guard: no sub-config may regrow a ``BaseSettings`` base — that would
     re-open the undocumented bare-env surface #1522 closed. New settings
-    sections must be ``pydantic.BaseModel`` and hang off ``Mem2MemConfig``."""
+    sections must inherit ``ConfigModel`` and hang off ``Mem2MemConfig``."""
     import inspect
 
     import pydantic
     from pydantic_settings import BaseSettings
 
-    settings_classes = [
-        name
+    from memtomem.config import ConfigModel
+
+    model_classes = {
+        name: obj
         for name, obj in inspect.getmembers(_cfg, inspect.isclass)
-        if issubclass(obj, pydantic.BaseModel)
-        and obj.__module__ == _cfg.__name__
-        and issubclass(obj, BaseSettings)
-    ]
+        if issubclass(obj, pydantic.BaseModel) and obj.__module__ == _cfg.__name__
+    }
+    settings_classes = [n for n, o in model_classes.items() if issubclass(o, BaseSettings)]
     assert settings_classes == ["Mem2MemConfig"], settings_classes
+
+    # Every other model must go through ConfigModel so it keeps the
+    # BaseSettings-era strictness (extra="forbid", validate_default=True) —
+    # a bare-BaseModel section would silently swallow config typos.
+    non_strict = [
+        n
+        for n, o in model_classes.items()
+        if n not in ("Mem2MemConfig", "ConfigModel") and not issubclass(o, ConfigModel)
+    ]
+    assert non_strict == [], non_strict
+
+
+def test_sub_configs_keep_base_settings_strictness(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dropping the ``BaseSettings`` base must not relax validation: unknown
+    keys still fail loudly (``extra="forbid"``), so an env typo like
+    ``MEMTOMEM_EMBEDDING__TYPO`` or a stray key in a ``namespace.rules`` entry
+    raises instead of being silently ignored (#1522)."""
+    import pydantic
+
+    from memtomem.config import NamespacePolicyRule
+
+    monkeypatch.setenv("MEMTOMEM_EMBEDDING__TYPO", "bad")
+    with pytest.raises(pydantic.ValidationError, match="typo"):
+        Mem2MemConfig()
+    monkeypatch.delenv("MEMTOMEM_EMBEDDING__TYPO")
+
+    with pytest.raises(pydantic.ValidationError, match="bogus"):
+        NamespacePolicyRule.model_validate({"path_glob": "notes/**", "namespace": "n", "bogus": 1})
 
 
 def test_namespace_rules_survive_config_json_roundtrip(

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -348,7 +348,7 @@ def test_config_d_namespace_rules_dedup_after_home_expansion(
     declare the same rule once with a leading ``~/`` and once with the expanded
     absolute path must collapse to a single rule.
 
-    ``_dedup_key`` hashes ``BaseSettings.model_dump(mode="json")`` — i.e. the
+    ``_dedup_key`` hashes ``BaseModel.model_dump(mode="json")`` — i.e. the
     *post-validator* field values. Since ``path_glob`` expands ``~/`` in its
     validator, both forms share an identity after coercion, so they dedupe.
     This test pins that contract: a future refactor that moved expansion out
@@ -714,3 +714,85 @@ def test_detect_provider_dirs_finds_claude_plans_and_codex(
     grouped = _cfg._detect_provider_dirs()
     assert grouped["claude-plans"] == [plans]
     assert grouped["codex"] == [codex]
+
+
+# ── #1522: env binding is MEMTOMEM_-prefixed only ──────────────────────────
+
+
+def test_sub_configs_ignore_bare_env_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sub-configs are plain ``BaseModel``s: generic shell exports like
+    ``API_KEY`` / ``ENABLED`` / ``MODEL`` must not bind, standalone or through
+    ``Mem2MemConfig``'s ``default_factory`` path (#1522)."""
+    monkeypatch.setenv("API_KEY", "bare-env-leak")
+    monkeypatch.setenv("ENABLED", "true")
+    monkeypatch.setenv("MODEL", "bare-model")
+
+    from memtomem.config import EmbeddingConfig, SessionTraceConfig
+
+    assert EmbeddingConfig().api_key == ""
+    assert EmbeddingConfig().model == ""
+    assert SessionTraceConfig().enabled is False
+
+    cfg = Mem2MemConfig()
+    assert cfg.embedding.api_key == ""
+    assert cfg.session_trace.enabled is False
+
+
+def test_nested_prefixed_env_still_binds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The documented ``MEMTOMEM_<SECTION>__<FIELD>`` surface keeps working
+    after the sub-configs stopped being ``BaseSettings`` (#1522)."""
+    monkeypatch.setenv("MEMTOMEM_EMBEDDING__API_KEY", "prefixed-ok")
+    monkeypatch.setenv("MEMTOMEM_SESSION_TRACE__JSONL_ENABLED", "false")
+
+    cfg = Mem2MemConfig()
+    assert cfg.embedding.api_key == "prefixed-ok"
+    assert cfg.session_trace.jsonl_enabled is False
+
+
+def test_only_root_config_is_base_settings() -> None:
+    """Guard: no sub-config may regrow a ``BaseSettings`` base — that would
+    re-open the undocumented bare-env surface #1522 closed. New settings
+    sections must be ``pydantic.BaseModel`` and hang off ``Mem2MemConfig``."""
+    import inspect
+
+    import pydantic
+    from pydantic_settings import BaseSettings
+
+    settings_classes = [
+        name
+        for name, obj in inspect.getmembers(_cfg, inspect.isclass)
+        if issubclass(obj, pydantic.BaseModel)
+        and obj.__module__ == _cfg.__name__
+        and issubclass(obj, BaseSettings)
+    ]
+    assert settings_classes == ["Mem2MemConfig"], settings_classes
+
+
+def test_namespace_rules_survive_config_json_roundtrip(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``_json_default`` must serialize ``NamespacePolicyRule`` items as dicts
+    (not ``str()`` fallback) now that rules are ``BaseModel``s — a missed
+    isinstance sweep here corrupts ``config.json`` silently (#1522)."""
+    from memtomem.config import NamespacePolicyRule, save_config_overrides
+
+    override = tmp_path / "config.json"
+    monkeypatch.setattr(_cfg, "_override_path", lambda: override)
+    monkeypatch.setattr(_cfg, "_config_d_path", lambda: tmp_path / "config.d")
+
+    cfg = Mem2MemConfig()
+    rule = NamespacePolicyRule(path_glob="**/notes/**", namespace="claude:notes")
+    cfg.namespace.rules = list(cfg.namespace.rules) + [rule]
+    save_config_overrides(cfg)
+
+    saved = json.loads(override.read_text(encoding="utf-8"))
+    dumped_rules = saved["namespace"]["rules"]
+    assert {"path_glob": "**/notes/**", "namespace": "claude:notes"} in dumped_rules
+    assert all(isinstance(r, dict) for r in dumped_rules)
+
+    fresh = Mem2MemConfig()
+    load_config_overrides(fresh)
+    assert any(
+        r.path_glob == "**/notes/**" and r.namespace == "claude:notes"
+        for r in fresh.namespace.rules
+    )

--- a/packages/memtomem/tests/test_session_tracing.py
+++ b/packages/memtomem/tests/test_session_tracing.py
@@ -99,6 +99,57 @@ class TestConfigConstraints:
                 )
             assert "package is not installed" in str(excinfo.value)
 
+    def test_langfuse_validator_accepts_sdk_env_credentials(self, monkeypatch):
+        # Deliberate exception to the MEMTOMEM_-only env surface (#1522): the
+        # Langfuse SDK's own documented variables satisfy the keys-required
+        # validator, but are never copied into the config object —
+        # ``get_langfuse_client`` lets the SDK read them itself.
+        from memtomem.config import SessionTraceConfig
+
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-env")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-env")
+        cfg = SessionTraceConfig(enabled=True, langfuse_enabled=True)
+        assert cfg.langfuse_public_key == ""
+        assert cfg.langfuse_secret_key == ""
+
+    def test_langfuse_validator_rejects_partial_sdk_env_credentials(self, monkeypatch):
+        from memtomem.config import SessionTraceConfig
+
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-env")
+        with pytest.raises(ValueError, match="langfuse_secret_key"):
+            SessionTraceConfig(enabled=True, langfuse_enabled=True)
+
+    def test_startup_path_prefixed_optin_with_sdk_env_credentials(self, monkeypatch):
+        # The real startup combination: tracing opted in through the documented
+        # MEMTOMEM_ surface, credentials supplied only through the SDK's env.
+        monkeypatch.setenv("MEMTOMEM_SESSION_TRACE__ENABLED", "true")
+        monkeypatch.setenv("MEMTOMEM_SESSION_TRACE__LANGFUSE_ENABLED", "true")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-env")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-env")
+        cfg = Mem2MemConfig()
+        assert cfg.session_trace.enabled is True
+        assert cfg.session_trace.langfuse_enabled is True
+        assert cfg.session_trace.langfuse_public_key == ""
+        assert cfg.session_trace.langfuse_secret_key == ""
+
+    def test_sdk_env_credentials_never_persisted(self, override_path: Path, monkeypatch):
+        # End-to-end pin for the no-copy contract: enabling langfuse with only
+        # SDK env credentials must not write any credential into config.json.
+        import memtomem.config as _cfg
+        from memtomem.config import Mem2MemConfig, save_config_overrides
+
+        monkeypatch.setattr(_cfg, "_config_d_path", lambda: override_path.parent / "config.d")
+        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-env")
+        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-env")
+        cfg = Mem2MemConfig()
+        cfg.session_trace.enabled = True
+        cfg.session_trace.langfuse_enabled = True
+        save_config_overrides(cfg)
+        saved = json.loads(override_path.read_text(encoding="utf-8"))
+        assert "pk-env" not in override_path.read_text(encoding="utf-8")
+        assert saved.get("session_trace", {}).get("langfuse_public_key", "") == ""
+        assert saved.get("session_trace", {}).get("langfuse_secret_key", "") == ""
+
 
 class TestPayloadSanitization:
     def test_metadata_mode(self):
@@ -657,7 +708,7 @@ class TestConfigSaveValidationAndRollback:
         from memtomem.config import save_config_overrides
 
         with pytest.raises(
-            ValueError, match="requires both langfuse_public_key and langfuse_secret_key"
+            ValueError, match="requires langfuse_public_key and langfuse_secret_key"
         ):
             save_config_overrides(cfg)
 
@@ -673,7 +724,7 @@ class TestConfigSaveValidationAndRollback:
 
         result = runner.invoke(cli, ["config", "set", "session_trace.langfuse_enabled", "true"])
         assert result.exit_code != 0
-        assert "requires both langfuse_public_key and langfuse_secret_key" in result.output
+        assert "requires langfuse_public_key and langfuse_secret_key" in result.output
 
         with open(override_path, "r", encoding="utf-8") as f:
             saved = json.load(f)
@@ -716,9 +767,7 @@ class TestConfigSaveValidationAndRollback:
                 search_pipeline=MagicMock(),
             )
         assert excinfo.value.status_code == 400
-        assert "requires both langfuse_public_key and langfuse_secret_key" in str(
-            excinfo.value.detail
-        )
+        assert "requires langfuse_public_key and langfuse_secret_key" in str(excinfo.value.detail)
 
         assert app_mock.state.config.session_trace.langfuse_enabled is False
 
@@ -746,7 +795,7 @@ class TestConfigSaveValidationAndRollback:
         )
 
         assert "Failed to persist config" in res
-        assert "requires both langfuse_public_key and langfuse_secret_key" in res
+        assert "requires langfuse_public_key and langfuse_secret_key" in res
 
         assert app_mock.config.session_trace.langfuse_enabled is False
 


### PR DESCRIPTION
## Summary

Closes #1522.

22 sub-config sections plus `NamespacePolicyRule` were `BaseSettings` classes with no `model_config`, so pydantic-settings bound their fields to **bare, case-insensitive, unprefixed env names** (`API_KEY`, `ENABLED`, `MODEL`, `LANGFUSE_*`, …) — a second, undocumented env surface next to the documented `MEMTOMEM_<SECTION>__<FIELD>` one. Generic shell exports silently overrode config, reached secret-bearing fields (`embedding.api_key`, `session_trace.langfuse_secret_key`), and defeated the langfuse keys-required validator from outside the documented surface (the #1508 failure mode).

## Changes

- **Convert the 23 classes off `BaseSettings` onto a shared strict `ConfigModel` base** (option A from the issue). Env binding now flows exclusively through `Mem2MemConfig`'s `env_prefix="MEMTOMEM_"` + `env_nested_delimiter="__"`. Verified: nested `MEMTOMEM_EMBEDDING__API_KEY` binding is unchanged with `BaseModel` submodels; since the prefixed name already won when both were set, users on the documented surface see zero change.
- **Sweep the `isinstance`/`issubclass` `BaseSettings` checks to `BaseModel`** (`_coerce` list path, `_dedup_key`, fragment-loader coercion, `_json_default`). Missing the `_json_default` one would have sent `namespace.rules` items through the `str()` fallback and silently corrupted `config.json` on save — pinned by a new round-trip test.
- **Deliberate, credentials-only Langfuse exception.** `SessionTraceConfig`'s field names happen to match the Langfuse SDK's standard env vars, so bare `LANGFUSE_*` setups worked today by accident. With `langfuse_enabled=true`, the keys-required validator now also accepts the SDK's own `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY`; `get_langfuse_client` already omits empty kwargs and lets the SDK read its documented variables itself. The values are **never copied into the config object** (pinned: they cannot reach `config.json` or config-display surfaces), and `LANGFUSE_ENABLED` alone never turns tracing on — activation requires the explicit memtomem opt-in.
- **Strictness preserved** (follow-up review fix, second commit): `BaseSettings` defaults to `extra="forbid"` + `validate_default=True`, so switching to plain `BaseModel` would have silently swallowed unknown keys — an env typo like `MEMTOMEM_EMBEDDING__TYPO=bad` raised before #1522 and was ignored after the switch, and `NamespacePolicyRule.model_validate()` dropped stray keys in `config.d` fragment entries (both reproduced). The shared `ConfigModel` base carries both settings, so the only behavior change this PR ships is the env-surface removal; a new pin test locks the loud-failure contract.
- **Guard test**: only `Mem2MemConfig` may be a `BaseSettings` subclass, and every other section model must inherit `ConfigModel` — the bare-env surface cannot silently regrow, and a bare-`BaseModel` section cannot silently relax validation.
- **Docs**: `configuration.md` states the prefixed-only contract + the single documented exception near the Session Trace table; bare field-name shorthand in prose (`BASE_URL`, `PROVIDER`, `ENABLED=false`, …) replaced with full `MEMTOMEM_*` names in `configuration.md` / `llm-providers.md`; CHANGELOG entry with migration snippet.

## Test plan

- New: bare-env kill (standalone + nested `default_factory` path), prefixed nested binding, `namespace.rules` config.json round-trip, Langfuse SDK-env acceptance / partial-keys rejection / startup-path combination / no-persistence pin, `BaseSettings` guard.
- Existing 4 validator tests updated to the new error message (now names both surfaces).
- Full suite: 7442 passed, 11 skipped (`-m "not ollama"`); ruff check + format clean; mypy clean on `config.py`.

Design review: gated through Codex (design pass + diff review); the review's docs findings and startup-path test suggestion are incorporated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

