### PR TITLE
feat(cli): add --dry-run preview to mm context update

### DIFF
--- a/docs/guides/context-gateway.md
+++ b/docs/guides/context-gateway.md
@@ -110,7 +110,9 @@ wiki (~/.memtomem-wiki)  ──install──▶  project Store (<project>/.memto
   the Web UI's Wiki section) snapshots one canonical asset from the wiki into the
   **current project's** `.memtomem/` Store, pinned to the wiki's HEAD commit.
 - **Update** — `mm context update <type> <name>` refreshes an installed snapshot
-  to the wiki's latest HEAD.
+  to the wiki's latest HEAD. Add `--dry-run` to print the would-update /
+  unchanged / refuse preview without writing anything (also works with
+  `--all`, where it prints the batch table and skips the confirm prompt).
 
 Install and Update only ever write the **project** Store. They do **not** edit
 `~/.memtomem/config.json` or the `~/.memtomem/<artifact>/` User tier — so a wiki

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -1906,12 +1906,22 @@ _WIKI_DIRTY_WARN = "warning: wiki has uncommitted changes; using HEAD which does
     is_flag=True,
     help="Overwrite local edits; each dirty file is preserved as <file>.bak.",
 )
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help=(
+        "Classify and print the preview only — nothing is written and no "
+        "prompt is shown. Exits 0 whenever the preview was computable, "
+        "including rows the real run would refuse."
+    ),
+)
 def update_cmd(
     asset_type: str,
     name: str,
     all_projects: bool,
     yes: bool,
     force: bool,
+    dry_run: bool,
 ) -> None:
     """Refresh an installed wiki asset from the wiki HEAD.
 
@@ -1928,6 +1938,11 @@ def update_cmd(
     skips the prompt for automation. ``--yes --force`` is the
     automation invariant — destructive batch with WARNING on stderr,
     no prompt.
+
+    With ``--dry-run``: print the same 4-state preview and stop — no
+    writes, no prompt. Works with and without ``--all``; a not-installed
+    asset still exits non-zero with the install hint (a dry run of an
+    impossible update fails the way the real run would).
     """
     root = _find_project_root()
 
@@ -1943,7 +1958,11 @@ def update_cmd(
         click.secho(_WIKI_DIRTY_WARN, fg="yellow", err=True)
 
     if all_projects:
-        _run_update_all(asset_type, name, root, wiki=wiki, yes=yes, force=force)
+        _run_update_all(asset_type, name, root, wiki=wiki, yes=yes, force=force, dry_run=dry_run)
+        return
+
+    if dry_run:
+        _run_update_dry_run_single(asset_type, name, root, wiki=wiki)
         return
 
     try:
@@ -2000,6 +2019,65 @@ def update_cmd(
         )
 
 
+def _run_update_dry_run_single(
+    asset_type: str,
+    name: str,
+    root: Path,
+    *,
+    wiki: WikiStore,
+) -> None:
+    """Read-only preview for the single-project ``update --dry-run`` path.
+
+    Reuses :func:`_classify_for_all_update` with a one-project list so the
+    preview carries the exact gate parity the ``--all`` table already has
+    (dirty / flat-layout / unprovable-record, #1247 id 13 family): what
+    this prints as ``refuse`` is what the real run would raise as
+    ``StaleInstallError`` — no duplicated gate logic to drift.
+    """
+    asset_type_plural = f"{asset_type}s"
+    try:
+        new_commit, classifications = _classify_for_all_update(
+            asset_type_plural,
+            name,
+            wiki=wiki,
+            projects=[root],
+        )
+    except InvalidNameError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except AssetNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except WikiUnbornHeadError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if not classifications:
+        # Not-installed parity: the classifier silently skips entry-less
+        # projects (right for the batch table, wrong for a targeted single
+        # asset) — fail with the same hint shape the real run's
+        # NotInstalledError carries, so `--dry-run` never reports an
+        # impossible update as previewable.
+        raise click.ClickException(
+            f"{asset_type_plural}/{name}: no lockfile entry; "
+            f"run `mm context install {asset_type} {name}` first"
+        )
+
+    _print_classification_table(classifications, asset_type_plural, name, new_commit)
+
+    row = classifications[0]
+    if row.state == "update":
+        old = (row.lock_entry or {}).get("wiki_commit", "")
+        old_abbr = old[:12] if isinstance(old, str) and old else "(unpinned)"
+        click.echo(f"\nDry run — nothing written; would update {old_abbr} → {new_commit[:12]}.")
+    elif row.state == "unchanged":
+        click.echo("\nDry run — nothing written; already up to date.")
+    elif row.state == "refuse":
+        click.echo(
+            "\nDry run — nothing written; the real run would refuse "
+            "(see reason above; --force overwrites with .bak siblings)."
+        )
+    else:  # "error"
+        click.echo("\nDry run — nothing written; lockfile error (see reason above).")
+
+
 def _run_update_all(
     asset_type: str,
     name: str,
@@ -2008,6 +2086,7 @@ def _run_update_all(
     wiki: WikiStore,
     yes: bool,
     force: bool,
+    dry_run: bool = False,
 ) -> None:
     """Orchestrate ``mm context update <type> <name> --all``.
 
@@ -2090,6 +2169,18 @@ def _run_update_all(
 
     if not needs_update and not needs_force and not has_errors:
         click.echo("\nAll projects are up to date.")
+        return
+
+    if dry_run:
+        # Preview verb: report what the wet run would do and stop — exit 0
+        # even with refuse/error rows (the table already shows them; the
+        # refusal exit belongs to the run that actually intends to write).
+        parts = [f"{len(needs_update)} would update"]
+        if needs_force:
+            parts.append(f"{len(needs_force)} would refuse without --force")
+        if has_errors:
+            parts.append(f"{len(has_errors)} in error")
+        click.echo(f"\nDry run — nothing written; {', '.join(parts)}.")
         return
 
     if needs_force and not force:

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -1805,3 +1805,163 @@ def test_classify_for_all_update_unusable_record_is_refuse(wiki_root: Path, tmp_
     [c] = classifications
     assert c.state == "refuse"
     assert "install record unusable" in (c.reason or "")
+
+
+# ── CLI --dry-run: read-only preview (single + --all) ────────────────────
+
+
+def test_cli_update_dry_run_would_update_writes_nothing(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    """``--dry-run`` on a behind install prints the ``update`` row plus the
+    old→new pin line, and mutates neither the dest tree nor the lockfile."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project_cwd, "foo")
+    old_pin = json.loads((project_cwd / ".memtomem" / "lock.json").read_text())["skills"]["foo"][
+        "wiki_commit"
+    ]
+    new_head = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "update" in result.output
+    assert "Dry run — nothing written" in result.output
+    assert f"would update {old_pin[:12]} → {new_head[:12]}" in result.output
+    # No-write invariant: dest bytes and lockfile pin are untouched.
+    assert (project_cwd / ".memtomem" / "skills" / "foo" / "SKILL.md").read_bytes() == b"v1\n"
+    lock_doc = json.loads((project_cwd / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == old_pin
+
+
+def test_cli_update_dry_run_unchanged(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    """Pin already at wiki HEAD → ``unchanged`` row, exit 0."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project_cwd, "foo")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "unchanged" in result.output
+    assert "already up to date" in result.output
+
+
+def test_cli_update_dry_run_dirty_previews_refusal_without_bak(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    """A dirty dest previews as ``refuse`` with the reason — exit 0, and
+    crucially no ``.bak`` sibling appears (the wet-run --force side effect
+    must not leak into the preview)."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project_cwd, "foo")
+    edited = project_cwd / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    edited.write_bytes(b"local\n")
+    _bump_mtime(edited)
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "refuse" in result.output
+    assert "modified" in result.output
+    assert "would refuse" in result.output
+    assert edited.read_bytes() == b"local\n"
+    assert not edited.with_suffix(edited.suffix + ".bak").exists()
+
+
+def test_cli_update_dry_run_not_installed_exits_nonzero(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    """A dry run of an impossible update fails the way the real run would:
+    non-zero exit with the ``mm context install`` hint."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--dry-run"])
+
+    assert result.exit_code != 0
+    assert "no lockfile entry" in result.output
+    assert "mm context install skill foo" in result.output
+
+
+def test_cli_update_all_dry_run_previews_and_skips_prompt(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--all --dry-run`` prints the 4-state table and exits 0 without a
+    confirm prompt (no input is supplied — a surviving prompt would abort
+    with a non-zero exit) and without writing any project. Refuse rows do
+    not flip the exit code the way the wet batch's refusal gate does."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+
+    proj_clean = tmp_path / "clean"
+    proj_clean.mkdir()
+    install_skill(proj_clean, "foo")
+
+    proj_dirty = tmp_path / "dirty"
+    proj_dirty.mkdir()
+    install_skill(proj_dirty, "foo")
+    edited = proj_dirty / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    edited.write_bytes(b"local\n")
+    _bump_mtime(edited)
+
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj_clean, proj_dirty])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "Dry run — nothing written" in result.output
+    assert "1 would update" in result.output
+    assert "1 would refuse without --force" in result.output
+    # Neither project was written: clean keeps v1 bytes + old pin, dirty
+    # keeps the local edit with no .bak.
+    assert (proj_clean / ".memtomem" / "skills" / "foo" / "SKILL.md").read_bytes() == b"v1\n"
+    assert edited.read_bytes() == b"local\n"
+    assert not edited.with_suffix(edited.suffix + ".bak").exists()
+    lock_doc = json.loads((proj_clean / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["wiki_commit"] != WikiStore.at_default().current_commit()
+
+
+def test_cli_update_all_dry_run_all_up_to_date(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--all --dry-run`` with every pin at HEAD reports up-to-date; the
+    dry-run summary line is not printed (nothing would change)."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    proj = tmp_path / "p"
+    proj.mkdir()
+    install_skill(proj, "foo")
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "All projects are up to date." in result.output


### PR DESCRIPTION
## Summary

T2-3 from the 2026-07-02 ctx/wiki re-review campaign (0629 wiki-audit backlog c, CLI half — the web half is the overview behind badge in #1546).

`mm context update` gains `--dry-run`:

- **Single project** — prints the same 4-state row (`update` / `unchanged` / `refuse` / `error`) the `--all` table renders, plus a `would update <old> → <new>` pin line, then stops. Implemented by routing through `_classify_for_all_update` with a one-project list, so the preview carries the exact gate parity (`dirty` / flat-layout shadow / unprovable install record) the batch table already has — no second copy of the gate logic to drift (the campaign's dominant defect pattern).
- **`--all`** — prints the existing preview table, then a `Dry run — nothing written; N would update, M would refuse without --force` summary and exits 0 without the confirm prompt.
- **Exit semantics** — 0 whenever the preview was computable, including refuse rows (the refusal exit belongs to the run that intends to write — deliberate contrast with #1536, where the *real* run refused but exited 0). A not-installed asset still exits non-zero with the `mm context install` hint, since the classifier's silent skip of entry-less projects would otherwise misreport an impossible update as previewable.

One guide line added under the Install/Update section of `docs/guides/context-gateway.md` (verified against the implemented flag).

## Tests

6 new CLI tests: would-update preview with no-write invariant (dest bytes + lockfile pin), unchanged, dirty-preview with no `.bak` leak, not-installed non-zero exit, `--all --dry-run` skipping the prompt with refuse rows not flipping the exit code, and the all-up-to-date early return. Full `test_context_update.py` 58/58, docs guards, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
