### PR TITLE
refactor(context): unify agents/commands reverse-sync/diff/listing into _atomic_reverse.py (#1515)

### DIFF
--- a/packages/memtomem/src/memtomem/context/_atomic_reverse.py
+++ b/packages/memtomem/src/memtomem/context/_atomic_reverse.py
@@ -1,0 +1,487 @@
+"""Shared reverse/diff/listing engine for atomic-file artifacts (issue #1515).
+
+Issue #900 extracted the FORWARD sync (canonical → runtime fan-out) into
+:mod:`memtomem.context._sync_atomic`. This module is the same extraction for
+the remaining near-identical halves of :mod:`memtomem.context.agents` and
+:mod:`memtomem.context.commands`:
+
+- canonical name/layout dispatch (:func:`canonical_artifact_name`),
+- flat-vs-dir canonical resolution and enumeration
+  (:func:`resolve_artifact_under_root` / :func:`list_canonical_artifacts` /
+  :func:`resolve_artifact_extract_target`),
+- the byte-passthrough reverse-import branch shared by the agents
+  claude+gemini importers and the commands claude importer
+  (:func:`import_passthrough_runtime`) — the commands gemini branch stays in
+  :mod:`memtomem.context.commands` (TOML→Markdown conversion, different
+  glob/error-code/writer),
+- the canonical ↔ runtime diff (:func:`diff_atomic_artifact`), parametrized
+  by the same :class:`~memtomem.context._sync_atomic.AtomicSyncAdapter` the
+  forward engine uses.
+
+Behavior is byte-for-byte identical to the pre-extraction implementations —
+result tuples, skip rows and reason codes, dedupe semantics, and RENDERED
+log text are unchanged. (Format strings are parametrized, so ``record.msg``
+/ ``record.args`` differ from the per-module originals; every rendered
+message is identical.) Log calls go through the per-artifact module logger
+passed by each wrapper, so filtering / ``caplog`` capture by
+``memtomem.context.agents`` and ``memtomem.context.commands`` keeps working.
+
+Skills stay out of scope for the same reason as in ``_sync_atomic`` — their
+staging-dir promotion and tree-shaped canonical don't fit the atomic-file
+shape. See :mod:`memtomem.context.skills`.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypeVar, cast
+
+from memtomem.config import TargetScope
+from memtomem.context import _skip_reasons as skip_codes
+from memtomem.context import override as _override
+from memtomem.context._atomic import atomic_write_bytes
+from memtomem.context._gate_a import GateABlocked, apply_gate_a
+from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
+from memtomem.context._runtime_targets import (
+    DiffRow,
+    runtime_artifact_listing,
+    runtime_fanout_root,
+)
+from memtomem.context._sync_atomic import AtomicSyncAdapter
+from memtomem.context.scope_resolver import ArtifactKind, canonical_artifact_dir
+
+T = TypeVar("T")
+
+
+def canonical_artifact_name(path: Path, layout: Layout) -> str:
+    """Single source of truth for canonical path → name dispatch.
+
+    Avoids the brittle ``path.name == "<kind>.md"`` heuristic — callers must
+    pass the layout tag they got from :func:`list_canonical_artifacts` or the
+    extract functions.
+    """
+    return path.parent.name if layout == "dir" else path.stem
+
+
+def resolve_artifact_under_root(
+    canonical_root: Path,
+    name: str,
+    *,
+    artifact_label: ArtifactKind,
+    dir_filename: str,
+    logger: logging.Logger,
+) -> tuple[Path, Layout] | None:
+    """Resolve ``name`` under ``canonical_root`` across both layouts.
+
+    Directory layout wins when both the legacy flat file and the ADR-0008
+    directory layout are present (with a WARNING so the silently divergent
+    flat file stays visible).
+    """
+    dir_target = canonical_root / name / dir_filename
+    flat_target = canonical_root / f"{name}.md"
+    has_dir = dir_target.is_file()
+    has_flat = flat_target.is_file()
+    if has_dir and has_flat:
+        logger.warning(
+            "%s/%s: reverse-sync updates dir layout (%s/%s); the flat "
+            "file (%s.md) is now silently divergent. Remove it or run "
+            "`mm context migrate` (PR-D).",
+            artifact_label,
+            name,
+            name,
+            dir_filename,
+            name,
+        )
+        return dir_target, "dir"
+    if has_dir:
+        return dir_target, "dir"
+    if has_flat:
+        return flat_target, "flat"
+    return None
+
+
+def list_canonical_artifacts(
+    project_root: Path,
+    *,
+    artifact_label: ArtifactKind,
+    dir_filename: str,
+    logger: logging.Logger,
+    scope: TargetScope = "project_shared",
+) -> list[tuple[Path, Layout]]:
+    """Enumerate canonical artifacts in both flat and directory layouts.
+
+    Flat layout (legacy): ``<label>/<name>.md``. Directory layout (ADR-0008
+    PR-C+): ``<label>/<name>/<dir_filename>``. When the same name has both
+    forms, the directory layout wins and a WARNING is logged so the silent
+    flat file is visible.
+
+    ADR-0011 PR-E3: ``scope`` selects the canonical root via
+    :func:`canonical_artifact_dir` (default ``project_shared`` preserves
+    pre-PR-E3 behavior).
+    """
+    root = canonical_artifact_dir(artifact_label, scope, project_root)
+    if not root.is_dir():
+        return []
+
+    flat: dict[str, Path] = {p.stem: p for p in sorted(root.glob("*.md")) if p.is_file()}
+    dirs: dict[str, Path] = {}
+    for entry in sorted(root.iterdir()):
+        if entry.is_dir():
+            item_md = entry / dir_filename
+            if item_md.is_file():
+                dirs[entry.name] = item_md
+
+    for name in sorted(set(flat) & set(dirs)):
+        logger.warning(
+            "%s/%s: both flat (%s.md) and dir (%s/%s) layouts present; "
+            "using dir. Remove the flat file or run `mm context migrate` (PR-D).",
+            artifact_label,
+            name,
+            name,
+            name,
+            dir_filename,
+        )
+
+    merged_paths = {**flat, **dirs}  # dir overrides flat on collision
+    layouts: dict[str, Layout] = {**dict.fromkeys(flat, "flat"), **dict.fromkeys(dirs, "dir")}
+    return [(merged_paths[k], layouts[k]) for k in sorted(merged_paths)]
+
+
+def resolve_artifact_extract_target(
+    canonical_root: Path,
+    name: str,
+    *,
+    artifact_label: ArtifactKind,
+    dir_filename: str,
+    logger: logging.Logger,
+) -> tuple[Path, Layout]:
+    """Decide where reverse-sync writes the canonical for ``name``.
+
+    Truth table (ADR-0008 PR-C):
+      dir+flat both → dir wins, flat is silently divergent → WARN
+      dir only      → dir
+      flat only     → flat (preserve existing layout; PR-C does not migrate)
+      neither       → dir (ADR-0008 layout for new artifacts)
+    """
+    resolved = resolve_artifact_under_root(
+        canonical_root,
+        name,
+        artifact_label=artifact_label,
+        dir_filename=dir_filename,
+        logger=logger,
+    )
+    if resolved is not None:
+        return resolved
+    return canonical_root / name / dir_filename, "dir"
+
+
+def import_passthrough_runtime(
+    runtime: str,
+    *,
+    artifact_label: ArtifactKind,
+    dir_filename: str,
+    name_kind: str,
+    message_kind: str,
+    audit_context: Callable[[Path, Path, str], dict[str, object]],
+    canonical_root: Path,
+    project_root: Path,
+    overwrite: bool,
+    scope: TargetScope,
+    force_unsafe_import: bool,
+    dry_run: bool,
+    surface: str,
+    only_name: str | None,
+    imported: list[tuple[Path, Layout]],
+    skipped: list[tuple[str, str, skip_codes.SkipCode]],
+    seen: dict[str, str],
+    logger: logging.Logger,
+) -> None:
+    """Import one runtime's ``*.md`` files into the canonical dir, byte-exact.
+
+    The shared passthrough branch of the reverse import: fan-out-root lookup
+    (a missing table entry is a defensive no-op — every shipped
+    (label, runtime, scope) tuple is in the table, so ``KeyError`` only
+    fires for a future runtime added without table churn), ``*.md`` glob,
+    name validation, cross-runtime dedupe, extract-target resolution,
+    overwrite gate, Gate A re-scan of the source bytes, and an atomic byte
+    write (skipped under ``dry_run``). Appends to the caller's ``imported``
+    / ``skipped`` and mutates ``seen`` in place so successive calls (agents:
+    claude then gemini) and sibling inline branches (commands: gemini TOML)
+    dedupe against each other.
+
+    ``seen`` mutation contract (pre-extraction semantics, byte-identical):
+    a name is marked seen on CANONICAL_EXISTS, on a Gate A block, and on
+    successful import — NOT on invalid-name or unreadable skips.
+
+    ``audit_context`` builds the per-file Gate A audit dict from
+    ``(src, dst, name)`` — the shapes intentionally differ per artifact
+    (agents carry ``agent_name`` and no ``runtime`` key; commands carry
+    ``runtime`` + ``command_name``), so the builder preserves them exactly.
+
+    Gate A notes (pre-extraction comments, still binding): the source bytes
+    are re-scanned before any write with ``errors="replace"`` so non-UTF8
+    bytes cannot mask an embedded ASCII secret (the replacement char ``�``
+    does not overlap with any provider-token alphanumeric pattern).
+    ``project_shared`` hard-abort (git-history-is-forever) is raised inside
+    :func:`apply_gate_a`; files imported earlier in the run that passed
+    Gate A stay (each was scanned independently).
+    """
+    try:
+        runtime_dir = runtime_fanout_root(artifact_label, runtime, scope, project_root)
+    except KeyError:
+        return
+    if runtime_dir is None or not runtime_dir.is_dir():
+        return
+    runtime_label = f"{runtime} ({runtime_dir})"
+    for md_file in sorted(runtime_dir.glob("*.md")):
+        name = md_file.stem
+        if only_name is not None and name != only_name:
+            continue
+        try:
+            validate_name(name, kind=name_kind)
+        except InvalidNameError as exc:
+            skipped.append((name, f"invalid name: {exc}", skip_codes.INVALID_NAME))
+            logger.warning("skip %r from %s: invalid name", name, runtime_label)
+            continue
+        if name in seen:
+            reason = f"already imported from {seen[name]}"
+            skipped.append((name, reason, skip_codes.ALREADY_IMPORTED))
+            logger.warning("skip %s from %s: %s", name, runtime_label, reason)
+            continue
+        dst, layout = resolve_artifact_extract_target(
+            canonical_root,
+            name,
+            artifact_label=artifact_label,
+            dir_filename=dir_filename,
+            logger=logger,
+        )
+        if dst.exists() and not overwrite:
+            reason = "canonical exists (use --overwrite)"
+            skipped.append((name, reason, skip_codes.CANONICAL_EXISTS))
+            logger.warning("skip %s from %s: %s", name, runtime_label, reason)
+            seen[name] = runtime_label
+            continue
+        try:
+            content_bytes = md_file.read_bytes()
+        except OSError as exc:
+            skipped.append((name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
+            continue
+        content_text = content_bytes.decode("utf-8", errors="replace")
+        outcome = apply_gate_a(
+            content_text=content_text,
+            src=md_file,
+            scope=scope,
+            force_unsafe_import=force_unsafe_import,
+            surface=surface,
+            audit_context=audit_context(md_file, dst, name),
+            message_kind=message_kind,
+            imported_so_far=len(imported),
+        )
+        if isinstance(outcome, GateABlocked):
+            skipped.append(
+                (
+                    name,
+                    f"blocked: {outcome.hits_count} privacy pattern hit(s){outcome.hint}",
+                    outcome.code,
+                )
+            )
+            seen[name] = runtime_label
+            continue
+        # outcome is GateAProceed — write. ``dry_run`` records the
+        # would-import target but skips the write so the preview never
+        # mutates disk (rank-10).
+        if not dry_run:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            atomic_write_bytes(dst, content_bytes)
+        imported.append((dst, layout))
+        seen[name] = runtime_label
+
+
+def diff_atomic_artifact(
+    adapter: AtomicSyncAdapter[T],
+    project_root: Path,
+    *,
+    scope: TargetScope = "project_shared",
+) -> list[tuple[str, str, str]]:
+    """Compare canonical artifacts against every registered runtime.
+
+    Returns ``(runtime, name, status)`` rows where status is one of
+    ``"in sync"``, ``"out of sync"``, ``"missing target"``,
+    ``"missing canonical"``, ``"parse error"``, or ``"invalid name"``.
+    Diagnostic rows are :class:`DiffRow` instances carrying ``reason``.
+
+    Adapter key contract (#1515 design gate): the loop iterates
+    ``adapter.generators`` by ``gen_name`` (e.g. ``"claude_agents"``);
+    ``runtime = gen_name.split("_", 1)[0]`` feeds ``runtime_fanout_root``,
+    ``runtime_artifact_listing``, and the ``adapter.runtime_suffixes``
+    lookup, while ``gen_name`` itself labels the result rows and keys
+    ``GENERATOR_VENDOR``.
+
+    ADR-0011 PR-E3: ``scope`` selects both the canonical source and the
+    runtime fan-out roots.
+    """
+    artifact_label = cast(ArtifactKind, adapter.artifact_label)
+    results: list[tuple[str, str, str]] = []
+    # Key canonicals by the parsed frontmatter ``name:`` — the identity sync
+    # targets (``_sync_atomic`` Phase 1: bytes → decode errors="replace" →
+    # parse → ``name_of``). Keying by file stem reported permanent phantom
+    # drift after a successful sync whenever stem and frontmatter name
+    # disagree: ('<stem>', 'missing target') + ('<name>', 'missing
+    # canonical') on every runtime, forever (#1229). The lenient decode also
+    # keeps a stray non-UTF-8 byte from aborting the whole diff with an
+    # uncaught UnicodeDecodeError while sync handles the same file fine.
+    # Unreadable / unparseable canonicals keep the stem / dir-name key
+    # (``None`` value) so their "parse error" row still names the file.
+    canonical_index: dict[str, T | None] = {}
+    # Parse failures keep the exception text (it embeds the source path) so
+    # the "parse error" row can carry a diagnostic reason — pre-#1229 the
+    # exception was swallowed here without even a log line.
+    parse_failures: dict[str, str] = {}
+    for path, layout in adapter.list_canonical(project_root, scope=scope):
+        fallback_name = canonical_artifact_name(path, layout)
+        try:
+            text = path.read_bytes().decode("utf-8", errors="replace")
+            parsed = adapter.parse_canonical_text(text, source=path, layout=layout)
+        except OSError as exc:
+            # Same first-parsed-wins precedence as below (#1247 Codex impl
+            # round): a fallback-name entry must not SHADOW an earlier
+            # successfully parsed canonical that claimed the same effective
+            # name — sync writes that name fine (the unreadable file never
+            # claims a name there), so a None overwrite here would report
+            # permanent phantom "parse error" drift no sync can clear. The
+            # warning below still fires, so the broken file stays loud.
+            if canonical_index.get(fallback_name) is None:
+                canonical_index[fallback_name] = None
+                parse_failures[fallback_name] = f"unreadable: {exc}"
+            adapter.logger.warning("canonical %s %s unreadable: %s", adapter.kind, path, exc)
+        except adapter.parse_error_type as exc:
+            if canonical_index.get(fallback_name) is None:
+                canonical_index[fallback_name] = None
+                parse_failures[fallback_name] = str(exc)
+            adapter.logger.warning("canonical %s %s failed to parse: %s", adapter.kind, path, exc)
+        else:
+            # First-parsed-wins on a frontmatter-name collision, matching the
+            # sync engine's duplicate-name dedupe (#1247) — last-wins here
+            # would diff the runtime file against the canonical sync never
+            # wrote, reporting permanent phantom drift. The loser surfaces in
+            # the sync result as a ``duplicate_name`` skip, not as a diff row
+            # (flat-vs-dir precedent: log-only in diff). A ``None`` entry
+            # (parse-failure fallback name) stays overwritable — pre-existing
+            # interplay, unchanged.
+            parsed_name = adapter.name_of(parsed)
+            if canonical_index.get(parsed_name) is not None:
+                adapter.logger.warning(
+                    "duplicate %s name %r: keeping first-seen canonical, ignoring %s",
+                    adapter.kind,
+                    parsed_name,
+                    path,
+                )
+            else:
+                canonical_index[parsed_name] = parsed
+    canonical_names = set(canonical_index)
+
+    for gen_name, gen in adapter.generators.items():
+        # ADR-0011 PR-E3 cleanup item #1: query the table directly via
+        # ``runtime_fanout_root``. Earlier code probed with a fixed artifact
+        # name (``__probe_891__``) which leaked the table-shape assumption
+        # into the call shape — call-shape fragility, not name-independence.
+        runtime = gen_name.split("_", 1)[0]
+        if runtime_fanout_root(artifact_label, runtime, scope, project_root) is None:
+            continue
+        suffix = adapter.runtime_suffixes.get(runtime, ".md")
+        runtime_names, invalid_runtime_names = runtime_artifact_listing(
+            artifact_label, runtime, project_root, scope, file_suffix=suffix
+        )
+        # Invalid-named runtime files used to vanish from diff entirely
+        # (log-only) — the dashboard read fully in-sync while an unmanaged
+        # runtime artifact existed (#1229). Surface them as a dedicated row;
+        # a canonical "parse error" row of the same fallback name wins
+        # (only possible when the canonical stem itself is invalid).
+        for raw_name, invalid_reason in invalid_runtime_names:
+            if raw_name not in canonical_names:
+                results.append(DiffRow(gen_name, raw_name, "invalid name", invalid_reason))
+        for name in sorted(canonical_names | runtime_names):
+            # Unparseable canonical (including an invalid *effective* name —
+            # frontmatter name, or stem fallback) checked BEFORE the
+            # missing-target branch: "missing target" implied sync would
+            # create the runtime file, which it never can — the row showed
+            # a permanent drift no sync clears (#1229).
+            if name in canonical_names and canonical_index[name] is None:
+                results.append(DiffRow(gen_name, name, "parse error", parse_failures.get(name)))
+                continue
+            if name in canonical_names and name not in runtime_names:
+                results.append((gen_name, name, "missing target"))
+                continue
+            if name in runtime_names and name not in canonical_names:
+                results.append((gen_name, name, "missing canonical"))
+                continue
+
+            item = canonical_index[name]
+            assert item is not None  # consumed by the parse-error branch above
+            # Cleanup item #2: the upstream ``runtime_fanout_root`` guard
+            # above guarantees this runtime+scope has a fan-out root, so
+            # ``gen.target_file`` cannot return ``None`` for any name.
+            # Earlier defensive ``if target is None: continue`` removed.
+            target = gen.target_file(project_root, name, scope=scope)
+            assert target is not None  # narrowed by upstream NO_FANOUT guard
+
+            # A per-vendor override replaces the rendered runtime file at sync
+            # time (``_sync_atomic`` Phase 2 / ADR-0008 Invariant 4) via
+            # ``atomic_write_bytes`` — raw bytes, no strip. Compare byte-exact
+            # against the same source so an override-carrying artifact isn't
+            # reported permanently "out of sync"; decoding as text would crash
+            # on a non-UTF-8 override and would mask whitespace-only byte drift.
+            vendor = GENERATOR_VENDOR.get(gen_name)
+            override_path = (
+                _override.resolve(project_root, artifact_label, name, vendor, scope=scope)
+                if vendor is not None
+                else None
+            )
+            if override_path is not None:
+                try:
+                    expected_bytes = override_path.read_bytes()
+                except OSError:
+                    # Sync skips an unreadable override (no effective fan-out),
+                    # so we can't assert parity — report drift, never mask it.
+                    results.append((gen_name, name, "out of sync"))
+                    continue
+                try:
+                    actual_bytes = target.read_bytes() if target.is_file() else b""
+                except OSError:
+                    # Unreadable runtime file — same contract as above.
+                    results.append((gen_name, name, "out of sync"))
+                    continue
+                status = "in sync" if expected_bytes == actual_bytes else "out of sync"
+                results.append((gen_name, name, status))
+                continue
+
+            expected, _ = gen.render(item)
+            # Byte-exact compare against what sync would write (Phase 2
+            # ``atomic_write_bytes`` of ``content.encode("utf-8")`` verbatim)
+            # — a ``.strip()`` compare reported whitespace-padded runtime
+            # files "in sync" while sync would rewrite them (#1229), and a
+            # lenient text decode collapses distinct invalid byte sequences
+            # to the same U+FFFD. Bytes cannot raise UnicodeDecodeError. An
+            # unreadable runtime file can't assert parity — report drift,
+            # never mask it.
+            try:
+                actual_bytes = target.read_bytes() if target.is_file() else b""
+            except OSError:
+                results.append((gen_name, name, "out of sync"))
+                continue
+            status = "in sync" if expected.encode("utf-8") == actual_bytes else "out of sync"
+            results.append((gen_name, name, status))
+
+    return results
+
+
+__all__ = [
+    "canonical_artifact_name",
+    "diff_atomic_artifact",
+    "import_passthrough_runtime",
+    "list_canonical_artifacts",
+    "resolve_artifact_extract_target",
+    "resolve_artifact_under_root",
+]

--- a/packages/memtomem/src/memtomem/context/_sync_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_sync_atomic.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Generic, Literal, Protocol, TypeVar
 
@@ -172,6 +172,12 @@ class AtomicSyncAdapter(Generic[T]):
     # raise the ``VersionError`` family (label/version not found, flat layout,
     # malformed manifest), which the engine isolates as per-item skips.
     resolve_canonical_bytes: Callable[[Path, Layout], tuple[bytes, Path]] | None = None
+    # #1515: per-runtime file suffix for the reverse/diff engine
+    # (:func:`memtomem.context._atomic_reverse.diff_atomic_artifact`).
+    # KEYED BY RUNTIME/VENDOR PREFIX — the part before the first ``_`` in a
+    # generator name (``"claude"``, NOT ``"claude_agents"``). Runtimes
+    # missing from the mapping fall back to ``".md"``.
+    runtime_suffixes: Mapping[str, str] = field(default_factory=dict)
 
 
 def sync_atomic_artifact(

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -41,14 +41,16 @@ from pathlib import Path
 from typing import Any, Protocol, cast
 
 from memtomem.context import _skip_reasons as skip_codes
-from memtomem.context import override as _override
-from memtomem.context._atomic import atomic_write_bytes
-from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
-from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
+from memtomem.context._atomic_reverse import (
+    canonical_artifact_name,
+    diff_atomic_artifact,
+    import_passthrough_runtime,
+    list_canonical_artifacts,
+    resolve_artifact_under_root,
+)
+from memtomem.context._names import InvalidNameError, Layout, validate_name
 from memtomem.context._runtime_targets import (
-    DiffRow,
-    runtime_artifact_listing,
     runtime_artifact_names,
     runtime_fanout_root,
 )
@@ -78,7 +80,7 @@ def canonical_agent_name(path: Path, layout: Layout) -> str:
     callers must pass the layout tag they got from
     :func:`list_canonical_agents` or :func:`extract_agents_to_canonical`.
     """
-    return path.parent.name if layout == "dir" else path.stem
+    return canonical_artifact_name(path, layout)
 
 
 # Reuse the same frontmatter regex used by the markdown chunker so canonical
@@ -267,28 +269,6 @@ def parse_canonical_agent(path: Path, *, layout: Layout = "flat") -> SubAgent:
     return _parse_canonical_agent_text(content, source=path, layout=layout)
 
 
-def _resolve_agent_under_root(canonical_root: Path, agent_name: str) -> tuple[Path, Layout] | None:
-    dir_target = canonical_root / agent_name / AGENT_DIR_FILENAME
-    flat_target = canonical_root / f"{agent_name}.md"
-    has_dir = dir_target.is_file()
-    has_flat = flat_target.is_file()
-    if has_dir and has_flat:
-        logger.warning(
-            "agents/%s: reverse-sync updates dir layout (%s/agent.md); the flat "
-            "file (%s.md) is now silently divergent. Remove it or run "
-            "`mm context migrate` (PR-D).",
-            agent_name,
-            agent_name,
-            agent_name,
-        )
-        return dir_target, "dir"
-    if has_dir:
-        return dir_target, "dir"
-    if has_flat:
-        return flat_target, "flat"
-    return None
-
-
 def resolve_canonical_agent(
     project_root: Path, name: str, *, scope: TargetScope = "project_shared"
 ) -> tuple[Path, Layout] | None:
@@ -301,7 +281,13 @@ def resolve_canonical_agent(
     ``scope`` selects the canonical residency tier (ADR-0016). Default
     ``project_shared`` preserves pre-#940 behavior.
     """
-    return _resolve_agent_under_root(canonical_artifact_dir("agents", scope, project_root), name)
+    return resolve_artifact_under_root(
+        canonical_artifact_dir("agents", scope, project_root),
+        name,
+        artifact_label="agents",
+        dir_filename=AGENT_DIR_FILENAME,
+        logger=logger,
+    )
 
 
 def list_canonical_agents(
@@ -321,30 +307,13 @@ def list_canonical_agents(
     :func:`canonical_artifact_dir` (default ``project_shared`` preserves
     pre-PR-E3 behavior of reading ``<project_root>/.memtomem/agents``).
     """
-    root = canonical_artifact_dir("agents", scope, project_root)
-    if not root.is_dir():
-        return []
-
-    flat: dict[str, Path] = {p.stem: p for p in sorted(root.glob("*.md")) if p.is_file()}
-    dirs: dict[str, Path] = {}
-    for entry in sorted(root.iterdir()):
-        if entry.is_dir():
-            agent_md = entry / AGENT_DIR_FILENAME
-            if agent_md.is_file():
-                dirs[entry.name] = agent_md
-
-    for name in sorted(set(flat) & set(dirs)):
-        logger.warning(
-            "agents/%s: both flat (%s.md) and dir (%s/agent.md) layouts present; "
-            "using dir. Remove the flat file or run `mm context migrate` (PR-D).",
-            name,
-            name,
-            name,
-        )
-
-    merged_paths = {**flat, **dirs}  # dir overrides flat on collision
-    layouts: dict[str, Layout] = {**dict.fromkeys(flat, "flat"), **dict.fromkeys(dirs, "dir")}
-    return [(merged_paths[k], layouts[k]) for k in sorted(merged_paths)]
+    return list_canonical_artifacts(
+        project_root,
+        artifact_label="agents",
+        dir_filename=AGENT_DIR_FILENAME,
+        logger=logger,
+        scope=scope,
+    )
 
 
 # ── Renderers ────────────────────────────────────────────────────────
@@ -697,7 +666,7 @@ class ExtractResult:
     :func:`canonical_agent_name` without re-deriving the layout from the
     path. ``layout`` is whichever form the canonical now lives in on disk
     (preserving an existing flat file or writing a new dir entry — see
-    :func:`_resolve_agent_extract_target`).
+    :func:`memtomem.context._atomic_reverse.resolve_artifact_extract_target`).
     """
 
     imported: list[tuple[Path, Layout]]
@@ -711,6 +680,19 @@ class ExtractResult:
 # into. Behavior is byte-for-byte identical (TOCTOU close on canonical and
 # override bytes, Phase 1 raise-early atomicity for ``project_shared``,
 # Phase 2 strict-drop partial-write boundary pinned by #908).
+# Per-runtime file suffix for agents fan-out. Used by ``diff_agents`` (via
+# the adapter's ``runtime_suffixes``) to delegate to
+# ``runtime_artifact_names``. Kept inline (rather than on each generator)
+# because the suffix is a property of the on-disk format, not of the
+# runtime conversion.
+_AGENT_RUNTIME_SUFFIX: dict[str, str] = {
+    "claude": ".md",
+    "gemini": ".md",
+    "codex": ".toml",
+    "kimi": ".yaml",
+}
+
+
 _AGENT_ADAPTER: AtomicSyncAdapter[SubAgent] = AtomicSyncAdapter(
     kind="agent",
     artifact_label="agents",
@@ -722,6 +704,7 @@ _AGENT_ADAPTER: AtomicSyncAdapter[SubAgent] = AtomicSyncAdapter(
     result_type=AgentSyncResult,
     strict_drop_error_type=StrictDropError,
     logger=logger,
+    runtime_suffixes=_AGENT_RUNTIME_SUFFIX,
 )
 
 
@@ -790,21 +773,6 @@ def generate_all_agents(
 
 
 # ── Reverse: runtime → canonical ────────────────────────────────────
-
-
-def _resolve_agent_extract_target(canonical_root: Path, agent_name: str) -> tuple[Path, Layout]:
-    """Decide where reverse-sync writes the canonical for ``agent_name``.
-
-    Truth table (ADR-0008 PR-C):
-      dir+flat both → dir wins, flat is silently divergent → WARN
-      dir only      → dir
-      flat only     → flat (preserve existing layout; PR-C does not migrate)
-      neither       → dir (ADR-0008 layout for new agents)
-    """
-    resolved = _resolve_agent_under_root(canonical_root, agent_name)
-    if resolved is not None:
-        return resolved
-    return canonical_root / agent_name / AGENT_DIR_FILENAME, "dir"
 
 
 def extract_agents_to_canonical(
@@ -879,108 +847,40 @@ def extract_agents_to_canonical(
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = []
     seen: dict[str, str] = {}  # agent_name → first runtime label
 
-    for runtime in ("claude", "gemini"):
-        try:
-            runtime_dir = runtime_fanout_root("agents", runtime, scope, project_root)
-        except KeyError:
-            # Defensive — every (agents, claude|gemini, scope) tuple is in
-            # the table at PR-E1 land time, so this only fires on a future
-            # runtime added without table churn.
-            continue
-        if runtime_dir is None or not runtime_dir.is_dir():
-            continue
-        runtime_label = f"{runtime} ({runtime_dir})"
-        for md_file in sorted(runtime_dir.glob("*.md")):
-            agent_name = md_file.stem
-            if only_name is not None and agent_name != only_name:
-                continue
-            try:
-                validate_name(agent_name, kind="agent name")
-            except InvalidNameError as exc:
-                skipped.append((agent_name, f"invalid name: {exc}", skip_codes.INVALID_NAME))
-                logger.warning(
-                    "skip %r from %s: invalid name",
-                    agent_name,
-                    runtime_label,
-                )
-                continue
-            if agent_name in seen:
-                reason = f"already imported from {seen[agent_name]}"
-                skipped.append((agent_name, reason, skip_codes.ALREADY_IMPORTED))
-                logger.warning("skip %s from %s: %s", agent_name, runtime_label, reason)
-                continue
-            dst, layout = _resolve_agent_extract_target(canonical_root, agent_name)
-            if dst.exists() and not overwrite:
-                reason = "canonical exists (use --overwrite)"
-                skipped.append((agent_name, reason, skip_codes.CANONICAL_EXISTS))
-                logger.warning("skip %s from %s: %s", agent_name, runtime_label, reason)
-                seen[agent_name] = runtime_label
-                continue
+    def _audit_context(src: Path, dst: Path, agent_name: str) -> dict[str, object]:
+        return {
+            "source": str(src),
+            "target": str(dst),
+            "kind": "agents",
+            "agent_name": agent_name,
+        }
 
-            # Gate A — re-scan the source bytes before any write. Use
-            # ``errors="replace"`` so non-UTF8 bytes cannot mask an
-            # embedded ASCII secret (the replacement char `�` does
-            # not overlap with any provider-token alphanumeric pattern).
-            # Project_shared hard-abort (git-history-is-forever) is
-            # raised inside ``apply_gate_a`` — Files imported earlier in
-            # this run that passed Gate A stay (each was scanned
-            # independently).
-            try:
-                content_bytes = md_file.read_bytes()
-            except OSError as exc:
-                skipped.append((agent_name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
-                continue
-            content_text = content_bytes.decode("utf-8", errors="replace")
-            outcome = apply_gate_a(
-                content_text=content_text,
-                src=md_file,
-                scope=scope,
-                force_unsafe_import=force_unsafe_import,
-                surface=surface,
-                audit_context={
-                    "source": str(md_file),
-                    "target": str(dst),
-                    "kind": "agents",
-                    "agent_name": agent_name,
-                },
-                message_kind="agent",
-                imported_so_far=len(imported),
-            )
-            if isinstance(outcome, GateABlocked):
-                skipped.append(
-                    (
-                        agent_name,
-                        f"blocked: {outcome.hits_count} privacy pattern hit(s){outcome.hint}",
-                        outcome.code,
-                    )
-                )
-                seen[agent_name] = runtime_label
-                continue
-            # outcome is GateAProceed — write. ``dry_run`` records the
-            # would-import target but skips the write so the preview never
-            # mutates disk (rank-10).
-            if not dry_run:
-                dst.parent.mkdir(parents=True, exist_ok=True)
-                atomic_write_bytes(dst, content_bytes)
-            imported.append((dst, layout))
-            seen[agent_name] = runtime_label
+    for runtime in ("claude", "gemini"):
+        import_passthrough_runtime(
+            runtime,
+            artifact_label="agents",
+            dir_filename=AGENT_DIR_FILENAME,
+            name_kind="agent name",
+            message_kind="agent",
+            audit_context=_audit_context,
+            canonical_root=canonical_root,
+            project_root=project_root,
+            overwrite=overwrite,
+            scope=scope,
+            force_unsafe_import=force_unsafe_import,
+            dry_run=dry_run,
+            surface=surface,
+            only_name=only_name,
+            imported=imported,
+            skipped=skipped,
+            seen=seen,
+            logger=logger,
+        )
 
     return ExtractResult(imported=imported, skipped=skipped)
 
 
 # ── Diff: canonical ↔ runtimes ──────────────────────────────────────
-
-
-# Per-runtime file suffix for agents fan-out. Used by ``diff_agents`` to
-# delegate to ``runtime_artifact_names``. Kept inline (rather than on each
-# generator) because (a) the suffix is a property of the on-disk format, not
-# of the runtime conversion, and (b) it's referenced from one site only.
-_AGENT_RUNTIME_SUFFIX: dict[str, str] = {
-    "claude": ".md",
-    "gemini": ".md",
-    "codex": ".toml",
-    "kimi": ".yaml",
-}
 
 
 def _runtime_agent_names(gen_name: str, project_root: Path) -> set[str]:
@@ -1014,156 +914,7 @@ def diff_agents(
     runtime fan-out roots. Default ``project_shared`` preserves
     pre-PR-E3 behavior.
     """
-    results: list[tuple[str, str, str]] = []
-    # Key canonicals by the parsed frontmatter ``name:`` — the identity sync
-    # targets (``_sync_atomic`` Phase 1: bytes → decode errors="replace" →
-    # parse → ``name_of``). Keying by file stem reported permanent phantom
-    # drift after a successful sync whenever stem and frontmatter name
-    # disagree: ('<stem>', 'missing target') + ('<name>', 'missing
-    # canonical') on every runtime, forever (#1229). The lenient decode also
-    # keeps a stray non-UTF-8 byte from aborting the whole diff with an
-    # uncaught UnicodeDecodeError while sync handles the same file fine.
-    # Unreadable / unparseable canonicals keep the stem / dir-name key
-    # (``None`` value) so their "parse error" row still names the file.
-    canonical_index: dict[str, SubAgent | None] = {}
-    # Parse failures keep the exception text (it embeds the source path) so
-    # the "parse error" row can carry a diagnostic reason — pre-#1229 the
-    # exception was swallowed here without even a log line.
-    parse_failures: dict[str, str] = {}
-    for path, layout in list_canonical_agents(project_root, scope=scope):
-        fallback_name = path.parent.name if layout == "dir" else path.stem
-        try:
-            text = path.read_bytes().decode("utf-8", errors="replace")
-            parsed = _parse_canonical_agent_text(text, source=path, layout=layout)
-        except OSError as exc:
-            # Same first-parsed-wins precedence as below (#1247 Codex impl
-            # round): a fallback-name entry must not SHADOW an earlier
-            # successfully parsed canonical that claimed the same effective
-            # name — sync writes that name fine (the unreadable file never
-            # claims a name there), so a None overwrite here would report
-            # permanent phantom "parse error" drift no sync can clear. The
-            # warning below still fires, so the broken file stays loud.
-            if canonical_index.get(fallback_name) is None:
-                canonical_index[fallback_name] = None
-                parse_failures[fallback_name] = f"unreadable: {exc}"
-            logger.warning("canonical agent %s unreadable: %s", path, exc)
-        except AgentParseError as exc:
-            if canonical_index.get(fallback_name) is None:
-                canonical_index[fallback_name] = None
-                parse_failures[fallback_name] = str(exc)
-            logger.warning("canonical agent %s failed to parse: %s", path, exc)
-        else:
-            # First-parsed-wins on a frontmatter-name collision, matching the
-            # sync engine's duplicate-name dedupe (#1247) — last-wins here
-            # would diff the runtime file against the canonical sync never
-            # wrote, reporting permanent phantom drift. The loser surfaces in
-            # the sync result as a ``duplicate_name`` skip, not as a diff row
-            # (flat-vs-dir precedent: log-only in diff). A ``None`` entry
-            # (parse-failure fallback name) stays overwritable — pre-existing
-            # interplay, unchanged.
-            if canonical_index.get(parsed.name) is not None:
-                logger.warning(
-                    "duplicate agent name %r: keeping first-seen canonical, ignoring %s",
-                    parsed.name,
-                    path,
-                )
-            else:
-                canonical_index[parsed.name] = parsed
-    canonical_names = set(canonical_index)
-
-    for gen_name, gen in AGENT_GENERATORS.items():
-        # ADR-0011 PR-E3 cleanup item #1: query the table directly via
-        # ``runtime_fanout_root``. Earlier code probed with a fixed agent
-        # name (``__probe_891__``) which leaked the table-shape assumption
-        # into the call shape — call-shape fragility, not name-independence.
-        runtime = gen_name.split("_", 1)[0]
-        if runtime_fanout_root("agents", runtime, scope, project_root) is None:
-            continue
-        suffix = _AGENT_RUNTIME_SUFFIX.get(runtime, ".md")
-        runtime_names, invalid_runtime_names = runtime_artifact_listing(
-            "agents", runtime, project_root, scope, file_suffix=suffix
-        )
-        # Invalid-named runtime files used to vanish from diff entirely
-        # (log-only) — the dashboard read fully in-sync while an unmanaged
-        # runtime artifact existed (#1229). Surface them as a dedicated row;
-        # a canonical "parse error" row of the same fallback name wins
-        # (only possible when the canonical stem itself is invalid).
-        for raw_name, invalid_reason in invalid_runtime_names:
-            if raw_name not in canonical_names:
-                results.append(DiffRow(gen_name, raw_name, "invalid name", invalid_reason))
-        for name in sorted(canonical_names | runtime_names):
-            # Unparseable canonical (including an invalid *effective* name —
-            # frontmatter name, or stem fallback) checked BEFORE the
-            # missing-target branch: "missing target" implied sync would
-            # create the runtime file, which it never can — the row showed
-            # a permanent drift no sync clears (#1229).
-            if name in canonical_names and canonical_index[name] is None:
-                results.append(DiffRow(gen_name, name, "parse error", parse_failures.get(name)))
-                continue
-            if name in canonical_names and name not in runtime_names:
-                results.append((gen_name, name, "missing target"))
-                continue
-            if name in runtime_names and name not in canonical_names:
-                results.append((gen_name, name, "missing canonical"))
-                continue
-
-            agent = canonical_index[name]
-            assert agent is not None  # consumed by the parse-error branch above
-            # Cleanup item #2: the upstream ``runtime_fanout_root`` guard
-            # above guarantees this runtime+scope has a fan-out root, so
-            # ``gen.target_file`` cannot return ``None`` for any name.
-            # Earlier defensive ``if target is None: continue`` removed.
-            target = gen.target_file(project_root, name, scope=scope)
-            assert target is not None  # narrowed by upstream NO_FANOUT guard
-
-            # A per-vendor override replaces the rendered runtime file at sync
-            # time (``_sync_atomic`` Phase 2 / ADR-0008 Invariant 4) via
-            # ``atomic_write_bytes`` — raw bytes, no strip. Compare byte-exact
-            # against the same source so an override-carrying agent isn't
-            # reported permanently "out of sync"; decoding as text would crash
-            # on a non-UTF-8 override and would mask whitespace-only byte drift.
-            vendor = GENERATOR_VENDOR.get(gen_name)
-            override_path = (
-                _override.resolve(project_root, "agents", name, vendor, scope=scope)
-                if vendor is not None
-                else None
-            )
-            if override_path is not None:
-                try:
-                    expected_bytes = override_path.read_bytes()
-                except OSError:
-                    # Sync skips an unreadable override (no effective fan-out),
-                    # so we can't assert parity — report drift, never mask it.
-                    results.append((gen_name, name, "out of sync"))
-                    continue
-                try:
-                    actual_bytes = target.read_bytes() if target.is_file() else b""
-                except OSError:
-                    # Unreadable runtime file — same contract as above.
-                    results.append((gen_name, name, "out of sync"))
-                    continue
-                status = "in sync" if expected_bytes == actual_bytes else "out of sync"
-                results.append((gen_name, name, status))
-                continue
-
-            expected, _ = gen.render(agent)
-            # Byte-exact compare against what sync would write (Phase 2
-            # ``atomic_write_bytes`` of ``content.encode("utf-8")`` verbatim)
-            # — a ``.strip()`` compare reported whitespace-padded runtime
-            # files "in sync" while sync would rewrite them (#1229), and a
-            # lenient text decode collapses distinct invalid byte sequences
-            # to the same U+FFFD. Bytes cannot raise UnicodeDecodeError. An
-            # unreadable runtime file can't assert parity — report drift,
-            # never mask it.
-            try:
-                actual_bytes = target.read_bytes() if target.is_file() else b""
-            except OSError:
-                results.append((gen_name, name, "out of sync"))
-                continue
-            status = "in sync" if expected.encode("utf-8") == actual_bytes else "out of sync"
-            results.append((gen_name, name, status))
-
-    return results
+    return diff_atomic_artifact(_AGENT_ADAPTER, project_root, scope=scope)
 
 
 __all__ = [

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -39,16 +39,19 @@ from pathlib import Path
 from typing import Protocol, cast
 
 from memtomem.context import _skip_reasons as skip_codes
-from memtomem.context import override as _override
-from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
+from memtomem.context._atomic import atomic_write_text
+from memtomem.context._atomic_reverse import (
+    canonical_artifact_name,
+    diff_atomic_artifact,
+    import_passthrough_runtime,
+    list_canonical_artifacts,
+    resolve_artifact_extract_target,
+    resolve_artifact_under_root,
+)
 from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
-from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
-from memtomem.context._runtime_targets import (
-    DiffRow,
-    runtime_artifact_listing,
-    runtime_fanout_root,
-)
+from memtomem.context._names import InvalidNameError, Layout, validate_name
+from memtomem.context._runtime_targets import runtime_fanout_root
 from memtomem.context._sync_atomic import (
     ON_DROP_LEVELS,
     AtomicSyncAdapter,
@@ -78,7 +81,7 @@ def canonical_command_name(path: Path, layout: Layout) -> str:
     pass the layout tag from :func:`list_canonical_commands` or
     :func:`extract_commands_to_canonical`.
     """
-    return path.parent.name if layout == "dir" else path.stem
+    return canonical_artifact_name(path, layout)
 
 
 # ── Canonical dataclass ──────────────────────────────────────────────
@@ -183,28 +186,6 @@ def parse_canonical_command(path: Path, *, layout: Layout = "flat") -> SlashComm
     return _parse_canonical_command_text(content, source=path, layout=layout)
 
 
-def _resolve_command_under_root(canonical_root: Path, cmd_name: str) -> tuple[Path, Layout] | None:
-    dir_target = canonical_root / cmd_name / COMMAND_DIR_FILENAME
-    flat_target = canonical_root / f"{cmd_name}.md"
-    has_dir = dir_target.is_file()
-    has_flat = flat_target.is_file()
-    if has_dir and has_flat:
-        logger.warning(
-            "commands/%s: reverse-sync updates dir layout (%s/command.md); the "
-            "flat file (%s.md) is now silently divergent. Remove it or run "
-            "`mm context migrate` (PR-D).",
-            cmd_name,
-            cmd_name,
-            cmd_name,
-        )
-        return dir_target, "dir"
-    if has_dir:
-        return dir_target, "dir"
-    if has_flat:
-        return flat_target, "flat"
-    return None
-
-
 def resolve_canonical_command(
     project_root: Path, name: str, *, scope: TargetScope = "project_shared"
 ) -> tuple[Path, Layout] | None:
@@ -217,8 +198,12 @@ def resolve_canonical_command(
     ``scope`` selects the canonical residency tier (ADR-0016). Default
     ``project_shared`` preserves pre-#940 behavior.
     """
-    return _resolve_command_under_root(
-        canonical_artifact_dir("commands", scope, project_root), name
+    return resolve_artifact_under_root(
+        canonical_artifact_dir("commands", scope, project_root),
+        name,
+        artifact_label="commands",
+        dir_filename=COMMAND_DIR_FILENAME,
+        logger=logger,
     )
 
 
@@ -238,31 +223,13 @@ def list_canonical_commands(
     :func:`canonical_artifact_dir` (default ``project_shared`` preserves
     pre-PR-E3 behavior).
     """
-    root = canonical_artifact_dir("commands", scope, project_root)
-    if not root.is_dir():
-        return []
-
-    flat: dict[str, Path] = {p.stem: p for p in sorted(root.glob("*.md")) if p.is_file()}
-    dirs: dict[str, Path] = {}
-    for entry in sorted(root.iterdir()):
-        if entry.is_dir():
-            cmd_md = entry / COMMAND_DIR_FILENAME
-            if cmd_md.is_file():
-                dirs[entry.name] = cmd_md
-
-    for name in sorted(set(flat) & set(dirs)):
-        logger.warning(
-            "commands/%s: both flat (%s.md) and dir (%s/command.md) layouts "
-            "present; using dir. Remove the flat file or run "
-            "`mm context migrate` (PR-D).",
-            name,
-            name,
-            name,
-        )
-
-    merged_paths = {**flat, **dirs}  # dir overrides flat on collision
-    layouts: dict[str, Layout] = {**dict.fromkeys(flat, "flat"), **dict.fromkeys(dirs, "dir")}
-    return [(merged_paths[k], layouts[k]) for k in sorted(merged_paths)]
+    return list_canonical_artifacts(
+        project_root,
+        artifact_label="commands",
+        dir_filename=COMMAND_DIR_FILENAME,
+        logger=logger,
+        scope=scope,
+    )
 
 
 # ── Placeholder rewriting ────────────────────────────────────────────
@@ -436,6 +403,18 @@ class ExtractResult:
 
 # Issue #900 extraction — see the matching adapter in
 # :mod:`memtomem.context.agents` for the design rationale.
+# Per-runtime file suffix for commands fan-out. Used by ``diff_commands``
+# (via the adapter's ``runtime_suffixes``) to delegate to
+# ``runtime_artifact_names``.
+_COMMAND_RUNTIME_SUFFIX: dict[str, str] = {
+    "claude": ".md",
+    "gemini": ".toml",
+    # Codex: project-tier has no fan-out (RUNTIME_FANOUT_TABLE returns None);
+    # user-tier prompts use ``.md`` per Codex docs.
+    "codex": ".md",
+}
+
+
 _COMMAND_ADAPTER: AtomicSyncAdapter[SlashCommand] = AtomicSyncAdapter(
     kind="command",
     artifact_label="commands",
@@ -447,6 +426,7 @@ _COMMAND_ADAPTER: AtomicSyncAdapter[SlashCommand] = AtomicSyncAdapter(
     result_type=CommandSyncResult,
     strict_drop_error_type=StrictDropError,
     logger=logger,
+    runtime_suffixes=_COMMAND_RUNTIME_SUFFIX,
 )
 
 
@@ -540,19 +520,6 @@ def _gemini_toml_to_canonical(toml_path: Path) -> str:
     return body
 
 
-def _resolve_command_extract_target(canonical_root: Path, cmd_name: str) -> tuple[Path, Layout]:
-    """Decide where reverse-sync writes the canonical for ``cmd_name``.
-
-    Truth table mirrors :func:`memtomem.context.agents._resolve_agent_extract_target`:
-    dir+flat both → dir wins (silent flat divergence WARNed);
-    dir only → dir; flat only → flat (preserve); neither → dir (ADR layout).
-    """
-    resolved = _resolve_command_under_root(canonical_root, cmd_name)
-    if resolved is not None:
-        return resolved
-    return canonical_root / cmd_name / COMMAND_DIR_FILENAME, "dir"
-
-
 def extract_commands_to_canonical(
     project_root: Path,
     overwrite: bool = False,
@@ -618,78 +585,39 @@ def extract_commands_to_canonical(
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = []
     seen: dict[str, str] = {}  # cmd_name → first runtime label
 
+    def _claude_audit_context(src: Path, dst: Path, cmd_name: str) -> dict[str, object]:
+        # Mirror agents.py audit_context shape — SOC pipelines grep both
+        # ``source=`` and ``target=`` for incident triage; commands' earlier
+        # omission was a sibling-parity gap (PR #889 review D1).
+        return {
+            "source": str(src),
+            "target": str(dst),
+            "kind": "commands",
+            "runtime": "claude",
+            "command_name": cmd_name,
+        }
+
     # ── Claude branch — byte-level passthrough (Markdown + YAML) ──
-    try:
-        claude_dir = runtime_fanout_root("commands", "claude", scope, project_root)
-    except KeyError:
-        claude_dir = None
-    if claude_dir is not None and claude_dir.is_dir():
-        claude_label = f"claude ({claude_dir})"
-        for md_file in sorted(claude_dir.glob("*.md")):
-            cmd_name = md_file.stem
-            if only_name is not None and cmd_name != only_name:
-                continue
-            try:
-                validate_name(cmd_name, kind="command name")
-            except InvalidNameError as exc:
-                skipped.append((cmd_name, f"invalid name: {exc}", skip_codes.INVALID_NAME))
-                logger.warning("skip %r from %s: invalid name", cmd_name, claude_label)
-                continue
-            if cmd_name in seen:
-                reason = f"already imported from {seen[cmd_name]}"
-                skipped.append((cmd_name, reason, skip_codes.ALREADY_IMPORTED))
-                logger.warning("skip %s from %s: %s", cmd_name, claude_label, reason)
-                continue
-            dst, layout = _resolve_command_extract_target(canonical_root, cmd_name)
-            if dst.exists() and not overwrite:
-                reason = "canonical exists (use --overwrite)"
-                skipped.append((cmd_name, reason, skip_codes.CANONICAL_EXISTS))
-                logger.warning("skip %s from %s: %s", cmd_name, claude_label, reason)
-                seen[cmd_name] = claude_label
-                continue
-            try:
-                content_bytes = md_file.read_bytes()
-            except OSError as exc:
-                skipped.append((cmd_name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
-                continue
-            content_text = content_bytes.decode("utf-8", errors="replace")
-            outcome = apply_gate_a(
-                content_text=content_text,
-                src=md_file,
-                scope=scope,
-                force_unsafe_import=force_unsafe_import,
-                surface=surface,
-                # Mirror agents.py audit_context shape — SOC pipelines grep
-                # both ``source=`` and ``target=`` for incident triage;
-                # commands' earlier omission was a sibling-parity gap
-                # (PR #889 review D1).
-                audit_context={
-                    "source": str(md_file),
-                    "target": str(dst),
-                    "kind": "commands",
-                    "runtime": "claude",
-                    "command_name": cmd_name,
-                },
-                message_kind="command",
-                imported_so_far=len(imported),
-            )
-            if isinstance(outcome, GateABlocked):
-                skipped.append(
-                    (
-                        cmd_name,
-                        f"blocked: {outcome.hits_count} privacy pattern hit(s){outcome.hint}",
-                        outcome.code,
-                    )
-                )
-                seen[cmd_name] = claude_label
-                continue
-            # ``dry_run`` records the would-import target but skips the write
-            # so the preview never mutates disk (rank-10).
-            if not dry_run:
-                dst.parent.mkdir(parents=True, exist_ok=True)
-                atomic_write_bytes(dst, content_bytes)
-            imported.append((dst, layout))
-            seen[cmd_name] = claude_label
+    import_passthrough_runtime(
+        "claude",
+        artifact_label="commands",
+        dir_filename=COMMAND_DIR_FILENAME,
+        name_kind="command name",
+        message_kind="command",
+        audit_context=_claude_audit_context,
+        canonical_root=canonical_root,
+        project_root=project_root,
+        overwrite=overwrite,
+        scope=scope,
+        force_unsafe_import=force_unsafe_import,
+        dry_run=dry_run,
+        surface=surface,
+        only_name=only_name,
+        imported=imported,
+        skipped=skipped,
+        seen=seen,
+        logger=logger,
+    )
 
     # ── Gemini branch — TOML → canonical Markdown conversion ──
     try:
@@ -713,7 +641,13 @@ def extract_commands_to_canonical(
                 skipped.append((cmd_name, reason, skip_codes.ALREADY_IMPORTED))
                 logger.warning("skip %s from %s: %s", cmd_name, gemini_label, reason)
                 continue
-            dst, layout = _resolve_command_extract_target(canonical_root, cmd_name)
+            dst, layout = resolve_artifact_extract_target(
+                canonical_root,
+                cmd_name,
+                artifact_label="commands",
+                dir_filename=COMMAND_DIR_FILENAME,
+                logger=logger,
+            )
             if dst.exists() and not overwrite:
                 reason = "canonical exists (use --overwrite)"
                 skipped.append((cmd_name, reason, skip_codes.CANONICAL_EXISTS))
@@ -770,17 +704,6 @@ def extract_commands_to_canonical(
 # ── Diff: canonical ↔ runtimes ──────────────────────────────────────
 
 
-# Per-runtime file suffix for commands fan-out. Used by ``diff_commands``
-# to delegate to ``runtime_artifact_names``.
-_COMMAND_RUNTIME_SUFFIX: dict[str, str] = {
-    "claude": ".md",
-    "gemini": ".toml",
-    # Codex: project-tier has no fan-out (RUNTIME_FANOUT_TABLE returns None);
-    # user-tier prompts use ``.md`` per Codex docs.
-    "codex": ".md",
-}
-
-
 def diff_commands(
     project_root: Path,
     *,
@@ -796,136 +719,7 @@ def diff_commands(
     runtime fan-out roots. Default ``project_shared`` preserves
     pre-PR-E3 behavior.
     """
-    results: list[tuple[str, str, str]] = []
-    # Key canonicals by the parsed frontmatter ``name:`` with a lenient
-    # decode — mirrors diff_agents; see the comment there for the phantom
-    # drift + UnicodeDecodeError rationale (#1229).
-    canonical_index: dict[str, SlashCommand | None] = {}
-    # Mirrors diff_agents: keep the exception text for the "parse error"
-    # row's diagnostic reason (#1229; previously swallowed without logging).
-    parse_failures: dict[str, str] = {}
-    for path, layout in list_canonical_commands(project_root, scope=scope):
-        fallback_name = path.parent.name if layout == "dir" else path.stem
-        try:
-            text = path.read_bytes().decode("utf-8", errors="replace")
-            parsed = _parse_canonical_command_text(text, source=path, layout=layout)
-        except OSError as exc:
-            # First-parsed-wins guard — see diff_agents (#1247 Codex impl
-            # round): a fallback-name entry must not shadow an earlier
-            # successfully parsed canonical claiming the same name.
-            if canonical_index.get(fallback_name) is None:
-                canonical_index[fallback_name] = None
-                parse_failures[fallback_name] = f"unreadable: {exc}"
-            logger.warning("canonical command %s unreadable: %s", path, exc)
-        except CommandParseError as exc:
-            if canonical_index.get(fallback_name) is None:
-                canonical_index[fallback_name] = None
-                parse_failures[fallback_name] = str(exc)
-            logger.warning("canonical command %s failed to parse: %s", path, exc)
-        else:
-            # First-parsed-wins on a frontmatter-name collision, matching the
-            # sync engine's duplicate-name dedupe (#1247) — see diff_agents.
-            if canonical_index.get(parsed.name) is not None:
-                logger.warning(
-                    "duplicate command name %r: keeping first-seen canonical, ignoring %s",
-                    parsed.name,
-                    path,
-                )
-            else:
-                canonical_index[parsed.name] = parsed
-    canonical_names = set(canonical_index)
-
-    for gen_name, gen in COMMAND_GENERATORS.items():
-        # ADR-0011 PR-E3 cleanup item #1: query the table directly via
-        # ``runtime_fanout_root``. Earlier code probed with a fixed command
-        # name (``__probe_891__``) which leaked the table-shape assumption
-        # into the call shape — call-shape fragility, not name-independence.
-        runtime = gen_name.split("_", 1)[0]
-        if runtime_fanout_root("commands", runtime, scope, project_root) is None:
-            continue
-        suffix = _COMMAND_RUNTIME_SUFFIX.get(runtime, ".md")
-        runtime_names, invalid_runtime_names = runtime_artifact_listing(
-            "commands", runtime, project_root, scope, file_suffix=suffix
-        )
-        # Invalid-named runtime files used to vanish from diff entirely
-        # (log-only) — surface them as a dedicated row; a canonical "parse
-        # error" row of the same fallback name wins (#1229, mirrors
-        # diff_agents).
-        for raw_name, invalid_reason in invalid_runtime_names:
-            if raw_name not in canonical_names:
-                results.append(DiffRow(gen_name, raw_name, "invalid name", invalid_reason))
-
-        for name in sorted(canonical_names | runtime_names):
-            # Unparseable canonical checked BEFORE missing-target — the
-            # "missing target" label implied sync would create the file,
-            # which it never can (#1229, mirrors diff_agents).
-            if name in canonical_names and canonical_index[name] is None:
-                results.append(DiffRow(gen_name, name, "parse error", parse_failures.get(name)))
-                continue
-            if name in canonical_names and name not in runtime_names:
-                results.append((gen_name, name, "missing target"))
-                continue
-            if name in runtime_names and name not in canonical_names:
-                results.append((gen_name, name, "missing canonical"))
-                continue
-
-            cmd = canonical_index[name]
-            assert cmd is not None  # consumed by the parse-error branch above
-            # Cleanup item #2: the upstream ``runtime_fanout_root`` guard
-            # above guarantees this runtime+scope has a fan-out root, so
-            # ``gen.target_file`` cannot return ``None`` for any name.
-            # Earlier defensive ``if target is None: continue`` removed.
-            target = gen.target_file(project_root, name, scope=scope)
-            assert target is not None  # narrowed by upstream NO_FANOUT guard
-
-            # A per-vendor override replaces the rendered runtime file at sync
-            # time (``_sync_atomic`` Phase 2 / ADR-0008 Invariant 4) via
-            # ``atomic_write_bytes`` — raw bytes, no strip. Compare byte-exact
-            # against the same source so an override-carrying command isn't
-            # reported permanently "out of sync"; decoding as text would crash
-            # on a non-UTF-8 override and would mask whitespace-only byte drift.
-            vendor = GENERATOR_VENDOR.get(gen_name)
-            override_path = (
-                _override.resolve(project_root, "commands", name, vendor, scope=scope)
-                if vendor is not None
-                else None
-            )
-            if override_path is not None:
-                try:
-                    expected_bytes = override_path.read_bytes()
-                except OSError:
-                    # Sync skips an unreadable override (no effective fan-out),
-                    # so we can't assert parity — report drift, never mask it.
-                    results.append((gen_name, name, "out of sync"))
-                    continue
-                try:
-                    actual_bytes = target.read_bytes() if target.is_file() else b""
-                except OSError:
-                    # Unreadable runtime file — same contract as above.
-                    results.append((gen_name, name, "out of sync"))
-                    continue
-                status = "in sync" if expected_bytes == actual_bytes else "out of sync"
-                results.append((gen_name, name, status))
-                continue
-
-            expected, _ = gen.render(cmd)
-            # Byte-exact compare against what sync would write (Phase 2
-            # ``atomic_write_bytes`` of ``content.encode("utf-8")`` verbatim)
-            # — a ``.strip()`` compare reported whitespace-padded runtime
-            # files "in sync" while sync would rewrite them (#1229), and a
-            # lenient text decode collapses distinct invalid byte sequences
-            # to the same U+FFFD. Bytes cannot raise UnicodeDecodeError. An
-            # unreadable runtime file can't assert parity — report drift,
-            # never mask it.
-            try:
-                actual_bytes = target.read_bytes() if target.is_file() else b""
-            except OSError:
-                results.append((gen_name, name, "out of sync"))
-                continue
-            status = "in sync" if expected.encode("utf-8") == actual_bytes else "out of sync"
-            results.append((gen_name, name, status))
-
-    return results
+    return diff_atomic_artifact(_COMMAND_ADAPTER, project_root, scope=scope)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

#900 unified only the **forward** sync into `_sync_atomic.py`. This PR is the same extraction for the remaining near-identical halves of `agents.py` and `commands.py` — the reverse (extract), diff, and canonical listing/resolve code the source itself annotated as "mirrors diff_agents" (2026-07-02 review, sync-engines dimension).

Closes #1515

## Changes

New `context/_atomic_reverse.py` (487 lines) carries the shared engine:

1. **Layout logic** — `canonical_artifact_name`, `resolve_artifact_under_root`, `list_canonical_artifacts`, `resolve_artifact_extract_target`, parametrized by `(artifact_label, dir_filename, logger)`. The per-module `_resolve_*_under_root` / `_resolve_*_extract_target` privates are deleted (zero external users, verified by grep); the public `resolve_canonical_*` / `list_canonical_*` / `canonical_*_name` keep their signatures and docstrings as thin delegations.
2. **`import_passthrough_runtime`** — the byte-passthrough reverse-import branch shared by the agents claude+gemini importers and the commands claude importer. The commands gemini TOML branch stays inline (different glob/loader/error-code/writer — the issue scopes only the Claude branch). The `seen`-dedupe contract is documented and preserved exactly: a name is marked seen on `CANONICAL_EXISTS`, on a Gate A block, and on successful import — **not** on invalid-name or unreadable skips. Divergent Gate A `audit_context` shapes (agents: `agent_name`, no `runtime` key; commands: `runtime` + `command_name`) are preserved via a per-caller builder callable.
3. **`diff_atomic_artifact`** — the canonical↔runtime diff, driven by the same `AtomicSyncAdapter` as the forward engine plus one new field `runtime_suffixes` (keyed by **runtime prefix** — `"claude"`, not `"claude_agents"` — `".md"` fallback). Key contract matches the originals: `gen_name` is iterated and labels result rows / keys `GENERATOR_VENDOR`; the runtime prefix feeds `runtime_fanout_root` / `runtime_artifact_listing` / suffix lookup.

`agents.py` 1192→943 lines, `commands.py` 951→746. Public API of both modules unchanged (`_parse_canonical_*_text`, `_AGENT_RUNTIME_SUFFIX`/`_COMMAND_RUNTIME_SUFFIX`, `_runtime_agent_names` stay put for their external users in migrate/transfer/web/wiki/tests).

## Byte-parity notes

- Result tuples, skip rows and reason codes, and `DiffRow` diagnostics are unchanged.
- Rendered log text is byte-identical; format strings are parametrized so `record.msg`/`record.args` differ from the per-module originals. Log calls go through each module's own logger, so `caplog` / log-filter targeting by `memtomem.context.agents` / `memtomem.context.commands` keeps working.
- `_runtime_targets.runtime_artifact_listing` structured logs are untouched.

## Process

- Design was Codex-gated before implementation (NEEDS-FIX round); its two majors — the diff `gen_name`/runtime key contract and the `seen` mutation contract — are folded into the implementation and pinned in docstrings. Module placement (new `_atomic_reverse.py` vs extending `_sync_atomic.py`) follows the same review.
- Implementation review: Codex **SHIP**, no findings (line-by-line parity of both deleted diff bodies and the three deleted passthrough branches).

## Verification

- `uv run pytest -m "not ollama"` — **7572 passed, 11 skipped, 0 failed**
- Targeted context/transfer/migrate/wiki/install subset — 2858 passed
- `ruff check` + `ruff format --check` — clean; `mypy` on touched files — clean (advisory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
