### PR TITLE
fix(web+wiki): degrade gracefully on an unborn-HEAD wiki

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -134,7 +134,7 @@ from memtomem.context.skills import (
     generate_all_skills,
 )
 from memtomem.context import _skip_reasons as skip_codes
-from memtomem.wiki.store import WikiNotFoundError, WikiStore
+from memtomem.wiki.store import WikiNotFoundError, WikiStore, WikiUnbornHeadError
 from typing import Any, Literal, cast, get_args
 
 from memtomem.config import (
@@ -1859,6 +1859,8 @@ def install_cmd(
             raise click.ClickException(f"unknown asset type: {asset_type}")
     except WikiNotFoundError as exc:
         raise click.ClickException(str(exc)) from exc
+    except WikiUnbornHeadError as exc:
+        raise click.ClickException(str(exc)) from exc
     except AssetNotFoundError as exc:
         raise click.ClickException(str(exc)) from exc
     except AlreadyInstalledError as exc:
@@ -1954,6 +1956,8 @@ def update_cmd(
         else:  # pragma: no cover — guarded by click.Choice
             raise click.ClickException(f"unknown asset type: {asset_type}")
     except WikiNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except WikiUnbornHeadError as exc:
         raise click.ClickException(str(exc)) from exc
     except AssetNotFoundError as exc:
         raise click.ClickException(str(exc)) from exc
@@ -2065,6 +2069,10 @@ def _run_update_all(
         # the message verbatim so the user knows which name was rejected.
         raise click.ClickException(str(exc)) from exc
     except AssetNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except WikiUnbornHeadError as exc:
+        # ``current_commit`` fires once at classification entry — a commit-less
+        # wiki (clone of an empty remote) has no HEAD to update to.
         raise click.ClickException(str(exc)) from exc
 
     if not classifications:

--- a/packages/memtomem/src/memtomem/cli/wiki_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/wiki_cmd.py
@@ -21,6 +21,7 @@ from memtomem.wiki import (
     WikiAlreadyExistsError,
     WikiNotFoundError,
     WikiStore,
+    WikiUnbornHeadError,
 )
 from memtomem.wiki.commit import (
     ResolvedTarget,
@@ -387,7 +388,12 @@ def list_cmd(asset_type: str | None) -> None:
         return
 
     click.secho(f"Wiki: {store.root}", fg="cyan")
-    click.echo(f"  HEAD: {store.current_commit()[:12]}")
+    try:
+        click.echo(f"  HEAD: {store.current_commit()[:12]}")
+    except WikiUnbornHeadError:
+        # A clone of an empty remote can still carry working-tree assets —
+        # keep listing them; only the HEAD line degrades.
+        click.echo("  HEAD: (no commits yet)")
     click.echo("")
     last_type: str | None = None
     for asset in assets:

--- a/packages/memtomem/src/memtomem/web/routes/_wiki_common.py
+++ b/packages/memtomem/src/memtomem/web/routes/_wiki_common.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from typing import Literal
 
 from memtomem.context._names import InvalidNameError, override_vendors, validate_name
-from memtomem.wiki.store import WikiNotFoundError
+from memtomem.wiki.store import WikiNotFoundError, WikiUnbornHeadError
 from memtomem.web.routes._errors import _error
 
 # Literal path param → FastAPI returns 422 for any other value, so a hostile
@@ -45,3 +45,17 @@ def _wiki_absent(exc: WikiNotFoundError) -> Exception:
     # ``MEMTOMEM_WIKI_PATH`` into the HTTP envelope. The ``exc`` is still chained
     # via ``raise ... from exc`` at the call sites for server-side tracebacks.
     return _error(404, "missing", "wiki not found; run `mm wiki init`", reason_code="wiki_absent")
+
+
+def _wiki_unborn(exc: WikiUnbornHeadError) -> Exception:
+    # Fixed message like ``_wiki_absent`` — ``WikiUnbornHeadError``'s message is
+    # path-free by contract, but the fixed literal keeps this envelope immune to
+    # a future wording change in the store layer. 409: the wiki resource exists;
+    # its state (no commits yet) is what blocks the request.
+    return _error(
+        409,
+        "conflict",
+        "wiki has no commits yet — make an initial commit in the wiki repo "
+        "(or pull a populated branch), then retry",
+        reason_code="wiki_unborn",
+    )

--- a/packages/memtomem/src/memtomem/web/routes/context_mutations.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mutations.py
@@ -44,10 +44,15 @@ from memtomem.context.install import (
 )
 from memtomem.context.lockfile import LockfileError
 from memtomem.context.privacy_scan import PrivacyScanError
-from memtomem.wiki.store import WikiNotFoundError, WikiStore
+from memtomem.wiki.store import WikiNotFoundError, WikiStore, WikiUnbornHeadError
 from memtomem.web.routes._errors import _error
 from memtomem.web.routes._locks import _gateway_lock
-from memtomem.web.routes._wiki_common import AssetType, _validate_name_or_error, _wiki_absent
+from memtomem.web.routes._wiki_common import (
+    AssetType,
+    _validate_name_or_error,
+    _wiki_absent,
+    _wiki_unborn,
+)
 from memtomem.web.routes.context_projects import resolve_project_shared_writable_scope_root
 
 router = APIRouter(tags=["context-mutations"])
@@ -135,6 +140,8 @@ async def install_asset(
         raise _error(503, "busy", "install timed out — another sync may be in progress")
     except WikiNotFoundError as exc:
         raise _wiki_absent(exc) from exc
+    except WikiUnbornHeadError as exc:
+        raise _wiki_unborn(exc) from exc
     except AssetNotFoundError as exc:
         raise _error(
             404, "missing", f"{asset_type}/{name} not found in wiki", reason_code="asset_absent"
@@ -214,6 +221,8 @@ async def update_asset(
         raise _error(503, "busy", "update timed out — another sync may be in progress")
     except WikiNotFoundError as exc:
         raise _wiki_absent(exc) from exc
+    except WikiUnbornHeadError as exc:
+        raise _wiki_unborn(exc) from exc
     except NotInstalledError as exc:
         raise _error(
             404,

--- a/packages/memtomem/src/memtomem/web/routes/wiki.py
+++ b/packages/memtomem/src/memtomem/web/routes/wiki.py
@@ -24,13 +24,14 @@ from fastapi import APIRouter, Query
 
 from memtomem.context._names import override_vendors, renderable_vendors
 from memtomem.wiki import inspect as wiki_inspect
-from memtomem.wiki.store import WikiNotFoundError, WikiStore
+from memtomem.wiki.store import WikiNotFoundError, WikiStore, WikiUnbornHeadError
 from memtomem.web.routes._errors import _error
 from memtomem.web.routes._wiki_common import (
     AssetType,
     _require_vendor,
     _validate_name_or_error,
     _wiki_absent,
+    _wiki_unborn,
 )
 
 router = APIRouter(prefix="/wiki", tags=["wiki"])
@@ -72,6 +73,8 @@ async def list_wiki() -> dict:
         return await asyncio.to_thread(_collect)
     except WikiNotFoundError as exc:
         raise _wiki_absent(exc) from exc
+    except WikiUnbornHeadError as exc:
+        raise _wiki_unborn(exc) from exc
 
 
 @router.get("/status")
@@ -101,6 +104,11 @@ async def wiki_status() -> dict:
     try:
         return await asyncio.to_thread(_probe)
     except WikiNotFoundError:
+        return {"present": False, "wiki_head": None, "is_dirty": False}
+    except WikiUnbornHeadError:
+        # A commit-less wiki (clone of an empty remote) cannot be installed
+        # from, so for the glance badge it is the same onboarding state as an
+        # absent wiki — hidden, never an error toast.
         return {"present": False, "wiki_head": None, "is_dirty": False}
 
 

--- a/packages/memtomem/src/memtomem/web/routes/wiki_mutations.py
+++ b/packages/memtomem/src/memtomem/web/routes/wiki_mutations.py
@@ -73,6 +73,7 @@ from memtomem.wiki.store import (
     WikiHeadMovedError,
     WikiNotFoundError,
     WikiStore,
+    WikiUnbornHeadError,
 )
 from memtomem.web.routes._errors import _error
 from memtomem.web.routes._locks import _gateway_lock
@@ -81,6 +82,7 @@ from memtomem.web.routes._wiki_common import (
     _require_vendor,
     _validate_name_or_error,
     _wiki_absent,
+    _wiki_unborn,
 )
 
 logger = logging.getLogger(__name__)
@@ -729,7 +731,12 @@ async def commit_wiki(asset_type: AssetType, name: str, body: WikiCommitRequest)
     except WikiHeadMovedError:
         try:
             fresh = store.current_commit()
-        except WikiNotFoundError:
+        except (WikiNotFoundError, WikiUnbornHeadError):
+            # The wiki vanished — or its branch was force-reset to empty —
+            # between the failed CAS and this freshness probe. The commit
+            # still failed because HEAD moved; report the conflict with an
+            # unknown fresh head rather than letting the probe's own error
+            # escape as a 500.
             fresh = ""
         return _commit_head_conflict(fresh)
     except WikiNotFoundError as exc:
@@ -741,6 +748,11 @@ async def commit_wiki(asset_type: AssetType, name: str, body: WikiCommitRequest)
         # envelopes (``override_exists``); the engine message is fixed and
         # deliberately path-free (see WikiDetachedHeadError in wiki/store.py).
         raise _error(409, "conflict", str(exc), reason_code="detached_head") from exc
+    except WikiUnbornHeadError as exc:
+        # Precede the broad RuntimeError arm like the detached-HEAD arm above:
+        # a commit-less wiki is a precise user-fixable state (409 + remedy),
+        # not an internal git failure (500).
+        raise _wiki_unborn(exc) from exc
     except TimeoutError as exc:
         raise _error(
             503, "busy", "wiki commit timed out — another wiki operation may be in progress"

--- a/packages/memtomem/src/memtomem/wiki/__init__.py
+++ b/packages/memtomem/src/memtomem/wiki/__init__.py
@@ -17,6 +17,7 @@ from memtomem.wiki.store import (
     WikiDetachedHeadError,
     WikiNotFoundError,
     WikiStore,
+    WikiUnbornHeadError,
 )
 
 __all__ = [
@@ -27,4 +28,5 @@ __all__ = [
     "WikiDetachedHeadError",
     "WikiNotFoundError",
     "WikiStore",
+    "WikiUnbornHeadError",
 ]

--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -113,6 +113,21 @@ class WikiDetachedHeadError(RuntimeError):
     """
 
 
+class WikiUnbornHeadError(RuntimeError):
+    """Raised when the wiki HEAD names a branch that has no commits yet.
+
+    The state a clone of an *empty* remote leaves behind (``mm wiki init
+    --from <url>`` of a just-created backup repo): ``.git`` exists, the
+    working tree may even carry files, but ``rev-parse HEAD`` has nothing
+    to resolve. Distinct from :class:`WikiNotFoundError` (no wiki at all)
+    so callers can degrade precisely — the web routes render a typed
+    envelope instead of a 500 traceback, and ``present``-style probes
+    report the wiki as not-yet-usable. The message is deliberately path-
+    and SHA-free (mirrors :class:`WikiDetachedHeadError`) so web surfaces
+    may return it verbatim.
+    """
+
+
 @dataclass(frozen=True)
 class WikiAsset:
     """An entry in the wiki — a skill, agent, or command directory."""
@@ -488,8 +503,46 @@ class WikiStore:
         the project lockfile (see ADR-0008).
         """
         self.require_exists()
-        result = _git(["rev-parse", "HEAD"], cwd=self.root)
+        try:
+            result = _git(["rev-parse", "HEAD"], cwd=self.root)
+        except RuntimeError as exc:
+            if self._head_is_unborn():
+                raise WikiUnbornHeadError(
+                    "wiki has no commits yet (a clone of an empty remote?) — make an "
+                    "initial commit in the wiki repo, or pull a populated branch with "
+                    "`mm wiki pull`"
+                ) from exc
+            raise
         return result.stdout.strip()
+
+    def _head_is_unborn(self) -> bool:
+        """``True`` when HEAD is a symbolic ref to a branch with no commits.
+
+        Called only after ``rev-parse HEAD`` failed, to classify that failure.
+        Three conditions gate the classification so a *corrupt* repo is never
+        misreported as merely unborn (any other failure re-raises the redacted
+        RuntimeError verbatim):
+
+        1. ``symbolic-ref -q HEAD`` resolves — HEAD itself is intact and names
+           a branch (a detached HEAD or a garbled HEAD file fails here);
+        2. ``show-ref --verify`` says the branch ref does not resolve (loose or
+           packed);
+        3. nothing sits at the ref's loose path — a directory (or unreadable
+           file) squatting at ``.git/refs/heads/<branch>`` also fails
+           ``show-ref``, but that is ref-store corruption, not an unborn
+           branch, and must keep the original git error.
+        """
+        sym = _git_query(["symbolic-ref", "-q", "HEAD"], self.root)
+        ref = sym.stdout.strip()
+        if sym.returncode != 0 or not ref:
+            return False
+        if _git_query(["show-ref", "--verify", "--quiet", ref], self.root).returncode == 0:
+            return False
+        ref_path = _git_query(["rev-parse", "--git-path", ref], self.root)
+        loose = ref_path.stdout.strip()
+        if ref_path.returncode != 0 or not loose:
+            return False
+        return not (self.root / loose).exists()
 
     def commit_is_reachable(self, commit: str) -> bool:
         """``True`` when *commit* resolves to an object in this wiki repo.

--- a/packages/memtomem/tests/_wiki_fixtures.py
+++ b/packages/memtomem/tests/_wiki_fixtures.py
@@ -35,3 +35,25 @@ def wiki_root(
     target = tmp_path / "wiki"
     monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(target))
     return target
+
+
+@pytest.fixture
+def unborn_wiki(wiki_root: Path, tmp_path: Path) -> Path:
+    """A clone of an EMPTY bare remote: ``.git`` exists but HEAD is unborn.
+
+    The state ``mm wiki init --from <url>`` leaves behind when the backup
+    remote has no commits yet. One working-tree skill is seeded so listing
+    surfaces have rows to render — the asset dirs exist, only HEAD is
+    missing (``rev-parse HEAD`` has nothing to resolve).
+    """
+    import subprocess
+
+    from memtomem.wiki.store import WikiStore
+
+    remote = tmp_path / "empty-remote.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True)
+    WikiStore.at_default().init_from_url(str(remote))
+    skill = wiki_root / "skills" / "alpha"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_bytes(b"# Alpha\n")
+    return wiki_root

--- a/packages/memtomem/tests/conftest.py
+++ b/packages/memtomem/tests/conftest.py
@@ -16,10 +16,10 @@ from memtomem.config import Mem2MemConfig
 from memtomem.server.component_factory import Components, create_components, close_components
 
 # Re-export wiki fixtures so any test in this directory can request
-# ``git_identity`` / ``wiki_root`` as a parameter without per-file imports.
-# Keeping the definitions in ``_wiki_fixtures.py`` avoids bloating this
-# already-heavy conftest with unrelated git-env plumbing.
-from _wiki_fixtures import git_identity, wiki_root  # noqa: F401
+# ``git_identity`` / ``wiki_root`` / ``unborn_wiki`` as a parameter without
+# per-file imports. Keeping the definitions in ``_wiki_fixtures.py`` avoids
+# bloating this already-heavy conftest with unrelated git-env plumbing.
+from _wiki_fixtures import git_identity, unborn_wiki, wiki_root  # noqa: F401
 
 
 # The Langfuse SDK's own env names. Sub-configs no longer bind bare env vars

--- a/packages/memtomem/tests/test_context_install.py
+++ b/packages/memtomem/tests/test_context_install.py
@@ -427,6 +427,20 @@ def test_cli_install_wiki_missing_message(
     assert "wiki not found at" in result.output
 
 
+def test_cli_install_unborn_wiki_message(
+    unborn_wiki: Path,
+    project_cwd: Path,
+) -> None:
+    # Clone of an empty remote: asset dir exists in the working tree but there
+    # is no HEAD commit to pin — a clean refusal with the remedy, no traceback.
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["install", "skill", "alpha"])
+
+    assert result.exit_code != 0
+    assert "no commits yet" in result.output
+    assert "Traceback" not in result.output
+
+
 def test_cli_install_rejects_unknown_type(project_cwd: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(context_group, ["install", "settings", "foo"])

--- a/packages/memtomem/tests/test_web_routes_context_mutations.py
+++ b/packages/memtomem/tests/test_web_routes_context_mutations.py
@@ -382,6 +382,33 @@ async def test_install_wiki_absent_is_404(client, wiki_root: Path) -> None:  # n
 
 
 @pytest.mark.asyncio
+async def test_install_unborn_wiki_is_409(client, unborn_wiki: Path) -> None:
+    # Clone of an empty remote: the asset dir exists in the working tree but
+    # there is no HEAD to pin — used to escape as a 500 RuntimeError.
+    resp = await client.post("/api/context/skills/alpha/install")
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["reason_code"] == "wiki_unborn"
+    assert str(unborn_wiki) not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_update_unborn_wiki_is_409(client, seeded_wiki: Path, project_root: Path) -> None:
+    # Install from a healthy wiki first, then delete the branch ref so HEAD
+    # becomes unborn again (the force-push-to-empty shape).
+    resp = await client.post("/api/context/skills/alpha/install")
+    assert resp.status_code == 200, resp.text
+    subprocess.run(
+        ["git", "-C", str(seeded_wiki), "update-ref", "-d", "refs/heads/main"],
+        check=True,
+        capture_output=True,
+    )
+    resp = await client.post("/api/context/skills/alpha/update")
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["reason_code"] == "wiki_unborn"
+    assert str(seeded_wiki) not in resp.text
+
+
+@pytest.mark.asyncio
 async def test_install_privacy_block_is_422_no_path_leak(
     client,
     wiki_root: Path,

--- a/packages/memtomem/tests/test_web_routes_wiki.py
+++ b/packages/memtomem/tests/test_web_routes_wiki.py
@@ -138,6 +138,33 @@ async def test_wiki_status_dirty(client, seeded_wiki: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_wiki_unborn_is_409_not_500(client, unborn_wiki: Path) -> None:
+    # A clone of an EMPTY remote: .git exists, HEAD is unborn — the RuntimeError
+    # from ``rev-parse HEAD`` used to escape as a 500 traceback ("never a
+    # traceback", ADR-0008 Invariant 3).
+    resp = await client.get("/api/wiki")
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["reason_code"] == "wiki_unborn"
+    # Path-free envelope: the absolute wiki root must not leak.
+    assert str(unborn_wiki) not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_wiki_status_unborn_is_present_false_not_500(
+    client,
+    unborn_wiki: Path,
+) -> None:
+    # The nav probe fires on every gateway open; a commit-less wiki cannot be
+    # installed from, so it degrades to the same hidden badge as an absent one.
+    resp = await client.get("/api/wiki/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["present"] is False
+    assert data["wiki_head"] is None
+    assert str(unborn_wiki) not in resp.text
+
+
+@pytest.mark.asyncio
 async def test_wiki_status_absent_is_present_false_not_404(
     client,
     wiki_root: Path,  # noqa: F811

--- a/packages/memtomem/tests/test_web_routes_wiki_mutations.py
+++ b/packages/memtomem/tests/test_web_routes_wiki_mutations.py
@@ -921,6 +921,24 @@ async def test_commit_isolates_unrelated_staged_index(dev_client, seeded_wiki: P
 
 
 @pytest.mark.asyncio
+async def test_commit_unborn_wiki_is_409_not_500(dev_client, unborn_wiki: Path) -> None:
+    # Clone of an EMPTY remote: the canonical exists in the working tree, but
+    # there is no HEAD for the CAS — a precise 409 with the remedy, not the
+    # fixed commit_failed 500 the broad RuntimeError arm returns.
+    skill_md = unborn_wiki / "skills" / "alpha" / "SKILL.md"
+    resp = await dev_client.post(
+        "/api/wiki/skills/alpha/commit",
+        json={
+            "expected_head": "0" * 40,
+            "targets": [{"kind": "canonical", "mtime_ns": str(skill_md.stat().st_mtime_ns)}],
+        },
+    )
+    assert resp.status_code == 409, resp.text
+    assert resp.json()["detail"]["reason_code"] == "wiki_unborn"
+    assert str(unborn_wiki) not in resp.text
+
+
+@pytest.mark.asyncio
 async def test_commit_stale_expected_head_is_409(dev_client, seeded_wiki: Path) -> None:
     mtime = await _save_canonical(dev_client, _EDITED)
     head = await _wiki_head(dev_client)

--- a/packages/memtomem/tests/test_wiki_cmd.py
+++ b/packages/memtomem/tests/test_wiki_cmd.py
@@ -69,6 +69,15 @@ class TestListCmd:
         assert result.exit_code == 0
         assert "no assets" in result.output
 
+    def test_list_unborn_wiki_degrades_head_line(self, unborn_wiki: Path) -> None:
+        # A clone of an empty remote still carries working-tree assets — the
+        # listing must survive; only the HEAD line degrades (no traceback).
+        runner = CliRunner()
+        result = runner.invoke(wiki, ["list"])
+        assert result.exit_code == 0, result.output
+        assert "HEAD: (no commits yet)" in result.output
+        assert "alpha" in result.output
+
     def test_list_shows_assets(self, isolated_wiki: Path) -> None:
         runner = CliRunner()
         runner.invoke(wiki, ["init"])

--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -18,6 +18,7 @@ from memtomem.wiki.store import (
     WikiNotFoundError,
     WikiNothingToCommitError,
     WikiStore,
+    WikiUnbornHeadError,
     _wiki_path_from_env,
 )
 
@@ -674,3 +675,47 @@ class TestCommitPaths:
         with pytest.raises(WikiDetachedHeadError, match="detached HEAD"):
             store.commit_paths({"agents/beta/agent.md": b"v2\n"}, message="e", expected_head=head)
         assert store.current_commit() == head  # nothing was committed
+
+
+class TestUnbornHead:
+    """``current_commit`` on a commit-less wiki (clone of an empty remote)."""
+
+    def test_current_commit_raises_typed_error(self, unborn_wiki) -> None:
+        with pytest.raises(WikiUnbornHeadError) as excinfo:
+            WikiStore.at_default().current_commit()
+        # Message contract: path- and SHA-free, so web surfaces may return it
+        # verbatim (mirrors WikiDetachedHeadError).
+        assert str(unborn_wiki) not in str(excinfo.value)
+        assert "no commits yet" in str(excinfo.value)
+
+    def test_is_dirty_still_works(self, unborn_wiki) -> None:
+        # The seeded working-tree skill is untracked → dirty; ``git status``
+        # itself needs no HEAD, so the probe must not raise.
+        assert WikiStore.at_default().is_dirty() is True
+
+    def test_corrupt_ref_directory_stays_plain_runtimeerror(self, wiki_root) -> None:
+        # Codex review repro: a DIRECTORY squatting at .git/refs/heads/main
+        # makes ``symbolic-ref`` succeed and ``show-ref`` fail — the unborn
+        # shape minus the "nothing at the loose ref path" condition. That is
+        # ref-store corruption and must keep the original git error, not be
+        # softened to "no commits yet".
+        store = WikiStore.at_default()
+        store.init()
+        ref = wiki_root / ".git" / "refs" / "heads" / "main"
+        ref.unlink()
+        ref.mkdir()
+        with pytest.raises(RuntimeError) as excinfo:
+            store.current_commit()
+        assert not isinstance(excinfo.value, WikiUnbornHeadError)
+
+    def test_corrupt_head_stays_plain_runtimeerror(self, wiki_root) -> None:
+        # Narrowness pin: a corrupt HEAD file (git: "not a git repository")
+        # fails BOTH rev-parse and symbolic-ref, so it must keep raising the
+        # redacted RuntimeError — only the symbolic-ref-to-unborn-branch shape
+        # classifies as WikiUnbornHeadError.
+        store = WikiStore.at_default()
+        store.init()
+        (wiki_root / ".git" / "HEAD").write_text("garbage\n", encoding="utf-8")
+        with pytest.raises(RuntimeError) as excinfo:
+            store.current_commit()
+        assert not isinstance(excinfo.value, WikiUnbornHeadError)


### PR DESCRIPTION
## Summary

T1-6 from the 2026-07-02 ctx-gateway/wiki re-review campaign (plan backlog; no standalone issue).

A clone of an **empty** remote (`mm wiki init --from <url>` of a just-created backup repo) leaves HEAD unborn: `.git` exists, the working tree may even carry assets, but `rev-parse HEAD` has nothing to resolve. `WikiStore.current_commit()` surfaced that as a raw `RuntimeError`, which escaped every surface that only classified `WikiNotFoundError` — violating the "never a traceback" contract (ADR-0008 Invariant 3). Reproduced end-to-end on a real empty bare remote:

- `GET /api/wiki` and `GET /api/wiki/status` → **500** (the status probe fires on every gateway open and is documented as "never surfaces an error toast")
- web wiki commit → misleading fixed `commit_failed` 500; web context install/update → 500
- `mm wiki list` (with working-tree assets), `mm context install`, `mm context update --all` → raw Python tracebacks

## Changes

- **`WikiUnbornHeadError`** (path- and SHA-free message, mirrors `WikiDetachedHeadError`), classified once at the chokepoint: `current_commit()` re-raises anything that is not exactly the unborn shape. Three gates so a *corrupt* repo is never misreported as unborn: `symbolic-ref -q HEAD` resolves, `show-ref --verify` fails, **and** nothing sits at the ref's loose path (a directory squatting at `.git/refs/heads/<branch>` is corruption, found by the Codex review pass — regression-pinned).
- **Web:** `/api/wiki/status` → `present:false` (same hidden badge as an absent wiki); `/api/wiki`, wiki commit, context install/update → **409 `wiki_unborn`** envelope with the remedy via a shared `_wiki_unborn` helper (`_wiki_common`, the `_wiki_absent` precedent). The commit route's `WikiHeadMovedError` recovery probe also catches the unborn race (second Codex finding).
- **CLI:** `mm wiki list` prints `HEAD: (no commits yet)` and still lists working-tree assets; `mm context install` / `update` / `update --all` refuse cleanly via `ClickException` with the remedy.
- `mm context status` already degraded gracefully via its broad `RuntimeError` arm ("present but unusable") and needs no change; it now shows the friendly message as the reason detail.

Out of scope: making the web editor's commit verb create the *initial* commit on an unborn wiki (would need a parentless `commit-tree` path in `commit_paths`); diff/lint read the working tree and never hit `current_commit`, so they were already traceback-free.

## Test plan

- New `unborn_wiki` fixture in `_wiki_fixtures.py` (clones a real empty bare remote via `init_from_url`, seeds one working-tree skill).
- Store: typed error + path-free message pin; `is_dirty` survives; two narrowness pins (garbled HEAD file, ref-directory corruption) stay plain `RuntimeError`.
- Web: list 409 / status `present:false` / commit 409 / install 409 / update 409 (born → ref deleted → unborn race), each with a no-path-leak assertion.
- CLI: `mm wiki list` degraded HEAD line; `mm context install` clean refusal, no traceback.
- Full suite: 7458 passed, 11 skipped (`-m "not ollama"`); ruff check + format clean.

Review: two Codex passes — round 1 NEEDS-FIX (corrupt-ref misclassification, HeadMoved-recovery race) both reproduced and fixed; round 2 findings are regression-pinned in `test_wiki_store.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
