### PR TITLE
fix(scheduler): claim schedules atomically before dispatch (#1564)

### DIFF
--- a/docs/guides/reference/automation.md
+++ b/docs/guides/reference/automation.md
@@ -209,6 +209,12 @@ loop that powers `mem_watchdog` — set
 `MEMTOMEM_SCHEDULER__ENABLED=true` on top of the watchdog config to
 enable dispatch.
 
+Dispatch is **at-most-once per cron slot**: each due schedule is claimed
+with an atomic compare-and-set before it runs, so two MCP servers sharing
+one database (e.g. Claude Code and Claude Desktop connected at the same
+time) cannot both fire the same slot, and a run interrupted by a crash is
+not re-fired on restart — it resumes at the next slot.
+
 > **Dispatch requires the MCP server, not `mm web`.** The watchdog (and
 > therefore the schedule dispatcher) is wired into the MCP server
 > lifespan only — it is not started by `mm web`. Schedules registered

--- a/packages/memtomem/src/memtomem/scheduler/jobs.py
+++ b/packages/memtomem/src/memtomem/scheduler/jobs.py
@@ -32,8 +32,15 @@ if TYPE_CHECKING:
     from memtomem.server.context import AppContext
 
 
-JobRunStatus = Literal["ok", "error", "timeout"]
-"""Status enum for ``ScheduleMixin.schedule_mark_run``."""
+JobRunStatus = Literal["ok", "error", "timeout", "running"]
+"""Status enum for schedule run outcomes.
+
+``ok``/``error``/``timeout`` are terminal, written by
+``ScheduleMixin.schedule_mark_run``. ``running`` is the transient claim
+state written by ``schedule_try_claim`` (issue #1564) — overwritten by a
+terminal status when the run completes, or left as a diagnostic breadcrumb
+if the process crashes mid-run (dispatch never gates on status, so a stuck
+``running`` doesn't starve the schedule)."""
 
 JobResult = dict[str, Any]
 """Runner return shape — small JSON-serializable summary."""

--- a/packages/memtomem/src/memtomem/server/health_watchdog.py
+++ b/packages/memtomem/src/memtomem/server/health_watchdog.py
@@ -136,6 +136,20 @@ class HealthWatchdog:
             await self._run_schedule(sched, timeout)
 
     async def _run_schedule(self, sched: dict, timeout: float) -> None:
+        # Atomic run-claim before any work: a concurrent dispatcher (a
+        # second MCP-server process on the same DB) or a post-crash restart
+        # that reads the same due row loses the CAS and skips. At-most-once
+        # per slot — a crash between here and the terminal mark_run skips
+        # the slot rather than re-running it (job bodies aren't all
+        # idempotent). Claim before the JOB_KINDS lookup so unknown-kind /
+        # invalid-params error marks are single-fire too. Known limit: this
+        # guards a *slot*, not job-kind mutual exclusion — a job that runs
+        # past its next cron slot can overlap a fresh claim from another
+        # process (pre-existing Phase A behavior). See issue #1564.
+        if not await self._app.storage.schedule_try_claim(sched["id"], sched["last_run_at"]):
+            logger.debug("schedule %s already claimed by another dispatcher; skipping", sched["id"])
+            return
+
         spec = JOB_KINDS.get(sched["job_kind"])
         if spec is None:
             logger.warning(

--- a/packages/memtomem/src/memtomem/storage/mixins/schedules.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/schedules.py
@@ -5,6 +5,14 @@ interpreted in UTC; ``created_at`` and ``last_run_at`` are stored as
 UTC ISO strings. ``schedule_list_due`` returns at-most-once catch-up
 semantics — if multiple cron slots elapsed since ``last_run_at``, the
 schedule fires exactly once on the next dispatcher tick (no backfill).
+
+Dispatch is also at-most-once **per slot** across processes and crashes:
+``schedule_try_claim`` does a compare-and-set on ``last_run_at`` so a
+second dispatcher (a concurrent MCP-server process on the same DB) or a
+post-crash restart that reads the same due row loses the claim and skips
+it. A crash between the claim and the terminal ``schedule_mark_run``
+skips the slot rather than re-running it — deliberate, because job
+bodies aren't all idempotent. See issue #1564.
 """
 
 from __future__ import annotations
@@ -146,6 +154,38 @@ class ScheduleMixin:
         cur = db.execute("DELETE FROM schedules WHERE id=?", (sched_id,))
         db.commit()
         return cur.rowcount > 0
+
+    async def schedule_try_claim(
+        self,
+        sched_id: str,
+        prev_last_run_at: str | None,
+        when: datetime | None = None,
+    ) -> bool:
+        """Atomically claim a due schedule for this dispatcher.
+
+        Compare-and-set on ``last_run_at``: advance it to ``when`` (now)
+        and set status='running' only if the row's ``last_run_at`` still
+        equals the value the caller read in ``schedule_list_due``
+        (``prev_last_run_at`` — possibly None on first run, hence ``IS``
+        not ``=``). Returns True iff this call won the claim
+        (``rowcount == 1``). See issue #1564.
+
+        ``last_run_error`` is cleared here so a stale error from the prior
+        run doesn't linger while the new run is in flight; the terminal
+        ``schedule_mark_run`` repopulates it on failure. WAL +
+        ``busy_timeout`` on the write connection serializes the racing
+        UPDATEs, so a single conditional statement is self-atomic — no
+        explicit transaction needed.
+        """
+        ts = (when or datetime.now(timezone.utc)).astimezone(timezone.utc)
+        db = self._get_db()
+        cur = db.execute(
+            "UPDATE schedules SET last_run_at=?, last_run_status='running', "
+            "last_run_error=NULL WHERE id=? AND last_run_at IS ?",
+            (ts.isoformat(timespec="seconds"), sched_id, prev_last_run_at),
+        )
+        db.commit()
+        return cur.rowcount == 1
 
     async def schedule_mark_run(
         self,

--- a/packages/memtomem/tests/test_schedules_store.py
+++ b/packages/memtomem/tests/test_schedules_store.py
@@ -141,3 +141,88 @@ class TestScheduleStore:
         # Should not raise.
         due = await storage.schedule_list_due(datetime.now(timezone.utc))
         assert due == []
+
+
+class TestScheduleClaim:
+    """Atomic run-claim CAS on ``last_run_at`` (issue #1564)."""
+
+    @pytest.mark.asyncio
+    async def test_claim_first_run_null_token_then_second_fails(self, storage):
+        sid = await storage.schedule_insert("* * * * *", "compaction")
+        # First run: last_run_at is NULL, so the CAS token is None.
+        assert await storage.schedule_try_claim(sid, None) is True
+        sched = await storage.schedule_get(sid)
+        assert sched["last_run_at"] is not None
+        assert sched["last_run_status"] == "running"
+        # A second dispatcher reading the same (stale) NULL token loses.
+        assert await storage.schedule_try_claim(sid, None) is False
+
+    @pytest.mark.asyncio
+    async def test_claim_clears_stale_error(self, storage):
+        sid = await storage.schedule_insert("* * * * *", "compaction")
+        await storage.schedule_mark_run(sid, "error", error="boom")
+        sched = await storage.schedule_get(sid)
+        token = sched["last_run_at"]
+        assert await storage.schedule_try_claim(sid, token) is True
+        sched = await storage.schedule_get(sid)
+        assert sched["last_run_status"] == "running"
+        assert sched["last_run_error"] is None
+
+    @pytest.mark.asyncio
+    async def test_claim_with_nonnull_token_then_second_fails(self, storage):
+        sid = await storage.schedule_insert("* * * * *", "compaction")
+        when = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        await storage.schedule_mark_run(sid, "ok", when=when)
+        token = when.isoformat(timespec="seconds")
+        assert await storage.schedule_try_claim(sid, token) is True
+        # Re-claiming with the now-stale token loses.
+        assert await storage.schedule_try_claim(sid, token) is False
+
+    @pytest.mark.asyncio
+    async def test_claim_wrong_token_fails(self, storage):
+        sid = await storage.schedule_insert("* * * * *", "compaction")
+        await storage.schedule_mark_run(sid, "ok")
+        # A token that never matched what's stored must not win.
+        assert await storage.schedule_try_claim(sid, "1999-01-01T00:00:00+00:00") is False
+
+    @pytest.mark.asyncio
+    async def test_claim_without_terminal_mark_blocks_refire(self, storage):
+        """Crash-re-fire pin: a claim advances last_run_at so the same slot
+        is no longer due even if the process dies before mark_run."""
+        sid = await storage.schedule_insert("0 * * * *", "compaction")
+        sched = await storage.schedule_get(sid)
+        created = datetime.fromisoformat(sched["created_at"])
+        now = created + timedelta(hours=2)
+
+        # Row is due at `now`.
+        assert len(await storage.schedule_list_due(now)) == 1
+        # Claim (simulating a crash before the terminal mark_run).
+        assert await storage.schedule_try_claim(sid, sched["last_run_at"], when=now) is True
+        # Same `now`: last_run_at advanced to `now`, next slot is in the
+        # future — no re-fire.
+        assert await storage.schedule_list_due(now) == []
+
+    @pytest.mark.asyncio
+    async def test_two_backends_only_one_claims(self, storage, tmp_path):
+        """Two SqliteBackends on the same DB file racing to claim one row —
+        exactly one wins (cross-process double-fire guard, in-process)."""
+        from memtomem.storage.sqlite_backend import SqliteBackend
+
+        sid = await storage.schedule_insert("* * * * *", "compaction")
+
+        # Second backend pointed at the same DB file, matching the fixture's
+        # embedding meta so initialize() doesn't trip the strict dim check.
+        other = SqliteBackend(
+            storage._config,
+            dimension=storage._dimension,
+            embedding_provider=storage._embedding_provider,
+            embedding_model=storage._embedding_model,
+            strict_dim_check=False,
+        )
+        await other.initialize()
+        try:
+            r1 = await storage.schedule_try_claim(sid, None)
+            r2 = await other.schedule_try_claim(sid, None)
+            assert [r1, r2].count(True) == 1
+        finally:
+            await other.close()

--- a/packages/memtomem/tests/test_watchdog_dispatch.py
+++ b/packages/memtomem/tests/test_watchdog_dispatch.py
@@ -88,6 +88,32 @@ async def test_single_due_fires_once_status_ok(storage, patch_jobs):
 
 
 @pytest.mark.asyncio
+async def test_second_dispatch_of_same_slot_does_not_refire(storage, patch_jobs):
+    """A second dispatcher reading the same due row loses the claim and does
+    not re-invoke the runner (issue #1564)."""
+    calls: list[str] = []
+
+    async def runner(app):
+        calls.append("ran")
+        return {"ok": True}
+
+    spec = JobSpec("compaction", "test", _NoParams, runner)
+    sid = await storage.schedule_insert("* * * * *", "compaction")
+    # Snapshot the pre-claim row so both _run_schedule calls carry the same
+    # (stale after the first) last_run_at token, as two racing dispatchers would.
+    sched = await storage.schedule_get(sid)
+
+    wd = _make_watchdog(storage)
+    with patch_jobs({"compaction": spec}):
+        await wd._run_schedule(sched, timeout=5.0)
+        await wd._run_schedule(sched, timeout=5.0)
+
+    assert calls == ["ran"]
+    final = await storage.schedule_get(sid)
+    assert final["last_run_status"] == "ok"
+
+
+@pytest.mark.asyncio
 async def test_two_due_serialized_with_concurrency_one(storage, patch_jobs):
     """max_concurrent_jobs=1 forces serial execution (B starts after A finishes)."""
     in_flight = 0


### PR DESCRIPTION
## Problem

Schedule dispatch has no atomic run-claim, so a due schedule can fire more than once for the same cron slot:

1. **Cross-process double-fire.** Two `HealthWatchdog` dispatchers sharing one `~/.memtomem/memtomem.db` both read the same due row on a tick and both run the job. `schedule_list_due` decides "due" purely from `last_run_at`, and `schedule_mark_run` is a blind `UPDATE` executed *after* the job body finishes.
2. **Post-crash re-fire.** The runner commits its writes, the process dies before `schedule_mark_run`; on restart the row is still due and runs again.

Job bodies are not all idempotent (`consolidation` can write duplicate consolidated chunks; `compaction` deletes), so the guarantee belongs at the dispatcher level: **at-most-once per slot regardless of job body**.

> **Note on the issue's premise.** The issue cites "MCP server + `mm web`" as the double-fire pair, but `mm web` does **not** dispatch schedules — it builds components via `create_components()` and never starts a watchdog (only `AppContext.ensure_initialized` does, `server/context.py:284-292`; see the footgun comment at `web/app.py:382-393`). The real cross-process vector is **two `memtomem-server` (MCP) processes** on the same DB, which is normal when memtomem is registered in multiple MCP clients at once — the server singleton flock is advisory (it logs `"Another instance is already running…"` and keeps running, `server/__init__.py:676-692`). The crash-re-fire vector is process-count-independent. The fix addresses both.

## Fix

A compare-and-set claim on `last_run_at`, matching the existing `cur.rowcount`-CAS idiom already used by `schedule_set_enabled` / `schedule_delete`.

- **`ScheduleMixin.schedule_try_claim(sched_id, prev_last_run_at, when=None)`** — `UPDATE schedules SET last_run_at=?, last_run_status='running', last_run_error=NULL WHERE id=? AND last_run_at IS ?`, returning `rowcount == 1`. `IS ?` (not `= ?`) so the first-run NULL token binds correctly. The token is the exact string `schedule_list_due` read (`row[6]`), passed straight back — no format drift. WAL + `busy_timeout=10s` on the single write connection already serialize the racing UPDATEs, so one conditional statement is self-atomic (no new lock / `BEGIN IMMEDIATE`).
- **`HealthWatchdog._run_schedule`** claims before any work (ahead of the `JOB_KINDS` lookup, so unknown-kind / invalid-params error marks are single-fire too) and returns when it loses the claim.
- **`JobRunStatus`** Literal gains `"running"` (documentation-only; consumers pass the string through — no runtime validation).

**Semantics: at-most-once (claim-then-run).** A crash between the claim and the terminal `schedule_mark_run` skips the slot rather than re-running it — the right trade given the non-idempotent bodies, and consistent with the existing at-most-once catch-up. A stuck `'running'` status cannot starve a schedule because dispatch is driven by `last_run_at` via `croniter`, never by status.

No schema/migration change — `last_run_status` already exists and `'running'` is just a new value.

## Tests

- `test_schedules_store.py::TestScheduleClaim` — CAS unit tests: first-run NULL token wins then a second claim loses; stale-error cleared on claim; non-NULL token round-trip then stale-token loss; wrong token loses; **crash-re-fire pin** (claim without terminal mark → `schedule_list_due` excludes the row until the next slot); **cross-process winner** (two `SqliteBackend`s on one DB file racing to claim → exactly one wins).
- `test_watchdog_dispatch.py` — dispatcher double-fire guard: two `_run_schedule` calls with the same stale token → runner invoked once, terminal status `ok`.

## Verification

`ruff check` + `ruff format --check` + `mypy` clean; `pytest test_schedules_store.py test_watchdog_dispatch.py` → 29 passed. Codex review verdict: SHIP (no findings; independently re-ran the tests green).

Closes #1564

🤖 Generated with [Claude Code](https://claude.com/claude-code)
