### PR TITLE
refactor(web): collapse the commands/agents route bodies into _atomic_kind.py

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/_atomic_kind.py
+++ b/packages/memtomem/src/memtomem/web/routes/_atomic_kind.py
@@ -1,0 +1,891 @@
+"""Shared handler bodies for the atomic-kind route pair (#1514).
+
+``context_commands.py`` and ``context_agents.py`` were ~91-95%
+line-identical after normalizing the kind token — contractual mirrors
+("Mirrored in context_agents.py") whose hand-maintained copies are where
+every hardening fix drifted (#1514). This module owns the handler BODIES
+once, parametrized by :class:`AtomicKindSpec`; the kind modules keep the
+thin ``@router``-decorated functions (decorator + signature + docstring +
+one delegation line). That split is deliberate:
+
+- The AST invariant registry (``test_web_invariants_registry.py``) walks
+  non-underscore route modules for ``@router.{post,put,patch,delete}``
+  decorators — the decorated per-kind functions keep the CSRF/redaction
+  classification surface exactly as before.
+- FastAPI endpoint names / OpenAPI operationIds derive from the decorated
+  function names — unchanged.
+- Tests monkeypatch engine functions on the kind modules
+  (``monkeypatch.setattr(context_agents, "generate_all_agents", ...)``),
+  so every callable on the spec MUST late-bind the kind module's globals
+  (``lambda *a, **kw: generate_all_agents(*a, **kw)``), never capture the
+  function object at import time.
+
+Skills and mcp-servers do not fold in here: skills diverge by design
+(dir-based canonical, no versioning layer, byte-exact diff, thread
+offload for cross-process sidecar locks, the decoupled ``import-to-user``
+route), mcp-servers are project_shared-only (ADR-0011 §1). They share the
+leaf helpers in ``_artifact_common`` instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import click
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+
+from memtomem.config import TargetScope
+from memtomem.context import versioning
+from memtomem.context._atomic import atomic_write_text
+from memtomem.context._names import InvalidNameError, validate_name
+from memtomem.context.privacy_scan import PrivacyScanError
+from memtomem.context.scope_resolver import ArtifactKind, canonical_artifact_dir
+from memtomem.web.routes._artifact_common import (
+    ArtifactCreateRequest,
+    ArtifactUpdateRequest,
+    AtomicSyncRequest,
+    ImportRequest,
+    mtime_conflict_response,
+    reject_project_local_write,
+    scanned_dirs_for,
+)
+from memtomem.web.routes._confirm import host_write_gate
+from memtomem.web.routes._errors import PRIVACY_BLOCK_DETAIL, PRIVACY_BLOCK_IMPORT_DETAIL, _error
+from memtomem.web.routes._locks import _gateway_lock
+from memtomem.web.routes._sync_phase import SyncPhaseError
+from memtomem.web.routes.context_gateway import (
+    _safe_rel,
+    delete_skip_entry,
+    expected_vs_runtime_row,
+    read_text_lenient,
+    sanitize_diff_reason,
+)
+from memtomem.web.routes.context_versions import include_has, version_summary
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AtomicKindSpec:
+    """Everything kind-specific the shared handler bodies need.
+
+    Every ``Callable`` field must be a late-binding lambda defined in the
+    kind module (see the module docstring) so ``monkeypatch.setattr`` on
+    that module keeps intercepting engine calls. Adding a capability flag
+    beyond ``rendered_includes_fields`` is the signal to split the
+    diverging route back out into its kind module instead.
+    """
+
+    kind: str  # singular, lowercase — messages and validate_name ("command")
+    kind_plural: ArtifactKind  # response collection key + scope-resolver kind
+    canonical_root: str
+    dir_filename: str  # working-file name inside a versioned artifact dir
+    scan_dirs: list[str]  # project-relative runtime scan hints (detector)
+    optional_fields: tuple[str, ...]  # droppable frontmatter keys (rendered)
+    rendered_includes_fields: bool  # agents' rendered response carries "fields"
+    parse_error: type[Exception]
+    strict_drop_error: type[Exception]
+    sync_surface: str
+    import_surface: str
+    generators: Callable[[], Mapping[str, Any]]
+    list_canonicals: Callable[..., Any]
+    resolve_canonical: Callable[..., Any]
+    diff: Callable[..., Any]
+    parse_canonical: Callable[..., Any]
+    parse_text: Callable[..., Any]
+    canonical_name: Callable[..., str]
+    generate_all: Callable[..., Any]
+    extract_to_canonical: Callable[..., Any]
+    fields_from_parsed: Callable[[Any], dict]
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _artifacts_root(
+    spec: AtomicKindSpec, project_root: Path, *, scope: TargetScope = "project_shared"
+) -> Path:
+    return canonical_artifact_dir(spec.kind_plural, scope, project_root)
+
+
+def _resolve_existing(
+    spec: AtomicKindSpec,
+    project_root: Path,
+    raw_name: str,
+    *,
+    scope: TargetScope = "project_shared",
+):
+    name = validate_name(raw_name, kind=spec.kind)
+    return name, spec.resolve_canonical(project_root, name, scope=scope)
+
+
+def user_sync_host_targets(spec: AtomicKindSpec, project_root: Path) -> list[str]:
+    """Pending user-tier fan-out destinations for the sync confirm gate.
+
+    Upper bound on the confirmed sync's writes, resolved from the PARSED
+    frontmatter name: ``sync_atomic_artifact`` fans out under
+    ``adapter.name_of(parse(...))``, not the canonical filename, so a
+    filename-derived disclosure could confirm one path while the engine
+    writes another (#1263 review Blocker). Canonicals the engine would
+    skip at read/parse time are excluded the same way; later preflight
+    skips (Gate A, override errors, conflicts, lock timeouts) only
+    shrink the actual write set below this disclosure.
+    """
+    targets: set[str] = set()
+    for path, layout in spec.list_canonicals(project_root, scope="user"):
+        try:
+            text = path.read_bytes().decode("utf-8", errors="replace")
+            parsed = spec.parse_text(text, source=path, layout=layout)
+        except (OSError, spec.parse_error):
+            continue  # the engine skips these too
+        for gen in spec.generators().values():
+            dst = gen.target_file(project_root, parsed.name, scope="user")
+            if dst is not None:
+                targets.add(str(dst))
+    return sorted(targets)
+
+
+def _import_payload(
+    spec: AtomicKindSpec,
+    result: Any,
+    project_root: Path,
+    target_scope: TargetScope,
+    dry_run: bool | None,
+) -> dict:
+    """Wire shape shared by both import routes (and the gate's nested plan).
+
+    ``dry_run=None`` omits the key, ``_safe_rel`` keeps user-tier
+    ``~/.memtomem`` paths encodable.
+    """
+    payload: dict = {
+        "imported": [
+            {
+                "name": spec.canonical_name(p, layout),
+                "canonical_path": _safe_rel(p, project_root),
+            }
+            for p, layout in result.imported
+        ],
+        "skipped": [
+            {"name": name, "reason": reason, "reason_code": code}
+            for name, reason, code in result.skipped
+        ],
+        "project_root": str(project_root),
+        "scanned_dirs": scanned_dirs_for(
+            target_scope, kind=spec.kind_plural, project_scan_dirs=spec.scan_dirs
+        ),
+    }
+    if dry_run is not None:
+        payload["dry_run"] = dry_run
+    return payload
+
+
+# ── List ─────────────────────────────────────────────────────────────────
+
+
+async def list_artifacts(
+    spec: AtomicKindSpec,
+    project_root: Path,
+    target_scope: TargetScope,
+    include: str | None,
+) -> dict:
+    want_versions = include_has(include, "versions")
+    canonicals = spec.list_canonicals(project_root, scope=target_scope)
+    diffs = spec.diff(project_root, scope=target_scope)
+
+    by_name: dict[str, list[dict]] = {}
+    for row in diffs:
+        entry: dict[str, object] = {"runtime": row[0], "status": row[2]}
+        reason = sanitize_diff_reason(getattr(row, "reason", None), project_root)
+        if reason:
+            entry["reason"] = reason
+        by_name.setdefault(row[1], []).append(entry)
+
+    items: list[dict[str, object]] = []
+    canonical_names: set[str] = set()
+    for path, layout in canonicals:
+        name = spec.canonical_name(path, layout)
+        canonical_names.add(name)
+        item: dict[str, object] = {
+            "name": name,
+            "canonical_path": _safe_rel(path, project_root),
+            "target_scope": target_scope,
+            "runtimes": by_name.get(name, []),
+        }
+        if want_versions:
+            item["versions"] = version_summary(path, layout)
+        items.append(item)
+
+    for item_name, runtimes in by_name.items():
+        if item_name not in canonical_names:
+            item = {
+                "name": item_name,
+                "canonical_path": None,
+                "target_scope": target_scope,
+                "runtimes": runtimes,
+            }
+            if want_versions:
+                # Runtime-only: no canonical file → nothing to version and no
+                # store to migrate. Keep the four-key shape for the JS reader.
+                item["versions"] = {
+                    "labels": {},
+                    "count": 0,
+                    "versionable": False,
+                    "migrate_required": False,
+                }
+            items.append(item)
+
+    return {
+        spec.kind_plural: items,
+        "canonical_root": spec.canonical_root,
+        "scanned_dirs": spec.scan_dirs,
+    }
+
+
+# ── Read ─────────────────────────────────────────────────────────────────
+
+
+async def read_artifact(
+    spec: AtomicKindSpec,
+    name: str,
+    project_root: Path,
+    target_scope: TargetScope,
+) -> dict:
+    name, resolved = _resolve_existing(spec, project_root, name, scope=target_scope)
+    if resolved is None:
+        raise _error(404, "missing", f"{spec.kind} {name!r} not found")
+    path, layout = resolved
+
+    content = path.read_text(encoding="utf-8")
+    # mtime_ns is serialized as a string because JavaScript Number cannot
+    # safely represent integers > 2^53; nanosecond epochs exceed that.
+    mtime_ns = path.stat().st_mtime_ns
+
+    fields: dict = {}
+    try:
+        parsed = spec.parse_canonical(path, layout=layout)
+        fields = spec.fields_from_parsed(parsed)
+    except spec.parse_error:
+        pass
+
+    # Issue #962 detail meta header — echo back ``target_scope`` and
+    # the resolved ``layout`` so the JS meta-header renderer stays
+    # type-agnostic across the three artifact types.
+    return {
+        "name": name,
+        "content": content,
+        "mtime_ns": str(mtime_ns),
+        "fields": fields,
+        "target_scope": target_scope,
+        "layout": layout,
+    }
+
+
+# ── Rendered (per-runtime output with dropped fields + field map) ────────
+
+
+async def rendered_artifact(
+    spec: AtomicKindSpec,
+    name: str,
+    project_root: Path,
+    target_scope: TargetScope,
+) -> JSONResponse:
+    name, resolved = _resolve_existing(spec, project_root, name, scope=target_scope)
+    if resolved is None:
+        raise _error(404, "missing", f"{spec.kind} {name!r} not found")
+    path, layout = resolved
+
+    content = path.read_text(encoding="utf-8")
+    try:
+        parsed = spec.parse_canonical(path, layout=layout)
+    except spec.parse_error as exc:
+        # ``str(exc)`` embeds the absolute canonical source path (the parser
+        # raises ``... (source: {path})`` / ``missing YAML frontmatter:
+        # {path}``); route it through the shared display-sanitize boundary so
+        # the loopback 422 detail stays path-free — the #1412 fix class the
+        # mcp-servers parse-422 already applies.
+        detail = sanitize_diff_reason(str(exc), project_root) or ""
+        return JSONResponse(
+            status_code=422,
+            content={"detail": {"error_kind": "parse", "message": f"Parse error: {detail}"}},
+        )
+
+    diffs = spec.diff(project_root, scope=target_scope)
+    status_map: dict[tuple[str, str], str] = {(rt, n): s for rt, n, s in diffs}
+
+    # ``field_map[field][runtime] = bool`` — True when the runtime keeps the
+    # field, False when it drops it, so the front-end renders one matrix for
+    # either surface.
+    runtimes = []
+    field_map: dict[str, dict[str, bool]] = {f: {} for f in spec.optional_fields}
+
+    for gen_name, gen in spec.generators().items():
+        rendered_content, dropped_fields = gen.render(parsed)
+        status = status_map.get((gen_name, name), "unknown")
+        runtimes.append(
+            {
+                "runtime": gen_name,
+                "content": rendered_content,
+                "dropped_fields": dropped_fields,
+                "status": status,
+            }
+        )
+        dropped_set = set(dropped_fields)
+        for f in spec.optional_fields:
+            field_map[f][gen_name] = f not in dropped_set
+
+    payload: dict[str, object] = {"name": name, "canonical_content": content}
+    if spec.rendered_includes_fields:
+        payload["fields"] = spec.fields_from_parsed(parsed)
+    payload["runtimes"] = runtimes
+    payload["field_map"] = field_map
+    return JSONResponse(content=payload)
+
+
+# ── Create ───────────────────────────────────────────────────────────────
+
+
+async def create_artifact(
+    spec: AtomicKindSpec,
+    body: ArtifactCreateRequest,
+    project_root: Path,
+    target_scope: TargetScope,
+) -> dict:
+    reject_project_local_write(target_scope, f"Create {spec.kind}")
+    name = validate_name(body.name, kind=spec.kind)
+
+    # Unlocked pre-checks so a duplicate is refused (409) rather than
+    # confirmed, and the gate discloses the exact artifact dir. The locked
+    # re-checks below stay authoritative for create races.
+    artifact_dir_unlocked = _artifacts_root(spec, project_root, scope=target_scope) / name
+    if (
+        spec.resolve_canonical(project_root, name, scope=target_scope) is not None
+        or artifact_dir_unlocked.exists()
+    ):
+        raise _error(
+            409,
+            "conflict",
+            f"{spec.kind.capitalize()} '{name}' already exists",
+            reason_code="already_exists",
+        )
+    gate = host_write_gate(
+        target_scope,
+        body.allow_host_writes,
+        action=f"Create {spec.kind}",
+        host_targets=[str(artifact_dir_unlocked)],
+    )
+    if gate is not None:
+        return gate
+
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                if spec.resolve_canonical(project_root, name, scope=target_scope) is not None:
+                    raise _error(
+                        409,
+                        "conflict",
+                        f"{spec.kind.capitalize()} '{name}' already exists",
+                        reason_code="already_exists",
+                    )
+                # ADR-0022: create in versioned directory layout (working file +
+                # versions/v1.md + manifest) from the start, so the artifact is
+                # immediately versionable in the detail panel instead of a flat
+                # file the version UI tells you to ``mm context migrate`` — which
+                # then skips it as an unowned manual flat (the split-brain).
+                artifact_dir = _artifacts_root(spec, project_root, scope=target_scope) / name
+                if artifact_dir.exists():
+                    # resolve_canonical found no working file above, but a
+                    # stale/orphan directory remains — surface a clean 409 rather
+                    # than a 500 from mkdir()'s FileExistsError.
+                    raise _error(
+                        409,
+                        "conflict",
+                        f"{spec.kind.capitalize()} '{name}' already exists",
+                        reason_code="already_exists",
+                    )
+                # Encode the submitted content up front, before anything touches
+                # disk. A lone-surrogate body can't be UTF-8 encoded; failing
+                # after mkdir would leave an orphan dir that wedges retries on the
+                # 409 above. These exact bytes become source_bytes for
+                # create_version, so v1.md is byte-identical to the working file
+                # with no re-read race (_gateway_lock guards only this process).
+                try:
+                    content_bytes = body.content.encode("utf-8")
+                except UnicodeEncodeError as exc:
+                    raise _error(
+                        400,
+                        "validation",
+                        f"{spec.kind.capitalize()} content is not valid UTF-8",
+                    ) from exc
+                artifact_dir.mkdir(parents=True)
+                path = artifact_dir / spec.dir_filename
+                try:
+                    atomic_write_text(path, body.content)
+                    versioning.create_version(
+                        artifact_dir,
+                        path,
+                        note="Initial version (created via web)",
+                        source_bytes=content_bytes,
+                    )
+                except BaseException:
+                    # Roll back the partial artifact dir so a transient failure
+                    # doesn't leave an empty directory that wedges every future
+                    # create of this name on the orphan-dir 409 above.
+                    shutil.rmtree(artifact_dir, ignore_errors=True)
+                    raise
+    except TimeoutError:
+        raise _error(
+            503,
+            "busy",
+            f"{spec.kind.capitalize()} create timed out — another sync may be in progress",
+        )
+    return {"name": name, "canonical_path": _safe_rel(path, project_root)}
+
+
+# ── Update ───────────────────────────────────────────────────────────────
+
+
+async def update_artifact(
+    spec: AtomicKindSpec,
+    name: str,
+    body: ArtifactUpdateRequest,
+    project_root: Path,
+    target_scope: TargetScope,
+) -> JSONResponse:
+    reject_project_local_write(target_scope, f"Update {spec.kind}")
+    name, resolved = _resolve_existing(spec, project_root, name, scope=target_scope)
+    if resolved is None:
+        raise _error(404, "missing", f"{spec.kind} {name!r} not found")
+    path, _layout = resolved
+
+    try:
+        body_mtime_ns = int(body.mtime_ns)
+    except ValueError:
+        raise _error(422, "validation", f"Invalid mtime_ns: {body.mtime_ns!r}")
+
+    # Unlocked pre-check before the host-write gate — a stale request is
+    # refused, never confirmed (see context_skills.update_skill).
+    pre_mtime_ns = path.stat().st_mtime_ns
+    if pre_mtime_ns != body_mtime_ns and not body.force:
+        return mtime_conflict_response(pre_mtime_ns)
+    gate = host_write_gate(
+        target_scope,
+        body.allow_host_writes,
+        action=f"Update {spec.kind}",
+        host_targets=[str(path)],
+    )
+    if gate is not None:
+        return JSONResponse(content=gate)
+
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                current_mtime_ns = path.stat().st_mtime_ns
+                if current_mtime_ns != body_mtime_ns:
+                    if not body.force:
+                        return mtime_conflict_response(current_mtime_ns)
+                    logger.warning(
+                        "force-save bypassed mtime check on %s "
+                        "(client_mtime_ns=%s server_mtime_ns=%s)",
+                        path,
+                        body_mtime_ns,
+                        current_mtime_ns,
+                    )
+                atomic_write_text(path, body.content)
+                new_mtime_ns = path.stat().st_mtime_ns
+    except TimeoutError:
+        raise _error(
+            503,
+            "busy",
+            f"{spec.kind.capitalize()} update timed out — another sync may be in progress",
+        )
+    return JSONResponse(content={"name": name, "mtime_ns": str(new_mtime_ns)})
+
+
+# ── Delete ───────────────────────────────────────────────────────────────
+
+
+async def delete_artifact(
+    spec: AtomicKindSpec,
+    name: str,
+    cascade: bool,
+    project_root: Path,
+    target_scope: TargetScope,
+    allow_host_writes: bool,
+) -> dict:
+    reject_project_local_write(target_scope, f"Delete {spec.kind}")
+    name, resolved = _resolve_existing(spec, project_root, name, scope=target_scope)
+
+    # Pending deletions, computed unlocked (see delete_skill): cascade
+    # targets resolve AT THIS TIER — scope= is load-bearing for user-tier
+    # cascades. Idempotent no-ops skip the gate.
+    pending: list[Path] = [resolved[0]] if resolved is not None else []
+    if cascade:
+        for gen in spec.generators().values():
+            target = gen.target_file(project_root, name, scope=target_scope)
+            if target is not None and target.is_file():
+                pending.append(target)
+    gate = host_write_gate(
+        target_scope,
+        allow_host_writes,
+        action=f"Delete {spec.kind}",
+        host_targets=[str(p) for p in pending],
+    )
+    if gate is not None:
+        return gate
+
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                removed: list[str] = []
+                skipped: list[dict[str, str]] = []
+
+                if resolved is not None:
+                    path, _layout = resolved
+                    try:
+                        path.unlink()
+                        removed.append(_safe_rel(path, project_root))
+                    except OSError as e:
+                        skipped.append(delete_skip_entry(path, e, project_root))
+
+                # Sibling of the canonical branch, not nested inside it — a
+                # runtime-only artifact (no canonical) + cascade=true must still
+                # remove the runtime copies; the nested shape silently no-opped
+                # (#1247 id 46). Matches delete_skill.
+                if cascade:
+                    for gen in spec.generators().values():
+                        target = gen.target_file(project_root, name, scope=target_scope)
+                        if target is None:
+                            continue
+                        if not target.is_file():
+                            continue
+                        try:
+                            target.unlink()
+                            removed.append(_safe_rel(target, project_root))
+                        except OSError as e:
+                            skipped.append(delete_skip_entry(target, e, project_root))
+    except TimeoutError:
+        raise _error(
+            503,
+            "busy",
+            f"{spec.kind.capitalize()} delete timed out — another sync may be in progress",
+        )
+
+    return {"deleted": removed, "skipped": skipped}
+
+
+# ── Diff ─────────────────────────────────────────────────────────────────
+
+
+async def diff_artifact(
+    spec: AtomicKindSpec,
+    name: str,
+    project_root: Path,
+    target_scope: TargetScope,
+) -> dict:
+    name, resolved = _resolve_existing(spec, project_root, name, scope=target_scope)
+
+    canonical_content = None
+    canonical_path = None
+    parse_error_reason = None
+    parsed = None
+    if resolved is not None:
+        path, layout = resolved
+        canonical_path = _safe_rel(path, project_root)
+        # Lenient read + re-parse — the pane must agree with the list badge
+        # instead of raw-comparing a malformed canonical into "out of sync" /
+        # "in sync" (#1229 U7); a non-UTF-8 canonical must render a
+        # diagnosable parse-error pane, not crash the endpoint (#1233).
+        canonical_content = read_text_lenient(path)
+        if canonical_content is None:
+            # Unreadable canonical (permission, race) — same tolerant path as
+            # the engine diff: every runtime row reports a diagnosable parse
+            # error instead of a 500 (Codex review).
+            parse_error_reason = sanitize_diff_reason(f"unreadable: {path}", project_root)
+        else:
+            try:
+                parsed = spec.parse_text(canonical_content, source=path, layout=layout)
+            except spec.parse_error as exc:
+                parse_error_reason = sanitize_diff_reason(str(exc), project_root)
+
+    runtimes = []
+    for gen_name, gen in spec.generators().items():
+        # Match the canonical side's tier — see context_skills.py diff_skill
+        # for the rationale (#1229). NO_FANOUT tiers return None → skipped.
+        target = gen.target_file(project_root, name, scope=target_scope)
+        if target is None:
+            continue
+        if parse_error_reason is not None:
+            entry: dict[str, object] = {
+                "runtime": gen_name,
+                "status": "parse error",
+                "reason": parse_error_reason,
+            }
+            if target.is_file():
+                runtime_preview = read_text_lenient(target)
+                if runtime_preview is not None:
+                    entry["runtime_content"] = runtime_preview
+            runtimes.append(entry)
+            continue
+        if canonical_content is None and not target.is_file():
+            continue
+        elif canonical_content is not None and not target.is_file():
+            runtimes.append({"runtime": gen_name, "status": "missing target"})
+        elif canonical_content is None and target.is_file():
+            runtimes.append(
+                {
+                    "runtime": gen_name,
+                    "status": "missing canonical",
+                    "runtime_content": read_text_lenient(target),
+                }
+            )
+        else:
+            # Compare on the engine's basis — vendor override bytes, else
+            # rendered output — NOT the raw canonical text: some targets are
+            # TOML/YAML, so a raw compare pinned this pane to a permanent
+            # "out of sync" under an "in sync" list badge (#1247 id 30).
+            assert parsed is not None  # parse failures took the branch above
+            artifact = parsed
+            runtimes.append(
+                expected_vs_runtime_row(
+                    kind=spec.kind_plural,
+                    gen_name=gen_name,
+                    render=lambda gen=gen, artifact=artifact: gen.render(artifact)[0],
+                    target=target,
+                    name=name,
+                    project_root=project_root,
+                    scope=target_scope,
+                )
+            )
+
+    return {
+        "name": name,
+        "canonical_content": canonical_content,
+        "canonical_path": canonical_path,
+        "runtimes": runtimes,
+    }
+
+
+# ── Sync ─────────────────────────────────────────────────────────────────
+
+
+async def sync_core(
+    spec: AtomicKindSpec,
+    project_root: Path,
+    target_scope: TargetScope,
+    *,
+    on_drop: str = "warn",
+    surface: str | None = None,
+    force_unsafe: bool = False,
+) -> dict:
+    """Lock-free atomic-kind sync core — the caller MUST hold ``_gateway_lock``.
+
+    Shared by the standalone per-kind route and ``POST /context/sync-all``
+    (#1278), which runs every per-type core under ONE outer lock
+    acquisition — the lock is a non-reentrant ``_LoopLocalLock``, so the
+    core must never acquire it itself. The engine call stays a direct
+    synchronous call (no worker thread): atomic kinds take no
+    cross-process file lock — each runtime artifact is one full-content
+    atomic ``os.replace`` — so there is no unbounded block to offload
+    (the skills/settings cores differ, see ``_sync_skills_core``).
+
+    Engine errors are raised as :class:`SyncPhaseError` — the standalone
+    route's historical status/detail pair (privacy 422 keeps its STRING
+    detail, issue-pinned; strict-drop keeps its dict detail) plus the
+    envelope attributes sync-all renders.
+    """
+    try:
+        result = spec.generate_all(
+            project_root,
+            on_drop=on_drop,
+            scope=target_scope,
+            surface=surface if surface is not None else spec.sync_surface,
+            force_unsafe=force_unsafe,
+        )
+    except PrivacyScanError as exc:
+        # Path-free detail — ``exc.message`` embeds the absolute canonical path
+        # (#1385 finding 1). The chained ``exc`` keeps the full text for logs.
+        raise SyncPhaseError(
+            422, PRIVACY_BLOCK_DETAIL, error_kind="validation", reason_code="privacy_blocked"
+        ) from exc
+    except spec.strict_drop_error as exc:
+        # on_drop="error" aborts mid-Phase-2 with earlier writes persisted
+        # (the #908 partial-write boundary). Surface the partial fan-out
+        # instead of an opaque 500 (#1247 id 47): the detail dict follows
+        # the #1210 ``{reason_code, message}`` shape the JS error path
+        # already renders, plus the writes that landed before the abort.
+        # API-only reachability — the UI never sends on_drop="error".
+        raise SyncPhaseError(
+            422,
+            detail={
+                "reason_code": "strict_drop",
+                "message": str(exc),
+                "generated": [
+                    {"runtime": rt, "path": _safe_rel(p, project_root)} for rt, p in exc.generated
+                ],
+            },
+            error_kind="validation",
+            reason_code="strict_drop",
+        ) from exc
+    return {
+        "generated": [
+            {"runtime": rt, "path": _safe_rel(p, project_root)} for rt, p in result.generated
+        ],
+        "dropped": [
+            {"runtime": rt, "name": name, "fields": fields} for rt, name, fields in result.dropped
+        ],
+        "skipped": [
+            {"runtime": rt, "reason": reason, "reason_code": code}
+            for rt, reason, code in result.skipped
+        ],
+        "canonical_root": spec.canonical_root,
+    }
+
+
+async def sync_artifacts(
+    spec: AtomicKindSpec,
+    body: AtomicSyncRequest | None,
+    project_root: Path,
+    target_scope: TargetScope,
+) -> dict:
+    reject_project_local_write(target_scope, f"Sync {spec.kind_plural}")
+    on_drop = body.on_drop if body else "warn"
+    gate = host_write_gate(
+        target_scope,
+        body.allow_host_writes if body else False,
+        action=f"Sync {spec.kind_plural}",
+        host_targets=user_sync_host_targets(spec, project_root),
+    )
+    if gate is not None:
+        return gate
+    force_unsafe = body.force_unsafe_sync if body else False
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                return await sync_core(
+                    spec, project_root, target_scope, on_drop=on_drop, force_unsafe=force_unsafe
+                )
+    except TimeoutError:
+        raise _error(
+            503,
+            "busy",
+            f"{spec.kind_plural.capitalize()} sync timed out — another sync may be in progress",
+        )
+
+
+# ── Import ───────────────────────────────────────────────────────────────
+
+
+async def import_artifacts(
+    spec: AtomicKindSpec,
+    body: ImportRequest | None,
+    project_root: Path,
+    target_scope: TargetScope,
+    dry_run: bool,
+) -> dict:
+    reject_project_local_write(target_scope, f"Import {spec.kind_plural}")
+    overwrite = body.overwrite if body else False
+    allow_host_writes = body.allow_host_writes if body else False
+    force_unsafe_import = body.force_unsafe_import if body else False
+
+    async def _run(dry: bool) -> Any:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                return spec.extract_to_canonical(
+                    project_root,
+                    overwrite=overwrite,
+                    dry_run=dry,
+                    scope=target_scope,
+                    force_unsafe_import=force_unsafe_import,
+                    surface=spec.import_surface,
+                )
+
+    try:
+        if not dry_run and target_scope == "user" and not allow_host_writes:
+            # Gate disclosure needs the engine's scan — dry-run preview,
+            # nested as ``plan`` (see context_skills.import_skills).
+            preview = await _run(dry=True)
+            gate = host_write_gate(
+                target_scope,
+                allow_host_writes,
+                action=f"Import {spec.kind_plural}",
+                host_targets=[str(p) for p, _layout in preview.imported],
+                plan=_import_payload(spec, preview, project_root, target_scope, dry_run=True),
+            )
+            if gate is not None:
+                return gate
+        result = await _run(dry=dry_run)
+    except TimeoutError:
+        raise _error(
+            503,
+            "busy",
+            f"{spec.kind_plural.capitalize()} import timed out — another sync may be in progress",
+        )
+    except click.ClickException as exc:
+        # project_shared Gate A privacy block → 422 (see context_skills.import_skills).
+        raise HTTPException(422, PRIVACY_BLOCK_IMPORT_DETAIL) from exc
+    return _import_payload(spec, result, project_root, target_scope, dry_run=dry_run)
+
+
+async def import_artifact(
+    spec: AtomicKindSpec,
+    name: str,
+    body: ImportRequest | None,
+    project_root: Path,
+    target_scope: TargetScope,
+) -> dict:
+    reject_project_local_write(target_scope, f"Import {spec.kind}")
+    try:
+        validate_name(name, kind=f"{spec.kind} name")
+    except InvalidNameError as exc:
+        raise _error(400, "validation", f"Invalid {spec.kind} name: {exc}")
+    overwrite = body.overwrite if body else False
+    allow_host_writes = body.allow_host_writes if body else False
+    force_unsafe_import = body.force_unsafe_import if body else False
+
+    async def _run(dry: bool) -> Any:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                return spec.extract_to_canonical(
+                    project_root,
+                    overwrite=overwrite,
+                    only_name=name,
+                    dry_run=dry,
+                    scope=target_scope,
+                    force_unsafe_import=force_unsafe_import,
+                    surface=spec.import_surface,
+                )
+
+    try:
+        if target_scope == "user" and not allow_host_writes:
+            preview = await _run(dry=True)
+            if not preview.imported and not preview.skipped:
+                raise _error(404, "missing", f"No runtime {spec.kind} named {name!r} to import")
+            gate = host_write_gate(
+                target_scope,
+                allow_host_writes,
+                action=f"Import {spec.kind}",
+                host_targets=[str(p) for p, _layout in preview.imported],
+                plan=_import_payload(spec, preview, project_root, target_scope, dry_run=None),
+            )
+            if gate is not None:
+                return gate
+        result = await _run(dry=False)
+    except TimeoutError:
+        raise _error(
+            503,
+            "busy",
+            f"{spec.kind.capitalize()} import timed out — another sync may be in progress",
+        )
+    except click.ClickException as exc:
+        # project_shared Gate A privacy block → 422 (see context_skills.import_skills).
+        raise HTTPException(422, PRIVACY_BLOCK_IMPORT_DETAIL) from exc
+    if not result.imported and not result.skipped:
+        raise _error(404, "missing", f"No runtime {spec.kind} named {name!r} to import")
+    return _import_payload(spec, result, project_root, target_scope, dry_run=None)

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -1,26 +1,26 @@
-"""Context gateway — Agents CRUD, diff, sync, import, rendered output, and field map."""
+"""Context gateway — Agents CRUD, diff, sync, import, rendered output, and field map.
+
+Thin route layer: the ``@router``-decorated functions below own the URL,
+signature, and OpenAPI surface (and the AST invariant registry keys on
+them — see ``test_web_invariants_registry.py``); the handler bodies live
+once in :mod:`memtomem.web.routes._atomic_kind`, parametrized by
+``_SPEC`` (#1514). Engine callables on the spec late-bind this module's
+globals so tests can keep monkeypatching them here.
+"""
 
 from __future__ import annotations
 
-import asyncio
-import logging
-import shutil
 from pathlib import Path
 
-import click
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 
 from memtomem.config import TargetScope
-from memtomem.context import versioning
-from memtomem.context._atomic import atomic_write_text
-from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context.agents import (
-    AGENT_DIR_FILENAME,
     AGENT_GENERATORS,
+    AGENT_DIR_FILENAME,
     CANONICAL_AGENT_ROOT,
     AgentParseError,
-    ExtractResult,
     StrictDropError,
     SubAgent,
     _parse_canonical_agent_text,
@@ -32,88 +32,35 @@ from memtomem.context.agents import (
     parse_canonical_agent,
     resolve_canonical_agent,
 )
+
+# Re-exports kept for test contracts: engine spies build ``module.ExtractResult``
+# values, and the lock-identity test imports ``_gateway_lock`` from each kind
+# module to pin the shared singleton.
+from memtomem.context.agents import ExtractResult as ExtractResult
 from memtomem.context.detector import AGENT_DIRS
-from memtomem.context.privacy_scan import PrivacyScanError
-from memtomem.web.routes.context_gateway import (
-    _safe_rel,
-    delete_skip_entry,
-    expected_vs_runtime_row,
-    read_text_lenient,
-    sanitize_diff_reason,
-)
-from memtomem.web.routes.context_projects import (
-    resolve_scope_root,
-    resolve_scope_root_cascade_gated,
-    resolve_writable_scope_root,
-)
-from memtomem.web.routes.context_versions import include_has, version_summary
+from memtomem.web.routes import _atomic_kind
 from memtomem.web.routes._artifact_common import (
     ArtifactCreateRequest,
     ArtifactUpdateRequest,
     AtomicSyncRequest,
     ImportRequest,
-    mtime_conflict_response,
-    reject_project_local_write,
-    scanned_dirs_for,
 )
-from memtomem.web.routes._confirm import host_write_gate
-from memtomem.web.routes._errors import PRIVACY_BLOCK_DETAIL, PRIVACY_BLOCK_IMPORT_DETAIL, _error
-from memtomem.web.routes._locks import _gateway_lock
-from memtomem.web.routes._sync_phase import SyncPhaseError
+from memtomem.web.routes._locks import _gateway_lock as _gateway_lock
+from memtomem.web.routes.context_projects import (
+    resolve_scope_root,
+    resolve_scope_root_cascade_gated,
+    resolve_writable_scope_root,
+)
 
 # Flat list of project-relative runtime scan paths reported on list / import
 # responses so the web UI's empty-state hint can name the exact directories
 # the detector inspects without hardcoding them client-side.
 _AGENT_SCAN_DIRS: list[str] = [d for paths in AGENT_DIRS.values() for d in paths]
 
-logger = logging.getLogger(__name__)
-
 router = APIRouter(tags=["context-agents"])
 
 # Fields present in the canonical SubAgent that may be dropped per-runtime.
 _ALL_OPTIONAL_FIELDS = ("tools", "model", "skills", "isolation", "kind", "temperature")
-
-
-# ── Helpers ──────────────────────────────────────────────────────────────
-
-
-def _agents_root(project_root: Path, *, scope: TargetScope = "project_shared") -> Path:
-    from memtomem.context.scope_resolver import canonical_artifact_dir
-
-    return canonical_artifact_dir("agents", scope, project_root)
-
-
-def _resolve_existing_agent(
-    project_root: Path, raw_name: str, *, scope: TargetScope = "project_shared"
-):
-    name = validate_name(raw_name, kind="agent")
-    return name, resolve_canonical_agent(project_root, name, scope=scope)
-
-
-def _user_sync_host_targets(project_root: Path) -> list[str]:
-    """Pending user-tier fan-out destinations for the sync confirm gate.
-
-    Upper bound on the confirmed sync's writes, resolved from the PARSED
-    frontmatter name: ``sync_atomic_artifact`` fans out under
-    ``adapter.name_of(parse(...))``, not the canonical filename, so a
-    filename-derived disclosure could confirm one path while the engine
-    writes another (#1263 review Blocker). Canonicals the engine would
-    skip at read/parse time are excluded the same way; later preflight
-    skips (Gate A, override errors, conflicts, lock timeouts) only
-    shrink the actual write set below this disclosure.
-    """
-    targets: set[str] = set()
-    for agent_path, layout in list_canonical_agents(project_root, scope="user"):
-        try:
-            text = agent_path.read_bytes().decode("utf-8", errors="replace")
-            parsed = _parse_canonical_agent_text(text, source=agent_path, layout=layout)
-        except (OSError, AgentParseError):
-            continue  # the engine skips these too
-        for gen in AGENT_GENERATORS.values():
-            dst = gen.target_file(project_root, parsed.name, scope="user")
-            if dst is not None:
-                targets.add(str(dst))
-    return sorted(targets)
 
 
 def _agent_to_dict(agent: SubAgent) -> dict:
@@ -127,6 +74,34 @@ def _agent_to_dict(agent: SubAgent) -> dict:
         "kind": agent.kind,
         "temperature": agent.temperature,
     }
+
+
+_SPEC = _atomic_kind.AtomicKindSpec(
+    kind="agent",
+    kind_plural="agents",
+    canonical_root=CANONICAL_AGENT_ROOT,
+    dir_filename=AGENT_DIR_FILENAME,
+    scan_dirs=_AGENT_SCAN_DIRS,
+    optional_fields=_ALL_OPTIONAL_FIELDS,
+    rendered_includes_fields=True,
+    parse_error=AgentParseError,
+    strict_drop_error=StrictDropError,
+    sync_surface="web_context_agents_sync",
+    import_surface="web_context_agents_import",
+    # Late-binding lambdas, not function references — they resolve this
+    # module's globals at call time so ``monkeypatch.setattr(context_agents,
+    # "generate_all_agents", ...)`` still intercepts the engine call.
+    generators=lambda: AGENT_GENERATORS,
+    list_canonicals=lambda *a, **kw: list_canonical_agents(*a, **kw),
+    resolve_canonical=lambda *a, **kw: resolve_canonical_agent(*a, **kw),
+    diff=lambda *a, **kw: diff_agents(*a, **kw),
+    parse_canonical=lambda *a, **kw: parse_canonical_agent(*a, **kw),
+    parse_text=lambda *a, **kw: _parse_canonical_agent_text(*a, **kw),
+    canonical_name=lambda *a, **kw: canonical_agent_name(*a, **kw),
+    generate_all=lambda *a, **kw: generate_all_agents(*a, **kw),
+    extract_to_canonical=lambda *a, **kw: extract_agents_to_canonical(*a, **kw),
+    fields_from_parsed=_agent_to_dict,
+)
 
 
 # ── List ─────────────────────────────────────────────────────────────────
@@ -152,57 +127,7 @@ async def list_agents(
     ),
 ) -> dict:
     """List canonical agents. Accepts project selector aliases like list_skills."""
-    want_versions = include_has(include, "versions")
-    canonicals = list_canonical_agents(project_root, scope=target_scope)
-    diffs = diff_agents(project_root, scope=target_scope)
-
-    by_name: dict[str, list[dict]] = {}
-    for row in diffs:
-        entry: dict[str, object] = {"runtime": row[0], "status": row[2]}
-        reason = sanitize_diff_reason(getattr(row, "reason", None), project_root)
-        if reason:
-            entry["reason"] = reason
-        by_name.setdefault(row[1], []).append(entry)
-
-    agents: list[dict[str, object]] = []
-    canonical_names: set[str] = set()
-    for agent_path, layout in canonicals:
-        name = canonical_agent_name(agent_path, layout)
-        canonical_names.add(name)
-        item: dict[str, object] = {
-            "name": name,
-            "canonical_path": _safe_rel(agent_path, project_root),
-            "target_scope": target_scope,
-            "runtimes": by_name.get(name, []),
-        }
-        if want_versions:
-            item["versions"] = version_summary(agent_path, layout)
-        agents.append(item)
-
-    for agent_name, runtimes in by_name.items():
-        if agent_name not in canonical_names:
-            item = {
-                "name": agent_name,
-                "canonical_path": None,
-                "target_scope": target_scope,
-                "runtimes": runtimes,
-            }
-            if want_versions:
-                # Runtime-only: no canonical file → nothing to version and no
-                # store to migrate. Keep the four-key shape for the JS reader.
-                item["versions"] = {
-                    "labels": {},
-                    "count": 0,
-                    "versionable": False,
-                    "migrate_required": False,
-                }
-            agents.append(item)
-
-    return {
-        "agents": agents,
-        "canonical_root": CANONICAL_AGENT_ROOT,
-        "scanned_dirs": _AGENT_SCAN_DIRS,
-    }
+    return await _atomic_kind.list_artifacts(_SPEC, project_root, target_scope, include)
 
 
 # ── Read ─────────────────────────────────────────────────────────────────
@@ -217,34 +142,7 @@ async def read_agent(
         description="Canonical-residency tier to read from (ADR-0016).",
     ),
 ) -> dict:
-    name, resolved = _resolve_existing_agent(project_root, name, scope=target_scope)
-    if resolved is None:
-        raise _error(404, "missing", f"agent {name!r} not found")
-    agent_path, layout = resolved
-
-    content = agent_path.read_text(encoding="utf-8")
-    # mtime_ns is serialized as a string because JavaScript Number cannot
-    # safely represent integers > 2^53; nanosecond epochs exceed that.
-    mtime_ns = agent_path.stat().st_mtime_ns
-
-    fields: dict = {}
-    try:
-        parsed = parse_canonical_agent(agent_path, layout=layout)
-        fields = _agent_to_dict(parsed)
-    except AgentParseError:
-        pass
-
-    # Issue #962 detail meta header — echo back ``target_scope`` and
-    # the resolved ``layout`` so the JS meta-header renderer stays
-    # type-agnostic across the three artifact types.
-    return {
-        "name": name,
-        "content": content,
-        "mtime_ns": str(mtime_ns),
-        "fields": fields,
-        "target_scope": target_scope,
-        "layout": layout,
-    }
+    return await _atomic_kind.read_artifact(_SPEC, name, project_root, target_scope)
 
 
 # ── Rendered (per-runtime output with dropped fields + field map) ────────
@@ -259,57 +157,7 @@ async def rendered_agent(
         description="Canonical-residency tier to render (ADR-0016).",
     ),
 ) -> JSONResponse:
-    name, resolved = _resolve_existing_agent(project_root, name, scope=target_scope)
-    if resolved is None:
-        raise _error(404, "missing", f"agent {name!r} not found")
-    agent_path, layout = resolved
-
-    content = agent_path.read_text(encoding="utf-8")
-    try:
-        parsed = parse_canonical_agent(agent_path, layout=layout)
-    except AgentParseError as exc:
-        # ``str(exc)`` embeds the absolute canonical source path (the parser
-        # raises ``missing YAML frontmatter: {path}`` / ``... (source: {path})``);
-        # route it through the shared display-sanitize boundary so the loopback
-        # 422 detail stays path-free — the #1412 fix class the mcp-servers
-        # parse-422 already applies.
-        detail = sanitize_diff_reason(str(exc), project_root) or ""
-        return JSONResponse(
-            status_code=422,
-            content={"detail": {"error_kind": "parse", "message": f"Parse error: {detail}"}},
-        )
-
-    diffs = diff_agents(project_root, scope=target_scope)
-    status_map: dict[tuple[str, str], str] = {(rt, n): s for rt, n, s in diffs}
-
-    runtimes = []
-    field_map: dict[str, dict[str, bool]] = {f: {} for f in _ALL_OPTIONAL_FIELDS}
-
-    for gen_name, gen in AGENT_GENERATORS.items():
-        rendered_content, dropped_fields = gen.render(parsed)
-        status = status_map.get((gen_name, name), "unknown")
-        runtimes.append(
-            {
-                "runtime": gen_name,
-                "content": rendered_content,
-                "dropped_fields": dropped_fields,
-                "status": status,
-            }
-        )
-        # Build field map
-        dropped_set = set(dropped_fields)
-        for f in _ALL_OPTIONAL_FIELDS:
-            field_map[f][gen_name] = f not in dropped_set
-
-    return JSONResponse(
-        content={
-            "name": name,
-            "canonical_content": content,
-            "fields": _agent_to_dict(parsed),
-            "runtimes": runtimes,
-            "field_map": field_map,
-        }
-    )
+    return await _atomic_kind.rendered_artifact(_SPEC, name, project_root, target_scope)
 
 
 # ── Create ───────────────────────────────────────────────────────────────
@@ -331,85 +179,7 @@ async def create_agent(
         ),
     ),
 ) -> dict:
-    reject_project_local_write(target_scope, "Create agent")
-    name = validate_name(body.name, kind="agent")
-
-    # Unlocked pre-checks so a duplicate is refused (409) rather than
-    # confirmed, and the gate discloses the exact artifact dir. The locked
-    # re-checks below stay authoritative for create races.
-    artifact_dir_unlocked = _agents_root(project_root, scope=target_scope) / name
-    if (
-        resolve_canonical_agent(project_root, name, scope=target_scope) is not None
-        or artifact_dir_unlocked.exists()
-    ):
-        raise _error(
-            409, "conflict", f"Agent '{name}' already exists", reason_code="already_exists"
-        )
-    gate = host_write_gate(
-        target_scope,
-        body.allow_host_writes,
-        action="Create agent",
-        host_targets=[str(artifact_dir_unlocked)],
-    )
-    if gate is not None:
-        return gate
-
-    try:
-        async with asyncio.timeout(60):
-            async with _gateway_lock:
-                if resolve_canonical_agent(project_root, name, scope=target_scope) is not None:
-                    raise _error(
-                        409,
-                        "conflict",
-                        f"Agent '{name}' already exists",
-                        reason_code="already_exists",
-                    )
-                # ADR-0022: create in versioned directory layout (agent.md +
-                # versions/v1.md + manifest) from the start, so the artifact is
-                # immediately versionable in the detail panel instead of a flat
-                # file the version UI tells you to ``mm context migrate`` — which
-                # then skips it as an unowned manual flat (the split-brain).
-                # Mirrored in context_commands.py.
-                artifact_dir = _agents_root(project_root, scope=target_scope) / name
-                if artifact_dir.exists():
-                    # resolve_canonical_agent found no working file above, but a
-                    # stale/orphan directory remains — surface a clean 409 rather
-                    # than a 500 from mkdir()'s FileExistsError.
-                    raise _error(
-                        409,
-                        "conflict",
-                        f"Agent '{name}' already exists",
-                        reason_code="already_exists",
-                    )
-                # Encode the submitted content up front, before anything touches
-                # disk. A lone-surrogate body can't be UTF-8 encoded; failing
-                # after mkdir would leave an orphan dir that wedges retries on the
-                # 409 above. These exact bytes become source_bytes for
-                # create_version, so v1.md is byte-identical to the working file
-                # with no re-read race (_gateway_lock guards only this process).
-                try:
-                    content_bytes = body.content.encode("utf-8")
-                except UnicodeEncodeError as exc:
-                    raise _error(400, "validation", "Agent content is not valid UTF-8") from exc
-                artifact_dir.mkdir(parents=True)
-                agent_path = artifact_dir / AGENT_DIR_FILENAME
-                try:
-                    atomic_write_text(agent_path, body.content)
-                    versioning.create_version(
-                        artifact_dir,
-                        agent_path,
-                        note="Initial version (created via web)",
-                        source_bytes=content_bytes,
-                    )
-                except BaseException:
-                    # Roll back the partial artifact dir so a transient failure
-                    # doesn't leave an empty directory that wedges every future
-                    # create of this name on the orphan-dir 409 above.
-                    shutil.rmtree(artifact_dir, ignore_errors=True)
-                    raise
-    except TimeoutError:
-        raise _error(503, "busy", "Agent create timed out — another sync may be in progress")
-    return {"name": name, "canonical_path": _safe_rel(agent_path, project_root)}
+    return await _atomic_kind.create_artifact(_SPEC, body, project_root, target_scope)
 
 
 # ── Update ───────────────────────────────────────────────────────────────
@@ -432,50 +202,7 @@ async def update_agent(
         ),
     ),
 ) -> JSONResponse:
-    reject_project_local_write(target_scope, "Update agent")
-    name, resolved = _resolve_existing_agent(project_root, name, scope=target_scope)
-    if resolved is None:
-        raise _error(404, "missing", f"agent {name!r} not found")
-    agent_path, _layout = resolved
-
-    try:
-        body_mtime_ns = int(body.mtime_ns)
-    except ValueError:
-        raise _error(422, "validation", f"Invalid mtime_ns: {body.mtime_ns!r}")
-
-    # Unlocked pre-check before the host-write gate — a stale request is
-    # refused, never confirmed (see context_skills.update_skill).
-    pre_mtime_ns = agent_path.stat().st_mtime_ns
-    if pre_mtime_ns != body_mtime_ns and not body.force:
-        return mtime_conflict_response(pre_mtime_ns)
-    gate = host_write_gate(
-        target_scope,
-        body.allow_host_writes,
-        action="Update agent",
-        host_targets=[str(agent_path)],
-    )
-    if gate is not None:
-        return JSONResponse(content=gate)
-
-    try:
-        async with asyncio.timeout(60):
-            async with _gateway_lock:
-                current_mtime_ns = agent_path.stat().st_mtime_ns
-                if current_mtime_ns != body_mtime_ns:
-                    if not body.force:
-                        return mtime_conflict_response(current_mtime_ns)
-                    logger.warning(
-                        "force-save bypassed mtime check on %s "
-                        "(client_mtime_ns=%s server_mtime_ns=%s)",
-                        agent_path,
-                        body_mtime_ns,
-                        current_mtime_ns,
-                    )
-                atomic_write_text(agent_path, body.content)
-                new_mtime_ns = agent_path.stat().st_mtime_ns
-    except TimeoutError:
-        raise _error(503, "busy", "Agent update timed out — another sync may be in progress")
-    return JSONResponse(content={"name": name, "mtime_ns": str(new_mtime_ns)})
+    return await _atomic_kind.update_artifact(_SPEC, name, body, project_root, target_scope)
 
 
 # ── Delete ───────────────────────────────────────────────────────────────
@@ -502,57 +229,9 @@ async def delete_agent(
         ),
     ),
 ) -> dict:
-    reject_project_local_write(target_scope, "Delete agent")
-    name, resolved = _resolve_existing_agent(project_root, name, scope=target_scope)
-
-    # Pending deletions, computed unlocked (see delete_skill): cascade
-    # targets resolve AT THIS TIER — scope= is load-bearing for user-tier
-    # cascades. Idempotent no-ops skip the gate.
-    pending: list[Path] = [resolved[0]] if resolved is not None else []
-    if cascade:
-        for gen in AGENT_GENERATORS.values():
-            target = gen.target_file(project_root, name, scope=target_scope)
-            if target is not None and target.is_file():
-                pending.append(target)
-    gate = host_write_gate(
-        target_scope,
-        allow_host_writes,
-        action="Delete agent",
-        host_targets=[str(p) for p in pending],
+    return await _atomic_kind.delete_artifact(
+        _SPEC, name, cascade, project_root, target_scope, allow_host_writes
     )
-    if gate is not None:
-        return gate
-
-    try:
-        async with asyncio.timeout(60):
-            async with _gateway_lock:
-                removed: list[str] = []
-                skipped: list[dict[str, str]] = []
-
-                if resolved is not None:
-                    agent_path, _layout = resolved
-                    try:
-                        agent_path.unlink()
-                        removed.append(_safe_rel(agent_path, project_root))
-                    except OSError as e:
-                        skipped.append(delete_skip_entry(agent_path, e, project_root))
-
-                if cascade:
-                    for gen in AGENT_GENERATORS.values():
-                        target = gen.target_file(project_root, name, scope=target_scope)
-                        if target is None:
-                            continue
-                        if not target.is_file():
-                            continue
-                        try:
-                            target.unlink()
-                            removed.append(_safe_rel(target, project_root))
-                        except OSError as e:
-                            skipped.append(delete_skip_entry(target, e, project_root))
-    except TimeoutError:
-        raise _error(503, "busy", "Agent delete timed out — another sync may be in progress")
-
-    return {"deleted": removed, "skipped": skipped}
 
 
 # ── Diff ─────────────────────────────────────────────────────────────────
@@ -567,90 +246,7 @@ async def diff_agent(
         description="Canonical-residency tier to diff against runtime fan-out (ADR-0016).",
     ),
 ) -> dict:
-    name, resolved = _resolve_existing_agent(project_root, name, scope=target_scope)
-
-    canonical_content = None
-    canonical_path = None
-    parse_error_reason = None
-    parsed = None
-    if resolved is not None:
-        agent_path, layout = resolved
-        canonical_path = _safe_rel(agent_path, project_root)
-        # Lenient read — a non-UTF-8 canonical must render a diagnosable
-        # parse-error pane, not crash the endpoint (#1233 contract).
-        canonical_content = read_text_lenient(agent_path)
-        # Re-parse so this pane agrees with the list badge: the raw string
-        # compare below reported a malformed canonical as "out of sync" /
-        # "in sync" while the list said "parse error" (#1229 U7).
-        if canonical_content is None:
-            # Unreadable canonical (permission, race) — same tolerant path as
-            # the engine diff: every runtime row reports a diagnosable parse
-            # error instead of a 500 (Codex review).
-            parse_error_reason = sanitize_diff_reason(f"unreadable: {agent_path}", project_root)
-        else:
-            try:
-                parsed = _parse_canonical_agent_text(
-                    canonical_content, source=agent_path, layout=layout
-                )
-            except AgentParseError as exc:
-                parse_error_reason = sanitize_diff_reason(str(exc), project_root)
-
-    runtimes = []
-    for gen_name, gen in AGENT_GENERATORS.items():
-        # Match the canonical side's tier — see context_skills.py diff_skill
-        # for the rationale (#1229). NO_FANOUT tiers return None → skipped.
-        target = gen.target_file(project_root, name, scope=target_scope)
-        if target is None:
-            continue
-        if parse_error_reason is not None:
-            entry: dict[str, object] = {
-                "runtime": gen_name,
-                "status": "parse error",
-                "reason": parse_error_reason,
-            }
-            if target.is_file():
-                runtime_preview = read_text_lenient(target)
-                if runtime_preview is not None:
-                    entry["runtime_content"] = runtime_preview
-            runtimes.append(entry)
-            continue
-        if canonical_content is None and not target.is_file():
-            continue
-        elif canonical_content is not None and not target.is_file():
-            runtimes.append({"runtime": gen_name, "status": "missing target"})
-        elif canonical_content is None and target.is_file():
-            runtimes.append(
-                {
-                    "runtime": gen_name,
-                    "status": "missing canonical",
-                    "runtime_content": read_text_lenient(target),
-                }
-            )
-        else:
-            # Compare on the engine's basis — vendor override bytes, else
-            # rendered output — NOT the raw canonical text: codex/kimi targets
-            # are TOML/YAML, so a raw compare pinned this pane to a permanent
-            # "out of sync" under an "in sync" list badge (#1247 id 30).
-            assert parsed is not None  # parse failures took the branch above
-            agent = parsed
-            runtimes.append(
-                expected_vs_runtime_row(
-                    kind="agents",
-                    gen_name=gen_name,
-                    render=lambda gen=gen, agent=agent: gen.render(agent)[0],
-                    target=target,
-                    name=name,
-                    project_root=project_root,
-                    scope=target_scope,
-                )
-            )
-
-    return {
-        "name": name,
-        "canonical_content": canonical_content,
-        "canonical_path": canonical_path,
-        "runtimes": runtimes,
-    }
+    return await _atomic_kind.diff_artifact(_SPEC, name, project_root, target_scope)
 
 
 # ── Sync ─────────────────────────────────────────────────────────────────
@@ -670,71 +266,19 @@ async def _sync_agents_core(
 ) -> dict:
     """Lock-free agents sync core — the caller MUST hold ``_gateway_lock``.
 
-    Shared by the standalone route below and ``POST /context/sync-all``
-    (#1278), which runs every per-type core under ONE outer lock
-    acquisition — the lock is a non-reentrant ``_LoopLocalLock``, so the
-    core must never acquire it itself. The engine call stays a direct
-    synchronous call (no worker thread): agents take no cross-process
-    file lock — each runtime artifact is one full-content atomic
-    ``os.replace`` — so there is no unbounded block to offload (the
-    skills/settings cores differ, see ``_sync_skills_core``).
-
-    Engine errors are raised as :class:`SyncPhaseError` — the standalone
-    route's historical status/detail pair (privacy 422 keeps its STRING
-    detail, issue-pinned; strict-drop keeps its dict detail) plus the
-    envelope attributes sync-all renders.
+    Kept as a module-level name because ``context_sync_all`` imports the
+    five per-type cores by name; the body lives in
+    :func:`_atomic_kind.sync_core` (see there for the lock and
+    thread-offload contract).
     """
-    try:
-        result = generate_all_agents(
-            project_root,
-            on_drop=on_drop,
-            scope=target_scope,
-            surface=surface,
-            force_unsafe=force_unsafe,
-        )
-    except PrivacyScanError as exc:
-        # 422 Unprocessable Entity — request is well-formed but the canonical
-        # bytes violate the project_shared privacy gate. ADR-0011 §5: no
-        # bypass valve, so the user must remove the secret or migrate the
-        # artifact to a writable tier (the message body explains how). The
-        # detail is fixed/path-free — ``exc.message`` embeds the absolute
-        # canonical path (#1385 finding 1); the chained ``exc`` keeps it for logs.
-        raise SyncPhaseError(
-            422, PRIVACY_BLOCK_DETAIL, error_kind="validation", reason_code="privacy_blocked"
-        ) from exc
-    except StrictDropError as exc:
-        # on_drop="error" aborts mid-Phase-2 with earlier writes persisted
-        # (the #908 partial-write boundary). Surface the partial fan-out
-        # instead of an opaque 500 (#1247 id 47): the detail dict follows
-        # the #1210 ``{reason_code, message}`` shape the JS error path
-        # already renders, plus the writes that landed before the abort.
-        # API-only reachability — the UI never sends on_drop="error".
-        raise SyncPhaseError(
-            422,
-            detail={
-                "reason_code": "strict_drop",
-                "message": str(exc),
-                "generated": [
-                    {"runtime": rt, "path": _safe_rel(p, project_root)} for rt, p in exc.generated
-                ],
-            },
-            error_kind="validation",
-            reason_code="strict_drop",
-        ) from exc
-
-    return {
-        "generated": [
-            {"runtime": rt, "path": _safe_rel(p, project_root)} for rt, p in result.generated
-        ],
-        "dropped": [
-            {"runtime": rt, "name": name, "fields": fields} for rt, name, fields in result.dropped
-        ],
-        "skipped": [
-            {"runtime": rt, "reason": reason, "reason_code": code}
-            for rt, reason, code in result.skipped
-        ],
-        "canonical_root": CANONICAL_AGENT_ROOT,
-    }
+    return await _atomic_kind.sync_core(
+        _SPEC,
+        project_root,
+        target_scope,
+        on_drop=on_drop,
+        surface=surface,
+        force_unsafe=force_unsafe,
+    )
 
 
 @router.post("/context/agents/sync")
@@ -751,61 +295,10 @@ async def sync_agents(
         ),
     ),
 ) -> dict:
-    reject_project_local_write(target_scope, "Sync agents")
-    on_drop = body.on_drop if body else "warn"
-    gate = host_write_gate(
-        target_scope,
-        body.allow_host_writes if body else False,
-        action="Sync agents",
-        host_targets=_user_sync_host_targets(project_root),
-    )
-    if gate is not None:
-        return gate
-    force_unsafe = body.force_unsafe_sync if body else False
-    try:
-        async with asyncio.timeout(60):
-            async with _gateway_lock:
-                return await _sync_agents_core(
-                    project_root, target_scope, on_drop=on_drop, force_unsafe=force_unsafe
-                )
-    except TimeoutError:
-        raise _error(503, "busy", "Agents sync timed out — another sync may be in progress")
+    return await _atomic_kind.sync_artifacts(_SPEC, body, project_root, target_scope)
 
 
 # ── Import ───────────────────────────────────────────────────────────────
-
-
-def _import_payload(
-    result: ExtractResult,
-    project_root: Path,
-    target_scope: TargetScope,
-    dry_run: bool | None,
-) -> dict:
-    """Wire shape shared by both import routes (and the gate's nested plan).
-
-    Mirrors context_skills._import_payload — ``dry_run=None`` omits the
-    key, ``_safe_rel`` keeps user-tier ``~/.memtomem`` paths encodable.
-    """
-    payload: dict = {
-        "imported": [
-            {
-                "name": canonical_agent_name(p, layout),
-                "canonical_path": _safe_rel(p, project_root),
-            }
-            for p, layout in result.imported
-        ],
-        "skipped": [
-            {"name": name, "reason": reason, "reason_code": code}
-            for name, reason, code in result.skipped
-        ],
-        "project_root": str(project_root),
-        "scanned_dirs": scanned_dirs_for(
-            target_scope, kind="agents", project_scan_dirs=_AGENT_SCAN_DIRS
-        ),
-    }
-    if dry_run is not None:
-        payload["dry_run"] = dry_run
-    return payload
 
 
 @router.post("/context/agents/import")
@@ -829,44 +322,7 @@ async def import_agents(
         ),
     ),
 ) -> dict:
-    reject_project_local_write(target_scope, "Import agents")
-    overwrite = body.overwrite if body else False
-    allow_host_writes = body.allow_host_writes if body else False
-    force_unsafe_import = body.force_unsafe_import if body else False
-
-    async def _run(dry: bool) -> ExtractResult:
-        async with asyncio.timeout(60):
-            async with _gateway_lock:
-                return extract_agents_to_canonical(
-                    project_root,
-                    overwrite=overwrite,
-                    dry_run=dry,
-                    scope=target_scope,
-                    force_unsafe_import=force_unsafe_import,
-                    surface="web_context_agents_import",
-                )
-
-    try:
-        if not dry_run and target_scope == "user" and not allow_host_writes:
-            # Gate disclosure needs the engine's scan — dry-run preview,
-            # nested as ``plan`` (see context_skills.import_skills).
-            preview = await _run(dry=True)
-            gate = host_write_gate(
-                target_scope,
-                allow_host_writes,
-                action="Import agents",
-                host_targets=[str(p) for p, _layout in preview.imported],
-                plan=_import_payload(preview, project_root, target_scope, dry_run=True),
-            )
-            if gate is not None:
-                return gate
-        result = await _run(dry=dry_run)
-    except TimeoutError:
-        raise _error(503, "busy", "Agents import timed out — another sync may be in progress")
-    except click.ClickException as exc:
-        # project_shared Gate A privacy block → 422 (see context_skills.import_skills).
-        raise HTTPException(422, PRIVACY_BLOCK_IMPORT_DETAIL) from exc
-    return _import_payload(result, project_root, target_scope, dry_run=dry_run)
+    return await _atomic_kind.import_artifacts(_SPEC, body, project_root, target_scope, dry_run)
 
 
 @router.post("/context/agents/{name}/import")
@@ -890,48 +346,4 @@ async def import_agent(
     feedback for "you clicked a specific item that doesn't exist") — pinned
     on the gate's dry-run preview too.
     """
-    reject_project_local_write(target_scope, "Import agent")
-    try:
-        validate_name(name, kind="agent name")
-    except InvalidNameError as exc:
-        raise _error(400, "validation", f"Invalid agent name: {exc}")
-    overwrite = body.overwrite if body else False
-    allow_host_writes = body.allow_host_writes if body else False
-    force_unsafe_import = body.force_unsafe_import if body else False
-
-    async def _run(dry: bool) -> ExtractResult:
-        async with asyncio.timeout(60):
-            async with _gateway_lock:
-                return extract_agents_to_canonical(
-                    project_root,
-                    overwrite=overwrite,
-                    only_name=name,
-                    dry_run=dry,
-                    scope=target_scope,
-                    force_unsafe_import=force_unsafe_import,
-                    surface="web_context_agents_import",
-                )
-
-    try:
-        if target_scope == "user" and not allow_host_writes:
-            preview = await _run(dry=True)
-            if not preview.imported and not preview.skipped:
-                raise _error(404, "missing", f"No runtime agent named {name!r} to import")
-            gate = host_write_gate(
-                target_scope,
-                allow_host_writes,
-                action="Import agent",
-                host_targets=[str(p) for p, _layout in preview.imported],
-                plan=_import_payload(preview, project_root, target_scope, dry_run=None),
-            )
-            if gate is not None:
-                return gate
-        result = await _run(dry=False)
-    except TimeoutError:
-        raise _error(503, "busy", "Agent import timed out — another sync may be in progress")
-    except click.ClickException as exc:
-        # project_shared Gate A privacy block → 422 (see context_skills.import_skills).
-        raise HTTPException(422, PRIVACY_BLOCK_IMPORT_DETAIL) from exc
-    if not result.imported and not result.skipped:
-        raise _error(404, "missing", f"No runtime agent named {name!r} to import")
-    return _import_payload(result, project_root, target_scope, dry_run=None)
+    return await _atomic_kind.import_artifact(_SPEC, name, body, project_root, target_scope)

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -1,27 +1,27 @@
-"""Context gateway — Commands CRUD, diff, sync, import, and rendered output."""
+"""Context gateway — Commands CRUD, diff, sync, import, and rendered output.
+
+Thin route layer: the ``@router``-decorated functions below own the URL,
+signature, and OpenAPI surface (and the AST invariant registry keys on
+them — see ``test_web_invariants_registry.py``); the handler bodies live
+once in :mod:`memtomem.web.routes._atomic_kind`, parametrized by
+``_SPEC`` (#1514). Engine callables on the spec late-bind this module's
+globals so tests can keep monkeypatching them here.
+"""
 
 from __future__ import annotations
 
-import asyncio
-import logging
-import shutil
 from pathlib import Path
 
-import click
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 
 from memtomem.config import TargetScope
-from memtomem.context import versioning
-from memtomem.context._atomic import atomic_write_text
-from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context.commands import (
     _parse_canonical_command_text,
     CANONICAL_COMMAND_ROOT,
     COMMAND_DIR_FILENAME,
     COMMAND_GENERATORS,
     CommandParseError,
-    ExtractResult,
     StrictDropError,
     canonical_command_name,
     diff_commands,
@@ -31,85 +31,75 @@ from memtomem.context.commands import (
     parse_canonical_command,
     resolve_canonical_command,
 )
+
+# Re-exports kept for test contracts: engine spies build ``module.ExtractResult``
+# values, and the lock-identity test imports ``_gateway_lock`` from each kind
+# module to pin the shared singleton.
+from memtomem.context.commands import ExtractResult as ExtractResult
 from memtomem.context.detector import COMMAND_DIRS
-from memtomem.context.privacy_scan import PrivacyScanError
-from memtomem.web.routes.context_gateway import (
-    _safe_rel,
-    delete_skip_entry,
-    expected_vs_runtime_row,
-    read_text_lenient,
-    sanitize_diff_reason,
-)
-from memtomem.web.routes.context_projects import (
-    resolve_scope_root,
-    resolve_scope_root_cascade_gated,
-    resolve_writable_scope_root,
-)
-from memtomem.web.routes.context_versions import include_has, version_summary
+from memtomem.web.routes import _atomic_kind
 from memtomem.web.routes._artifact_common import (
     ArtifactCreateRequest,
     ArtifactUpdateRequest,
     AtomicSyncRequest,
     ImportRequest,
-    mtime_conflict_response,
-    reject_project_local_write,
-    scanned_dirs_for,
 )
-from memtomem.web.routes._confirm import host_write_gate
-from memtomem.web.routes._errors import PRIVACY_BLOCK_DETAIL, PRIVACY_BLOCK_IMPORT_DETAIL, _error
-from memtomem.web.routes._locks import _gateway_lock
-from memtomem.web.routes._sync_phase import SyncPhaseError
+from memtomem.web.routes._locks import _gateway_lock as _gateway_lock
+from memtomem.web.routes.context_projects import (
+    resolve_scope_root,
+    resolve_scope_root_cascade_gated,
+    resolve_writable_scope_root,
+)
 
 # Flat list of project-relative runtime scan paths reported on list / import
 # responses so the web UI's empty-state hint can name the exact directories
 # the detector inspects without hardcoding them client-side.
 _COMMAND_SCAN_DIRS: list[str] = [rel for rel, _suffix in COMMAND_DIRS.values()]
 
-logger = logging.getLogger(__name__)
-
 router = APIRouter(tags=["context-commands"])
 
-
-# ── Helpers ──────────────────────────────────────────────────────────────
-
-
-def _commands_root(project_root: Path, *, scope: TargetScope = "project_shared") -> Path:
-    from memtomem.context.scope_resolver import canonical_artifact_dir
-
-    return canonical_artifact_dir("commands", scope, project_root)
+# Frontmatter keys that any command generator may drop. Hyphenated to match
+# the strings the renderers emit on ``dropped_fields`` (see
+# ``memtomem.context.commands._subcommand_to_gemini_toml``). Required fields
+# (``name``, ``description``) are never dropped, so they aren't tracked here.
+_ALL_OPTIONAL_FIELDS = ("argument-hint", "allowed-tools", "model")
 
 
-def _resolve_existing_command(
-    project_root: Path, raw_name: str, *, scope: TargetScope = "project_shared"
-):
-    name = validate_name(raw_name, kind="command")
-    return name, resolve_canonical_command(project_root, name, scope=scope)
+def _command_fields(parsed) -> dict:
+    return {
+        "description": parsed.description,
+        "argument_hint": parsed.argument_hint,
+        "allowed_tools": parsed.allowed_tools,
+        "model": parsed.model,
+    }
 
 
-def _user_sync_host_targets(project_root: Path) -> list[str]:
-    """Pending user-tier fan-out destinations for the sync confirm gate.
-
-    Upper bound on the confirmed sync's writes, resolved from the PARSED
-    frontmatter name: ``sync_atomic_artifact`` fans out under
-    ``adapter.name_of(parse(...))``, not the canonical filename, so a
-    filename-derived disclosure could confirm one path while the engine
-    writes another (#1263 review Blocker). Canonicals the engine would
-    skip at read/parse time are excluded the same way; later preflight
-    skips (Gate A, override errors, conflicts, lock timeouts) only
-    shrink the actual write set below this disclosure.
-    """
-    targets: set[str] = set()
-    for cmd_path, layout in list_canonical_commands(project_root, scope="user"):
-        try:
-            text = cmd_path.read_bytes().decode("utf-8", errors="replace")
-            parsed = _parse_canonical_command_text(text, source=cmd_path, layout=layout)
-        except (OSError, CommandParseError):
-            continue  # the engine skips these too
-        for gen in COMMAND_GENERATORS.values():
-            dst = gen.target_file(project_root, parsed.name, scope="user")
-            if dst is not None:
-                targets.add(str(dst))
-    return sorted(targets)
+_SPEC = _atomic_kind.AtomicKindSpec(
+    kind="command",
+    kind_plural="commands",
+    canonical_root=CANONICAL_COMMAND_ROOT,
+    dir_filename=COMMAND_DIR_FILENAME,
+    scan_dirs=_COMMAND_SCAN_DIRS,
+    optional_fields=_ALL_OPTIONAL_FIELDS,
+    rendered_includes_fields=False,
+    parse_error=CommandParseError,
+    strict_drop_error=StrictDropError,
+    sync_surface="web_context_commands_sync",
+    import_surface="web_context_commands_import",
+    # Late-binding lambdas, not function references — they resolve this
+    # module's globals at call time so ``monkeypatch.setattr(context_commands,
+    # "generate_all_commands", ...)`` still intercepts the engine call.
+    generators=lambda: COMMAND_GENERATORS,
+    list_canonicals=lambda *a, **kw: list_canonical_commands(*a, **kw),
+    resolve_canonical=lambda *a, **kw: resolve_canonical_command(*a, **kw),
+    diff=lambda *a, **kw: diff_commands(*a, **kw),
+    parse_canonical=lambda *a, **kw: parse_canonical_command(*a, **kw),
+    parse_text=lambda *a, **kw: _parse_canonical_command_text(*a, **kw),
+    canonical_name=lambda *a, **kw: canonical_command_name(*a, **kw),
+    generate_all=lambda *a, **kw: generate_all_commands(*a, **kw),
+    extract_to_canonical=lambda *a, **kw: extract_commands_to_canonical(*a, **kw),
+    fields_from_parsed=_command_fields,
+)
 
 
 # ── List ─────────────────────────────────────────────────────────────────
@@ -135,57 +125,7 @@ async def list_commands(
     ),
 ) -> dict:
     """List canonical commands. Accepts project selector aliases like list_skills."""
-    want_versions = include_has(include, "versions")
-    canonicals = list_canonical_commands(project_root, scope=target_scope)
-    diffs = diff_commands(project_root, scope=target_scope)
-
-    by_name: dict[str, list[dict]] = {}
-    for row in diffs:
-        entry: dict[str, object] = {"runtime": row[0], "status": row[2]}
-        reason = sanitize_diff_reason(getattr(row, "reason", None), project_root)
-        if reason:
-            entry["reason"] = reason
-        by_name.setdefault(row[1], []).append(entry)
-
-    commands: list[dict[str, object]] = []
-    canonical_names: set[str] = set()
-    for cmd_path, layout in canonicals:
-        name = canonical_command_name(cmd_path, layout)
-        canonical_names.add(name)
-        item: dict[str, object] = {
-            "name": name,
-            "canonical_path": _safe_rel(cmd_path, project_root),
-            "target_scope": target_scope,
-            "runtimes": by_name.get(name, []),
-        }
-        if want_versions:
-            item["versions"] = version_summary(cmd_path, layout)
-        commands.append(item)
-
-    for cmd_name, runtimes in by_name.items():
-        if cmd_name not in canonical_names:
-            item = {
-                "name": cmd_name,
-                "canonical_path": None,
-                "target_scope": target_scope,
-                "runtimes": runtimes,
-            }
-            if want_versions:
-                # Runtime-only: no canonical file → nothing to version and no
-                # store to migrate. Keep the four-key shape for the JS reader.
-                item["versions"] = {
-                    "labels": {},
-                    "count": 0,
-                    "versionable": False,
-                    "migrate_required": False,
-                }
-            commands.append(item)
-
-    return {
-        "commands": commands,
-        "canonical_root": CANONICAL_COMMAND_ROOT,
-        "scanned_dirs": _COMMAND_SCAN_DIRS,
-    }
+    return await _atomic_kind.list_artifacts(_SPEC, project_root, target_scope, include)
 
 
 # ── Read ─────────────────────────────────────────────────────────────────
@@ -200,47 +140,10 @@ async def read_command(
         description="Canonical-residency tier to read from (ADR-0016).",
     ),
 ) -> dict:
-    name, resolved = _resolve_existing_command(project_root, name, scope=target_scope)
-    if resolved is None:
-        raise _error(404, "missing", f"command {name!r} not found")
-    cmd_path, layout = resolved
-
-    content = cmd_path.read_text(encoding="utf-8")
-    # mtime_ns serialized as string (JS bigint-unsafe).
-    mtime_ns = cmd_path.stat().st_mtime_ns
-
-    fields: dict = {}
-    try:
-        parsed = parse_canonical_command(cmd_path, layout=layout)
-        fields = {
-            "description": parsed.description,
-            "argument_hint": parsed.argument_hint,
-            "allowed_tools": parsed.allowed_tools,
-            "model": parsed.model,
-        }
-    except CommandParseError:
-        pass
-
-    # Issue #962 detail meta header — echo back ``target_scope`` and
-    # the resolved ``layout`` so the JS meta-header renderer stays
-    # type-agnostic across the three artifact types.
-    return {
-        "name": name,
-        "content": content,
-        "mtime_ns": str(mtime_ns),
-        "fields": fields,
-        "target_scope": target_scope,
-        "layout": layout,
-    }
+    return await _atomic_kind.read_artifact(_SPEC, name, project_root, target_scope)
 
 
 # ── Rendered (per-runtime output with dropped fields + field map) ────────
-
-# Frontmatter keys that any command generator may drop. Hyphenated to match
-# the strings the renderers emit on ``dropped_fields`` (see
-# ``memtomem.context.commands._subcommand_to_gemini_toml``). Required fields
-# (``name``, ``description``) are never dropped, so they aren't tracked here.
-_ALL_OPTIONAL_FIELDS = ("argument-hint", "allowed-tools", "model")
 
 
 @router.get("/context/commands/{name}/rendered")
@@ -252,56 +155,7 @@ async def rendered_command(
         description="Canonical-residency tier to render (ADR-0016).",
     ),
 ) -> JSONResponse:
-    name, resolved = _resolve_existing_command(project_root, name, scope=target_scope)
-    if resolved is None:
-        raise _error(404, "missing", f"command {name!r} not found")
-    cmd_path, layout = resolved
-
-    content = cmd_path.read_text(encoding="utf-8")
-    try:
-        parsed = parse_canonical_command(cmd_path, layout=layout)
-    except CommandParseError as exc:
-        # ``str(exc)`` embeds the absolute canonical source path (the parser
-        # raises ``... (source: {path})``); route it through the shared
-        # display-sanitize boundary so the loopback 422 detail stays path-free
-        # — the #1412 fix class the mcp-servers parse-422 already applies.
-        detail = sanitize_diff_reason(str(exc), project_root) or ""
-        return JSONResponse(
-            status_code=422,
-            content={"detail": {"error_kind": "parse", "message": f"Parse error: {detail}"}},
-        )
-
-    runtimes = []
-    diffs = diff_commands(project_root, scope=target_scope)
-    status_map: dict[tuple[str, str], str] = {(rt, n): s for rt, n, s in diffs}
-    # ``field_map[field][runtime] = bool`` — True when the runtime keeps the
-    # field, False when it drops it. Mirrors ``context_agents.rendered_agent``
-    # so the front-end can render a single matrix for either surface.
-    field_map: dict[str, dict[str, bool]] = {f: {} for f in _ALL_OPTIONAL_FIELDS}
-
-    for gen_name, gen in COMMAND_GENERATORS.items():
-        rendered_content, dropped_fields = gen.render(parsed)
-        status = status_map.get((gen_name, name), "unknown")
-        runtimes.append(
-            {
-                "runtime": gen_name,
-                "content": rendered_content,
-                "dropped_fields": dropped_fields,
-                "status": status,
-            }
-        )
-        dropped_set = set(dropped_fields)
-        for f in _ALL_OPTIONAL_FIELDS:
-            field_map[f][gen_name] = f not in dropped_set
-
-    return JSONResponse(
-        content={
-            "name": name,
-            "canonical_content": content,
-            "runtimes": runtimes,
-            "field_map": field_map,
-        }
-    )
+    return await _atomic_kind.rendered_artifact(_SPEC, name, project_root, target_scope)
 
 
 # ── Create ───────────────────────────────────────────────────────────────
@@ -323,85 +177,7 @@ async def create_command(
         ),
     ),
 ) -> dict:
-    reject_project_local_write(target_scope, "Create command")
-    name = validate_name(body.name, kind="command")
-
-    # Unlocked pre-checks so a duplicate is refused (409) rather than
-    # confirmed, and the gate discloses the exact artifact dir. The locked
-    # re-checks below stay authoritative for create races.
-    artifact_dir_unlocked = _commands_root(project_root, scope=target_scope) / name
-    if (
-        resolve_canonical_command(project_root, name, scope=target_scope) is not None
-        or artifact_dir_unlocked.exists()
-    ):
-        raise _error(
-            409, "conflict", f"Command '{name}' already exists", reason_code="already_exists"
-        )
-    gate = host_write_gate(
-        target_scope,
-        body.allow_host_writes,
-        action="Create command",
-        host_targets=[str(artifact_dir_unlocked)],
-    )
-    if gate is not None:
-        return gate
-
-    try:
-        async with asyncio.timeout(60):
-            async with _gateway_lock:
-                if resolve_canonical_command(project_root, name, scope=target_scope) is not None:
-                    raise _error(
-                        409,
-                        "conflict",
-                        f"Command '{name}' already exists",
-                        reason_code="already_exists",
-                    )
-                # ADR-0022: create in versioned directory layout (command.md +
-                # versions/v1.md + manifest) from the start, so the artifact is
-                # immediately versionable in the detail panel instead of a flat
-                # file the version UI tells you to ``mm context migrate`` — which
-                # then skips it as an unowned manual flat (the split-brain).
-                # Mirrored in context_agents.py.
-                artifact_dir = _commands_root(project_root, scope=target_scope) / name
-                if artifact_dir.exists():
-                    # resolve_canonical_command found no working file above, but a
-                    # stale/orphan directory remains — surface a clean 409 rather
-                    # than a 500 from mkdir()'s FileExistsError.
-                    raise _error(
-                        409,
-                        "conflict",
-                        f"Command '{name}' already exists",
-                        reason_code="already_exists",
-                    )
-                # Encode the submitted content up front, before anything touches
-                # disk. A lone-surrogate body can't be UTF-8 encoded; failing
-                # after mkdir would leave an orphan dir that wedges retries on the
-                # 409 above. These exact bytes become source_bytes for
-                # create_version, so v1.md is byte-identical to the working file
-                # with no re-read race (_gateway_lock guards only this process).
-                try:
-                    content_bytes = body.content.encode("utf-8")
-                except UnicodeEncodeError as exc:
-                    raise _error(400, "validation", "Command content is not valid UTF-8") from exc
-                artifact_dir.mkdir(parents=True)
-                cmd_path = artifact_dir / COMMAND_DIR_FILENAME
-                try:
-                    atomic_write_text(cmd_path, body.content)
-                    versioning.create_version(
-                        artifact_dir,
-                        cmd_path,
-                        note="Initial version (created via web)",
-                        source_bytes=content_bytes,
-                    )
-                except BaseException:
-                    # Roll back the partial artifact dir so a transient failure
-                    # doesn't leave an empty directory that wedges every future
-                    # create of this name on the orphan-dir 409 above.
-                    shutil.rmtree(artifact_dir, ignore_errors=True)
-                    raise
-    except TimeoutError:
-        raise _error(503, "busy", "Command create timed out — another sync may be in progress")
-    return {"name": name, "canonical_path": _safe_rel(cmd_path, project_root)}
+    return await _atomic_kind.create_artifact(_SPEC, body, project_root, target_scope)
 
 
 # ── Update ───────────────────────────────────────────────────────────────
@@ -424,50 +200,7 @@ async def update_command(
         ),
     ),
 ) -> JSONResponse:
-    reject_project_local_write(target_scope, "Update command")
-    name, resolved = _resolve_existing_command(project_root, name, scope=target_scope)
-    if resolved is None:
-        raise _error(404, "missing", f"command {name!r} not found")
-    cmd_path, _layout = resolved
-
-    try:
-        body_mtime_ns = int(body.mtime_ns)
-    except ValueError:
-        raise _error(422, "validation", f"Invalid mtime_ns: {body.mtime_ns!r}")
-
-    # Unlocked pre-check before the host-write gate — a stale request is
-    # refused, never confirmed (see context_skills.update_skill).
-    pre_mtime_ns = cmd_path.stat().st_mtime_ns
-    if pre_mtime_ns != body_mtime_ns and not body.force:
-        return mtime_conflict_response(pre_mtime_ns)
-    gate = host_write_gate(
-        target_scope,
-        body.allow_host_writes,
-        action="Update command",
-        host_targets=[str(cmd_path)],
-    )
-    if gate is not None:
-        return JSONResponse(content=gate)
-
-    try:
-        async with asyncio.timeout(60):
-            async with _gateway_lock:
-                current_mtime_ns = cmd_path.stat().st_mtime_ns
-                if current_mtime_ns != body_mtime_ns:
-                    if not body.force:
-                        return mtime_conflict_response(current_mtime_ns)
-                    logger.warning(
-                        "force-save bypassed mtime check on %s "
-                        "(client_mtime_ns=%s server_mtime_ns=%s)",
-                        cmd_path,
-                        body_mtime_ns,
-                        current_mtime_ns,
-                    )
-                atomic_write_text(cmd_path, body.content)
-                new_mtime_ns = cmd_path.stat().st_mtime_ns
-    except TimeoutError:
-        raise _error(503, "busy", "Command update timed out — another sync may be in progress")
-    return JSONResponse(content={"name": name, "mtime_ns": str(new_mtime_ns)})
+    return await _atomic_kind.update_artifact(_SPEC, name, body, project_root, target_scope)
 
 
 # ── Delete ───────────────────────────────────────────────────────────────
@@ -494,61 +227,9 @@ async def delete_command(
         ),
     ),
 ) -> dict:
-    reject_project_local_write(target_scope, "Delete command")
-    name, resolved = _resolve_existing_command(project_root, name, scope=target_scope)
-
-    # Pending deletions, computed unlocked (see delete_skill): cascade
-    # targets resolve AT THIS TIER — scope= is load-bearing for user-tier
-    # cascades. Idempotent no-ops skip the gate.
-    pending: list[Path] = [resolved[0]] if resolved is not None else []
-    if cascade:
-        for gen in COMMAND_GENERATORS.values():
-            target = gen.target_file(project_root, name, scope=target_scope)
-            if target is not None and target.is_file():
-                pending.append(target)
-    gate = host_write_gate(
-        target_scope,
-        allow_host_writes,
-        action="Delete command",
-        host_targets=[str(p) for p in pending],
+    return await _atomic_kind.delete_artifact(
+        _SPEC, name, cascade, project_root, target_scope, allow_host_writes
     )
-    if gate is not None:
-        return gate
-
-    try:
-        async with asyncio.timeout(60):
-            async with _gateway_lock:
-                removed: list[str] = []
-                skipped: list[dict[str, str]] = []
-
-                if resolved is not None:
-                    cmd_path, _layout = resolved
-                    try:
-                        cmd_path.unlink()
-                        removed.append(_safe_rel(cmd_path, project_root))
-                    except OSError as e:
-                        skipped.append(delete_skip_entry(cmd_path, e, project_root))
-
-                # Sibling of the canonical branch, not nested inside it — a
-                # runtime-only command (no canonical) + cascade=true must still
-                # remove the runtime copies; the nested shape silently no-opped
-                # (#1247 id 46). Matches delete_agent / delete_skill.
-                if cascade:
-                    for gen in COMMAND_GENERATORS.values():
-                        target = gen.target_file(project_root, name, scope=target_scope)
-                        if target is None:
-                            continue
-                        if not target.is_file():
-                            continue
-                        try:
-                            target.unlink()
-                            removed.append(_safe_rel(target, project_root))
-                        except OSError as e:
-                            skipped.append(delete_skip_entry(target, e, project_root))
-    except TimeoutError:
-        raise _error(503, "busy", "Command delete timed out — another sync may be in progress")
-
-    return {"deleted": removed, "skipped": skipped}
 
 
 # ── Diff ─────────────────────────────────────────────────────────────────
@@ -563,88 +244,7 @@ async def diff_command(
         description="Canonical-residency tier to diff against runtime fan-out (ADR-0016).",
     ),
 ) -> dict:
-    name, resolved = _resolve_existing_command(project_root, name, scope=target_scope)
-
-    canonical_content = None
-    canonical_path = None
-    parse_error_reason = None
-    parsed = None
-    if resolved is not None:
-        cmd_path, layout = resolved
-        canonical_path = _safe_rel(cmd_path, project_root)
-        # Lenient read + re-parse — mirrors diff_agent: the pane must agree
-        # with the list badge instead of raw-comparing a malformed canonical
-        # into "out of sync" / "in sync" (#1229 U7).
-        canonical_content = read_text_lenient(cmd_path)
-        if canonical_content is None:
-            # Unreadable canonical (permission, race) — same tolerant path as
-            # the engine diff: every runtime row reports a diagnosable parse
-            # error instead of a 500 (Codex review).
-            parse_error_reason = sanitize_diff_reason(f"unreadable: {cmd_path}", project_root)
-        else:
-            try:
-                parsed = _parse_canonical_command_text(
-                    canonical_content, source=cmd_path, layout=layout
-                )
-            except CommandParseError as exc:
-                parse_error_reason = sanitize_diff_reason(str(exc), project_root)
-
-    runtimes = []
-    for gen_name, gen in COMMAND_GENERATORS.items():
-        # Match the canonical side's tier — see context_skills.py diff_skill
-        # for the rationale (#1229). NO_FANOUT tiers return None → skipped.
-        target = gen.target_file(project_root, name, scope=target_scope)
-        if target is None:
-            continue
-        if parse_error_reason is not None:
-            entry: dict[str, object] = {
-                "runtime": gen_name,
-                "status": "parse error",
-                "reason": parse_error_reason,
-            }
-            if target.is_file():
-                runtime_preview = read_text_lenient(target)
-                if runtime_preview is not None:
-                    entry["runtime_content"] = runtime_preview
-            runtimes.append(entry)
-            continue
-        if canonical_content is None and not target.is_file():
-            continue
-        elif canonical_content is not None and not target.is_file():
-            runtimes.append({"runtime": gen_name, "status": "missing target"})
-        elif canonical_content is None and target.is_file():
-            runtimes.append(
-                {
-                    "runtime": gen_name,
-                    "status": "missing canonical",
-                    "runtime_content": read_text_lenient(target),
-                }
-            )
-        else:
-            # Compare on the engine's basis — vendor override bytes, else
-            # rendered output — NOT the raw canonical text: gemini targets
-            # are TOML, so a raw compare pinned this pane to a permanent
-            # "out of sync" under an "in sync" list badge (#1247 id 30).
-            assert parsed is not None  # parse failures took the branch above
-            cmd = parsed
-            runtimes.append(
-                expected_vs_runtime_row(
-                    kind="commands",
-                    gen_name=gen_name,
-                    render=lambda gen=gen, cmd=cmd: gen.render(cmd)[0],
-                    target=target,
-                    name=name,
-                    project_root=project_root,
-                    scope=target_scope,
-                )
-            )
-
-    return {
-        "name": name,
-        "canonical_content": canonical_content,
-        "canonical_path": canonical_path,
-        "runtimes": runtimes,
-    }
+    return await _atomic_kind.diff_artifact(_SPEC, name, project_root, target_scope)
 
 
 # ── Sync ─────────────────────────────────────────────────────────────────
@@ -664,66 +264,19 @@ async def _sync_commands_core(
 ) -> dict:
     """Lock-free commands sync core — the caller MUST hold ``_gateway_lock``.
 
-    Shared by the standalone route below and ``POST /context/sync-all``
-    (#1278), which runs every per-type core under ONE outer lock
-    acquisition — the lock is a non-reentrant ``_LoopLocalLock``, so the
-    core must never acquire it itself. The engine call stays a direct
-    synchronous call (no worker thread): commands take no cross-process
-    file lock — each runtime artifact is one full-content atomic
-    ``os.replace`` — so there is no unbounded block to offload (the
-    skills/settings cores differ, see ``_sync_skills_core``).
-
-    Engine errors are raised as :class:`SyncPhaseError` — the standalone
-    route's historical status/detail pair (privacy 422 keeps its STRING
-    detail, issue-pinned; strict-drop keeps its dict detail) plus the
-    envelope attributes sync-all renders.
+    Kept as a module-level name because ``context_sync_all`` imports the
+    five per-type cores by name; the body lives in
+    :func:`_atomic_kind.sync_core` (see there for the lock and
+    thread-offload contract).
     """
-    try:
-        result = generate_all_commands(
-            project_root,
-            on_drop=on_drop,
-            scope=target_scope,
-            surface=surface,
-            force_unsafe=force_unsafe,
-        )
-    except PrivacyScanError as exc:
-        # Path-free detail — ``exc.message`` embeds the absolute canonical path
-        # (#1385 finding 1). The chained ``exc`` keeps the full text for logs.
-        raise SyncPhaseError(
-            422, PRIVACY_BLOCK_DETAIL, error_kind="validation", reason_code="privacy_blocked"
-        ) from exc
-    except StrictDropError as exc:
-        # on_drop="error" aborts mid-Phase-2 with earlier writes persisted
-        # (the #908 partial-write boundary). Surface the partial fan-out
-        # instead of an opaque 500 (#1247 id 47): the detail dict follows
-        # the #1210 ``{reason_code, message}`` shape the JS error path
-        # already renders, plus the writes that landed before the abort.
-        # API-only reachability — the UI never sends on_drop="error".
-        raise SyncPhaseError(
-            422,
-            detail={
-                "reason_code": "strict_drop",
-                "message": str(exc),
-                "generated": [
-                    {"runtime": rt, "path": _safe_rel(p, project_root)} for rt, p in exc.generated
-                ],
-            },
-            error_kind="validation",
-            reason_code="strict_drop",
-        ) from exc
-    return {
-        "generated": [
-            {"runtime": rt, "path": _safe_rel(p, project_root)} for rt, p in result.generated
-        ],
-        "dropped": [
-            {"runtime": rt, "name": name, "fields": fields} for rt, name, fields in result.dropped
-        ],
-        "skipped": [
-            {"runtime": rt, "reason": reason, "reason_code": code}
-            for rt, reason, code in result.skipped
-        ],
-        "canonical_root": CANONICAL_COMMAND_ROOT,
-    }
+    return await _atomic_kind.sync_core(
+        _SPEC,
+        project_root,
+        target_scope,
+        on_drop=on_drop,
+        surface=surface,
+        force_unsafe=force_unsafe,
+    )
 
 
 @router.post("/context/commands/sync")
@@ -740,61 +293,10 @@ async def sync_commands(
         ),
     ),
 ) -> dict:
-    reject_project_local_write(target_scope, "Sync commands")
-    on_drop = body.on_drop if body else "warn"
-    gate = host_write_gate(
-        target_scope,
-        body.allow_host_writes if body else False,
-        action="Sync commands",
-        host_targets=_user_sync_host_targets(project_root),
-    )
-    if gate is not None:
-        return gate
-    force_unsafe = body.force_unsafe_sync if body else False
-    try:
-        async with asyncio.timeout(60):
-            async with _gateway_lock:
-                return await _sync_commands_core(
-                    project_root, target_scope, on_drop=on_drop, force_unsafe=force_unsafe
-                )
-    except TimeoutError:
-        raise _error(503, "busy", "Commands sync timed out — another sync may be in progress")
+    return await _atomic_kind.sync_artifacts(_SPEC, body, project_root, target_scope)
 
 
 # ── Import ───────────────────────────────────────────────────────────────
-
-
-def _import_payload(
-    result: ExtractResult,
-    project_root: Path,
-    target_scope: TargetScope,
-    dry_run: bool | None,
-) -> dict:
-    """Wire shape shared by both import routes (and the gate's nested plan).
-
-    Mirrors context_skills._import_payload — ``dry_run=None`` omits the
-    key, ``_safe_rel`` keeps user-tier ``~/.memtomem`` paths encodable.
-    """
-    payload: dict = {
-        "imported": [
-            {
-                "name": canonical_command_name(p, layout),
-                "canonical_path": _safe_rel(p, project_root),
-            }
-            for p, layout in result.imported
-        ],
-        "skipped": [
-            {"name": name, "reason": reason, "reason_code": code}
-            for name, reason, code in result.skipped
-        ],
-        "project_root": str(project_root),
-        "scanned_dirs": scanned_dirs_for(
-            target_scope, kind="commands", project_scan_dirs=_COMMAND_SCAN_DIRS
-        ),
-    }
-    if dry_run is not None:
-        payload["dry_run"] = dry_run
-    return payload
 
 
 @router.post("/context/commands/import")
@@ -818,44 +320,7 @@ async def import_commands(
         ),
     ),
 ) -> dict:
-    reject_project_local_write(target_scope, "Import commands")
-    overwrite = body.overwrite if body else False
-    allow_host_writes = body.allow_host_writes if body else False
-    force_unsafe_import = body.force_unsafe_import if body else False
-
-    async def _run(dry: bool) -> ExtractResult:
-        async with asyncio.timeout(60):
-            async with _gateway_lock:
-                return extract_commands_to_canonical(
-                    project_root,
-                    overwrite=overwrite,
-                    dry_run=dry,
-                    scope=target_scope,
-                    force_unsafe_import=force_unsafe_import,
-                    surface="web_context_commands_import",
-                )
-
-    try:
-        if not dry_run and target_scope == "user" and not allow_host_writes:
-            # Gate disclosure needs the engine's scan — dry-run preview,
-            # nested as ``plan`` (see context_skills.import_skills).
-            preview = await _run(dry=True)
-            gate = host_write_gate(
-                target_scope,
-                allow_host_writes,
-                action="Import commands",
-                host_targets=[str(p) for p, _layout in preview.imported],
-                plan=_import_payload(preview, project_root, target_scope, dry_run=True),
-            )
-            if gate is not None:
-                return gate
-        result = await _run(dry=dry_run)
-    except TimeoutError:
-        raise _error(503, "busy", "Commands import timed out — another sync may be in progress")
-    except click.ClickException as exc:
-        # project_shared Gate A privacy block → 422 (see context_skills.import_skills).
-        raise HTTPException(422, PRIVACY_BLOCK_IMPORT_DETAIL) from exc
-    return _import_payload(result, project_root, target_scope, dry_run=dry_run)
+    return await _atomic_kind.import_artifacts(_SPEC, body, project_root, target_scope, dry_run)
 
 
 @router.post("/context/commands/{name}/import")
@@ -879,48 +344,4 @@ async def import_command(
     feedback for "you clicked a specific item that doesn't exist") — pinned
     on the gate's dry-run preview too.
     """
-    reject_project_local_write(target_scope, "Import command")
-    try:
-        validate_name(name, kind="command name")
-    except InvalidNameError as exc:
-        raise _error(400, "validation", f"Invalid command name: {exc}")
-    overwrite = body.overwrite if body else False
-    allow_host_writes = body.allow_host_writes if body else False
-    force_unsafe_import = body.force_unsafe_import if body else False
-
-    async def _run(dry: bool) -> ExtractResult:
-        async with asyncio.timeout(60):
-            async with _gateway_lock:
-                return extract_commands_to_canonical(
-                    project_root,
-                    overwrite=overwrite,
-                    only_name=name,
-                    dry_run=dry,
-                    scope=target_scope,
-                    force_unsafe_import=force_unsafe_import,
-                    surface="web_context_commands_import",
-                )
-
-    try:
-        if target_scope == "user" and not allow_host_writes:
-            preview = await _run(dry=True)
-            if not preview.imported and not preview.skipped:
-                raise _error(404, "missing", f"No runtime command named {name!r} to import")
-            gate = host_write_gate(
-                target_scope,
-                allow_host_writes,
-                action="Import command",
-                host_targets=[str(p) for p, _layout in preview.imported],
-                plan=_import_payload(preview, project_root, target_scope, dry_run=None),
-            )
-            if gate is not None:
-                return gate
-        result = await _run(dry=False)
-    except TimeoutError:
-        raise _error(503, "busy", "Command import timed out — another sync may be in progress")
-    except click.ClickException as exc:
-        # project_shared Gate A privacy block → 422 (see context_skills.import_skills).
-        raise HTTPException(422, PRIVACY_BLOCK_IMPORT_DETAIL) from exc
-    if not result.imported and not result.skipped:
-        raise _error(404, "missing", f"No runtime command named {name!r} to import")
-    return _import_payload(result, project_root, target_scope, dry_run=None)
+    return await _atomic_kind.import_artifact(_SPEC, name, body, project_root, target_scope)

--- a/packages/memtomem/tests/test_web_routes_context_mutators.py
+++ b/packages/memtomem/tests/test_web_routes_context_mutators.py
@@ -392,18 +392,19 @@ async def test_PUT_holds_gateway_lock(
     mtime_ns = read.json()["mtime_ns"]
 
     from memtomem.web.routes._locks import _gateway_lock
-    import memtomem.web.routes.context_agents as _ca
-    import memtomem.web.routes.context_commands as _cc
+    import memtomem.web.routes._atomic_kind as _ak
     import memtomem.web.routes.context_skills as _cs
 
     observed = {"locked": False}
-    real = _ca.atomic_write_text  # same symbol, all three route modules
+    real = _cs.atomic_write_text  # same symbol at both write sites
 
     def probe(path, text, **kw):
         observed["locked"] = _gateway_lock.locked()
         return real(path, text, **kw)
 
-    for mod in (_ca, _cc, _cs):
+    # Patch where the write actually runs: the shared ``_atomic_kind``
+    # bodies serve commands/agents (#1514); skills keeps its own handler.
+    for mod in (_ak, _cs):
         monkeypatch.setattr(mod, "atomic_write_text", probe)
 
     r = await client.put(


### PR DESCRIPTION
## Summary

Part 2 of #1514, **stacked on #1575** (retarget/rebase after it merges). `context_commands.py` and `context_agents.py` were ~91-95% line-identical after normalizing the kind token — contractual mirrors whose hand-maintained copies are where the #1514 hardening fixes drifted. This PR moves the handler **bodies** into one parametrized module, `web/routes/_atomic_kind.py` (`AtomicKindSpec` + shared list / read / rendered / create / update / delete / diff / sync / import implementations); each kind module shrinks to its spec plus thin `@router`-decorated functions (1032/1021 → ~350 lines each).

## Why thin handlers instead of a full router factory

Keeping the decorated functions in the kind modules preserves three contracts verbatim:

- **AST invariant registry** (`test_web_invariants_registry.py`) keys on `<module>.<function>` of decorated handlers in non-underscore route modules — zero registry churn, the CSRF/redaction guard keeps its exact surface
- **FastAPI endpoint names / OpenAPI operationIds** derive from the decorated function names — unchanged
- **Monkeypatch contracts**: tests patch engine functions on the kind modules (`monkeypatch.setattr(context_agents, "generate_all_agents", …)`); every callable on the spec is a late-binding lambda over module globals, never a captured function object

The only per-kind capability flag is `rendered_includes_fields` (agents' rendered response carries a `fields` key). A second flag is the agreed signal to split a diverging route back out rather than grow the spec. Skills and mcp-servers stay separate by design — rationale in the module docstring.

`test_PUT_holds_gateway_lock` now probes `atomic_write_text` at the actual write site (`_atomic_kind` + `context_skills`); the invariant and its fail-closed shape are unchanged.

## Parity gates

- Full `pytest -m "not ollama"`: **7574 passed, 11 skipped** (collected test IDs identical to part 1's tree)
- `app.openapi()` diff vs `main` (sorted keys): **empty** — operationIds, params, descriptions, component names all identical
- `ruff check` + `ruff format --check`: clean; `mypy`: pre-existing baseline

## Review

Codex design gate flagged three majors against the factory approach (scanner blindness, monkeypatch capture, operationId drift); this thin-handler fork makes the first and third moot and handles the second via late-binding lambdas. Codex diff review of the fork: **SHIP**, zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
