### PR TITLE
fix(web,mcp): sanitize settings-sync reason/target/dup-tier emissions — the settings axis missed the #1412 sweep

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -171,13 +171,22 @@ def _settings_dup_tier_warnings(root: Path, active_scope: str) -> list[str]:
     memtomem-managed hook was duplicated in a non-active tier. Surface them
     here so the MCP and CLI settings surfaces agree. Non-blocking — duplicates
     are informational.
+
+    ``format_warning`` embeds the raw tier path — absolute ``$HOME`` for a
+    user-tier duplicate — so redact the PATH before formatting (#1550, the
+    dup-tier leg the #1539 sweep missed). Redacting the formatted line instead
+    would hit the 200-char ``redact_message`` cap and truncate the migrate
+    hint; the path-only substitution keeps the CLI-parity wording whole.
     """
+    from dataclasses import replace
+
     from memtomem.context.settings_doctor import detect_duplicate_tiers, format_warning
 
-    return [
-        f"  warning: {format_warning(dup, active_scope=active_scope)}"
-        for dup in detect_duplicate_tiers(root, active_scope=active_scope)
-    ]
+    lines: list[str] = []
+    for dup in detect_duplicate_tiers(root, active_scope=active_scope):
+        redacted = replace(dup, path=Path(_redact_reason(str(dup.path), root)))
+        lines.append(f"  warning: {format_warning(redacted, active_scope=active_scope)}")
+    return lines
 
 
 @mcp.tool()

--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -48,6 +48,7 @@ from memtomem.context.settings_doctor import (
 from memtomem.web.routes._confirm import needs_confirmation_envelope
 from memtomem.web.routes._errors import _error
 from memtomem.web.routes._locks import _gateway_lock
+from memtomem.web.routes.context_gateway import sanitize_diff_reason
 from memtomem.web.routes.context_projects import (
     resolve_scope_root,
     resolve_writable_scope_root,
@@ -154,17 +155,21 @@ def _stale_mtime_response(current_mtime_ns: int | None) -> JSONResponse:
     )
 
 
-def _serialize_duplicate_tiers(duplicates: list[DuplicateTier]) -> list[dict]:
+def _serialize_duplicate_tiers(duplicates: list[DuplicateTier], project_root: Path) -> list[dict]:
     """Serialize :class:`DuplicateTier` results for the JSON response.
 
     Per ADR-0010 §4 the Web hooks panel surfaces this list as a
     read-only banner; the schema mirrors the CLI ``settings-doctor
-    --json`` payload so both surfaces stay in lock-step.
+    --json`` payload so both surfaces stay in lock-step. ``path`` is
+    display-sanitized (#1550): a user-tier duplicate is the absolute
+    ``$HOME``-anchored settings file, the same disclosure class as the
+    sync-result ``target`` below — the banner is display-only, so the
+    collapsed form stays actionable.
     """
     return [
         {
             "tier": dup.tier,
-            "path": str(dup.path),
+            "path": sanitize_diff_reason(str(dup.path), project_root),
             "entries": [
                 {
                     "event": sig.event,
@@ -453,13 +458,24 @@ async def get_settings_sync(
     canonical_path = project_root / CANONICAL_SETTINGS_FILE
     target_path = _claude_target(project_root, target_scope)
     payload = _compare_hooks(canonical_path, target_path)
+    # ``_compare_hooks`` builds its malformed-JSON ``error`` from the absolute
+    # canonical/target path and echoes both paths as fields (#1550 sweep) —
+    # sanitize at the wire boundary so the comparer keeps full paths for any
+    # future non-wire caller. The which-file information survives: the
+    # root-stripped/$HOME-collapsed remainder still names the file, and the
+    # hooks panel uses ``target_path`` for display only (the rule-action POSTs
+    # round-trip mtime tokens and rule identity, never these paths).
+    if payload.get("error"):
+        payload["error"] = sanitize_diff_reason(payload["error"], project_root)
+    payload["canonical_path"] = sanitize_diff_reason(payload["canonical_path"], project_root)
+    payload["target_path"] = sanitize_diff_reason(payload["target_path"], project_root)
     # Surface the active scope so the Web UI can render a scope-accurate
     # target label (issue #962). Without this the panel falls back to a
     # hardcoded "User-scope target:" that lies when the scope is
     # project_shared or project_local.
     payload["target_scope"] = target_scope
     payload["duplicate_tier_warnings"] = _serialize_duplicate_tiers(
-        detect_duplicate_tiers(project_root, active_scope=target_scope)
+        detect_duplicate_tiers(project_root, active_scope=target_scope), project_root
     )
     return payload
 
@@ -519,20 +535,28 @@ async def _sync_settings_core(
         scope=target_scope,
         allow_host_writes=allow_host_writes,
     )
+    # Settings reasons embed absolute ``canonical_path`` / ``target_path``
+    # values (context/settings.py f-strings), and the ok-row target is an
+    # absolute path ($HOME-anchored for user scope) — the settings axis of the
+    # #1412 reason sweep (#1550). Same treatment as the MCP twin
+    # (``server/tools/context.py`` settings loops); warnings are label/event
+    # prose, no paths. The needs_confirmation host-path disclosure contract
+    # survives the collapse: the confirm modal shows ``~/.claude/...`` and the
+    # re-POST carries only ``allow_host_writes``, never the path.
     out: list[dict] = []
     for name, r in results.items():
         out.append(
             {
                 "name": name,
                 "status": r.status,
-                "reason": r.reason,
+                "reason": sanitize_diff_reason(r.reason, project_root),
                 "warnings": r.warnings,
-                "target": str(r.target) if r.target else None,
+                "target": (sanitize_diff_reason(str(r.target), project_root) if r.target else None),
             }
         )
     return {
         "results": out,
-        "duplicate_tier_warnings": _serialize_duplicate_tiers(duplicates),
+        "duplicate_tier_warnings": _serialize_duplicate_tiers(duplicates, project_root),
     }
 
 
@@ -986,6 +1010,11 @@ async def promote_target_rule(
                     project_root=project_root,
                 )
                 if fragment_scan.decision in ("blocked", "blocked_project_shared"):
+                    # The remediation hint names the file holding the secret —
+                    # display-sanitized (#1550): the root-stripped/$HOME-collapsed
+                    # form still points at the exact file, without echoing the
+                    # absolute host path over the wire. (The rest of the Gate A
+                    # message uses ``blocked.path.name`` — already path-free.)
                     raise HTTPException(
                         422,
                         format_scan_block_message(
@@ -995,8 +1024,8 @@ async def promote_target_rule(
                             artifact_name=label,
                             remediation_hint=(
                                 f"Remove the secret from the hook rule in "
-                                f"{target_path}, or keep the rule in your "
-                                f"private tier."
+                                f"{sanitize_diff_reason(str(target_path), project_root)}, "
+                                f"or keep the rule in your private tier."
                             ),
                         ),
                     )

--- a/packages/memtomem/tests/test_context_kind_routes_path_free.py
+++ b/packages/memtomem/tests/test_context_kind_routes_path_free.py
@@ -1,6 +1,7 @@
 """Path-disclosure regression pins for the skills / commands / agents context
 routes — the #1412 sweep that never finished (dde6fd33 hardened only
-mcp-servers).
+mcp-servers) — plus the settings axis that same sweep never covered (#1550,
+section (d) below).
 
 Two legs, both already fixed for mcp-servers, previously drifted here:
 
@@ -25,6 +26,7 @@ delete tests in ``test_web_routes_context_mcp_servers.py``.)
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -173,3 +175,191 @@ def test_rendered_agent_parse_error_422_is_path_free(tmp_path: Path) -> None:
     canon = canonical_artifact_dir("agents", "project_shared", tmp_path) / "broken.md"
     _assert_path_free(body, canon, canon.parent, tmp_path)
     assert "Parse error" in body["detail"]["message"], body
+
+
+# ── (d) settings axis (#1550): SettingsSyncResult reason/target ──────────
+
+
+def _settings_results(root: Path) -> dict[str, object]:
+    """One result per branch that renders a reason or target on the web wire.
+
+    Mirrors ``test_server_tools_context_redaction._settings_results`` (the
+    MCP-twin pin from the #1539 fix) so the two boundaries redact the SAME
+    engine rows.
+    """
+    from memtomem.context.settings import SettingsSyncResult
+
+    return {
+        "claude_settings": SettingsSyncResult(
+            status="ok", target=root / ".claude" / "settings.json"
+        ),
+        "user_settings": SettingsSyncResult(
+            status="needs_confirmation",
+            reason=f"{Path.home() / '.claude' / 'settings.json'} is outside the project "
+            "root; pass allow_host_writes=True.",
+            target=Path.home() / ".claude" / "settings.json",
+        ),
+        "codex_settings": SettingsSyncResult(
+            status="error",
+            reason=f"{root / '.memtomem' / 'settings.json'} is not valid JSON "
+            "(or not a JSON object).",
+        ),
+    }
+
+
+def _settings_client(project_root: Path) -> TestClient:
+    """`_client_for` variant for the write route (``resolve_writable_scope_root``)."""
+    from memtomem.web.routes import settings_sync
+    from memtomem.web.routes.context_projects import resolve_writable_scope_root
+
+    app = FastAPI()
+    app.include_router(settings_sync.router)
+    app.dependency_overrides[resolve_writable_scope_root] = lambda: project_root
+    return TestClient(app)
+
+
+def test_settings_sync_results_reason_and_target_are_path_free(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """POST /settings-sync rows redact reason + target (#1550).
+
+    The raw engine rows embed the absolute canonical/target paths
+    (``context/settings.py`` f-strings) and the ok/needs_confirmation
+    ``target`` is an absolute — $HOME-anchored for user scope — path.
+    """
+    from memtomem.web.routes import settings_sync as ss
+
+    monkeypatch.setattr(ss, "generate_all_settings", lambda *a, **k: _settings_results(tmp_path))
+    monkeypatch.setattr(ss, "detect_duplicate_tiers", lambda *a, **k: [])
+
+    res = _settings_client(tmp_path).post("/settings-sync")
+
+    assert res.status_code == 200, res.text
+    body = res.json()
+    _assert_path_free(body, tmp_path, tmp_path / ".memtomem", tmp_path / ".claude")
+    rows = {r["name"]: r for r in body["results"]}
+    # Project-tier target relativizes; the user-tier target $HOME-collapses —
+    # the host-write confirm modal still shows the exact host target.
+    assert rows["claude_settings"]["target"] == str(Path(".claude/settings.json")), rows
+    assert rows["user_settings"]["target"] == os.path.join("~", ".claude", "settings.json"), rows
+    # Diagnostics survive, path-stripped (actionable which-file remainder).
+    assert "is not valid JSON" in rows["codex_settings"]["reason"], rows
+    assert "outside the project root" in rows["user_settings"]["reason"], rows
+
+
+def test_get_settings_sync_malformed_target_payload_is_path_free(tmp_path: Path) -> None:
+    """GET /settings-sync sanitizes ``error`` AND the echoed path fields.
+
+    ``_compare_hooks`` builds the malformed-JSON ``error`` from the absolute
+    target path and echoes ``canonical_path`` / ``target_path`` raw — for a
+    project under ``$HOME`` (the normal case) that is the same OS-username
+    disclosure the #1412 ``_safe_rel`` sweep closed on the kind routes.
+    """
+    from memtomem.web.routes import settings_sync
+
+    target = tmp_path / ".claude" / "settings.json"
+    target.parent.mkdir(parents=True)
+    target.write_text("{not json", encoding="utf-8")
+
+    res = _client_for(settings_sync.router, tmp_path).get(
+        "/settings-sync?target_scope=project_shared"
+    )
+
+    assert res.status_code == 200, res.text
+    data = res.json()
+    assert data["status"] == "error", data
+    _assert_path_free(data, tmp_path)
+    assert "is not valid JSON" in data["error"], data
+    assert ".claude" in data["error"], data  # which-file info survives
+    assert data["canonical_path"] == str(Path(".memtomem/settings.json")), data
+    assert data["target_path"] == str(Path(".claude/settings.json")), data
+
+
+def test_get_settings_sync_user_scope_target_path_collapses_home(tmp_path: Path) -> None:
+    """``target_scope=user`` echoes the $HOME-anchored target collapsed to ``~``.
+
+    Field-level assert only: this scope reads the REAL ``~/.claude`` tier, so a
+    developer machine's own hook rules may legitimately carry home paths inside
+    the ``target_hooks`` rows (user content, not engine leakage).
+    """
+    from memtomem.web.routes import settings_sync
+
+    res = _client_for(settings_sync.router, tmp_path).get("/settings-sync?target_scope=user")
+
+    assert res.status_code == 200, res.text
+    data = res.json()
+    assert data["target_path"] == os.path.join("~", ".claude", "settings.json"), data
+    assert data["canonical_path"] == str(Path(".memtomem/settings.json")), data
+
+
+def test_settings_sync_duplicate_tier_path_is_sanitized(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``duplicate_tier_warnings[*].path`` collapses the user-tier $HOME path.
+
+    The Codex round on this fix (#1550) caught that ``_serialize_duplicate_tiers``
+    still emitted ``str(dup.path)`` raw while the sibling ``results[*].target``
+    was being sanitized — same payload, same disclosure class.
+    """
+    from memtomem.context.settings_doctor import DuplicateTier, HookSignature
+    from memtomem.web.routes import settings_sync as ss
+
+    user_dup = DuplicateTier(
+        tier="user",
+        path=Path.home() / ".claude" / "settings.json",
+        entries=(HookSignature("PreToolUse", "Bash", "echo ok"),),
+    )
+    monkeypatch.setattr(ss, "generate_all_settings", lambda *a, **k: {})
+    monkeypatch.setattr(ss, "detect_duplicate_tiers", lambda *a, **k: [user_dup])
+
+    res = _settings_client(tmp_path).post("/settings-sync")
+
+    assert res.status_code == 200, res.text
+    body = res.json()
+    _assert_path_free(body, tmp_path)
+    dup = body["duplicate_tier_warnings"][0]
+    assert dup["path"] == os.path.join("~", ".claude", "settings.json"), dup
+    assert dup["tier"] == "user", dup  # banner keys survive for the JS renderer
+
+
+def test_promote_privacy_block_422_hint_is_path_free(tmp_path: Path) -> None:
+    """The Gate A 422 remediation hint names the file without the absolute path.
+
+    The hint is the remediation-critical channel — it must keep pointing at the
+    exact file holding the secret — but the root-stripped form does that
+    without echoing the absolute host path (#1550 Codex round, leg 2).
+    """
+    from memtomem.web.routes import settings_sync
+    from memtomem.web.routes.settings_sync import _rule_hash
+
+    target = tmp_path / ".claude" / "settings.local.json"
+    target.parent.mkdir(parents=True)
+    rule = {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "echo api_key=AKIA1234567890ABCDEF"}],
+    }
+    target.write_text(json.dumps({"hooks": {"PreToolUse": [rule]}}), encoding="utf-8")
+
+    res = _client_for(settings_sync.router, tmp_path).post(
+        "/settings-sync/rules/promote?target_scope=project_local",
+        json={
+            "event": "PreToolUse",
+            "matcher": "Bash",
+            "rule_index": 0,
+            "rule_hash": _rule_hash(rule),
+            "target_mtime_ns": str(target.stat().st_mtime_ns),
+            "canonical_mtime_ns": None,
+            "confirm_private_to_shared": True,
+        },
+    )
+
+    assert res.status_code == 422, res.text
+    detail = res.json()["detail"]
+    assert "Gate A" in detail, detail
+    assert str(tmp_path) not in detail, detail
+    assert str(tmp_path.resolve()) not in detail, detail
+    assert str(Path.home()) not in detail, detail
+    # The which-file remediation hint survives, root-stripped.
+    assert str(Path(".claude/settings.local.json")) in detail, detail
+    # The matched secret bytes never echo back (existing Gate A contract).
+    assert "AKIA1234567890ABCDEF" not in res.text

--- a/packages/memtomem/tests/test_server_tools_context_redaction.py
+++ b/packages/memtomem/tests/test_server_tools_context_redaction.py
@@ -458,6 +458,40 @@ async def test_diff_settings_reasons_redact_absolute_paths(
     assert "error codex_settings:" in out
 
 
+@pytest.mark.anyio
+async def test_generate_settings_dup_tier_warning_redacts_path_untruncated(
+    layout, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Dup-tier warning lines redact the tier path (#1550 — the leg #1539 missed).
+
+    Only the PATH is substituted before ``format_warning`` runs: redacting the
+    formatted line would hit the 200-char ``redact_message`` cap and truncate
+    the migrate hint, so pin the tail's survival too. (The $HOME-collapse of a
+    user-tier path is pinned at the web boundary and in the neutral-redactor
+    contract tests; ``layout``'s fake HOME differs from the import-frozen
+    ``_HOME`` anchor, so this pin uses an in-root project_local duplicate.)
+    """
+    from memtomem.context import settings as ctx_settings
+    from memtomem.context import settings_doctor as ctx_doctor
+    from memtomem.server.tools.context import mem_context_generate
+
+    root = layout["project_root"]
+    dup = ctx_doctor.DuplicateTier(
+        tier="project_local",
+        path=root / ".claude" / "settings.local.json",
+        entries=(ctx_doctor.HookSignature("PreToolUse", "Bash", "echo ok"),),
+    )
+    monkeypatch.setattr(ctx_doctor, "detect_duplicate_tiers", lambda *a, **k: [dup])
+    monkeypatch.setattr(ctx_settings, "generate_all_settings", lambda *a, **k: {})
+
+    out = await mem_context_generate(include="settings")
+
+    _assert_no_abs_path(out, root)
+    assert f"({Path('.claude/settings.local.json')})" in out  # root-stripped, still named
+    assert "settings-migrate" in out  # the remediation command survives
+    assert "Active scope:" in out  # the tail survives — no 200-char cap bite
+
+
 # ── parity guard: the neutral leaf must not drift from the web twins ─────────
 
 


### PR DESCRIPTION
Closes #1550

## Gap

`web/routes/settings_sync.py` was the last unsanitized emitter of raw engine reasons and absolute host paths on the settings axis. The #1385/#1412 sweeps covered the context kind routes and #1539 closed the MCP settings loops, but the web settings surface missed both sweeps:

| Emit site | Leak |
|---|---|
| `_sync_settings_core` (POST `/settings-sync`, `/context/sync-all` settings phase) | raw `SettingsSyncResult.reason` (absolute canonical/target paths in `context/settings.py` f-strings) + raw absolute `target` ($HOME-anchored for user scope) |
| GET `/settings-sync` | raw `canonical_path` / `target_path` fields + malformed-JSON `error` built from the absolute target path |
| `_serialize_duplicate_tiers` (GET + POST) | raw duplicate tier path (absolute `~/.claude/settings.json` for a user-tier duplicate) |
| promote Gate A 422 | `remediation_hint` embedded the absolute target path |
| MCP `_settings_dup_tier_warnings` | same dup-tier gap — the leg the #1539 sweep missed |

## Fix

All web emissions route through `sanitize_diff_reason` at the wire boundary (engine values stay raw internally). The root-stripped/$HOME-collapsed remainder still names the exact file, so:

- the host-write `needs_confirmation` disclosure contract survives — the confirm modal shows `~/.claude/settings.json` and the re-POST carries only `allow_host_writes`, never a path (the JS fail-closed empty-targets check is unaffected);
- the Gate A remediation hint still points at the file holding the secret;
- the dup-tier banner keys (`tier`/`path`/`entries`) keep the CLI-parity schema.

On the MCP side, only the *path* is substituted (`dataclasses.replace`) before `format_warning` runs — redacting the formatted line would hit the 200-char `redact_message` cap and truncate the migrate hint (user-tier line measures 201 chars).

Deliberately unchanged, per existing contracts: the hook-copy `host_targets` host-write consent disclosure and cross-project plan paths (#1281 A-5 contract), and the fixed path-free `_PRIVACY_BLOCK_DETAIL` 422s.

## Tests

Five new pins (all verified RED against the unfixed code):

- `test_settings_sync_results_reason_and_target_are_path_free` — POST rows, mirrors the MCP-twin fixture from #1539 so both boundaries redact the same engine rows
- `test_get_settings_sync_malformed_target_payload_is_path_free` — whole-payload assert incl. relativized `canonical_path`/`target_path`
- `test_get_settings_sync_user_scope_target_path_collapses_home`
- `test_settings_sync_duplicate_tier_path_is_sanitized`
- `test_promote_privacy_block_422_hint_is_path_free`
- `test_generate_settings_dup_tier_warning_redacts_path_untruncated` (MCP; pins the un-truncated migrate hint tail)

Full suite: 7565 passed, 11 skipped (`-m "not ollama"`). Codex review: 3 rounds, final verdict SHIP (rounds 1–2 caught the dup-tier serializer, the promote hint, and the GET path fields — all folded in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
