### PR TITLE
test(mcp): fix Windows-only dup-warning pin broken by the #1556 path redaction

### DIFF
--- a/packages/memtomem/tests/test_server_tools_context_dup_warnings.py
+++ b/packages/memtomem/tests/test_server_tools_context_dup_warnings.py
@@ -6,20 +6,24 @@ The CLI emits these via ``_print_duplicate_tier_warnings`` (ADR-0010 §4) inside
 the real generate / diff / sync workflow. The MCP settings branches dropped
 them, so an MCP caller never learned that a memtomem-managed hook was
 duplicated in a non-active tier. Each test asserts the MCP output contains the
-exact ``format_warning`` string the detector produces — so a future revert that
-forgets to thread the warnings fails CI immediately.
+exact warning line the MCP surface emits — ``format_warning`` over the
+path-redacted duplicate record (#1550/#1556) — so a future revert that forgets
+to thread the warnings fails CI immediately.
 """
 
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
+from memtomem.context import error_redact
 from memtomem.context.settings import CANONICAL_SETTINGS_FILE
 from memtomem.context.settings_doctor import detect_duplicate_tiers, format_warning
 from memtomem.server.tools.context import (
+    _redact_reason,
     mem_context_diff,
     mem_context_generate,
     mem_context_sync,
@@ -61,6 +65,13 @@ def dup_project(tmp_path, monkeypatch):
     home = tmp_path / "home"
     home.mkdir()
     set_home(monkeypatch, home)
+    # Freeze the display-redaction home to the pytest tmp root so the
+    # ``$HOME`` → ``~`` collapse in ``redact_message`` fires deterministically
+    # on every platform. Windows CI hits it naturally (the pytest tmp dir
+    # lives under the real, import-frozen ``_HOME``) while POSIX tmp dirs sit
+    # outside it — so asserting the raw ``format_warning`` string here used to
+    # pass on POSIX and fail on Windows once #1556 redacted the emission.
+    monkeypatch.setattr(error_redact, "_HOME", str(tmp_path))
 
     _write_settings(project / CANONICAL_SETTINGS_FILE, _bundled_hook())
     _write_settings(home / ".claude" / "settings.json", _bundled_hook())
@@ -69,7 +80,12 @@ def dup_project(tmp_path, monkeypatch):
     # Sanity: the fixture actually produced a duplicate to surface.
     dups = detect_duplicate_tiers(project, active_scope="project_shared")
     assert dups, "fixture did not create a cross-tier duplicate"
-    expected = format_warning(dups[0], active_scope="project_shared")
+    # Mirror the MCP emission exactly: the tier path is redacted BEFORE
+    # formatting (path-only, so the 200-char ``redact_message`` cap cannot
+    # truncate the migrate hint — see ``_settings_dup_tier_warnings``).
+    redacted = replace(dups[0], path=Path(_redact_reason(str(dups[0].path), project)))
+    expected = format_warning(redacted, active_scope="project_shared")
+    assert str(tmp_path) not in expected, "home collapse did not fire — pin would be vacuous"
     return project, expected
 
 


### PR DESCRIPTION
## Summary

`test (windows-latest)` has been red on `main` since the #1556 merge run (green through #1555): the three cross-tier dup-warning parity pins in `test_server_tools_context_dup_warnings.py` fail on Windows only.

## Root cause

#1556 (closing #1550) made the MCP `_settings_dup_tier_warnings` redact the duplicate tier path (`dataclasses.replace` + `_redact_reason`) **before** `format_warning`, but the pins still asserted the raw `format_warning` string. `redact_message` collapses the import-frozen `error_redact._HOME` to `~` — and on Windows the pytest tmp dir lives under the real home (`C:\Users\runneradmin\AppData\Local\Temp\...`), so the collapse fired and the raw-path expectation stopped matching. POSIX tmp dirs sit outside `$HOME`, which kept the redaction a no-op there and the platform split invisible to the PR's own CI legs.

## Fix (test-only; the #1556 prod redaction is correct and unchanged)

- Freeze `error_redact._HOME` to the pytest tmp root in the `dup_project` fixture so the `~` collapse fires deterministically on **every** platform — the same technique `test_server_tools_context_redaction.py` already uses. The monkeypatch alone reproduced the Windows CI failure locally (same 3 tests FAILED).
- Build the expected line through the same path-only redaction the MCP surface applies (`replace(dup, path=Path(_redact_reason(str(dup.path), project)))` → `format_warning`), keeping the pin's intent — a revert that drops the warning threading still fails — while matching the emission byte-exact.
- Guard `assert str(tmp_path) not in expected` so the pin can never go vacuous if the collapse stops firing.

## Verification

- Pre-fix expectation + deterministic collapse → 3 FAILED locally (byte-identical failure shape to the windows-latest log).
- Fixed expectation → 4 passed; `-k server_tools_context` sweep 166 passed; ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
