### PR TITLE
feat(web): surface the wiki update-available (behind) axis on the overview

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -17,6 +17,7 @@ from memtomem.context._names import GENERATOR_VENDOR
 from memtomem.context.projects import sync_skip_reason
 from memtomem.context.status import (
     ProjectStatus,
+    classify_status,
     collect_project_status,
     summarize_diff_with_canonical,
     summarize_settings_statuses,
@@ -351,6 +352,38 @@ async def context_overview(
         logger.exception("diff_settings failed")
         result["settings"] = _error_payload(exc, shape="status")
 
+    # Wiki-install staleness axis (0629 backlog c/d): the count of installed
+    # assets whose lockfile pin sits behind wiki HEAD ("update available").
+    # This is the lockfile↔wiki axis — none of the canonical→runtime tiles
+    # above carry it, and the cross-project /context/status-all route that
+    # does has zero web consumers by design. ``None`` (not zeros) on failure:
+    # the badge is a pure header enhancement, but "0 behind" is a clean-state
+    # claim we can't back when the classifier itself raised.
+    wiki_installs: dict[str, int] | None
+    try:
+        if target_scope == "project_shared":
+            # classify_status shells out to git per lockfile entry
+            # (HEAD probe + per-pin reachability), so it runs off the event
+            # loop (#1145 discipline); the diff blocks above are filesystem
+            # reads only.
+            _wiki_head, status_rows = await asyncio.to_thread(classify_status, project_root)
+            tracked = [
+                row
+                for row in status_rows
+                if row.tier == "project_shared" and row.state != "untracked"
+            ]
+            wiki_installs = {
+                "total": len(tracked),
+                "behind": sum(1 for row in tracked if row.state == "behind"),
+            }
+        else:
+            # Wiki installs are lockfile-tracked project_shared snapshots
+            # only — mirror the mcp_servers single-tier placeholder.
+            wiki_installs = {"total": 0, "behind": 0}
+    except Exception:
+        logger.exception("classify_status failed")
+        wiki_installs = None
+
     try:
         detected_runtimes = _compute_detected_runtimes(project_root)
     except Exception:
@@ -368,6 +401,7 @@ async def context_overview(
         "project_root": str(project_root),
         "detected_runtimes": detected_runtimes,
         "last_synced_at": last_synced_at,
+        "wiki_installs": wiki_installs,
         **result,
     }
 

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -1970,6 +1970,24 @@ function _renderCtxOverview(data) {
       </div>`;
   }
 
+  // Wiki update-available badge — the lockfile↔wiki staleness axis from the
+  // overview payload's ``wiki_installs`` block. Renders only when actionable
+  // (behind > 0); an absent/null block (older cached payloads replaying
+  // through langchange, or a degraded backend classifier) reads as no badge —
+  // the same defensive-reader posture as ``detected_runtimes`` above. Plain
+  // flex child of the header, no wrapper: the ``badge`` primitives already
+  // carry the styling (no style.css change needed).
+  const wikiInstalls = (data.wiki_installs && typeof data.wiki_installs === 'object')
+    ? data.wiki_installs : null;
+  const wikiBehind = (wikiInstalls && typeof wikiInstalls.behind === 'number')
+    ? wikiInstalls.behind : 0;
+  let wikiBehindHtml = '';
+  if (wikiBehind > 0) {
+    const behindTip = escapeHtml(t('settings.ctx.wiki_behind_tip', { n: wikiBehind }));
+    const behindLabel = escapeHtml(t('settings.ctx.wiki_behind_badge', { n: wikiBehind }));
+    wikiBehindHtml = `<span class="badge badge-warning ctx-overview-wiki-behind" title="${behindTip}">${behindLabel}</span>`;
+  }
+
   // Inline ``t()`` text rather than ``data-i18n`` attrs: the langchange
   // listener applies ``I18N.applyDOM`` first and then re-renders this
   // panel, so any ``data-i18n`` attr written *during* the re-render would
@@ -1991,6 +2009,7 @@ function _renderCtxOverview(data) {
         ${chips}
       </div>
       ${lastSyncHtml}
+      ${wikiBehindHtml}
     </div>`;
   // ADR-0026 P1a (#1353): in Simple mode, render a one-line verdict + per-type
   // rows ABOVE the grid; ``.ctx-simple`` CSS hides the grid so the Advanced

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1764,7 +1764,7 @@
   <script src="/settings-harness.js?v=5"></script>
   <script src="/settings-hooks-watchdog.js?v=21"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=98"></script>
+  <script src="/context-gateway.js?v=99"></script>
   <script src="/context-portal.js?v=7"></script>
   <script src="/wiki.js?v=7"></script>
   <script src="/path-picker.js?v=4"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -438,6 +438,8 @@
   "settings.ctx.runtimes_glossary": "The AI tools memtomem syncs to — Claude Code, Codex, Kimi, and others detected on this machine.",
   "settings.ctx.last_synced_label": "Store updated",
   "settings.ctx.last_synced_tooltip": "Reflects the most recent stored-file mtime, not a recorded sync event. Editing a stored file without Sync All also bumps this.",
+  "settings.ctx.wiki_behind_badge": "Wiki updates available: {n}",
+  "settings.ctx.wiki_behind_tip": "The wiki has newer commits than {n} installed asset(s) in this project. Update them from the Wiki section, or run `mm context update --all`.",
   "settings.ctx.runtime_undetected_tooltip": "Not detected in this project",
   "settings.ctx.refresh": "Refresh",
   "settings.ctx.sync_all": "Sync All",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -438,6 +438,8 @@
   "settings.ctx.runtimes_glossary": "memtomem 이 동기화하는 AI 도구 — Claude Code, Codex, Kimi 등 이 컴퓨터에서 감지된 도구.",
   "settings.ctx.last_synced_label": "저장소 갱신",
   "settings.ctx.last_synced_tooltip": "기록된 동기화 이벤트가 아니라 저장소에서 가장 최근에 바뀐 파일의 수정 시각 기준입니다. 전체 동기화 없이 저장된 파일을 편집해도 이 값이 갱신됩니다.",
+  "settings.ctx.wiki_behind_badge": "위키 업데이트 가능: {n}",
+  "settings.ctx.wiki_behind_tip": "이 프로젝트에 설치된 자산 {n}개보다 위키에 더 새로운 커밋이 있습니다. 위키 섹션에서 업데이트하거나 `mm context update --all` 을 실행하세요.",
   "settings.ctx.runtime_undetected_tooltip": "이 프로젝트에서 감지되지 않음",
   "settings.ctx.refresh": "새로고침",
   "settings.ctx.sync_all": "전체 동기화",

--- a/packages/memtomem/tests-js/ctx-overview-wiki-behind.test.mjs
+++ b/packages/memtomem/tests-js/ctx-overview-wiki-behind.test.mjs
@@ -1,0 +1,72 @@
+/* Overview wiki update-available badge (0629 backlog c/d — the web half).
+ *
+ * `/api/context/overview` carries a `wiki_installs: {total, behind}` block —
+ * the lockfile↔wiki staleness axis none of the canonical→runtime tiles
+ * cover. The header renders a warning badge ONLY when actionable
+ * (behind > 0); zero, a null block (degraded backend classifier), or an
+ * absent key (older cached payloads replaying through langchange) must all
+ * render nothing — a permanent "0 updates" chip would train users to stop
+ * reading the header.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+function stubOverviewFetch(window, wikiInstalls) {
+  const upstream = window.fetch;
+  window.fetch = async (input) => {
+    const url = typeof input === 'string' ? input : input?.url || '';
+    if (url.endsWith('/api/context/overview')) {
+      const body = {
+        skills:   { total: 1, in_sync: 1 },
+        commands: { total: 0 },
+        agents:   { total: 0 },
+      };
+      if (wikiInstalls !== undefined) body.wiki_installs = wikiInstalls;
+      return { ok: true, status: 200, json: async () => body };
+    }
+    // Valid empty projects payload so no error toast races the render.
+    if (url.includes('/api/context/projects')) {
+      return { ok: true, status: 200, json: async () => ({ scopes: [] }) };
+    }
+    return upstream(input);
+  };
+}
+
+async function renderOverview(wikiInstalls) {
+  const dom = await bootApp({
+    scripts: ['i18n.js', 'app.js', 'context-gateway.js'],
+  });
+  const { window } = dom;
+  stubOverviewFetch(window, wikiInstalls);
+  await window.I18N.init();
+  await window.loadCtxOverview();
+  return window;
+}
+
+describe('overview wiki behind badge', () => {
+  it('renders a warning badge with the behind count when updates exist', async () => {
+    const window = await renderOverview({ total: 3, behind: 2 });
+    const badge = window.document.querySelector('.ctx-overview-wiki-behind');
+    expect(badge).toBeTruthy();
+    expect(badge.classList.contains('badge-warning')).toBe(true);
+    expect(badge.textContent).toContain('2');
+    // The hover tip explains the remediation path (Wiki section / CLI verb).
+    expect(badge.getAttribute('title')).toContain('mm context update');
+  });
+
+  it('renders nothing when no install is behind', async () => {
+    const window = await renderOverview({ total: 3, behind: 0 });
+    expect(window.document.querySelector('.ctx-overview-wiki-behind')).toBeNull();
+  });
+
+  it('renders nothing when the block is null (degraded classifier)', async () => {
+    const window = await renderOverview(null);
+    expect(window.document.querySelector('.ctx-overview-wiki-behind')).toBeNull();
+  });
+
+  it('renders nothing when the key is absent (older cached payload)', async () => {
+    const window = await renderOverview(undefined);
+    expect(window.document.querySelector('.ctx-overview-wiki-behind')).toBeNull();
+  });
+});

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -296,6 +296,98 @@ class TestOverview:
             f"last_synced_at must be max(skill_mtime, agent_mtime); got {ts!r}"
         )
 
+    # ── wiki_installs — the lockfile↔wiki staleness axis (0629 backlog c/d) ──
+
+    def _install_pinned_skill(self, project: Path, wiki_root: Path, name: str) -> str:
+        """Seed ``skills/<name>`` in the wiki, mirror it into *project*'s
+        dest tree, and pin the lockfile at the seeding commit. Returns the
+        pin SHA — advance the wiki afterwards to produce a ``behind`` row.
+        """
+        import subprocess
+
+        from memtomem.context._atomic import installed_at_from_dest
+        from memtomem.context.lockfile import Lockfile
+        from memtomem.wiki.store import WikiStore
+
+        store = WikiStore.at_default()
+        if not (wiki_root / ".git").exists():
+            store.init()
+        skill_dir = wiki_root / "skills" / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / SKILL_MANIFEST).write_bytes(b"v1\n")
+        subprocess.run(["git", "-C", str(wiki_root), "add", "."], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(wiki_root), "commit", "-m", f"add {name}"],
+            check=True,
+            capture_output=True,
+        )
+        pin = store.current_commit()
+
+        dest = project / ".memtomem" / "skills" / name
+        dest.mkdir(parents=True)
+        (dest / SKILL_MANIFEST).write_bytes(b"v1\n")
+        Lockfile.at(project).upsert_entry(
+            "skills", name, wiki_commit=pin, installed_at=installed_at_from_dest(dest)
+        )
+        return pin
+
+    @pytest.mark.anyio
+    async def test_overview_wiki_installs_reports_behind_count(
+        self, client: AsyncClient, tmp_path: Path, wiki_root: Path
+    ):
+        """An install pinned below wiki HEAD surfaces as ``behind`` in the
+        overview's ``wiki_installs`` block — the count the header badge
+        renders. Before the wiki advances the same install reads clean.
+        """
+        import subprocess
+
+        self._install_pinned_skill(tmp_path, wiki_root, "pinned")
+
+        r = await client.get("/api/context/overview")
+        assert r.status_code == 200
+        assert r.json()["wiki_installs"] == {"total": 1, "behind": 0}
+
+        # Advance the wiki past the pin — the dest stays clean, so the
+        # entry flips to ``behind`` ("update available").
+        (wiki_root / "skills" / "pinned" / SKILL_MANIFEST).write_bytes(b"v2\n")
+        subprocess.run(["git", "-C", str(wiki_root), "add", "."], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(wiki_root), "commit", "-m", "advance"],
+            check=True,
+            capture_output=True,
+        )
+
+        r = await client.get("/api/context/overview")
+        assert r.json()["wiki_installs"] == {"total": 1, "behind": 1}
+
+    @pytest.mark.anyio
+    async def test_overview_wiki_installs_excludes_untracked_canonicals(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """Canonical artifacts with no lockfile entry (reverse-imported /
+        migrated-in) have no wiki pin to fall behind — they must not
+        inflate ``wiki_installs.total`` the way they join the skills tile.
+        """
+        _make_skill(tmp_path, "untracked-only")
+        r = await client.get("/api/context/overview")
+        data = r.json()
+        assert data["skills"]["total"] >= 1
+        assert data["wiki_installs"] == {"total": 0, "behind": 0}
+
+    @pytest.mark.anyio
+    async def test_overview_wiki_installs_placeholder_on_other_tiers(
+        self, client: AsyncClient, tmp_path: Path, wiki_root: Path
+    ):
+        """Wiki installs are lockfile-tracked project_shared snapshots only;
+        the user / project_local overviews carry the zero placeholder
+        (mirror of the ``mcp_servers`` single-tier convention).
+        """
+        self._install_pinned_skill(tmp_path, wiki_root, "pinned")
+        for tier in ("user", "project_local"):
+            r = await client.get("/api/context/overview", params={"target_scope": tier})
+            assert r.status_code == 200
+            assert r.json()["wiki_installs"] == {"total": 0, "behind": 0}, tier
+
 
 class TestSettingsCountShape:
     """Q-PR3 Visual-1 pins for the new ``settings`` count envelope.


### PR DESCRIPTION
## Summary

T2-2 from the 2026-07-02 ctx/wiki re-review campaign (0629 wiki audit backlog c+d, web half).

The overview aggregates the canonical→runtime axis but carried nothing from the lockfile↔wiki axis: an install whose pin sits behind wiki HEAD ("update available") was only visible via `mm context status` or by opening each asset in the Wiki section. `/context/status-all` does carry it but has zero web consumers by design (re-confirmed: `grep -rn "status-all" web/static/` → 0 hits).

- **Backend** — `/api/context/overview` returns `wiki_installs: {total, behind}` computed from `classify_status` via `asyncio.to_thread` (it shells out to git per lockfile entry; #1145 offload discipline). Untracked canonicals are excluded (no pin to fall behind). Non-`project_shared` tiers get the zero placeholder (the `mcp_servers` single-tier convention). A classifier failure yields `null`, not zeros — "0 behind" is a clean-state claim the route can't back when the classifier raised.
- **Frontend** — warning badge in the overview header, rendered only when `behind > 0`; zero / `null` / absent key (older cached payloads replaying through langchange) all render nothing. No new CSS (badge primitives + header flex slot), so only `context-gateway.js?v=99` bumps.
- **i18n** — `settings.ctx.wiki_behind_badge` / `wiki_behind_tip` in en/ko; the tip names the remediation path (Wiki section or `mm context update --all`).

Semantics note: what counts as "behind" is classify_status's call — with #1535 merged, a diverged pin classifies as `stale-pin`, not `behind`, and this badge follows automatically (no coupling to that PR's diff).

## Tests

- Route: behind count surfaces after the wiki advances past a pin (and reads 0 before); untracked canonicals excluded from `total`; user/project_local tiers pinned to the placeholder.
- JS (vitest): badge renders with count + remediation tip when `behind > 0`; nothing on zero, `null`, or absent key.
- Gates: ruff, pytest (route + invariants + Playwright overview suites), vitest 400/400, test_i18n en/ko parity.

Codex review: SHIP (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
