### PR TITLE
security(privacy): forward-sync the quoted-label + x-amz-security-token rules from memtomem-stm#562/#561

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Security
 
+- **Quoted-JSON credential labels and the `x-amz-security-token` wire label
+  are redacted — forward-sync of memtomem-stm#562 / memtomem-stm#561.** Two
+  more STM-origin secret-class rules mirrored forward in one pass so the sets
+  move together. (1) *Quoted-label generalization* (memtomem-stm#562): the
+  generic label rules end in `\s*[:=]`, and a quoted key's closing quote sits
+  between the label and the colon, so `"password": "hunter2"`,
+  `"api_key": "sk-…"`, camelCase `"accessToken": "ya29.…"`, and dict-repr
+  `{'password': 'hunter2'}` — the exact shape of a pasted `docker inspect` /
+  `kubectl get secret -o json` / DB-config note — crossed the write boundary
+  unredacted. One general quoted-label rule reuses the #553 FP-guard shape
+  (quote directly on both sides of the label, value must open as a string, so
+  JSON-Schema object values, embedded labels, and prefixed keys never fire);
+  `pwd` is deliberately excluded — shell/file tools legitimately emit
+  `"pwd": "/home/user"` working-directory fields. (2) *AWS wire label*
+  (memtomem-stm#561): botocore DEBUG logs emit the `x-amz-security-token`
+  request header verbatim and every presigned URL generated with temporary
+  credentials carries `X-Amz-Security-Token=…`, but `session[_-]?token`
+  cannot cross the `security-token` spelling, so those notes scanned clean
+  unless an `ASIA…` key ID co-occurred. The new rule's unquoted branch
+  carries a separator-only left boundary (`(?<![_.\-])`): kebab/dotted
+  compounds that merely name the header (`forward-x-amz-security-token:
+  true`, `proxy.headers.x-amz-security-token`) stay negative, while
+  bytes-repr wire dumps — which render the newline before the header line as
+  a literal `\r\n`, putting an alphanumeric directly before the label — stay
+  positive. The two sides are byte-identical again at 19 patterns, same
+  order (STM pin memtomem-stm@`67689db`); both patterns translate cleanly to
+  the Web UI's client-side JS scan (position-0 `(?i)` lift + fixed-width
+  lookbehind, ES2018+), and each gets its paired JS-translation parity
+  fixture. A content-hash pin over the shared subset is tracked in
+  memtomem-stm#559.
 - **AWS secret material is redacted by label (`SECRET_ACCESS_KEY` /
   `SESSION_TOKEN`) — forward-sync of memtomem-stm#553.** The redaction guard
   caught AWS key **IDs** (`AKIA`/`ASIA`) but not the secret **material** those

--- a/packages/memtomem/src/memtomem/privacy.py
+++ b/packages/memtomem/src/memtomem/privacy.py
@@ -1,16 +1,18 @@
 """Content redaction guard at the LTM trust boundary.
 
 The pattern set has two provenance tiers, both secret-class only. As of
-STM commit ``5ab5467`` the two sides are in sync: this module's 17
+STM commit ``67689db`` the two sides are in sync: this module's 19
 secret-class patterns are byte-identical to memtomem-stm
 ``proxy/privacy.py:CREDENTIAL_PATTERNS``.
 
-1. **STM-synced subset** (10 patterns) — originally mirrored from
-   memtomem-stm; the AWS secret-material label rule (memtomem-stm#553)
-   is the first STM-origin addition forward-synced after the #1491
-   reverse mirror. The SHA above tracks the STM commit this module is
+1. **STM-synced subset** (12 patterns) — originally mirrored from
+   memtomem-stm; the AWS secret-material label rule (memtomem-stm#553),
+   the general quoted-JSON label rule (memtomem-stm#562), and the
+   x-amz-security-token wire-label rule (memtomem-stm#561) are the
+   STM-origin additions forward-synced after the #1491 reverse mirror.
+   The SHA above tracks the STM commit this module is
    audited-consistent with (history: ``a98636e`` -> ``3e585b5`` ->
-   ``8c884cb`` -> ``5ab5467``). STM's full set also carries PII patterns
+   ``8c884cb`` -> ``5ab5467`` -> ``67689db``). STM's full set also carries PII patterns
    (email, etc.); those are excluded here by design because PII false
    positives on prose ingress would be unworkable — they live in STM's
    separate ``PII_PATTERNS`` list.
@@ -71,6 +73,25 @@ logger = logging.getLogger(__name__)
 DEFAULT_PATTERNS: tuple[str, ...] = (
     r"(?i)(api[_-]?key|secret[_-]?key|access[_-]?token)\s*[:=]",
     r"(?i)(password|passwd|pwd)\s*[:=]",
+    # Quoted-JSON / dict-repr forms of the generic labels above (STM-origin;
+    # forward-synced from memtomem-stm#562). The two label rules end in
+    # ``\s*[:=]``, and a quoted key's closing quote sits between the label
+    # and the colon — ``"password": "hunter2"``, ``"api_key": "sk-…"``,
+    # ``"accessToken": "ya29.…"``, ``{'password': 'hunter2'}`` match none
+    # of them — and JSON-serialized credentials are exactly what a pasted
+    # ``docker inspect`` / ``kubectl get secret -o json`` / DB-config note
+    # carries. Same FP-guard shape as the AWS rule below: the quote must
+    # sit DIRECTLY on both sides of the label and the value must open as a
+    # string, so a JSON-Schema property (``"access_token": {"type"…`` —
+    # object value), an identifier that merely embeds a label
+    # (``"my_api_key_name": …``), and a prefixed key (``"tools.api_key": …``)
+    # never fire. The ``[_-]?`` separator is optional, so camelCase JSON
+    # keys (``"apiKey"``, ``"accessToken"``) match under ``(?i)``. ``pwd``
+    # is deliberately NOT in this vocabulary (unlike the unquoted rule
+    # above): shell/file tools legitimately emit working-directory fields
+    # (``"pwd": "/home/user"``).
+    r"(?i)[\"'](?:api[_-]?key|secret[_-]?(?:access[_-]?)?key"
+    r"|(?:access|session)[_-]?token|password|passwd)[\"']\s*:\s*[\"']",
     # AWS secret material by label (STM-origin; forward-synced from
     # memtomem-stm#553). The generic label rule above misses both spellings
     # the AWS toolchain actually emits: ``secret[_-]?key`` needs its two
@@ -100,6 +121,36 @@ DEFAULT_PATTERNS: tuple[str, ...] = (
     r"(?i)(?:[\"'](?:secret[_-]?access[_-]?key|session[_-]?token)[\"']\s*:\s*[\"']"
     r"|(?:(?<![A-Za-z0-9_.-])|(?<=aws[._-]))"
     r"(?:secret[_-]?access[_-]?key|session[_-]?token)\s*[:=])",
+    # The label AWS actually puts on the WIRE for that same session-token
+    # material (STM-origin; forward-synced from memtomem-stm#561): botocore
+    # DEBUG logs emit the ``x-amz-security-token`` request header verbatim,
+    # and every presigned URL generated with temporary credentials carries
+    # the ``X-Amz-Security-Token=…`` query parameter — both are routine
+    # paste-into-a-note shapes. No rule above reaches either:
+    # ``session[_-]?token`` cannot cross the ``security-token`` spelling,
+    # and the kebab header shape has no ``aws`` separator directly before
+    # the label, so the left-boundary form above misses it too. Two
+    # alternatives, mirroring the rule above:
+    #
+    # - quoted form — ``"x-amz-security-token": "…"`` (serialized header
+    #   dicts, JSON or python repr). Quote directly on both sides of the
+    #   label and a string-opening value, so an OpenAPI/JSON-Schema header
+    #   *definition* (``"X-Amz-Security-Token": {"type"…`` — object value)
+    #   never fires.
+    # - unquoted form — the raw header line (``x-amz-security-token: FwoG…``)
+    #   and the presigned-URL query param. The left boundary rejects only a
+    #   directly preceding SEPARATOR (``[_.-]``), not alphanumerics —
+    #   narrower than the rule above, on purpose: kebab/dotted compounds
+    #   that merely NAME the header (``forward-x-amz-security-token: true``,
+    #   ``proxy.headers.x-amz-security-token``) must not fire, but a
+    #   bytes-repr wire dump renders the newline before the label as a
+    #   LITERAL ``\r\n`` (``send: b'…\r\nx-amz-security-token: FwoG…'`` —
+    #   http.client debuglevel), putting ``n`` right before the ``x``, and
+    #   that must stay a match. Prose that merely NAMES the header
+    #   (``header: x-amz-security-token``) stays negative — the separator
+    #   must directly follow the label.
+    r"(?i)(?:[\"']x-amz-security-token[\"']\s*:\s*[\"']"
+    r"|(?<![_.\-])x-amz-security-token\s*[:=])",
     # Provider-prefixed token formats. Anchored by prefix so false positives
     # on arbitrary high-entropy strings are rare.
     r"(?i)(sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|xox[bps]-[0-9A-Za-z-]+)",

--- a/packages/memtomem/tests/test_privacy.py
+++ b/packages/memtomem/tests/test_privacy.py
@@ -40,11 +40,12 @@ def _reset_counters():
 
 class TestPatternSurface:
     def test_pattern_count_pinned(self):
-        # 10 STM-synced secret-class patterns (incl. the memtomem-stm#553
-        # AWS-label forward-sync) + 7 LTM-origin additions (#1488). Bump
+        # 12 STM-synced secret-class patterns (incl. the memtomem-stm#553
+        # AWS-label, #562 quoted-label, and #561 x-amz-security-token
+        # forward-syncs) + 7 LTM-origin additions (#1488). Bump
         # deliberately when adding a pattern so a silent add/drop surfaces
         # here.
-        assert len(privacy.DEFAULT_PATTERNS) == 17
+        assert len(privacy.DEFAULT_PATTERNS) == 19
 
     @pytest.mark.parametrize(
         "clean_input",
@@ -68,6 +69,12 @@ class TestScan:
         [
             "api_key: AKIAIOSFODNN7EXAMPL",
             "password = hunter2hunter2",
+            # Quoted-JSON label (memtomem-stm#562 forward-sync) — the closing
+            # quote blocks the unquoted rules' [:=].
+            '"password": "hunter2"',
+            # AWS wire label (memtomem-stm#561 forward-sync) — header line as
+            # botocore DEBUG logs emit it (value is FAKE).
+            "x-amz-security-token: FAKEFwoGZXIvYXdzFAKE",
             "sk-" + "a" * 30,
             "github_pat_" + "x" * 30,
             "sk_live_" + "a" * 25,
@@ -115,7 +122,7 @@ class TestScan:
         # input, so the same shape must hit. A regression that re-adds
         # the cap fails this assertion loudly.
         #
-        # Uses the ``sk-`` prefix shape (DEFAULT_PATTERNS index 2)
+        # Uses the ``sk-`` prefix shape (the sk-/ghp_/xox rule)
         # rather than the AWS AKIA shape — the latter is anchored with
         # ``\b`` and would silently no-match against a leading run of
         # word chars even when the scan does cover the position, which
@@ -364,50 +371,58 @@ _PATTERN_FIXTURES: tuple[tuple[str, str], ...] = (
     ("API_KEY: abc123", "api keys are documented separately"),
     # 1: password/passwd/pwd
     ("Password = hunter2", "passport renewal next month"),
-    # 2: AWS secret-material label (memtomem-stm#553 forward-sync).
+    # 2: general quoted-JSON label (memtomem-stm#562 forward-sync).
+    #    Negative: the pwd exclusion — a working-directory field must not
+    #    classify as credential-bearing.
+    ('"password": "hunter2"', '"pwd": "/home/user"'),
+    # 3: AWS secret-material label (memtomem-stm#553 forward-sync).
     #    Negative: an identifier that embeds the label — the unquoted
     #    branch's left boundary must reject it.
     ('"SessionToken": "FAKEFwoGZXIvYXdzFAKE"', "supports_session_token: true"),
-    # 3: sk-/ghp_/xox prefix
+    # 4: x-amz-security-token wire label (memtomem-stm#561 forward-sync).
+    #    Negative: a kebab compound that embeds the label — the
+    #    separator-only left boundary must reject it.
+    ("x-amz-security-token: FAKEFwoGZXIvYXdzFAKE", "forward-x-amz-security-token: true"),
+    # 5: sk-/ghp_/xox prefix
     ("token=sk-" + "a" * 30, "Sky color today is blue"),
-    # 4: github_pat_
+    # 6: github_pat_
     ("github_pat_" + "x" * 30, "github_user joined the org"),
-    # 5: stripe-style sk_live_, pk_test_, whsec_
+    # 7: stripe-style sk_live_, pk_test_, whsec_
     ("sk_live_" + "a" * 25, "sk_live_short"),
-    # 6: npm_
+    # 8: npm_
     ("npm_" + "a" * 30, "npm install foo"),
-    # 7: AWS access key id (AKIA/ASIA)
+    # 9: AWS access key id (AKIA/ASIA)
     ("AKIAIOSFODNN7EXAMPLE", "AKIA-no-good"),
-    # 8: JWT
+    # 10: JWT
     ("eyJhbGciOiJIUzI1NiJ9.eyJzdWIicm9vdA.SflKxwRJSMeK", "eyJ-not-a-jwt"),
-    # 9: PEM private key header
+    # 11: PEM private key header
     ("-----BEGIN RSA PRIVATE KEY-----", "RSA public key"),
-    # 10: OpenAI modern (sk-proj-/svcacct-/admin-, T3BlbkFJ-anchored).
+    # 12: OpenAI modern (sk-proj-/svcacct-/admin-, T3BlbkFJ-anchored).
     #     Negative: a kebab slug with the prefix but no marker.
     (
         "sk-proj-FAKE0aaaa1111bbbb2222cccc3333T3Blbk" + "FJEXAMPLE0dddd4444eeee5555ffff6666",
         "sk-project-management-tool",
     ),
-    # 11: Anthropic (sk-ant-NN-, exact 93-char body + AA). Negative: a
+    # 13: Anthropic (sk-ant-NN-, exact 93-char body + AA). Negative: a
     #     digit-bearing kebab slug carrying the infix (a loose body matched
     #     it; the exact length + AA terminal rejects it).
     (
         "sk-ant-api03-" + ("FAKEfake0123456789" * 6)[:93] + "AA",
         "sk-ant-api03-release-notes-2026-migration-guide",
     ),
-    # 12: GitHub gh*_ family completion. Negative: an English word that
+    # 14: GitHub gh*_ family completion. Negative: an English word that
     #     starts "gho" but is not a gho_ token.
     ("ghs_FAKEfake0123456789FAKEfake0123456789", "ghost_writer_mode_enabled"),
-    # 13: Google API key (AIza + exactly 35). Negative: too short.
+    # 15: Google API key (AIza + exactly 35). Negative: too short.
     ("AIzaSy0_-BcdSy0_-BcdSy0_-BcdSy0_-BcdSy0", "AIzaShortKey"),
-    # 14: GitLab PAT (glpat-, exact 20-char body). Negative: a digit-bearing
+    # 16: GitLab PAT (glpat-, exact 20-char body). Negative: a digit-bearing
     #     "glpat-" kebab slug (a {20,} superset matched it; exact length
     #     rejects it).
     ("glpat-" + ("FAKEfake0123456789" * 2)[:20], "glpat-form-builder-component-name-2026"),
-    # 15: Hugging Face (hf_ + exactly 34, digit-guarded). Negative: a
+    # 17: Hugging Face (hf_ + exactly 34, digit-guarded). Negative: a
     #     34-char letter-only run (no digit) directly after hf_.
     ("hf" + "_FAKEfake0123456789FAKEfake01234567", "hf" + "_abcdefghijklmnopqrstuvwxyzabcdefgh"),
-    # 16: PyPI / TestPyPI macaroon token. Negative: the prefix without the
+    # 18: PyPI / TestPyPI macaroon token. Negative: the prefix without the
     #     fixed base64 header.
     (
         "pypi-AgEIcHlwaS5vcmcFAKEfake0123456789FAKEfake0123456789FAKEfake0123456789",
@@ -626,20 +641,21 @@ class TestNewSecretPatterns1488:
     @pytest.mark.parametrize("text", _NEW_PATTERN_NEAR_MISSES)
     def test_new_pattern_near_miss_does_not_hit(self, text):
         # The contract is "no false positive from the #1488 additions"
-        # (indices >= 10 since the memtomem-stm#553 forward-sync inserted
-        # at index 2). A near-miss may legitimately stay clean of the
-        # earlier 0-9 rules too, but those are pinned elsewhere; here we
-        # isolate the new set so a future loosening surfaces precisely.
-        offending = [h.pattern_index for h in privacy.scan(text) if h.pattern_index >= 10]
+        # (indices >= 12 since the memtomem-stm#553/#562/#561 forward-syncs
+        # inserted at indices 2-4). A near-miss may legitimately stay clean
+        # of the earlier 0-11 rules too, but those are pinned elsewhere;
+        # here we isolate the new set so a future loosening surfaces
+        # precisely.
+        offending = [h.pattern_index for h in privacy.scan(text) if h.pattern_index >= 12]
         assert not offending, f"#1488 pattern(s) {offending} false-positived on {text[:50]!r}"
 
     def test_ghp_still_covered_by_legacy_not_duplicated(self):
-        # ghp_ stays the legacy sk-/ghp_/xox rule's job (index 3 since the
-        # memtomem-stm#553 forward-sync inserted at index 2); the new
-        # gh[ousr]_ pattern (index 12) deliberately excludes 'p' to avoid a
-        # duplicate hit. Locks the dedup intent + guards against the
+        # ghp_ stays the legacy sk-/ghp_/xox rule's job (index 5 since the
+        # memtomem-stm#553/#562/#561 forward-syncs inserted at indices 2-4);
+        # the new gh[ousr]_ pattern (index 14) deliberately excludes 'p' to
+        # avoid a duplicate hit. Locks the dedup intent + guards against the
         # change accidentally dropping ghp_ coverage.
         ghp = "ghp_" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8"  # ghp_ + 36 base62
         idxs = {h.pattern_index for h in privacy.scan(ghp)}
-        assert 3 in idxs, "ghp_ must still be caught by the legacy sk-/ghp_/xox rule"
-        assert 12 not in idxs, "gh[ousr]_ (index 12) must exclude 'p' — no duplication"
+        assert 5 in idxs, "ghp_ must still be caught by the legacy sk-/ghp_/xox rule"
+        assert 14 not in idxs, "gh[ousr]_ (index 14) must exclude 'p' — no duplication"

--- a/packages/memtomem/tests/test_privacy_long_content.py
+++ b/packages/memtomem/tests/test_privacy_long_content.py
@@ -110,13 +110,13 @@ class TestLongContentScan:
     def test_one_megabyte_scan_under_perf_ceiling(self):
         # Soft ceiling — not a microbenchmark, just a non-linear-regression
         # guard. ``scan()`` runs one ``re.finditer`` pass per pattern, so cost
-        # grows linearly with the pattern count: the 17 short prefix-anchored
+        # grows linearly with the pattern count: the 19 short prefix-anchored
         # ``DEFAULT_PATTERNS`` take ~100 ms locally and ~200 ms on a loaded CI
         # runner for a 1 MB input (#1488 grew the set 9 -> 16, each added
         # secret class a linear pass — no single hot spot; the
-        # memtomem-stm#553 forward-sync makes it 17). The 500 ms ceiling
-        # — matching ``test_crafted_repetition_scans_linearly`` below — keeps
-        # ~2x headroom over that worst case while still catching a genuine
+        # memtomem-stm#553/#562/#561 forward-syncs make it 19). The 500 ms
+        # ceiling — matching ``test_crafted_repetition_scans_linearly`` below
+        # — keeps ~2x headroom over that worst case while still catching a genuine
         # non-linear rewrite (e.g. a naive overlap-window scan that re-reads
         # large prefixes), which would run in seconds at 1 MB, not hundreds of
         # ms. The dedicated O(N^2) backtracking guard is that sibling test.


### PR DESCRIPTION
## Background

Forward-syncs the two STM-origin secret-class rules that landed today as memtomem-stm#564 (issue memtomem-stm#561) and memtomem-stm#565 (issue memtomem-stm#562), in one pass so the LTM mirror moves once, not twice. Per the asymmetric sync rule in the module docstring, STM additions of secret-class patterns require sync into this module + a SHA bump.

## The two rules

**General quoted-JSON label rule** (memtomem-stm#562, inserted at index 2): the generic label rules end in `\s*[:=]`, and a quoted key's closing quote sits between the label and the colon, so `"password": "hunter2"`, `"api_key": "sk-…"`, camelCase `"accessToken": "ya29.…"`, and dict-repr `{'password': 'hunter2'}` crossed the write boundary unredacted — the exact shape of a pasted `docker inspect` / `kubectl get secret -o json` / DB-config note. Reuses the #553 FP-guard shape (quote directly on both sides, string-opening value: JSON-Schema object values, embedded labels, prefixed keys never fire). `pwd` is deliberately excluded (`"pwd": "/home/user"` working-directory fields).

**`x-amz-security-token` wire label** (memtomem-stm#561, inserted at index 4): botocore DEBUG logs emit the header verbatim and every presigned URL generated with temporary credentials carries `X-Amz-Security-Token=…`; `session[_-]?token` cannot cross the `security-token` spelling, so these scanned clean unless an `ASIA…` key ID co-occurred. The unquoted branch carries a **separator-only left boundary** `(?<![_.\-])` — adjudicated during the STM review (codex cross-review; see memtomem-stm#564's review comment): kebab/dotted compounds that merely name the header (`forward-x-amz-security-token: true`) stay negative, while bytes-repr wire dumps (literal `\r\n` before the header line → alphanumeric directly before the label) stay positive.

## Sync bookkeeping

- Both rules are byte-identical to STM's and inserted at STM's indices (2 and 4), so the sets are **byte-identical AND same-order again at 19 patterns** — verified by an elementwise import-level comparison of both modules.
- Docstring: tier-1 count 10 → 12, audited-consistent STM pin `5ab5467` → `67689db` (history appended).
- The index shift moves the legacy sk-/ghp_/xox rule to 5 and the #1488 additions to ≥ 12; index-pinned tests and fixture numbering updated accordingly (same sweep shape as #1533).
- Both patterns translate cleanly to the Web UI's client-side JS scan (position-0 `(?i)` lift; the fixed-width lookbehind is ES2018+, same as #553's), and each gets its paired JS-translation parity fixture — `test_fixtures_cover_every_pattern` enforces this.
- The content-hash pin over the shared subset (memtomem-stm#559) can now land with the sets equal on both sides.

## Behavior change

Notes carrying quoted credential labels (`"password": "…"`, `"api_key": "…"`, `"accessToken": "…"`, dict reprs) or the `x-amz-security-token` label (header lines, presigned URLs, serialized header dicts) are now **blocked at the write boundary** unless `force_unsafe=True` — the same treatment the unquoted spellings and the #553 AWS labels already get. The Web UI's compose-mode client-side warning picks the rules up automatically via `JS_PATTERNS`.

## Testing

- Count pin 17 → 19; per-rule positive samples in `TestScan`; paired positive/negative JS-parity fixtures at indices 2 and 4 (`"pwd": "/home/user"` and `forward-x-amz-security-token: true` as the negatives).
- Full suite + ruff pass; 1 MB perf ceiling unaffected (two more linear passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
