### PR TITLE
fix(wiki): store subprocess boundary hygiene (git show + URL end-of-options)

### DIFF
--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -217,11 +217,12 @@ def _git(
 def _git_bytes(args: list[str], cwd: Path) -> subprocess.CompletedProcess[bytes]:
     """Run ``git <args>`` in ``cwd`` returning raw *bytes* stdout.
 
-    Twin of :func:`_git` for path-carrying porcelain output (``ls-tree -z``):
-    ``text=True`` decodes with the host's preferred locale encoding, which
-    corrupts non-ASCII pathnames on non-UTF-8 hosts — the caller decodes
-    explicitly instead. Failure classification and credential redaction
-    mirror :func:`_git`.
+    Twin of :func:`_git` for byte-exact output — path-carrying porcelain
+    (``ls-tree -z``) and blob content (``show <rev>:<path>``): ``text=True``
+    decodes with the host's preferred locale encoding, which corrupts
+    non-ASCII pathnames (and any binary blob) on non-UTF-8 hosts — the
+    caller decodes explicitly instead. Failure classification and credential
+    redaction mirror :func:`_git`.
     """
     try:
         return subprocess.run(
@@ -377,7 +378,10 @@ class WikiStore:
         # remove it first so clone owns the layout.
         if self.root.exists():
             self.root.rmdir()
-        _git(["clone", url, str(self.root)], cwd=self.root.parent)
+        # ``--`` pins the user-supplied URL as positional: a ``-``-prefixed
+        # value must never be parsed as a git option (``--upload-pack=<cmd>``
+        # would run an arbitrary command). Same guard on remote add/set-url.
+        _git(["clone", "--", url, str(self.root)], cwd=self.root.parent)
 
     # ── Remote / backup (ADR-0008: "git remotes — no new sync protocol") ─────
     #
@@ -427,9 +431,9 @@ class WikiStore:
         """
         self.require_exists()
         if self.remote_url(name) is None:
-            _git(["remote", "add", name, url], cwd=self.root)
+            _git(["remote", "add", "--", name, url], cwd=self.root)
             return "added"
-        _git(["remote", "set-url", name, url], cwd=self.root)
+        _git(["remote", "set-url", "--", name, url], cwd=self.root)
         return "updated"
 
     def current_branch(self) -> str:
@@ -786,13 +790,15 @@ class WikiStore:
         tree is never consulted, so the bytes are immutable for a given
         commit. Shared by :meth:`copy_asset_at_commit` (extraction) and the
         pinned-install Gate A privacy scan (#1247), which must observe
-        exactly the bytes the extractor would write.
+        exactly the bytes the extractor would write. Runs via
+        :func:`_git_bytes` so a failure (rel absent at the commit for a racy
+        caller, GC'd object, missing git binary) surfaces as a normalized
+        ``RuntimeError`` instead of a raw ``CalledProcessError`` / ``OSError``
+        escaping the callers' ``except RuntimeError`` boundaries.
         """
-        result = subprocess.run(
-            ["git", "show", f"{commit}:{asset_type}/{name}/{rel}"],
+        result = _git_bytes(
+            ["show", f"{commit}:{asset_type}/{name}/{rel}"],
             cwd=self.root,
-            check=True,
-            capture_output=True,
         )
         return result.stdout
 

--- a/packages/memtomem/tests/test_wiki_remote.py
+++ b/packages/memtomem/tests/test_wiki_remote.py
@@ -108,6 +108,16 @@ class TestSetRemote:
         with pytest.raises(WikiNotFoundError):
             store.set_remote("file:///x")
 
+    def test_dash_prefixed_url_is_positional(self, tmp_path: Path, git_identity: None) -> None:
+        """Both legs (``remote add`` / ``remote set-url``) must pass the user
+        URL after ``--`` so a ``-``-prefixed value is stored verbatim, never
+        parsed as a git option (argument-injection guard)."""
+        store = _init_wiki(tmp_path / "wiki")
+        assert store.set_remote("-dash-added") == "added"
+        assert store.remote_url() == "-dash-added"
+        assert store.set_remote("-dash-set-url") == "updated"
+        assert store.remote_url() == "-dash-set-url"
+
 
 # ── current_branch ──────────────────────────────────────────────────────
 

--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -187,6 +187,21 @@ class TestInitFromUrl:
         with pytest.raises(RuntimeError, match="git clone"):
             store.init_from_url("file:///definitely/not/a/repo")
 
+    def test_dash_prefixed_url_is_positional(self, wiki_root: Path, tmp_path: Path) -> None:
+        """A ``-``-prefixed source must reach git AFTER ``--`` — always a repo
+        path, never an option (``--upload-pack=<cmd>`` would otherwise run an
+        arbitrary command). The bare repo sits in ``root.parent``, the clone's
+        cwd, so the dash-named relative path resolves once git treats it as
+        positional."""
+        subprocess.run(
+            ["git", "init", "--bare", str(tmp_path / "-dash-remote.git")],
+            check=True,
+            capture_output=True,
+        )
+        store = WikiStore.at_default()
+        store.init_from_url("-dash-remote.git")
+        assert store.exists()
+
 
 class TestListAssets:
     def test_list_empty_after_init(self, wiki_root: Path) -> None:
@@ -525,6 +540,49 @@ class TestCopyAssetAtCommit:
         assert sorted(digest_map) == ["SKILL.md"]  # skipped rel absent from the map too
         assert (dest / "SKILL.md").read_bytes() == b"# foo\n"
         assert not (dest / "__pycache__").exists()
+
+
+class TestReadAssetFileAtCommit:
+    """`git show` failures must cross the :func:`_git_bytes` boundary.
+
+    The Gate A privacy scan and ``install --all`` digest reconciliation call
+    :meth:`WikiStore.read_asset_file_at_commit` directly — a raw
+    ``CalledProcessError`` / ``OSError`` escapes every CLI/web
+    ``except RuntimeError`` handler as a traceback (500 on the web routes).
+    """
+
+    def test_reads_bytes_at_commit(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        pin = _seed_skill(wiki_root, "foo", {"SKILL.md": b"pinned\n"})
+        assert store.read_asset_file_at_commit(pin, "skills", "foo", "SKILL.md") == b"pinned\n"
+
+    def test_git_failure_is_normalized_runtimeerror(self, wiki_root: Path) -> None:
+        """A rel absent at the commit (racy caller, GC'd object) is a plain
+        ``git show`` failure — normalized, not a raw ``CalledProcessError``."""
+        store = WikiStore.at_default()
+        store.init()
+        head = store.current_commit()  # initial scaffold; no skills/foo yet
+        with pytest.raises(RuntimeError, match="git show"):
+            store.read_asset_file_at_commit(head, "skills", "foo", "SKILL.md")
+
+    def test_oserror_is_normalized_runtimeerror(
+        self, wiki_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing git binary / vanished cwd → RuntimeError, mirroring
+        :func:`_git` (see ``TestRemoteUrl.test_oserror_normalized_to_runtimeerror``)."""
+        import memtomem.wiki.store as store_module
+
+        store = WikiStore.at_default()
+        store.init()
+        pin = _seed_skill(wiki_root, "foo", {"SKILL.md": b"pinned\n"})
+
+        def _boom(*_a: object, **_k: object) -> object:
+            raise FileNotFoundError("git")
+
+        monkeypatch.setattr(store_module.subprocess, "run", _boom)
+        with pytest.raises(RuntimeError, match="git show"):
+            store.read_asset_file_at_commit(pin, "skills", "foo", "SKILL.md")
 
 
 class TestAssetFilesNonAsciiPaths:


### PR DESCRIPTION
## Summary

T1-10 from the 2026-07-02 ctx/wiki review: two subprocess-boundary hygiene gaps in `wiki/store.py`.

**(a) `read_asset_file_at_commit` bypassed the `_git` error boundary.**
It ran a raw `subprocess.run(check=True)`, so a failing `git show` — the rel absent at the commit for a racy caller, a GC'd object, or a missing git binary — escaped as a raw `CalledProcessError` / `OSError` instead of the normalized, credential-redacted `RuntimeError` every other store subprocess produces. That skips every caller's `except RuntimeError` handler (CLI traceback, web 500), and both the Gate A privacy scan and `install --all` digest reconciliation call this method directly. It now routes through `_git_bytes` (the byte-exact twin introduced in #1521), which preserves the exact-bytes contract the Gate A scan depends on.

**(b) User-supplied URLs could be parsed as git options.**
`clone` / `remote add` / `remote set-url` passed the URL without an end-of-options `--`, so a `-`-prefixed value was consumed by git's option parser — `--upload-pack=<cmd>` on clone runs an arbitrary command. All three legs now pin the URL as positional after `--`.

## Tests

New tests were RED before the fix, green after:

- `TestReadAssetFileAtCommit`: happy-path bytes pin, `git show` failure → normalized `RuntimeError` (not `CalledProcessError`), `OSError` → `RuntimeError` (mirrors the existing `remote_url` pin).
- `TestInitFromUrl::test_dash_prefixed_url_is_positional`: real-git clone from a `-`-named bare repo succeeds (treated as a path, not an option).
- `TestSetRemote::test_dash_prefixed_url_is_positional`: both `remote add` and `remote set-url` legs store a `-`-prefixed URL verbatim and round-trip it.

`uv run pytest -m "not ollama"`: 7481 passed. `ruff check` + `ruff format --check`: clean. Codex review: SHIP, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
