### PR TITLE
refactor(web): hoist per-kind route policy helpers into _artifact_common.py

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/_artifact_common.py
+++ b/packages/memtomem/src/memtomem/web/routes/_artifact_common.py
@@ -1,0 +1,173 @@
+"""Shared policy helpers for the per-kind context route files (#1514).
+
+Leaf module (like ``_errors`` / ``_locks`` / ``_confirm``): the per-kind route
+files — skills / commands / agents / mcp-servers — import from here, never the
+reverse. These helpers used to be copy-pasted per file ("mirrored here so each
+route file stays self-contained"), and that self-containment is exactly what
+let hardening fixes drift between siblings (#1514: the #1412 ``_safe_rel``
+fix, the #1229/#1233 lenient reads, and the mtime-conflict envelope each
+reached some copies and not others).
+
+The request models here are bases: each per-kind module subclasses them under
+its historical class name (``CommandCreateRequest``, ``SyncRequest``, …)
+because the class name is the OpenAPI component name — a plain alias would
+rename the published schema components. ``ImportRequest`` is the exception:
+the three per-kind copies were byte-identical, so FastAPI already collapsed
+them into one ``ImportRequest`` component; sharing the class keeps that name.
+"""
+
+from __future__ import annotations
+
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, field_validator
+
+from memtomem.config import TargetScope
+from memtomem.context._runtime_targets import KNOWN_RUNTIMES, runtime_fanout_root
+from memtomem.context._sync_atomic import ON_DROP_LEVELS
+from memtomem.context.scope_resolver import ArtifactKind
+from memtomem.web.routes._errors import _error
+
+# ── Mtime conflict envelope ──────────────────────────────────────────────
+
+MTIME_CONFLICT_REASON = "File was modified by another process. Reload and retry."
+
+
+def mtime_conflict_response(current_mtime_ns: int) -> JSONResponse:
+    return JSONResponse(
+        status_code=409,
+        content={
+            "status": "aborted",
+            "reason": MTIME_CONFLICT_REASON,
+            "mtime_ns": str(current_mtime_ns),
+            "error_kind": "conflict",
+            "reason_code": "stale_mtime",
+        },
+    )
+
+
+# ── Tier policy ──────────────────────────────────────────────────────────
+
+
+def reject_project_local_write(target_scope: TargetScope, action: str) -> None:
+    """Reject writes on the ``project_local`` tier with HTTP 400.
+
+    Reads honor every tier (the canonical content differs per scope).
+    Writes accept ``project_shared`` (ungated, today's default) and —
+    since #1263 — ``user``, whose host-path writes complete only through
+    the ``allow_host_writes`` disclose-then-confirm round-trip
+    (:func:`memtomem.web.routes._confirm.host_write_gate`).
+    ``project_local`` stays rejected: it is a gitignored draft tier with
+    no runtime fan-out (ADR-0011 §3), so sync would be a no-op and its
+    authoring policy is still deliberately deferred. Rejecting the
+    explicit param is preferred over silently overriding the client's
+    selection — silent override is exactly the cross-tier crossover
+    (ADR-0011) P1 flagged ("mutates a same-named project_shared artifact
+    while the UI is showing a user/local row").
+    """
+    if target_scope == "project_local":
+        raise _error(
+            400,
+            "validation",
+            (
+                f"{action} is supported on the project_shared and user tiers; "
+                f"project_local is a draft tier with no runtime fan-out "
+                f"(ADR-0011 §3)."
+            ),
+            reason_code="project_local_unsupported",
+        )
+
+
+# ── Scan-dir hints ───────────────────────────────────────────────────────
+
+
+def user_scan_dirs(kind: ArtifactKind) -> list[str]:
+    """User-tier runtime roots the import scan reads (absolute, expanded).
+
+    ``kind`` is the artifact-kind key ``runtime_fanout_root`` understands
+    (``"skills"`` / ``"commands"`` / ``"agents"``). The project-relative
+    scan-dir hints would lie on ``target_scope=user`` — the engine's
+    user-tier import reads ``~/.claude/skills`` etc. via
+    ``runtime_fanout_root``, not the project's runtime dirs.
+    """
+    dirs: list[str] = []
+    for runtime in KNOWN_RUNTIMES:
+        root = runtime_fanout_root(kind, runtime, "user", None)
+        if root is not None:
+            dirs.append(str(root))
+    return sorted(set(dirs))
+
+
+def scanned_dirs_for(
+    target_scope: TargetScope, *, kind: ArtifactKind, project_scan_dirs: list[str]
+) -> list[str]:
+    """Where the import read from, for the list / import response hint."""
+    return user_scan_dirs(kind) if target_scope == "user" else project_scan_dirs
+
+
+# ── Request models ───────────────────────────────────────────────────────
+
+
+class ArtifactCreateRequest(BaseModel):
+    name: str
+    content: str
+    # #1263 host-write opt-in: required true for target_scope=user (the
+    # canonical lands under ~/.memtomem/, outside any project root). The
+    # first POST without it returns the needs_confirmation envelope.
+    allow_host_writes: bool = False
+
+
+class ArtifactUpdateRequest(BaseModel):
+    content: str
+    # mtime_ns is transported as a string (JS bigint-unsafe); parsed to int in handler.
+    mtime_ns: str
+    # Bypass the mtime guard. The Web UI sets this only after the user
+    # explicitly chose "Force save" in the conflict resolution dialog
+    # (see issue #763); every force-save emits a WARNING with both mtime
+    # values for the audit trail.
+    force: bool = False
+    # #1263 host-write opt-in for target_scope=user (see ArtifactCreateRequest).
+    allow_host_writes: bool = False
+
+
+class ImportRequest(BaseModel):
+    overwrite: bool = False
+    # #1263 host-write opt-in for target_scope=user (the canonical
+    # destination is ~/.memtomem/<kind>/, outside any project root).
+    allow_host_writes: bool = False
+    # Gate A bypass valve — mirrors the CLI's --force-unsafe-import and the
+    # ``force_unsafe`` field the upload/memory/chunk web write surfaces already
+    # expose. Lets a reviewed false positive (e.g. ``api_key: str`` type
+    # annotations, ``secret_key=settings.x`` kwargs) proceed on the only
+    # bypassable web import tier: ``user``. ``project_local`` is rejected
+    # outright and ``project_shared`` hard-refuses regardless of this flag
+    # (ADR-0011 §5 — git history is forever), enforced in the import engine.
+    force_unsafe_import: bool = False
+
+
+class HostWriteSyncRequest(BaseModel):
+    # #1263 host-write opt-in for target_scope=user (see ArtifactCreateRequest).
+    allow_host_writes: bool = False
+    # Gate A bypass valve for fan-out — the sync-side mirror of
+    # ImportRequest.force_unsafe_import (#1379). Lets a reviewed false
+    # positive (e.g. an ``api_key: str`` type annotation in a doc) fan out
+    # to the only bypassable tier: ``user``. ``project_local`` is rejected
+    # outright and ``project_shared`` hard-refuses regardless of this flag
+    # (ADR-0011 §5 — the engine's Gate A is authoritative).
+    force_unsafe_sync: bool = False
+
+
+class AtomicSyncRequest(HostWriteSyncRequest):
+    on_drop: str = "warn"
+
+    # An out-of-vocabulary value used to slip through to the engine, where it
+    # silently behaved as "ignore" (#1247 id 47) — reject at the boundary
+    # instead (FastAPI renders the ValueError as a native 422). Validates
+    # against the engine's ON_DROP_LEVELS so the vocabulary has one owner
+    # (no Literal duplication; CLI click.Choice and MCP _validate_on_drop
+    # already gate the same way).
+    @field_validator("on_drop")
+    @classmethod
+    def _check_on_drop(cls, value: str) -> str:
+        if value not in ON_DROP_LEVELS:
+            raise ValueError(f"on_drop must be one of {ON_DROP_LEVELS}, got {value!r}")
+        return value

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -10,18 +10,15 @@ from pathlib import Path
 import click
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, field_validator
 
 from memtomem.config import TargetScope
 from memtomem.context import versioning
 from memtomem.context._atomic import atomic_write_text
 from memtomem.context._names import InvalidNameError, validate_name
-from memtomem.context._runtime_targets import KNOWN_RUNTIMES, runtime_fanout_root
 from memtomem.context.agents import (
     AGENT_DIR_FILENAME,
     AGENT_GENERATORS,
     CANONICAL_AGENT_ROOT,
-    ON_DROP_LEVELS,
     AgentParseError,
     ExtractResult,
     StrictDropError,
@@ -50,6 +47,15 @@ from memtomem.web.routes.context_projects import (
     resolve_writable_scope_root,
 )
 from memtomem.web.routes.context_versions import include_has, version_summary
+from memtomem.web.routes._artifact_common import (
+    ArtifactCreateRequest,
+    ArtifactUpdateRequest,
+    AtomicSyncRequest,
+    ImportRequest,
+    mtime_conflict_response,
+    reject_project_local_write,
+    scanned_dirs_for,
+)
 from memtomem.web.routes._confirm import host_write_gate
 from memtomem.web.routes._errors import PRIVACY_BLOCK_DETAIL, PRIVACY_BLOCK_IMPORT_DETAIL, _error
 from memtomem.web.routes._locks import _gateway_lock
@@ -82,45 +88,6 @@ def _resolve_existing_agent(
 ):
     name = validate_name(raw_name, kind="agent")
     return name, resolve_canonical_agent(project_root, name, scope=scope)
-
-
-def _reject_project_local_write(target_scope: TargetScope, action: str) -> None:
-    """Reject writes on the ``project_local`` tier with HTTP 400.
-
-    See context_skills.py:_reject_project_local_write for the rationale
-    (user accepted behind the #1263 host-write confirm; project_local
-    deferred per ADR-0011 §3). Mirrored here so each route file stays
-    self-contained.
-    """
-    if target_scope == "project_local":
-        raise _error(
-            400,
-            "validation",
-            (
-                f"{action} is supported on the project_shared and user tiers; "
-                f"project_local is a draft tier with no runtime fan-out "
-                f"(ADR-0011 §3)."
-            ),
-            reason_code="project_local_unsupported",
-        )
-
-
-def _user_scan_dirs() -> list[str]:
-    """User-tier runtime roots the import scan reads (absolute, expanded).
-
-    Mirrors context_skills._user_scan_dirs — the project-relative
-    ``_AGENT_SCAN_DIRS`` hint would lie on ``target_scope=user``.
-    """
-    dirs: list[str] = []
-    for runtime in KNOWN_RUNTIMES:
-        root = runtime_fanout_root("agents", runtime, "user", None)
-        if root is not None:
-            dirs.append(str(root))
-    return sorted(set(dirs))
-
-
-def _scanned_dirs_for(target_scope: TargetScope) -> list[str]:
-    return _user_scan_dirs() if target_scope == "user" else _AGENT_SCAN_DIRS
 
 
 def _user_sync_host_targets(project_root: Path) -> list[str]:
@@ -348,13 +315,8 @@ async def rendered_agent(
 # ── Create ───────────────────────────────────────────────────────────────
 
 
-class AgentCreateRequest(BaseModel):
-    name: str
-    content: str
-    # #1263 host-write opt-in: required true for target_scope=user (the
-    # canonical lands under ~/.memtomem/, outside any project root). The
-    # first POST without it returns the needs_confirmation envelope.
-    allow_host_writes: bool = False
+class AgentCreateRequest(ArtifactCreateRequest):
+    pass
 
 
 @router.post("/context/agents")
@@ -369,7 +331,7 @@ async def create_agent(
         ),
     ),
 ) -> dict:
-    _reject_project_local_write(target_scope, "Create agent")
+    reject_project_local_write(target_scope, "Create agent")
     name = validate_name(body.name, kind="agent")
 
     # Unlocked pre-checks so a duplicate is refused (409) rather than
@@ -453,33 +415,8 @@ async def create_agent(
 # ── Update ───────────────────────────────────────────────────────────────
 
 
-class AgentUpdateRequest(BaseModel):
-    content: str
-    # mtime_ns is transported as a string (JS bigint-unsafe); parsed to int in handler.
-    mtime_ns: str
-    # Bypass the mtime guard. The Web UI sets this only after the user
-    # explicitly chose "Force save" in the conflict resolution dialog
-    # (see issue #763); every force-save emits a WARNING with both mtime
-    # values for the audit trail.
-    force: bool = False
-    # #1263 host-write opt-in for target_scope=user (see AgentCreateRequest).
-    allow_host_writes: bool = False
-
-
-_MTIME_CONFLICT_REASON = "File was modified by another process. Reload and retry."
-
-
-def _mtime_conflict_response(current_mtime_ns: int) -> JSONResponse:
-    return JSONResponse(
-        status_code=409,
-        content={
-            "status": "aborted",
-            "reason": _MTIME_CONFLICT_REASON,
-            "mtime_ns": str(current_mtime_ns),
-            "error_kind": "conflict",
-            "reason_code": "stale_mtime",
-        },
-    )
+class AgentUpdateRequest(ArtifactUpdateRequest):
+    pass
 
 
 @router.put("/context/agents/{name}")
@@ -495,7 +432,7 @@ async def update_agent(
         ),
     ),
 ) -> JSONResponse:
-    _reject_project_local_write(target_scope, "Update agent")
+    reject_project_local_write(target_scope, "Update agent")
     name, resolved = _resolve_existing_agent(project_root, name, scope=target_scope)
     if resolved is None:
         raise _error(404, "missing", f"agent {name!r} not found")
@@ -510,7 +447,7 @@ async def update_agent(
     # refused, never confirmed (see context_skills.update_skill).
     pre_mtime_ns = agent_path.stat().st_mtime_ns
     if pre_mtime_ns != body_mtime_ns and not body.force:
-        return _mtime_conflict_response(pre_mtime_ns)
+        return mtime_conflict_response(pre_mtime_ns)
     gate = host_write_gate(
         target_scope,
         body.allow_host_writes,
@@ -526,7 +463,7 @@ async def update_agent(
                 current_mtime_ns = agent_path.stat().st_mtime_ns
                 if current_mtime_ns != body_mtime_ns:
                     if not body.force:
-                        return _mtime_conflict_response(current_mtime_ns)
+                        return mtime_conflict_response(current_mtime_ns)
                     logger.warning(
                         "force-save bypassed mtime check on %s "
                         "(client_mtime_ns=%s server_mtime_ns=%s)",
@@ -565,7 +502,7 @@ async def delete_agent(
         ),
     ),
 ) -> dict:
-    _reject_project_local_write(target_scope, "Delete agent")
+    reject_project_local_write(target_scope, "Delete agent")
     name, resolved = _resolve_existing_agent(project_root, name, scope=target_scope)
 
     # Pending deletions, computed unlocked (see delete_skill): cascade
@@ -719,28 +656,8 @@ async def diff_agent(
 # ── Sync ─────────────────────────────────────────────────────────────────
 
 
-class SyncRequest(BaseModel):
-    on_drop: str = "warn"
-    # #1263 host-write opt-in for target_scope=user (see AgentCreateRequest).
-    allow_host_writes: bool = False
-    # Gate A bypass valve for fan-out — the sync-side mirror of
-    # ImportRequest.force_unsafe_import (#1379). user-tier only;
-    # project_shared hard-refuses regardless (ADR-0011 §5). See
-    # context_skills.SyncRequest.
-    force_unsafe_sync: bool = False
-
-    # An out-of-vocabulary value used to slip through to the engine, where it
-    # silently behaved as "ignore" (#1247 id 47) — reject at the boundary
-    # instead (FastAPI renders the ValueError as a native 422). Validates
-    # against the engine's ON_DROP_LEVELS so the vocabulary has one owner
-    # (no Literal duplication; CLI click.Choice and MCP _validate_on_drop
-    # already gate the same way).
-    @field_validator("on_drop")
-    @classmethod
-    def _check_on_drop(cls, value: str) -> str:
-        if value not in ON_DROP_LEVELS:
-            raise ValueError(f"on_drop must be one of {ON_DROP_LEVELS}, got {value!r}")
-        return value
+class SyncRequest(AtomicSyncRequest):
+    pass
 
 
 async def _sync_agents_core(
@@ -834,7 +751,7 @@ async def sync_agents(
         ),
     ),
 ) -> dict:
-    _reject_project_local_write(target_scope, "Sync agents")
+    reject_project_local_write(target_scope, "Sync agents")
     on_drop = body.on_drop if body else "warn"
     gate = host_write_gate(
         target_scope,
@@ -856,20 +773,6 @@ async def sync_agents(
 
 
 # ── Import ───────────────────────────────────────────────────────────────
-
-
-class ImportRequest(BaseModel):
-    overwrite: bool = False
-    # #1263 host-write opt-in for target_scope=user (the canonical
-    # destination is ~/.memtomem/agents/, outside any project root).
-    allow_host_writes: bool = False
-    # Gate A bypass valve — mirrors the CLI's --force-unsafe-import and the
-    # ``force_unsafe`` field the upload/memory/chunk web write surfaces already
-    # expose. Lets a reviewed false positive proceed on the only bypassable web
-    # import tier: ``user``. ``project_local`` is rejected outright and
-    # ``project_shared`` hard-refuses regardless of this flag (ADR-0011 §5),
-    # enforced in the import engine. See context_skills.ImportRequest.
-    force_unsafe_import: bool = False
 
 
 def _import_payload(
@@ -896,7 +799,9 @@ def _import_payload(
             for name, reason, code in result.skipped
         ],
         "project_root": str(project_root),
-        "scanned_dirs": _scanned_dirs_for(target_scope),
+        "scanned_dirs": scanned_dirs_for(
+            target_scope, kind="agents", project_scan_dirs=_AGENT_SCAN_DIRS
+        ),
     }
     if dry_run is not None:
         payload["dry_run"] = dry_run
@@ -924,7 +829,7 @@ async def import_agents(
         ),
     ),
 ) -> dict:
-    _reject_project_local_write(target_scope, "Import agents")
+    reject_project_local_write(target_scope, "Import agents")
     overwrite = body.overwrite if body else False
     allow_host_writes = body.allow_host_writes if body else False
     force_unsafe_import = body.force_unsafe_import if body else False
@@ -985,7 +890,7 @@ async def import_agent(
     feedback for "you clicked a specific item that doesn't exist") — pinned
     on the gate's dry-run preview too.
     """
-    _reject_project_local_write(target_scope, "Import agent")
+    reject_project_local_write(target_scope, "Import agent")
     try:
         validate_name(name, kind="agent name")
     except InvalidNameError as exc:

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -10,19 +10,16 @@ from pathlib import Path
 import click
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, field_validator
 
 from memtomem.config import TargetScope
 from memtomem.context import versioning
 from memtomem.context._atomic import atomic_write_text
 from memtomem.context._names import InvalidNameError, validate_name
-from memtomem.context._runtime_targets import KNOWN_RUNTIMES, runtime_fanout_root
 from memtomem.context.commands import (
     _parse_canonical_command_text,
     CANONICAL_COMMAND_ROOT,
     COMMAND_DIR_FILENAME,
     COMMAND_GENERATORS,
-    ON_DROP_LEVELS,
     CommandParseError,
     ExtractResult,
     StrictDropError,
@@ -49,6 +46,15 @@ from memtomem.web.routes.context_projects import (
     resolve_writable_scope_root,
 )
 from memtomem.web.routes.context_versions import include_has, version_summary
+from memtomem.web.routes._artifact_common import (
+    ArtifactCreateRequest,
+    ArtifactUpdateRequest,
+    AtomicSyncRequest,
+    ImportRequest,
+    mtime_conflict_response,
+    reject_project_local_write,
+    scanned_dirs_for,
+)
 from memtomem.web.routes._confirm import host_write_gate
 from memtomem.web.routes._errors import PRIVACY_BLOCK_DETAIL, PRIVACY_BLOCK_IMPORT_DETAIL, _error
 from memtomem.web.routes._locks import _gateway_lock
@@ -78,45 +84,6 @@ def _resolve_existing_command(
 ):
     name = validate_name(raw_name, kind="command")
     return name, resolve_canonical_command(project_root, name, scope=scope)
-
-
-def _reject_project_local_write(target_scope: TargetScope, action: str) -> None:
-    """Reject writes on the ``project_local`` tier with HTTP 400.
-
-    See context_skills.py:_reject_project_local_write for the rationale
-    (user accepted behind the #1263 host-write confirm; project_local
-    deferred per ADR-0011 §3). Mirrored here so each route file stays
-    self-contained.
-    """
-    if target_scope == "project_local":
-        raise _error(
-            400,
-            "validation",
-            (
-                f"{action} is supported on the project_shared and user tiers; "
-                f"project_local is a draft tier with no runtime fan-out "
-                f"(ADR-0011 §3)."
-            ),
-            reason_code="project_local_unsupported",
-        )
-
-
-def _user_scan_dirs() -> list[str]:
-    """User-tier runtime roots the import scan reads (absolute, expanded).
-
-    Mirrors context_skills._user_scan_dirs — the project-relative
-    ``_COMMAND_SCAN_DIRS`` hint would lie on ``target_scope=user``.
-    """
-    dirs: list[str] = []
-    for runtime in KNOWN_RUNTIMES:
-        root = runtime_fanout_root("commands", runtime, "user", None)
-        if root is not None:
-            dirs.append(str(root))
-    return sorted(set(dirs))
-
-
-def _scanned_dirs_for(target_scope: TargetScope) -> list[str]:
-    return _user_scan_dirs() if target_scope == "user" else _COMMAND_SCAN_DIRS
 
 
 def _user_sync_host_targets(project_root: Path) -> list[str]:
@@ -340,13 +307,8 @@ async def rendered_command(
 # ── Create ───────────────────────────────────────────────────────────────
 
 
-class CommandCreateRequest(BaseModel):
-    name: str
-    content: str
-    # #1263 host-write opt-in: required true for target_scope=user (the
-    # canonical lands under ~/.memtomem/, outside any project root). The
-    # first POST without it returns the needs_confirmation envelope.
-    allow_host_writes: bool = False
+class CommandCreateRequest(ArtifactCreateRequest):
+    pass
 
 
 @router.post("/context/commands")
@@ -361,7 +323,7 @@ async def create_command(
         ),
     ),
 ) -> dict:
-    _reject_project_local_write(target_scope, "Create command")
+    reject_project_local_write(target_scope, "Create command")
     name = validate_name(body.name, kind="command")
 
     # Unlocked pre-checks so a duplicate is refused (409) rather than
@@ -445,33 +407,8 @@ async def create_command(
 # ── Update ───────────────────────────────────────────────────────────────
 
 
-class CommandUpdateRequest(BaseModel):
-    content: str
-    # mtime_ns is transported as a string (JS bigint-unsafe); parsed to int in handler.
-    mtime_ns: str
-    # Bypass the mtime guard. The Web UI sets this only after the user
-    # explicitly chose "Force save" in the conflict resolution dialog
-    # (see issue #763); every force-save emits a WARNING with both mtime
-    # values for the audit trail.
-    force: bool = False
-    # #1263 host-write opt-in for target_scope=user (see CommandCreateRequest).
-    allow_host_writes: bool = False
-
-
-_MTIME_CONFLICT_REASON = "File was modified by another process. Reload and retry."
-
-
-def _mtime_conflict_response(current_mtime_ns: int) -> JSONResponse:
-    return JSONResponse(
-        status_code=409,
-        content={
-            "status": "aborted",
-            "reason": _MTIME_CONFLICT_REASON,
-            "mtime_ns": str(current_mtime_ns),
-            "error_kind": "conflict",
-            "reason_code": "stale_mtime",
-        },
-    )
+class CommandUpdateRequest(ArtifactUpdateRequest):
+    pass
 
 
 @router.put("/context/commands/{name}")
@@ -487,7 +424,7 @@ async def update_command(
         ),
     ),
 ) -> JSONResponse:
-    _reject_project_local_write(target_scope, "Update command")
+    reject_project_local_write(target_scope, "Update command")
     name, resolved = _resolve_existing_command(project_root, name, scope=target_scope)
     if resolved is None:
         raise _error(404, "missing", f"command {name!r} not found")
@@ -502,7 +439,7 @@ async def update_command(
     # refused, never confirmed (see context_skills.update_skill).
     pre_mtime_ns = cmd_path.stat().st_mtime_ns
     if pre_mtime_ns != body_mtime_ns and not body.force:
-        return _mtime_conflict_response(pre_mtime_ns)
+        return mtime_conflict_response(pre_mtime_ns)
     gate = host_write_gate(
         target_scope,
         body.allow_host_writes,
@@ -518,7 +455,7 @@ async def update_command(
                 current_mtime_ns = cmd_path.stat().st_mtime_ns
                 if current_mtime_ns != body_mtime_ns:
                     if not body.force:
-                        return _mtime_conflict_response(current_mtime_ns)
+                        return mtime_conflict_response(current_mtime_ns)
                     logger.warning(
                         "force-save bypassed mtime check on %s "
                         "(client_mtime_ns=%s server_mtime_ns=%s)",
@@ -557,7 +494,7 @@ async def delete_command(
         ),
     ),
 ) -> dict:
-    _reject_project_local_write(target_scope, "Delete command")
+    reject_project_local_write(target_scope, "Delete command")
     name, resolved = _resolve_existing_command(project_root, name, scope=target_scope)
 
     # Pending deletions, computed unlocked (see delete_skill): cascade
@@ -713,28 +650,8 @@ async def diff_command(
 # ── Sync ─────────────────────────────────────────────────────────────────
 
 
-class SyncRequest(BaseModel):
-    on_drop: str = "warn"
-    # #1263 host-write opt-in for target_scope=user (see CommandCreateRequest).
-    allow_host_writes: bool = False
-    # Gate A bypass valve for fan-out — the sync-side mirror of
-    # ImportRequest.force_unsafe_import (#1379). user-tier only;
-    # project_shared hard-refuses regardless (ADR-0011 §5). See
-    # context_skills.SyncRequest.
-    force_unsafe_sync: bool = False
-
-    # An out-of-vocabulary value used to slip through to the engine, where it
-    # silently behaved as "ignore" (#1247 id 47) — reject at the boundary
-    # instead (FastAPI renders the ValueError as a native 422). Validates
-    # against the engine's ON_DROP_LEVELS so the vocabulary has one owner
-    # (no Literal duplication; CLI click.Choice and MCP _validate_on_drop
-    # already gate the same way).
-    @field_validator("on_drop")
-    @classmethod
-    def _check_on_drop(cls, value: str) -> str:
-        if value not in ON_DROP_LEVELS:
-            raise ValueError(f"on_drop must be one of {ON_DROP_LEVELS}, got {value!r}")
-        return value
+class SyncRequest(AtomicSyncRequest):
+    pass
 
 
 async def _sync_commands_core(
@@ -823,7 +740,7 @@ async def sync_commands(
         ),
     ),
 ) -> dict:
-    _reject_project_local_write(target_scope, "Sync commands")
+    reject_project_local_write(target_scope, "Sync commands")
     on_drop = body.on_drop if body else "warn"
     gate = host_write_gate(
         target_scope,
@@ -845,20 +762,6 @@ async def sync_commands(
 
 
 # ── Import ───────────────────────────────────────────────────────────────
-
-
-class ImportRequest(BaseModel):
-    overwrite: bool = False
-    # #1263 host-write opt-in for target_scope=user (the canonical
-    # destination is ~/.memtomem/commands/, outside any project root).
-    allow_host_writes: bool = False
-    # Gate A bypass valve — mirrors the CLI's --force-unsafe-import and the
-    # ``force_unsafe`` field the upload/memory/chunk web write surfaces already
-    # expose. Lets a reviewed false positive proceed on the only bypassable web
-    # import tier: ``user``. ``project_local`` is rejected outright and
-    # ``project_shared`` hard-refuses regardless of this flag (ADR-0011 §5),
-    # enforced in the import engine. See context_skills.ImportRequest.
-    force_unsafe_import: bool = False
 
 
 def _import_payload(
@@ -885,7 +788,9 @@ def _import_payload(
             for name, reason, code in result.skipped
         ],
         "project_root": str(project_root),
-        "scanned_dirs": _scanned_dirs_for(target_scope),
+        "scanned_dirs": scanned_dirs_for(
+            target_scope, kind="commands", project_scan_dirs=_COMMAND_SCAN_DIRS
+        ),
     }
     if dry_run is not None:
         payload["dry_run"] = dry_run
@@ -913,7 +818,7 @@ async def import_commands(
         ),
     ),
 ) -> dict:
-    _reject_project_local_write(target_scope, "Import commands")
+    reject_project_local_write(target_scope, "Import commands")
     overwrite = body.overwrite if body else False
     allow_host_writes = body.allow_host_writes if body else False
     force_unsafe_import = body.force_unsafe_import if body else False
@@ -974,7 +879,7 @@ async def import_command(
     feedback for "you clicked a specific item that doesn't exist") — pinned
     on the gate's dry-run preview too.
     """
-    _reject_project_local_write(target_scope, "Import command")
+    reject_project_local_write(target_scope, "Import command")
     try:
         validate_name(name, kind="command name")
     except InvalidNameError as exc:

--- a/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
@@ -27,6 +27,7 @@ from memtomem.context.mcp_servers import (
     parse_mcp_server_text,
     scan_mcp_server_text,
 )
+from memtomem.web.routes._artifact_common import mtime_conflict_response
 from memtomem.web.routes._errors import _error
 from memtomem.web.routes._locks import _gateway_lock
 from memtomem.web.routes._sync_phase import SyncPhaseError
@@ -248,18 +249,7 @@ async def _update_mcp_server_impl(
                 current_mtime_ns = path.stat().st_mtime_ns
                 if current_mtime_ns != body_mtime_ns:
                     if not body.force:
-                        return JSONResponse(
-                            status_code=409,
-                            content={
-                                "status": "aborted",
-                                "reason": (
-                                    "File was modified by another process. Reload and retry."
-                                ),
-                                "mtime_ns": str(current_mtime_ns),
-                                "error_kind": "conflict",
-                                "reason_code": "stale_mtime",
-                            },
-                        )
+                        return mtime_conflict_response(current_mtime_ns)
                     logger.warning(
                         "force-save bypassed mtime check on %s "
                         "(client_mtime_ns=%s server_mtime_ns=%s)",

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -11,11 +11,9 @@ from pathlib import Path
 import click
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
 
 from memtomem.context._atomic import atomic_write_text
 from memtomem.context._names import InvalidNameError, validate_name
-from memtomem.context._runtime_targets import KNOWN_RUNTIMES, runtime_fanout_root
 from memtomem.context.detector import SKILL_DIRS
 from memtomem.context.privacy_scan import PrivacyScanError
 from memtomem.context.skills import (
@@ -30,6 +28,15 @@ from memtomem.context.skills import (
     list_canonical_skills,
 )
 from memtomem.config import TargetScope
+from memtomem.web.routes._artifact_common import (
+    ArtifactCreateRequest,
+    ArtifactUpdateRequest,
+    HostWriteSyncRequest,
+    ImportRequest,
+    mtime_conflict_response,
+    reject_project_local_write,
+    scanned_dirs_for,
+)
 from memtomem.web.routes._confirm import host_write_gate
 from memtomem.web.routes._errors import PRIVACY_BLOCK_DETAIL, PRIVACY_BLOCK_IMPORT_DETAIL, _error
 from memtomem.web.routes._locks import _gateway_lock
@@ -69,55 +76,6 @@ def _canonical_skill_dir(
     """
     name = validate_name(raw_name, kind="skill")
     return canonical_skills_root(project_root, scope=scope) / name
-
-
-def _reject_project_local_write(target_scope: TargetScope, action: str) -> None:
-    """Reject writes on the ``project_local`` tier with HTTP 400.
-
-    Reads honor every tier (the canonical content differs per scope).
-    Writes accept ``project_shared`` (ungated, today's default) and —
-    since #1263 — ``user``, whose host-path writes complete only through
-    the ``allow_host_writes`` disclose-then-confirm round-trip
-    (:func:`memtomem.web.routes._confirm.host_write_gate`).
-    ``project_local`` stays rejected: it is a gitignored draft tier with
-    no runtime fan-out (ADR-0011 §3), so sync would be a no-op and its
-    authoring policy is still deliberately deferred. Rejecting the
-    explicit param is preferred over silently overriding the client's
-    selection — silent override is exactly the cross-tier crossover
-    (ADR-0011) P1 flagged ("mutates a same-named project_shared artifact
-    while the UI is showing a user/local row").
-    """
-    if target_scope == "project_local":
-        raise _error(
-            400,
-            "validation",
-            (
-                f"{action} is supported on the project_shared and user tiers; "
-                f"project_local is a draft tier with no runtime fan-out "
-                f"(ADR-0011 §3)."
-            ),
-            reason_code="project_local_unsupported",
-        )
-
-
-def _user_scan_dirs() -> list[str]:
-    """User-tier runtime roots the import scan reads (absolute, expanded).
-
-    The project-relative ``_SKILL_SCAN_DIRS`` hint would lie on
-    ``target_scope=user`` — the engine's user-tier import reads
-    ``~/.claude/skills`` etc. via ``runtime_fanout_root``, not the
-    project's runtime dirs.
-    """
-    dirs: list[str] = []
-    for runtime in KNOWN_RUNTIMES:
-        root = runtime_fanout_root("skills", runtime, "user", None)
-        if root is not None:
-            dirs.append(str(root))
-    return sorted(set(dirs))
-
-
-def _scanned_dirs_for(target_scope: TargetScope) -> list[str]:
-    return _user_scan_dirs() if target_scope == "user" else _SKILL_SCAN_DIRS
 
 
 def _user_sync_host_targets(project_root: Path) -> list[str]:
@@ -305,13 +263,8 @@ async def read_skill(
 # ── Create ───────────────────────────────────────────────────────────────
 
 
-class SkillCreateRequest(BaseModel):
-    name: str
-    content: str
-    # #1263 host-write opt-in: required true for target_scope=user (the
-    # canonical lands under ~/.memtomem/, outside any project root). The
-    # first POST without it returns the needs_confirmation envelope.
-    allow_host_writes: bool = False
+class SkillCreateRequest(ArtifactCreateRequest):
+    pass
 
 
 @router.post("/context/skills")
@@ -327,7 +280,7 @@ async def create_skill(
     ),
 ) -> dict:
     """Create a new canonical skill."""
-    _reject_project_local_write(target_scope, "Create skill")
+    reject_project_local_write(target_scope, "Create skill")
     skill_dir = _canonical_skill_dir(project_root, body.name, scope=target_scope)
 
     # Unlocked pre-checks so a request that cannot succeed is refused
@@ -392,33 +345,8 @@ async def create_skill(
 # ── Update ───────────────────────────────────────────────────────────────
 
 
-class SkillUpdateRequest(BaseModel):
-    content: str
-    # mtime_ns is transported as a string (JS bigint-unsafe); parsed to int in handler.
-    mtime_ns: str
-    # Bypass the mtime guard. The Web UI sets this only after the user
-    # explicitly chose "Force save" in the conflict resolution dialog
-    # (see issue #763); every force-save emits a WARNING with both mtime
-    # values for the audit trail.
-    force: bool = False
-    # #1263 host-write opt-in for target_scope=user (see SkillCreateRequest).
-    allow_host_writes: bool = False
-
-
-_MTIME_CONFLICT_REASON = "File was modified by another process. Reload and retry."
-
-
-def _mtime_conflict_response(current_mtime_ns: int) -> JSONResponse:
-    return JSONResponse(
-        status_code=409,
-        content={
-            "status": "aborted",
-            "reason": _MTIME_CONFLICT_REASON,
-            "mtime_ns": str(current_mtime_ns),
-            "error_kind": "conflict",
-            "reason_code": "stale_mtime",
-        },
-    )
+class SkillUpdateRequest(ArtifactUpdateRequest):
+    pass
 
 
 @router.put("/context/skills/{name}")
@@ -435,7 +363,7 @@ async def update_skill(
     ),
 ) -> JSONResponse:
     """Update a canonical skill's SKILL.md (mtime-guarded, atomic, locked)."""
-    _reject_project_local_write(target_scope, "Update skill")
+    reject_project_local_write(target_scope, "Update skill")
     skill_dir = _canonical_skill_dir(project_root, name, scope=target_scope)
     manifest = skill_dir / SKILL_MANIFEST
     if not manifest.is_file():
@@ -453,7 +381,7 @@ async def update_skill(
     # path keeps emitting its audit WARNING exactly once.
     pre_mtime_ns = manifest.stat().st_mtime_ns
     if pre_mtime_ns != body_mtime_ns and not body.force:
-        return _mtime_conflict_response(pre_mtime_ns)
+        return mtime_conflict_response(pre_mtime_ns)
     gate = host_write_gate(
         target_scope,
         body.allow_host_writes,
@@ -469,7 +397,7 @@ async def update_skill(
                 current_mtime_ns = manifest.stat().st_mtime_ns
                 if current_mtime_ns != body_mtime_ns:
                     if not body.force:
-                        return _mtime_conflict_response(current_mtime_ns)
+                        return mtime_conflict_response(current_mtime_ns)
                     logger.warning(
                         "force-save bypassed mtime check on %s "
                         "(client_mtime_ns=%s server_mtime_ns=%s)",
@@ -512,7 +440,7 @@ async def delete_skill(
 
     Idempotent: missing canonical directory returns ``deleted: []``.
     """
-    _reject_project_local_write(target_scope, "Delete skill")
+    reject_project_local_write(target_scope, "Delete skill")
     skill_dir = _canonical_skill_dir(project_root, name, scope=target_scope)
 
     # Pending deletions, computed unlocked: the canonical dir plus — on
@@ -643,20 +571,13 @@ async def diff_skill(
 # ── Sync (fan-out) ──────────────────────────────────────────────────────
 
 
-class SyncRequest(BaseModel):
+# No ``on_drop`` (plain HostWriteSyncRequest, not AtomicSyncRequest): skills
+# fan out byte-exact, so there are no droppable fields.
+class SyncRequest(HostWriteSyncRequest):
     """Optional body for the sync routes (#1263).
 
     Absent body keeps the historical no-body POST working.
     """
-
-    allow_host_writes: bool = False
-    # Gate A bypass valve for fan-out — the sync-side mirror of
-    # ImportRequest.force_unsafe_import (#1379). Lets a reviewed false
-    # positive (e.g. an ``api_key: str`` type annotation in a skill doc)
-    # fan out to the only bypassable tier: ``user``. ``project_local`` is
-    # rejected outright and ``project_shared`` hard-refuses regardless of
-    # this flag (ADR-0011 §5 — the engine's Gate A is authoritative).
-    force_unsafe_sync: bool = False
 
 
 async def _sync_skills_core(
@@ -728,7 +649,7 @@ async def sync_skills(
     ),
 ) -> dict:
     """Fan out canonical skills to all runtimes."""
-    _reject_project_local_write(target_scope, "Sync skills")
+    reject_project_local_write(target_scope, "Sync skills")
     gate = host_write_gate(
         target_scope,
         body.allow_host_writes if body else False,
@@ -749,21 +670,6 @@ async def sync_skills(
 
 
 # ── Import (reverse sync) ───────────────────────────────────────────────
-
-
-class ImportRequest(BaseModel):
-    overwrite: bool = False
-    # #1263 host-write opt-in for target_scope=user (the canonical
-    # destination is ~/.memtomem/skills/, outside any project root).
-    allow_host_writes: bool = False
-    # Gate A bypass valve — mirrors the CLI's --force-unsafe-import and the
-    # ``force_unsafe`` field the upload/memory/chunk web write surfaces already
-    # expose. Lets a reviewed false positive (e.g. ``api_key: str`` type
-    # annotations, ``secret_key=settings.x`` kwargs) proceed on the only
-    # bypassable web import tier: ``user``. ``project_local`` is rejected
-    # outright and ``project_shared`` hard-refuses regardless of this flag
-    # (ADR-0011 §5 — git history is forever), enforced in the import engine.
-    force_unsafe_import: bool = False
 
 
 def _import_payload(
@@ -795,8 +701,10 @@ def _import_payload(
             for name, reason, code in result.skipped
         ],
         "project_root": str(project_root),
-        "scanned_dirs": _scanned_dirs_for(
-            source_scope if source_scope is not None else target_scope
+        "scanned_dirs": scanned_dirs_for(
+            source_scope if source_scope is not None else target_scope,
+            kind="skills",
+            project_scan_dirs=_SKILL_SCAN_DIRS,
         ),
     }
     if dry_run is not None:
@@ -826,7 +734,7 @@ async def import_skills(
     ),
 ) -> dict:
     """Import runtime skills into the scoped canonical directory."""
-    _reject_project_local_write(target_scope, "Import skills")
+    reject_project_local_write(target_scope, "Import skills")
     overwrite = body.overwrite if body else False
     allow_host_writes = body.allow_host_writes if body else False
     force_unsafe_import = body.force_unsafe_import if body else False
@@ -902,7 +810,7 @@ async def import_skill(
     — pinned on the gate's dry-run preview too, so a misnamed user-tier
     import 404s instead of asking for confirmation.
     """
-    _reject_project_local_write(target_scope, "Import skill")
+    reject_project_local_write(target_scope, "Import skill")
     try:
         validate_name(name, kind="skill name")
     except InvalidNameError as exc:


### PR DESCRIPTION
## Summary

Part 1 of #1514 (the mechanical hoist). The four per-kind context route files carried "mirrored here so each route file stays self-contained" copies of the same policy surface — and per #1514's drift catalogue, that self-containment is exactly what let hardening fixes land in one copy and not its siblings.

This PR hoists the verbatim copies into a new leaf module `web/routes/_artifact_common.py` (the `_errors.py` / `_locks.py` / `_confirm.py` precedent):

- **mtime-conflict 409 envelope** — 3 module copies plus the hand-inlined 4th in `_update_mcp_server_impl` → 1
- **`project_local` write rejection** — 3 copies → 1; the full ADR-0011 §3 rationale docstring now lives once instead of "see context_skills.py"
- **user-tier scan-dir hints** (`user_scan_dirs` / `scanned_dirs_for`) — 3 copies → 1, typed by `ArtifactKind`
- **request-model bases** (`ArtifactCreateRequest` / `ArtifactUpdateRequest` / `ImportRequest` / `HostWriteSyncRequest` / `AtomicSyncRequest`) — per-kind modules subclass them under their historical class names because the class name is the OpenAPI component name; `ImportRequest` is shared directly since FastAPI had already collapsed the three byte-identical copies into one component

No behavior change intended. The structural collapse of the commands/agents route pair (the ~91-95% identical file pair) follows in a separate PR.

## Parity gates

- Full `pytest -m "not ollama"`: **7573 passed, 11 skipped**
- `app.openapi()` diff vs `main` (sorted keys): **empty** — routes, component names, descriptions all byte-identical
- `ruff check` + `ruff format --check`: clean
- `mypy`: at the pre-existing baseline (41 errors in 6 files, none in touched files)

## Review

Codex design gate (NEEDS-FIX → remedies folded into the PR-2 plan) + diff review: **SHIP**, zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
