### PR TITLE
test(privacy): pin the STM<->LTM secret-class sync by content hash (memtomem-stm#559)

### DIFF
--- a/packages/memtomem/tests/test_privacy.py
+++ b/packages/memtomem/tests/test_privacy.py
@@ -38,6 +38,22 @@ def _reset_counters():
     privacy.reset_for_tests()
 
 
+# Golden SHA-256 over the newline-joined ``DEFAULT_PATTERNS`` strings.
+# ``test_pattern_count_pinned`` catches a silent add/drop; this catches a
+# silent EDIT of a pattern body. The set is mirrored byte-identical and
+# same-order with memtomem-stm's ``CREDENTIAL_PATTERNS`` (see the privacy.py
+# module docstring), and the STM suite pins the SAME constant (same variable
+# name, greppable across both repos), so tightening one side alone fails
+# that side's suite — updating a pattern is a deliberate two-sided bump.
+# A cross-import equality test is off the table by design: STM holds no
+# Python-level dependency on memtomem core (memtomem-stm#559). During a
+# deliberate divergence window (one side merged ahead of its sync — e.g. an
+# LTM-origin addition awaiting its reverse mirror), bump the leading side's
+# constant with a sync-tracking note, then re-align the trailing side's
+# constant when the sync lands.
+_SECRET_CLASS_SET_SHA256 = "237d505d119c08ba85fc4474aa85bd07c603439809d03915331fab6b435a9f65"
+
+
 class TestPatternSurface:
     def test_pattern_count_pinned(self):
         # 12 STM-synced secret-class patterns (incl. the memtomem-stm#553
@@ -46,6 +62,15 @@ class TestPatternSurface:
         # deliberately when adding a pattern so a silent add/drop surfaces
         # here.
         assert len(privacy.DEFAULT_PATTERNS) == 19
+
+    def test_pattern_content_pinned_for_stm_sync(self):
+        joined = "\n".join(privacy.DEFAULT_PATTERNS).encode("utf-8")
+        assert hashlib.sha256(joined).hexdigest() == _SECRET_CLASS_SET_SHA256, (
+            "DEFAULT_PATTERNS content changed — this set is mirrored "
+            "byte-identical and same-order with memtomem-stm's "
+            "CREDENTIAL_PATTERNS; bump _SECRET_CLASS_SET_SHA256 together "
+            "with the STM-side pin of the same name (memtomem-stm#559)"
+        )
 
     @pytest.mark.parametrize(
         "clean_input",


### PR DESCRIPTION
## Background

LTM half of memtomem-stm#559. The only guard on the mirrored secret-class set was a **count** pin on each side; nothing compared the regex strings, so a one-sided edit of a pattern body left both suites green while the write-rejection gate here and STM's routing gate silently diverged. A cross-import equality test is off the table by design (STM holds no Python-level dependency on memtomem core).

## The pin

A committed golden SHA-256 over the newline-joined `DEFAULT_PATTERNS` strings — the same trick as this module's `JS_PATTERNS_SHA`, sync-scoped. The STM side pins the **same constant under the same name** (`_SECRET_CLASS_SET_SHA256`, paired PR memtomem-stm#567) so the pair is greppable across both repos. A one-sided edit fails that side's suite; updating a pattern becomes a deliberate two-sided bump. The constant's comment documents the divergence-window protocol, including the LTM-ahead direction (an LTM-origin addition awaiting its reverse mirror).

## Timing

Lands with the sets byte-identical and same-order at 19 on both sides (#1541 merged, STM pin `67689db`+). The two PRs are independent (each asserts its own repo's list) and can merge in either order.

## Behavior change

None — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)