### PR TITLE
fix(indexing): reject short embedding arrays instead of truncating the zip (#1563)

### DIFF
--- a/packages/memtomem/src/memtomem/embedding/ollama.py
+++ b/packages/memtomem/src/memtomem/embedding/ollama.py
@@ -55,6 +55,17 @@ class OllamaEmbedder:
             raise EmbeddingError(
                 f"Ollama API returned unexpected response (missing 'embeddings' key): {list(data.keys())}"
             )
+        if len(embeddings) != len(batch):
+            # A short array (flaky/OOM-pressured server) must be a hard error,
+            # not silent truncation: the index engine ``zip``s these vectors
+            # against chunks, so a dropped tail would land BM25-only rows whose
+            # content_hash is still committed — poisoning the re-index skip
+            # forever (issue #1563). EmbeddingError is non-retryable and aborts
+            # the whole index pass with zero DB writes.
+            raise EmbeddingError(
+                f"Ollama returned {len(embeddings)} embeddings for {len(batch)} inputs "
+                f"(model={self._config.model!r}); refusing to truncate."
+            )
         return embeddings
 
     async def embed_texts(

--- a/packages/memtomem/src/memtomem/embedding/openai.py
+++ b/packages/memtomem/src/memtomem/embedding/openai.py
@@ -64,6 +64,15 @@ class OpenAIEmbedder:
         resp.raise_for_status()
         data = resp.json()["data"]
         data.sort(key=lambda x: x["index"])
+        if len(data) != len(batch):
+            # A short ``data`` array (endpoint dropping items under load) must
+            # fail loudly rather than truncate the zip in the index engine and
+            # poison the content-hash skip forever (issue #1563, same failure
+            # class as OllamaEmbedder). Non-retryable by design.
+            raise EmbeddingError(
+                f"OpenAI endpoint returned {len(data)} embeddings for {len(batch)} inputs "
+                f"(model={self._config.model!r}); refusing to truncate."
+            )
         return [item["embedding"] for item in data]
 
     async def embed_texts(

--- a/packages/memtomem/src/memtomem/embedding/openai.py
+++ b/packages/memtomem/src/memtomem/embedding/openai.py
@@ -73,6 +73,17 @@ class OpenAIEmbedder:
                 f"OpenAI endpoint returned {len(data)} embeddings for {len(batch)} inputs "
                 f"(model={self._config.model!r}); refusing to truncate."
             )
+        if [item["index"] for item in data] != list(range(len(batch))):
+            # Right count, wrong indices — duplicate or non-contiguous ``index``
+            # values (e.g. two records for index=0 and none for index=1). Since
+            # we extract positionally after sorting, this silently maps the
+            # wrong vector to a chunk, a mis-embedding the content-hash skip
+            # would preserve permanently (issue #1563, alignment variant).
+            raise EmbeddingError(
+                f"OpenAI endpoint returned malformed embedding indices for "
+                f"{len(batch)} inputs (model={self._config.model!r}); refusing "
+                "a misaligned result."
+            )
         return [item["embedding"] for item in data]
 
     async def embed_texts(

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -31,6 +31,7 @@ from memtomem.config import (
     provider_for_category,
 )
 from memtomem import privacy
+from memtomem.errors import EmbeddingError
 from memtomem.indexing.differ import DiffResult, compute_diff
 from memtomem.models import Chunk, IndexingStats
 
@@ -1025,6 +1026,21 @@ class IndexEngine:
                     texts,
                     on_progress=on_chunk_progress if emit_progress else None,
                 )
+                if len(embeddings) != len(texts):
+                    # Defense in depth against a short embedding array (issue
+                    # #1563). The HTTP providers now assert per-batch, but a
+                    # bare ``zip`` here would silently drop the trailing chunks'
+                    # vectors while still committing their content_hash — the
+                    # diff logic would then classify them ``unchanged`` forever
+                    # and never re-embed, a permanent semantic-search hole with
+                    # no audit trail. Fail loud; the ``except`` below turns this
+                    # into a zero-write early return so the file stays un-hashed
+                    # and re-indexes cleanly on the next trigger.
+                    raise EmbeddingError(
+                        f"Embedder returned {len(embeddings)} vectors for "
+                        f"{len(texts)} chunks in {file_path}; refusing to index "
+                        "a truncated result."
+                    )
                 for chunk, emb in zip(diff_result.to_upsert, embeddings):
                     chunk.embedding = emb
             except Exception as exc:

--- a/packages/memtomem/src/memtomem/tools/export_import.py
+++ b/packages/memtomem/src/memtomem/tools/export_import.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal, get_args
 from uuid import UUID, uuid4
 
+from memtomem.errors import EmbeddingError
 from memtomem.models import Chunk, ChunkMetadata, ChunkType
 
 if TYPE_CHECKING:
@@ -447,6 +448,18 @@ async def import_chunks(
         contents = [c.retrieval_content for c in to_upsert]
         try:
             embeddings = await embedder.embed_texts(contents)
+            if len(embeddings) != len(contents):
+                # Same truncation class as the index engine (issue #1563): a
+                # short array would ``zip``-drop the trailing chunks' vectors
+                # while ``upsert_chunks`` still commits their content_hash,
+                # leaving hash-poisoned BM25-only rows that never re-embed.
+                # Fail loud so the ``except`` below returns the zero-import
+                # failure path before any upsert.
+                raise EmbeddingError(
+                    f"Embedder returned {len(embeddings)} vectors for "
+                    f"{len(contents)} chunks during import; refusing to store "
+                    "a truncated result."
+                )
             for chunk, emb in zip(to_upsert, embeddings):
                 chunk.embedding = emb
         except Exception as exc:

--- a/packages/memtomem/tests/test_embedding_providers.py
+++ b/packages/memtomem/tests/test_embedding_providers.py
@@ -402,6 +402,32 @@ class TestOpenAIEmbedder:
         with pytest.raises(EmbeddingError, match="refusing to truncate"):
             await embedder.embed_texts(["hello", "world"])
 
+    async def test_malformed_indices_raise(self):
+        """Right count, wrong indices (duplicate/non-contiguous) must raise.
+
+        Issue #1563 alignment variant: two records for index=0 and none for
+        index=1 pass the length guard, but positional extraction would map the
+        wrong vector to a chunk — a silent mis-embedding the content-hash skip
+        preserves permanently.
+        """
+        config = _openai_config(dimension=3)
+        embedder = OpenAIEmbedder(config)
+        # Two records, correct count, but index=1 is missing (index=0 dupes).
+        malformed_resp = _make_httpx_response(
+            json_data={
+                "data": [
+                    {"index": 0, "embedding": [0.1, 0.2, 0.3]},
+                    {"index": 0, "embedding": [0.4, 0.5, 0.6]},
+                ],
+            },
+        )
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post = AsyncMock(return_value=malformed_resp)
+        embedder._client = mock_client
+
+        with pytest.raises(EmbeddingError, match="malformed embedding indices"):
+            await embedder.embed_texts(["hello", "world"])
+
     async def test_close_clears_client(self):
         config = _openai_config()
         embedder = OpenAIEmbedder(config)

--- a/packages/memtomem/tests/test_embedding_providers.py
+++ b/packages/memtomem/tests/test_embedding_providers.py
@@ -244,6 +244,25 @@ class TestOllamaEmbedder:
         with pytest.raises(EmbeddingError, match="missing 'embeddings' key"):
             await embedder.embed_texts(["test"])
 
+    async def test_short_embedding_array_raises(self):
+        """A batch returning fewer vectors than inputs raises (issue #1563).
+
+        Silent ``zip`` truncation would land BM25-only chunks whose
+        content_hash is still committed, poisoning the re-index skip forever.
+        """
+        config = _ollama_config(dimension=2)
+        embedder = OllamaEmbedder(config)
+        # Three inputs, only two vectors back.
+        short_resp = _make_httpx_response(
+            json_data={"embeddings": [[1.0, 2.0], [3.0, 4.0]]},
+        )
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post = AsyncMock(return_value=short_resp)
+        embedder._client = mock_client
+
+        with pytest.raises(EmbeddingError, match="refusing to truncate"):
+            await embedder.embed_texts(["a", "b", "c"])
+
     async def test_close_clears_client(self):
         """close() calls aclose() on the httpx client and sets it to None."""
         config = _ollama_config()
@@ -363,6 +382,25 @@ class TestOpenAIEmbedder:
 
         with pytest.raises(EmbeddingError, match="Cannot connect to OpenAI"):
             await embedder.embed_texts(["test"])
+
+    async def test_short_data_array_raises(self):
+        """A response dropping a ``data`` item raises rather than truncating.
+
+        Same failure class as OllamaEmbedder (issue #1563): a short array must
+        not silently drop trailing chunks' vectors downstream.
+        """
+        config = _openai_config(dimension=3)
+        embedder = OpenAIEmbedder(config)
+        # Two inputs, only one vector back.
+        short_resp = _make_httpx_response(
+            json_data={"data": [{"index": 0, "embedding": [0.1, 0.2, 0.3]}]},
+        )
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post = AsyncMock(return_value=short_resp)
+        embedder._client = mock_client
+
+        with pytest.raises(EmbeddingError, match="refusing to truncate"):
+            await embedder.embed_texts(["hello", "world"])
 
     async def test_close_clears_client(self):
         config = _openai_config()

--- a/packages/memtomem/tests/test_export_import_roundtrip.py
+++ b/packages/memtomem/tests/test_export_import_roundtrip.py
@@ -683,3 +683,44 @@ class TestOnConflictModes:
         finally:
             await close_components(comp_a)
             await close_components(comp_b)
+
+
+class TestImportShortEmbeddingArray:
+    """Issue #1563, reproduced outside the index engine: the import path must
+    not silently ``zip``-truncate a short embedding array into hash-poisoned
+    BM25-only rows. Export/import preserves ``content_hash``, so a truncated
+    import would commit chunks that never re-embed on any later pass.
+    """
+
+    async def test_short_array_aborts_import_with_no_writes(self, tmp_path):
+        comp_a, mem_a = await _make_components(tmp_path, "short_a")
+        comp_b, _ = await _make_components(tmp_path, "short_b")
+        try:
+            await _index_corpus(comp_a, mem_a)
+            bundle_path = tmp_path / "bundle.json"
+            await export_chunks(comp_a.storage, output_path=bundle_path)
+
+            class _ShortEmbedder(_DeterministicEmbedder):
+                """Drops the last vector — the partial-failure shape a flaky
+                HTTP endpoint produces, injected straight into the import call.
+                """
+
+                async def embed_texts(self, texts, *, on_progress=None):
+                    vectors = await super().embed_texts(texts, on_progress=on_progress)
+                    return vectors[:-1]
+
+            assert await comp_b.storage.recall_chunks(limit=10_000) == []
+
+            stats = await import_chunks(comp_b.storage, _ShortEmbedder(384), bundle_path)
+
+            assert stats.imported_chunks == 0
+            assert stats.failed_chunks > 0
+            # The distinguishing pin vs. the bug: the buggy ``zip`` would have
+            # committed the non-truncated chunks (BM25-only) here. With the
+            # guard, nothing lands and no content_hash is recorded.
+            assert await comp_b.storage.recall_chunks(limit=10_000) == [], (
+                "no chunks may be committed when import embedding truncates"
+            )
+        finally:
+            await close_components(comp_a)
+            await close_components(comp_b)

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -721,6 +721,72 @@ class TestChunkProgressStream:
         assert engine.is_active is False
 
 
+class _ShortArrayEmbedder(_FakeProgressEmbedder):
+    """Returns one fewer vector than inputs — the exact partial-failure shape
+    a flaky HTTP endpoint produces. Bypasses the per-provider count guard so
+    it reaches the engine's zip-site defense-in-depth check directly.
+    """
+
+    async def embed_texts(self, texts, *, on_progress=None):
+        return [[0.0] * self._dim for _ in texts][:-1]
+
+
+class TestShortEmbeddingArrayGuard:
+    """Issue #1563: a short embedding array must abort the file with zero DB
+    writes — never silently ``zip``-truncate into BM25-only chunks whose
+    content_hash is nonetheless committed, which would classify them
+    ``unchanged`` on every later pass and never re-embed them (a permanent,
+    silent semantic-search hole).
+    """
+
+    async def test_short_array_surfaces_error_and_writes_nothing(self, components, memory_dir):
+        notes = memory_dir / "big.md"
+        notes.write_text(_many_chunk_md(20))
+        engine = components.index_engine
+        # Match the DB's configured vector dimension (the live embedder is
+        # lazy and reports 0 until loaded) so a healthy pass would upsert
+        # cleanly — isolating the short-array failure from any dim skew.
+        dim = components.config.embedding.dimension
+        engine._embedder = _ShortArrayEmbedder(dim)
+
+        events = [ev async for ev in engine.index_path_stream(memory_dir, recursive=True)]
+        complete = next(e for e in events if e.get("type") == "complete")
+        assert complete["errors"], "short embedding array must surface an error"
+        assert any("Embedding failed" in err for err in complete["errors"])
+        # The distinguishing pin vs. the bug: the buggy ``zip`` would have
+        # committed N-1 chunks here. With the guard, the file stays un-hashed
+        # and nothing lands.
+        chunks = await components.storage.list_chunks_by_source(notes)
+        assert chunks == [], "no chunks may be committed when embedding truncates"
+
+    async def test_reindex_recovers_after_short_array(self, components, memory_dir):
+        """The crux of #1563: because the failed pass wrote nothing (and thus
+        recorded no content_hash), a later pass with a healthy embedder
+        re-embeds the file cleanly instead of skipping it as ``unchanged``.
+        """
+        notes = memory_dir / "big.md"
+        notes.write_text(_many_chunk_md(20))
+        engine = components.index_engine
+        dim = components.config.embedding.dimension
+
+        engine._embedder = _ShortArrayEmbedder(dim)
+        _ = [ev async for ev in engine.index_path_stream(memory_dir, recursive=True)]
+        assert await components.storage.list_chunks_by_source(notes) == []
+
+        # Healthy embedder on the next trigger — a poisoned content_hash would
+        # have made ``compute_diff`` see the file as ``unchanged`` and skip it.
+        engine._embedder = _FakeProgressEmbedder(dim)
+        events = [ev async for ev in engine.index_path_stream(memory_dir, recursive=True)]
+        complete = next(e for e in events if e.get("type") == "complete")
+        assert complete["indexed_chunks"] >= 1, (
+            "file must re-embed cleanly on recovery; a poisoned content_hash "
+            "would have skipped it as unchanged (issue #1563)"
+        )
+        assert await components.storage.list_chunks_by_source(notes), (
+            "chunks must land on the recovery pass"
+        )
+
+
 # ===========================================================================
 # 1.b _active_runs / is_active counter
 # ===========================================================================


### PR DESCRIPTION
## Summary

`IndexEngine._index_file` (and `import_chunks`) zipped the chunk list against whatever the embedder returned without checking the counts match. When a provider returns **fewer vectors than inputs** — a flaky/OOM-pressured Ollama server, or an OpenAI-compatible endpoint dropping a `data` item — `zip` truncated silently: the trailing chunks were upserted with an empty embedding, landed in `chunks` + `chunks_fts` but **not** `chunks_vec` (the `if c.embedding` insert gate skips them), and their `content_hash` was still committed. From then on every re-index classified them `unchanged` and never re-embedded them — a permanent, silent semantic-search hole with no error and no audit trail.

This is the same failure class the `dimension == 0` guard directly above was added for, but for a **partial** rather than total embedding failure.

## Fix — loud, non-retryable invariant (defense in depth)

- **`embedding/ollama.py`, `embedding/openai.py`** — assert `len(embeddings) == len(batch)` per batch and raise `EmbeddingError`. It is non-retryable (the retry decorator only retries transient network/429 exceptions), so a short array aborts the pass immediately instead of being retried.
- **`indexing/engine.py`** — assert `len(embeddings) == len(texts)` before the `zip`. The existing `except` returns a **zero-DB-write** early exit, so the file stays un-hashed and re-indexes cleanly on the next trigger.
- **`tools/export_import.py`** — `import_chunks()` had the same `zip` class outside the engine, and import preserves `content_hash`, so it can create the same poisoned rows. Same guard added before its existing zero-import failure path.

Local embedders (`onnx`/`fastembed`/`noop`) map 1:1 to their inputs and are unaffected. The `dedup` and health-check call sites are read-only or single-input and are additionally covered by the provider guards.

## Tests (+6)

- Providers: short array → `EmbeddingError` (ollama + openai).
- Engine: loud error + **zero writes** (the distinguishing pin — the buggy `zip` would have committed N-1 chunks), then a clean recovery re-index proving the file is **not** skipped as `unchanged`.
- Import: short array → **zero chunks stored** (no `content_hash` recorded).

## Verification

- `ruff check` + `ruff format --check` ✅ · `mypy` clean (advisory) ✅
- Targeted suites: **228 passed** (`test_embedding_providers`, `test_indexing_engine`, `test_export_import_roundtrip`).

Found during the 2026-07-03 operational-stability audit (idempotency / crash-safety / concurrency sweep).

Closes #1563

🤖 Generated with [Claude Code](https://claude.com/claude-code)
