### PR TITLE
fix(web): point the wiki dirty-dot tooltip at a remediation that exists in prod

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -607,9 +607,9 @@
                it appears). -->
           <span class="wiki-nav-dirty" role="img" hidden
                 data-i18n-title="settings.nav.ctx_wiki_dirty_tip"
-                title="Uncommitted wiki edits — not yet reachable by `mm context install`"
+                title="Uncommitted wiki edits — not yet reachable by `mm context install`. Commit with `mm wiki commit`."
                 data-i18n-aria-label="settings.nav.ctx_wiki_dirty_tip"
-                aria-label="Uncommitted wiki edits — not yet reachable by `mm context install`"></span>
+                aria-label="Uncommitted wiki edits — not yet reachable by `mm context install`. Commit with `mm wiki commit`."></span>
         </button>
       </nav>
       <div class="settings-content">

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -403,7 +403,7 @@
   "settings.nav.ctx_wiki": "Wiki",
   "settings.nav.ctx_wiki_sub": "Reuse across your own projects",
   "settings.nav.ctx_wiki_tip": "Your personal git library of canonical skills, subagents, and commands — canonical = the one authoritative copy each project pulls a pinned snapshot from via `mm context install` (it never renders into a project on its own). It lives at ~/.memtomem-wiki; to move it to another machine, push and pull it yourself with ordinary git. The wiki is optional — your projects keep working without it.",
-  "settings.nav.ctx_wiki_dirty_tip": "Uncommitted wiki edits — not yet reachable by `mm context install` (it installs committed git objects only). Commit them in the Wiki section to let projects pull them.",
+  "settings.nav.ctx_wiki_dirty_tip": "Uncommitted wiki edits — not yet reachable by `mm context install` (it installs committed git objects only). Commit them with `mm wiki commit` — or, in dev mode, the Wiki section's Commit button — to let projects pull them.",
   "settings.nav.dedup": "Deduplicate",
   "settings.nav.dedup_sub": "Remove near-duplicates",
   "settings.nav.decay": "Age-out",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -403,7 +403,7 @@
   "settings.nav.ctx_wiki": "위키",
   "settings.nav.ctx_wiki_sub": "내 여러 프로젝트에서 재사용",
   "settings.nav.ctx_wiki_tip": "내 canonical skill·subagent·command 를 모아 둔 개인 git 라이브러리 — Canonical = 각 프로젝트가 `mm context install` 로 고정된 스냅샷을 가져오는 단일 권위 사본(위키가 프로젝트로 직접 렌더링하지는 않음). ~/.memtomem-wiki 에 있으며, 다른 컴퓨터로 옮기려면 일반 git 으로 직접 push/pull 하세요. 위키는 선택 사항이라 없어도 프로젝트는 그대로 동작합니다.",
-  "settings.nav.ctx_wiki_dirty_tip": "커밋되지 않은 위키 변경 — 아직 `mm context install` 로 전달되지 않습니다(install 은 커밋된 git 객체만 가져옴). 위키 섹션에서 커밋하면 프로젝트가 가져갈 수 있습니다.",
+  "settings.nav.ctx_wiki_dirty_tip": "커밋되지 않은 위키 변경 — 아직 `mm context install` 로 전달되지 않습니다(install 은 커밋된 git 객체만 가져옴). `mm wiki commit` 으로 — dev 모드에서는 위키 섹션의 커밋 버튼으로도 — 커밋하면 프로젝트가 가져갈 수 있습니다.",
   "settings.nav.dedup": "중복 정리",
   "settings.nav.dedup_sub": "유사 청크 제거",
   "settings.nav.decay": "오래된 기억 만료",

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -109,6 +109,21 @@ class TestLocaleFiles:
             empty = [k for k, v in data.items() if not v.strip()]
             assert not empty, f"Empty values in {name}.json: {empty}"
 
+    def test_wiki_dirty_tip_remediation_is_tier_portable(
+        self, en: dict[str, str], ko: dict[str, str]
+    ) -> None:
+        """The nav dirty-dot tooltip must lead with ``mm wiki commit`` —
+        the remediation that works on every tier. The web Commit button is
+        dev-mode-only (wiki write routes mount in dev), so a wording that
+        ONLY points at the Wiki section sends prod users to an affordance
+        that does not exist (0629 wiki-audit backlog f)."""
+        for name, data in [("en", en), ("ko", ko)]:
+            tip = data["settings.nav.ctx_wiki_dirty_tip"]
+            assert "mm wiki commit" in tip, (
+                f"{name}.json settings.nav.ctx_wiki_dirty_tip must name the "
+                f"tier-portable `mm wiki commit` remediation; got: {tip!r}"
+            )
+
 
 _STATIC_JS_DIR = _LOCALES_DIR.parent
 


### PR DESCRIPTION
## Summary

T2-4 from the 2026-07-02 ctx/wiki re-review campaign (0629 wiki-audit backlog f).

The nav dirty-dot tooltip said "Commit them in the Wiki section" — but the Wiki section's Commit button is dev-tier only (wiki write routes mount in dev), so prod users were pointed at an affordance that doesn't exist (the same self-contradictory-guidance class as #1510).

- Both locales now lead with `mm wiki commit` (works on every tier), with the Commit button mentioned as the dev-mode alternative.
- The pre-i18n HTML fallback `title`/`aria-label` on the dot gains the CLI hint as well (it previously carried no remediation at all).
- A `test_i18n.py` pin guards that both locales keep naming the tier-portable `mm wiki commit` remediation.

Locale JSON is served no-store and index.html is the root document — no `?v=` bump needed (no JS/CSS touched).

## Tests

`test_i18n.py` 91/91 (incl. the new pin), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
