### PR TITLE
fix(web): unify enable-versioning invalid-name envelope with sibling version routes

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_versions.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_versions.py
@@ -41,7 +41,7 @@ from pydantic import BaseModel
 
 from memtomem.config import TargetScope
 from memtomem.context import versioning
-from memtomem.context._names import Layout, validate_name
+from memtomem.context._names import InvalidNameError, Layout, validate_name
 from memtomem.context.agents import resolve_canonical_agent
 from memtomem.context.commands import resolve_canonical_command
 from memtomem.context.migrate import adopt_flat_to_dir
@@ -474,6 +474,13 @@ async def enable_artifact_versioning(
         raise _error(
             409, "conflict", _PATH_RE.sub("<path>", str(exc)), reason_code="destination_exists"
         )
+    except InvalidNameError:
+        # The sibling version routes resolve the name outside any try, so an
+        # invalid name reaches the app-level ValueError handler (string
+        # ``detail``). Resolution here must stay under the gateway lock — so
+        # re-raise instead of letting the generic ValueError arm below
+        # re-shape the same input into the ``_error`` object envelope (#1519).
+        raise
     except (OSError, ValueError) as exc:
         raise _error(400, "validation", _PATH_RE.sub("<path>", str(exc)))
 

--- a/packages/memtomem/tests/test_web_routes_context_versions.py
+++ b/packages/memtomem/tests/test_web_routes_context_versions.py
@@ -717,3 +717,32 @@ class TestEnableVersioning:
         assert sorted([r1.json()["migrated"], r2.json()["migrated"]]) == [False, True]
         assert (tmp_path / ".memtomem" / "agents" / "racer" / "agent.md").is_file()
         assert not (tmp_path / ".memtomem" / "agents" / "racer.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Invalid-name envelope parity across the five version/label routes (#1519)
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidNameEnvelopeParity:
+    @pytest.mark.anyio
+    async def test_invalid_name_same_envelope_across_all_five_routes(self, client, tmp_path):
+        """All five version/label routes reject an invalid artifact name with the
+        SAME wire shape: ``InvalidNameError`` propagates to the app-level
+        ValueError handler's legacy string detail. ``enable`` resolves under the
+        gateway lock (inside its try), so without an explicit re-raise its
+        generic ValueError arm would re-shape the error into the ``_error``
+        object envelope — same input, same 400, different body (#1519)."""
+        expected = {"detail": "invalid agent '-bad': leading dash"}
+        responses = {
+            "list": await client.get("/api/context/agents/-bad/versions"),
+            "create": await client.post("/api/context/agents/-bad/versions", json={}),
+            "enable": await client.post("/api/context/agents/-bad/versions/enable", json={}),
+            "promote": await client.put(
+                "/api/context/agents/-bad/labels/production", json={"version": "v1"}
+            ),
+            "delete": await client.delete("/api/context/agents/-bad/labels/production"),
+        }
+        for route, r in responses.items():
+            assert r.status_code == 400, f"{route}: unexpected status {r.status_code}"
+            assert r.json() == expected, f"{route}: {r.json()}"


### PR DESCRIPTION
## Summary

`enable_artifact_versioning` returned a different wire shape for an invalid artifact name than its four sibling version/label routes on the same resource. Its name resolver runs inside the `try` (deliberately under the gateway lock — the concurrent-enable race protection), so `validate_name`'s `InvalidNameError` (a `ValueError` subclass) was caught by the generic `except (OSError, ValueError)` arm and re-shaped into the `_error` object envelope `{"detail": {"error_kind": "validation", "message": ...}}`. The siblings (list / create / promote / delete) resolve outside any try, so the same error propagates to the app-level ValueError handler and yields the legacy string detail `{"detail": "<msg>"}`. Same bad input, same 400 status, two body shapes.

## Fix

Re-raise `InvalidNameError` ahead of the generic `(OSError, ValueError)` arm so it reaches the app-level handler exactly like the siblings. Resolution stays under the gateway lock — the under-lock rationale documented in the route is unchanged; only the error's exit path changes. This picks the shape `_resolve_versionable` already documents ("lets `validate_name`'s `InvalidNameError` propagate to the app's 400 handler — matching every other context route's name policy") rather than converting the four siblings to the object envelope.

## Tests

- New `TestInvalidNameEnvelopeParity` pins the contract with full-equality assertions across all five routes (verified RED before the fix: `enable` returned the object envelope while the other four returned the string detail).
- Full suite: 7566 passed, 11 skipped (`-m "not ollama"`); `ruff check` + `ruff format --check` clean.
- Codex review: SHIP, no findings.

Closes #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)
