### PR TITLE
chore(context,wiki): apply the mechanical subset of the #1520 code-health batch

### DIFF
--- a/packages/memtomem/src/memtomem/context/dirty.py
+++ b/packages/memtomem/src/memtomem/context/dirty.py
@@ -48,12 +48,16 @@ from __future__ import annotations
 import hashlib
 import logging
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal
 
 from memtomem.context._atomic import iter_installed_files
-from memtomem.context.lockfile import Lockfile, digests_from_entry, manifest_from_entry
+from memtomem.context.lockfile import (
+    Lockfile,
+    digests_from_entry,
+    installed_at_epoch_from_entry,
+    manifest_from_entry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -169,17 +173,14 @@ def is_asset_dirty(
     # siblings — previously a malformed string returned missing_dest when
     # the dest was gone but crashed with ValueError when it existed (#1247).
     installed_at = lock_entry.get("installed_at")
-    installed_at_epoch: float | None = None
-    if isinstance(installed_at, str):
-        try:
-            installed_at_epoch = datetime.fromisoformat(installed_at).timestamp()
-        except ValueError:
-            logger.warning(
-                "%s/%s: lockfile installed_at %r is not ISO-8601; treating as never installed",
-                asset_type,
-                name,
-                installed_at,
-            )
+    installed_at_epoch = installed_at_epoch_from_entry(lock_entry)
+    if installed_at_epoch is None and isinstance(installed_at, str):
+        logger.warning(
+            "%s/%s: lockfile installed_at %r is not ISO-8601; treating as never installed",
+            asset_type,
+            name,
+            installed_at,
+        )
     if installed_at_epoch is None:
         return DirtyReport(
             reason="never_installed",

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -28,7 +28,6 @@ import logging
 import shutil
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -45,6 +44,7 @@ from memtomem.context.lockfile import (
     Lockfile,
     LockfileError,
     digests_from_entry,
+    installed_at_epoch_from_entry,
     manifest_from_entry,
 )
 from memtomem.context.privacy_scan import (
@@ -261,21 +261,6 @@ def install_command(
     )
 
 
-def _installed_at_epoch(lock_entry: dict[str, Any]) -> float | None:
-    """Parse the entry's ``installed_at`` to an epoch, or ``None``.
-
-    Tolerant on purpose: the reconcile mtime guard must degrade to "keep"
-    (never delete) when the timestamp is missing or malformed.
-    """
-    raw = lock_entry.get("installed_at")
-    if not isinstance(raw, str):
-        return None
-    try:
-        return datetime.fromisoformat(raw).timestamp()
-    except ValueError:
-        return None
-
-
 def _flat_layout_probe(
     dest: Path,
     asset_type: str,
@@ -297,7 +282,7 @@ def _flat_layout_probe(
     The dirty rule matches ``migrate._is_flat_file_dirty`` — strict
     ``mtime > installed_at_epoch`` — with one addition: an entry whose
     ``installed_at`` is missing/non-string/unparseable
-    (:func:`_installed_at_epoch` → ``None``) counts as dirty-or-unprovable.
+    (:func:`installed_at_epoch_from_entry` → ``None``) counts as dirty-or-unprovable.
     "Can't prove clean" must protect, not proceed — without this, a
     malformed timestamp (classified ``never_installed``) would skip the
     guard entirely (#1247 design gate M1). Skills have no flat layout;
@@ -308,7 +293,7 @@ def _flat_layout_probe(
     flat = dest.parent / f"{name}.md"
     if not flat.is_file():
         return None, False
-    epoch = _installed_at_epoch(lock_entry or {})
+    epoch = installed_at_epoch_from_entry(lock_entry or {})
     if epoch is None:
         return flat, True
     return flat, flat.stat().st_mtime > epoch
@@ -989,7 +974,7 @@ def _apply_update(
     files_removed = _reconcile_removed_files(
         dest,
         src_has=lambda rel: rel in digest_map,
-        old_installed_at_epoch=_installed_at_epoch(lock_entry),
+        old_installed_at_epoch=installed_at_epoch_from_entry(lock_entry),
         baked=frozenset(files_to_bak),
         manifest=manifest_from_entry(lock_entry),
         old_digests=digests_from_entry(lock_entry),
@@ -1641,7 +1626,7 @@ def _apply_pinned_install(
         files_removed = _reconcile_removed_files(
             dest,
             src_has=lambda rel: rel in expected,
-            old_installed_at_epoch=_installed_at_epoch(entry),
+            old_installed_at_epoch=installed_at_epoch_from_entry(entry),
             baked=frozenset(files_to_bak),
             manifest=manifest_from_entry(entry),
             old_digests=digests_from_entry(entry),

--- a/packages/memtomem/src/memtomem/context/lockfile.py
+++ b/packages/memtomem/src/memtomem/context/lockfile.py
@@ -192,6 +192,29 @@ def digests_from_entry(entry: dict[str, Any]) -> dict[str, str] | None:
     return out
 
 
+def installed_at_epoch_from_entry(entry: dict[str, Any]) -> float | None:
+    """Parse the entry's ``installed_at`` ISO-8601 string to an epoch, or ``None``.
+
+    Tolerant on purpose: consumers use the epoch as an mtime guard and must
+    degrade to their fail-safe branch — "keep, never delete" in install's
+    reconcile, ``never_installed`` in the dirty probe — when the timestamp is
+    missing, non-string, or malformed. ``lock.json`` can be git-tracked and
+    hand-merged, so malformed shapes are an ordinary event.
+
+    ``migrate._is_flat_file_dirty`` deliberately does NOT use this helper: there
+    a malformed timestamp must crash, because degrading to "clean" would approve
+    overwriting user edits (#1247 id 1) — its callers pre-validate with
+    ``_installed_at_parseable`` instead.
+    """
+    raw = entry.get("installed_at")
+    if not isinstance(raw, str):
+        return None
+    try:
+        return datetime.fromisoformat(raw).timestamp()
+    except ValueError:
+        return None
+
+
 class Lockfile:
     """Read / mutate ``<project>/.memtomem/lock.json``.
 

--- a/packages/memtomem/src/memtomem/context/transfer.py
+++ b/packages/memtomem/src/memtomem/context/transfer.py
@@ -495,11 +495,14 @@ def _stage_copy(src: Path, dst_parent: Path, name_hint: str) -> Path:
     staging = dst_parent / f".migrate-{name_hint}-{suffix}.tmp"
     if staging.exists():
         # Crashed prior run with a colliding suffix (extremely unlikely
-        # given pid+rand) — leftover is from us; safe to clear.
-        if staging.is_dir():
-            shutil.rmtree(staging)
-        else:
-            staging.unlink()
+        # given pid+rand) — leftover is from us; safe to clear. The clear
+        # must stay LOUD here (pre-copy): a survivor — e.g. a symlink
+        # rmtree refuses, or an undeletable dir — would make the
+        # file-source copy below write INTO the leftover instead of
+        # replacing the staging path.
+        _remove_staging(staging)
+        if staging.exists():
+            raise OSError(f"could not clear leftover staging entry: {staging}")
     try:
         if src.is_dir():
             shutil.copytree(src, staging, symlinks=True)

--- a/packages/memtomem/src/memtomem/wiki/commit.py
+++ b/packages/memtomem/src/memtomem/wiki/commit.py
@@ -131,6 +131,11 @@ def commit_targets(
     also runs on the no-op path so a save-identical-bytes-then-commit never
     leaves the wiki dirty.
 
+    Known limitation: ``mtime_ns`` is the whole staleness token, so two
+    ``os.replace`` saves landing within one mtime tick are indistinguishable —
+    negligible with nanosecond mtime resolution (APFS/ext4); a coarse-mtime
+    filesystem would need the token paired with a size/content hash (#1520).
+
     ``expected_head`` is the compare-and-swap guard threaded to
     :meth:`WikiStore.commit_paths`:
 

--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -692,6 +692,14 @@ class WikiStore:
         if the wiki itself is missing (no ``.git`` directory) — caller
         should ``require_exists()`` first if the missing-wiki path is
         not desired.
+
+        Caveat: ``status`` honors any ``.gitattributes`` clean/eol filter the
+        wiki carries, while :meth:`commit_paths` writes blobs byte-exact
+        (``hash-object --no-filters``). A file whose committed raw bytes
+        differ from their filter-normalized form (e.g. CRLF content under
+        ``* text=auto``) therefore reads back permanently dirty. memtomem
+        ships no ``.gitattributes`` in the wiki, so this arises only when a
+        user adds a normalizing one to their own wiki clone.
         """
         self.require_exists()
         result = _git(["status", "--porcelain"], cwd=self.root)
@@ -722,7 +730,9 @@ class WikiStore:
            consulted and never swept into the commit.
         2. Each target's bytes are stored byte-exact (``hash-object -w
            --no-filters``, so override Invariant 4 holds despite any repo
-           ``.gitattributes`` eol/clean filters) and staged via
+           ``.gitattributes`` eol/clean filters; the flip side — a plain
+           ``git status`` still applies them — is the :meth:`is_dirty`
+           caveat) and staged via
            ``update-index --add --cacheinfo`` under a mode resolved by
            :meth:`_commit_blob_mode` (the exec bit is preserved, not
            hardcoded to 100644 — see that method).

--- a/packages/memtomem/tests/test_lockfile.py
+++ b/packages/memtomem/tests/test_lockfile.py
@@ -21,6 +21,7 @@ from memtomem.context.lockfile import (
     LockfileCorruptError,
     LockfileError,
     LockfileVersionError,
+    installed_at_epoch_from_entry,
 )
 
 
@@ -433,3 +434,26 @@ def test_read_paths_raise_over_corrupt_file(tmp_path: Path) -> None:
         lock.read_entry("skills", "foo")
     with pytest.raises(LockfileCorruptError):
         list(lock.iter_entries())
+
+
+# ── installed_at_epoch_from_entry ────────────────────────────────────────
+
+
+def test_installed_at_epoch_from_entry_parses_iso() -> None:
+    assert installed_at_epoch_from_entry({"installed_at": "1970-01-01T00:00:00+00:00"}) == 0.0
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {},
+        {"installed_at": None},
+        {"installed_at": 1234567890},
+        {"installed_at": "not-a-timestamp"},
+    ],
+)
+def test_installed_at_epoch_from_entry_degrades_to_none(entry: dict) -> None:
+    """Missing / non-string / malformed ``installed_at`` → ``None``, never a
+    crash — consumers (install's reconcile guard, the dirty probe) treat
+    ``None`` as their fail-safe branch."""
+    assert installed_at_epoch_from_entry(entry) is None


### PR DESCRIPTION
## Summary

Applies the mechanical (no-decision) subset of the #1520 small-batch code-health follow-ups — items 1, 2, 8, 9. Items 3–7 need maintainer decisions and stay open on the issue.

## Changes

- **Item 1 — `installed_at` parsing deduplicated.** The fromisoformat→epoch/`None` contract lived twice: `install.py:_installed_at_epoch` and an inline block in `dirty.py`. Both now use `lockfile.installed_at_epoch_from_entry`, placed next to the other entry accessors (`digests_from_entry` / `manifest_from_entry`). `dirty.py` keeps its malformed-string warning at the call site (same trigger condition: string present but unparseable). `migrate._is_flat_file_dirty`'s deliberately unguarded parse (#1247 id 1) is untouched, and the helper docstring records why it must not adopt it.
- **Item 2 — `_stage_copy` leftover clear unified.** The pre-copy leftover-staging cleanup re-implemented `_remove_staging` without its best-effort semantics; it now calls `_remove_staging` and then **fails loudly if a survivor remains** — Codex review caught that a silent survivor (undeletable dir, symlink-to-dir that `rmtree(ignore_errors=True)` leaves in place) would let the file-source `copy2` write *into* the leftover instead of replacing the staging path. Verdict after the fix: SHIP.
- **Item 8 — `is_dirty` × `--no-filters` interaction documented.** `commit_paths` writes blobs byte-exact while `git status` honors `.gitattributes` clean/eol filters, so a normalizing filter makes byte-exact commits read back permanently dirty. Noted on both `wiki/store.py` methods (memtomem ships no `.gitattributes` in the wiki; the caveat applies to user-added ones).
- **Item 9 — mtime token sub-tick limitation recorded** in `wiki/commit.py:commit_targets`: two `os.replace` saves within one mtime tick are indistinguishable; negligible at nanosecond resolution, and the docstring names the size/hash pairing a coarse-mtime filesystem would need.

## Tests

- New unit tests pin `installed_at_epoch_from_entry` (ISO parse + missing/non-string/malformed → `None`).
- Full suite 7571 passed / 11 skipped (`-m "not ollama"`); transfer sweep (`-k transfer`) 170 passed; ruff check + format clean.

Part of #1520 (items 1, 2, 8, 9 — does not close the issue; items 3–7 pending decisions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
