### PR TITLE
security(web): write-time Gate A for canonical create/update editors (#1509)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Security
 
+- **The web canonical create/update editors for skills / commands / agents
+  now run the write-time Gate A privacy scan** before any byte reaches the
+  git-tracked `project_shared` canonical, matching the mcp-servers editor: a
+  secret typed or pasted into the editor is refused with the path-free
+  privacy 422 (count + artifact name only) instead of landing in git and
+  only being caught at the next sync/import. `force: true` still bypasses
+  only the mtime guard, never the scan; user-tier saves are unscanned by
+  design (not git-tracked, `allow_host_writes`-gated, sync-time valve
+  intact — ADR-0011 §5). The six handlers moved to `_REDACTION_PROTECTED`
+  in the web invariants registry. (#1509)
 - **Quoted-JSON credential labels and the `x-amz-security-token` wire label
   are redacted — forward-sync of memtomem-stm#562 / memtomem-stm#561.** Two
   more STM-origin secret-class rules mirrored forward in one pass so the sets

--- a/docs/adr/0011-canonical-artifact-scope-hierarchy.md
+++ b/docs/adr/0011-canonical-artifact-scope-hierarchy.md
@@ -247,6 +247,17 @@ project_shared, the sync write is blocked regardless of `--force-unsafe`.
 > command itself carries the surface intent; only the scan half was
 > missing.
 
+> **2026-07 (#1509):** Gate A also fires at write time in the web
+> canonical create/update editors (skills / commands / agents),
+> matching the mcp-servers editor: the handlers scan `body.content`
+> before `atomic_write_text`, so a pasted secret is refused (path-free
+> 422) instead of landing in the git-tracked canonical and only being
+> caught at the next sync/import. The sync/import backstop is
+> unchanged. This closes the gap that falsified the "every first-party
+> byte path scans before landing" claim above. User-tier editor saves
+> stay unscanned by design: not git-tracked, gated by
+> `allow_host_writes`, and still subject to the sync-time valve.
+
 **Gate B (surface).** Explicit `--scope project_shared` flag plus
 confirm prompt at the CLI/MCP write surface (`mm mem add`,
 `mm context init`, `mm context migrate --to project_shared`). The flag must be passed

--- a/packages/memtomem/src/memtomem/web/routes/_artifact_common.py
+++ b/packages/memtomem/src/memtomem/web/routes/_artifact_common.py
@@ -18,12 +18,14 @@ them into one ``ImportRequest`` component; sharing the class keeps that name.
 
 from __future__ import annotations
 
+from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 
 from memtomem.config import TargetScope
 from memtomem.context._runtime_targets import KNOWN_RUNTIMES, runtime_fanout_root
 from memtomem.context._sync_atomic import ON_DROP_LEVELS
+from memtomem.context.privacy_scan import FileScan, format_scan_block_message
 from memtomem.context.scope_resolver import ArtifactKind
 from memtomem.web.routes._errors import _error
 
@@ -75,6 +77,37 @@ def reject_project_local_write(target_scope: TargetScope, action: str) -> None:
             ),
             reason_code="project_local_unsupported",
         )
+
+
+# ── Write-time Gate A (#1509) ────────────────────────────────────────────
+
+
+def raise_if_privacy_blocked(scan: FileScan, *, kind: str, artifact_name: str) -> None:
+    """Map a blocked canonical-editor content scan to the privacy 422.
+
+    The create/update editors scan ``body.content`` via
+    :func:`memtomem.context.privacy_scan.scan_text_content` before any
+    bytes reach the git-tracked project_shared canonical (#1509); this
+    helper owns the shared refusal so the wording cannot drift between
+    the six call sites. The detail is a *string* (privacy-422 convention,
+    see ``_errors``) and stays path-free: count + artifact basename only,
+    never the matched bytes or an absolute path (#1385/#1412).
+    """
+    if scan.decision not in ("blocked", "blocked_project_shared"):
+        return
+    raise HTTPException(
+        status_code=422,
+        detail=format_scan_block_message(
+            scan,
+            scope="project_shared",
+            kind=kind,
+            artifact_name=artifact_name,
+            remediation_hint=(
+                f"Remove the secret from the editor content, or keep the {kind} "
+                f"in your private user tier (target_scope=user)."
+            ),
+        ),
+    )
 
 
 # ── Scan-dir hints ───────────────────────────────────────────────────────

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -38,12 +38,14 @@ from memtomem.context.agents import (
 # module to pin the shared singleton.
 from memtomem.context.agents import ExtractResult as ExtractResult
 from memtomem.context.detector import AGENT_DIRS
+from memtomem.context.privacy_scan import scan_text_content
 from memtomem.web.routes import _atomic_kind
 from memtomem.web.routes._artifact_common import (
     ArtifactCreateRequest,
     ArtifactUpdateRequest,
     AtomicSyncRequest,
     ImportRequest,
+    raise_if_privacy_blocked,
 )
 from memtomem.web.routes._locks import _gateway_lock as _gateway_lock
 from memtomem.web.routes.context_projects import (
@@ -179,6 +181,21 @@ async def create_agent(
         ),
     ),
 ) -> dict:
+    if target_scope == "project_shared":
+        # #1509 write-time Gate A — scan the exact in-memory string that
+        # atomic_write_text will write (no TOCTOU). user-tier saves are not
+        # scanned: not git-tracked, gated by allow_host_writes, and keep the
+        # sync-time force valve (ADR-0011 §5 asymmetry). source_path is the
+        # intended canonical location (never opened — safe for a
+        # not-yet-validated create name) so path.name is the artifact name.
+        scan = scan_text_content(
+            body.content,
+            source_path=project_root / _SPEC.canonical_root / body.name,
+            surface="web_context_agents_create",
+            scope="project_shared",
+            project_root=project_root,
+        )
+        raise_if_privacy_blocked(scan, kind="agent", artifact_name=body.name)
     return await _atomic_kind.create_artifact(_SPEC, body, project_root, target_scope)
 
 
@@ -202,6 +219,17 @@ async def update_agent(
         ),
     ),
 ) -> JSONResponse:
+    if target_scope == "project_shared":
+        # #1509 write-time Gate A — see create_agent. force=True only
+        # bypasses the mtime guard, never this scan.
+        scan = scan_text_content(
+            body.content,
+            source_path=project_root / _SPEC.canonical_root / name,
+            surface="web_context_agents_update",
+            scope="project_shared",
+            project_root=project_root,
+        )
+        raise_if_privacy_blocked(scan, kind="agent", artifact_name=name)
     return await _atomic_kind.update_artifact(_SPEC, name, body, project_root, target_scope)
 
 

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -37,12 +37,14 @@ from memtomem.context.commands import (
 # module to pin the shared singleton.
 from memtomem.context.commands import ExtractResult as ExtractResult
 from memtomem.context.detector import COMMAND_DIRS
+from memtomem.context.privacy_scan import scan_text_content
 from memtomem.web.routes import _atomic_kind
 from memtomem.web.routes._artifact_common import (
     ArtifactCreateRequest,
     ArtifactUpdateRequest,
     AtomicSyncRequest,
     ImportRequest,
+    raise_if_privacy_blocked,
 )
 from memtomem.web.routes._locks import _gateway_lock as _gateway_lock
 from memtomem.web.routes.context_projects import (
@@ -177,6 +179,21 @@ async def create_command(
         ),
     ),
 ) -> dict:
+    if target_scope == "project_shared":
+        # #1509 write-time Gate A — scan the exact in-memory string that
+        # atomic_write_text will write (no TOCTOU). user-tier saves are not
+        # scanned: not git-tracked, gated by allow_host_writes, and keep the
+        # sync-time force valve (ADR-0011 §5 asymmetry). source_path is the
+        # intended canonical location (never opened — safe for a
+        # not-yet-validated create name) so path.name is the artifact name.
+        scan = scan_text_content(
+            body.content,
+            source_path=project_root / _SPEC.canonical_root / body.name,
+            surface="web_context_commands_create",
+            scope="project_shared",
+            project_root=project_root,
+        )
+        raise_if_privacy_blocked(scan, kind="command", artifact_name=body.name)
     return await _atomic_kind.create_artifact(_SPEC, body, project_root, target_scope)
 
 
@@ -200,6 +217,17 @@ async def update_command(
         ),
     ),
 ) -> JSONResponse:
+    if target_scope == "project_shared":
+        # #1509 write-time Gate A — see create_command. force=True only
+        # bypasses the mtime guard, never this scan.
+        scan = scan_text_content(
+            body.content,
+            source_path=project_root / _SPEC.canonical_root / name,
+            surface="web_context_commands_update",
+            scope="project_shared",
+            project_root=project_root,
+        )
+        raise_if_privacy_blocked(scan, kind="command", artifact_name=name)
     return await _atomic_kind.update_artifact(_SPEC, name, body, project_root, target_scope)
 
 

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -15,7 +15,7 @@ from fastapi.responses import JSONResponse
 from memtomem.context._atomic import atomic_write_text
 from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context.detector import SKILL_DIRS
-from memtomem.context.privacy_scan import PrivacyScanError
+from memtomem.context.privacy_scan import PrivacyScanError, scan_text_content
 from memtomem.context.skills import (
     CANONICAL_SKILL_ROOT,
     SKILL_GENERATORS,
@@ -34,6 +34,7 @@ from memtomem.web.routes._artifact_common import (
     HostWriteSyncRequest,
     ImportRequest,
     mtime_conflict_response,
+    raise_if_privacy_blocked,
     reject_project_local_write,
     scanned_dirs_for,
 )
@@ -282,6 +283,21 @@ async def create_skill(
     """Create a new canonical skill."""
     reject_project_local_write(target_scope, "Create skill")
     skill_dir = _canonical_skill_dir(project_root, body.name, scope=target_scope)
+    if target_scope == "project_shared":
+        # #1509 write-time Gate A — scan the exact in-memory string that
+        # atomic_write_text will write (no TOCTOU). user-tier saves are not
+        # scanned: not git-tracked, gated by allow_host_writes, and keep the
+        # sync-time force valve (ADR-0011 §5 asymmetry). source_path is the
+        # skill dir (never opened here) so path.name is the artifact name,
+        # not the useless constant SKILL.md.
+        scan = scan_text_content(
+            body.content,
+            source_path=skill_dir,
+            surface="web_context_skills_create",
+            scope="project_shared",
+            project_root=project_root,
+        )
+        raise_if_privacy_blocked(scan, kind="skill", artifact_name=body.name)
 
     # Unlocked pre-checks so a request that cannot succeed is refused
     # (409) rather than confirmed, and a no-op never prompts. The locked
@@ -366,6 +382,19 @@ async def update_skill(
     reject_project_local_write(target_scope, "Update skill")
     skill_dir = _canonical_skill_dir(project_root, name, scope=target_scope)
     manifest = skill_dir / SKILL_MANIFEST
+    if target_scope == "project_shared":
+        # #1509 write-time Gate A — see create_skill. Runs before the 404
+        # check so privacy refusal wins over existence, matching the
+        # commands/agents editors; force=True only bypasses the mtime
+        # guard, never this scan.
+        scan = scan_text_content(
+            body.content,
+            source_path=skill_dir,
+            surface="web_context_skills_update",
+            scope="project_shared",
+            project_root=project_root,
+        )
+        raise_if_privacy_blocked(scan, kind="skill", artifact_name=name)
     if not manifest.is_file():
         raise _error(404, "missing", f"skill {name!r} not found")
 

--- a/packages/memtomem/tests/test_web_invariants_registry.py
+++ b/packages/memtomem/tests/test_web_invariants_registry.py
@@ -12,8 +12,9 @@ Pins two cross-cutting invariants per RFC #787 stage 1:
    acknowledge the new surface.
 
 2. **Redaction guard coverage.** Every web-route handler that writes
-   user-supplied content to LTM must call
-   ``privacy.enforce_write_guard(...)`` somewhere in its body, or be in
+   user-supplied content to LTM must scan it (``enforce_write_guard``
+   directly, or the ``scan_text_content`` wrapper *and* a refusal on the
+   result — see ``_function_scans_and_refuses``), or be in
    ``_REDACTION_EXEMPT``. The list of handlers requiring redaction is
    explicit (``_REDACTION_PROTECTED``) — drift is caught by the
    classification test, which fails when an unsafe-method route is
@@ -28,6 +29,7 @@ from __future__ import annotations
 
 import ast
 import re
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -143,10 +145,12 @@ _CSRF_EXEMPT: dict[str, str] = {
 # --- Redaction registry ----------------------------------------------------
 #
 # Handlers that ingest user-supplied content and persist it to LTM. Each
-# *must* call ``privacy.enforce_write_guard(...)`` in its body. New
-# content-writing handlers either join this list (and the body must
-# include the guard call) or join ``_REDACTION_EXEMPT`` with a
-# justification.
+# *must* both scan (``enforce_write_guard`` / ``scan_text_content``) and
+# refuse on a hit (``raise_if_privacy_blocked`` / ``raise_or_collect`` /
+# an inline ``.decision`` check that raises) in its body — see
+# ``_function_scans_and_refuses``. New content-writing handlers either
+# join this list (and the body must scan-and-refuse) or join
+# ``_REDACTION_EXEMPT`` with a justification.
 
 _REDACTION_PROTECTED: frozenset[str] = frozenset(
     {
@@ -378,44 +382,201 @@ def _iter_unsafe_route_handlers() -> list[tuple[str, str, str]]:
     return handlers
 
 
-def _function_calls_write_guard(module: str, function_name: str) -> bool:
-    """True iff ``function_name`` in ``module`` calls the privacy chokepoint.
+_NESTED_SCOPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
 
-    Accepts ``privacy.enforce_write_guard(...)`` (direct chokepoint) and
-    ``scan_text_content(...)`` (the ``context.privacy_scan`` Gate A wrapper,
-    which calls ``enforce_write_guard`` internally — used by route handlers
-    that scan an in-memory fragment before a ``project_shared`` write,
-    e.g. ``settings_sync.promote_target_rule``, #1247).
+
+def _walk_own_scope(node: ast.AST):
+    """Yield descendants of ``node`` in its OWN lexical scope.
+
+    Unlike ``ast.walk``, this does not descend into nested
+    function / lambda / class bodies — code inside an uncalled nested
+    ``def`` must not count as the handler's scan or refusal (#1509
+    re-review — Codex, dead nested-function reconstruction).
     """
-    path = ROUTES_DIR / f"{module}.py"
-    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for child in ast.iter_child_nodes(node):
+        yield child
+        if not isinstance(child, _NESTED_SCOPES):
+            yield from _walk_own_scope(child)
+
+
+def _call_name(call: ast.Call) -> str | None:
+    """The called function's bare or attribute name, or None."""
+    f = call.func
+    if isinstance(f, ast.Name):
+        return f.id
+    if isinstance(f, ast.Attribute):
+        return f.attr
+    return None
+
+
+def _arg_names(call: ast.Call) -> set[str]:
+    """Names passed as positional or keyword-value args of ``call``."""
+    names: set[str] = set()
+    for arg in call.args:
+        if isinstance(arg, ast.Name):
+            names.add(arg.id)
+    for kw in call.keywords:
+        if isinstance(kw.value, ast.Name):
+            names.add(kw.value.id)
+    return names
+
+
+# The decision strings that mean "blocked" — the ``if`` test of an inline
+# refusal must compare the scan's ``.decision`` against one of these, so an
+# inverted ``if scan.decision == "allowed": raise`` is not mistaken for a
+# refusal (#1509 re-review — Codex).
+_BLOCKED_DECISIONS = frozenset({"blocked", "blocked_project_shared"})
+
+
+def _is_scan_decision(node: ast.AST, scan_vars: set[str]) -> bool:
+    """True iff ``node`` is ``<scan_var>.decision`` for a tracked scan var."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "decision"
+        and isinstance(node.value, ast.Name)
+        and node.value.id in scan_vars
+    )
+
+
+def _is_blocked_const(node: ast.AST) -> bool:
+    return isinstance(node, ast.Constant) and node.value in _BLOCKED_DECISIONS
+
+
+def _test_checks_blocked_decision(test: ast.AST, scan_vars: set[str]) -> bool:
+    """True iff ``test`` is a *positive* blocked-decision comparison whose
+    truthiness means "the scan is blocked".
+
+    Only ``<scan_var>.decision == <blocked literal>`` (``Eq``) or
+    ``<scan_var>.decision in (<...blocked...>)`` (``In``) qualify. Negated
+    polarity (``!=`` / ``not in`` / ``not (...)``) is rejected: those raise on
+    the *allowed* case and let blocked content fall through to the write
+    (#1509 re-review — Codex). Matches the single real inline handler,
+    ``settings_sync.promote_target_rule``; any fancier shape fails closed.
+    """
+    if not isinstance(test, ast.Compare) or len(test.ops) != 1:
+        return False
+    if not _is_scan_decision(test.left, scan_vars):
+        return False
+    op, comparator = test.ops[0], test.comparators[0]
+    if isinstance(op, ast.Eq):
+        return _is_blocked_const(comparator)
+    if isinstance(op, ast.In):
+        return isinstance(comparator, ast.Tuple | ast.List | ast.Set) and any(
+            _is_blocked_const(elt) for elt in comparator.elts
+        )
+    return False
+
+
+def _contains_own_scope_raise(body: list[ast.stmt]) -> bool:
+    """True iff ``body`` raises in its own scope (not inside a nested def)."""
+    for stmt in body:
+        if isinstance(stmt, ast.Raise):
+            return True
+        if not isinstance(stmt, _NESTED_SCOPES):
+            if any(isinstance(s, ast.Raise) for s in _walk_own_scope(stmt)):
+                return True
+    return False
+
+
+def _wrapper_scan_refused(func: ast.AST, scan_vars: set[str]) -> bool:
+    """True iff ``func`` refuses on a ``scan_text_content`` result, in its own
+    scope.
+
+    The refusal must be *tied to the scan variable* AND reachable in the
+    handler's own scope — an unrelated ``.decision`` check, an unrelated
+    validation ``raise``, a refusal buried in an uncalled nested ``def``, or
+    an inverted/else-branch shape does not count (#1509 re-review — Codex).
+    Accepts either:
+
+    * a call to ``raise_if_privacy_blocked`` / ``raise_or_collect`` whose
+      args include a tracked scan var; or
+    * an ``if`` whose test compares ``<scan_var>.decision`` against a blocked
+      decision literal and whose *true branch* raises in its own scope — the
+      ``settings_sync.promote_target_rule`` shape. (The blocked-literal and
+      true-branch requirements reject ``if scan.decision == "allowed": raise``
+      and a ``raise`` that only lives in the ``else``.)
+    """
+    for sub in _walk_own_scope(func):
+        if isinstance(sub, ast.Call):
+            if _call_name(sub) in ("raise_if_privacy_blocked", "raise_or_collect"):
+                if _arg_names(sub) & scan_vars:
+                    return True
+        elif isinstance(sub, ast.If) and _test_checks_blocked_decision(sub.test, scan_vars):
+            if _contains_own_scope_raise(sub.body):
+                return True
+    return False
+
+
+def _function_scans_and_refuses(module: str, function_name: str) -> bool:
+    """Wrapper over :func:`_source_scans_and_refuses` reading a route module."""
+    source = (ROUTES_DIR / f"{module}.py").read_text(encoding="utf-8")
+    return _source_scans_and_refuses(source, function_name)
+
+
+def _source_scans_and_refuses(source: str, function_name: str) -> bool:
+    """True iff ``function_name`` in ``source`` scans user content — and, when
+    it scans through the thin ``scan_text_content`` wrapper, refuses on the
+    result *bound to that scan*.
+
+    Two accepted scan shapes with different strengths:
+
+    * ``privacy.enforce_write_guard(...)`` — the audited chokepoint. The call
+      itself records the blocked outcome (``record_outcome=True``), so its
+      presence is the meaningful boundary event; the handler's own refusal
+      may legitimately be a non-raising skip (``system.upload_files`` records
+      a per-file error and ``continue``s past the write). We do not second-
+      guess the refusal shape for direct chokepoint callers.
+    * ``scan_text_content(...)`` — a thin ``context.privacy_scan`` wrapper that
+      only *returns* a ``FileScan``. Dropping the paired refusal keeps the scan
+      but writes the blocked bytes anyway. So a wrapper-scanning handler must
+      also refuse *on the scan variable* (``_wrapper_scan_refused``); an
+      unrelated ``.decision`` / ``raise`` no longer satisfies the invariant
+      (#1509 re-review — Codex).
+
+    Scan detection, scan-variable tracking, and the refusal check all walk the
+    handler's OWN scope only (``_walk_own_scope``) so an uncalled nested
+    ``def`` cannot supply a phantom scan or refusal. **Enforced convention:**
+    the scan result must be bound by a plain ``scan = scan_text_content(...)``
+    assignment — tuple-unpacking / annotated / walrus targets are deliberately
+    not tracked (no handler uses them; a future one that does fails this test
+    closed, which forces either the simple-assignment convention or a guard
+    update).
+    """
+    tree = ast.parse(source)
     for node in ast.walk(tree):
         if not isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef):
             continue
         if node.name != function_name:
             continue
-        for sub in ast.walk(node):
-            if not isinstance(sub, ast.Call):
-                continue
-            f = sub.func
-            # Match ``privacy.enforce_write_guard(...)``.
-            if (
-                isinstance(f, ast.Attribute)
-                and f.attr == "enforce_write_guard"
-                and isinstance(f.value, ast.Name)
-                and f.value.id == "privacy"
-            ):
-                return True
-            # Match bare ``enforce_write_guard(...)`` after
-            # ``from memtomem.privacy import enforce_write_guard``.
-            if isinstance(f, ast.Name) and f.id == "enforce_write_guard":
-                return True
-            # Match ``scan_text_content(...)`` (qualified or bare) — the
-            # Gate A wrapper around enforce_write_guard.
-            if isinstance(f, ast.Name) and f.id == "scan_text_content":
-                return True
-            if isinstance(f, ast.Attribute) and f.attr == "scan_text_content":
-                return True
+        has_chokepoint = False
+        scan_vars: set[str] = set()
+        for sub in _walk_own_scope(node):
+            if isinstance(sub, ast.Call):
+                name = _call_name(sub)
+                f = sub.func
+                # ``privacy.enforce_write_guard(...)`` (qualified) or bare
+                # ``enforce_write_guard(...)`` — the audited chokepoint.
+                if name == "enforce_write_guard" and (
+                    isinstance(f, ast.Name)
+                    or (
+                        isinstance(f, ast.Attribute)
+                        and isinstance(f.value, ast.Name)
+                        and f.value.id == "privacy"
+                    )
+                ):
+                    has_chokepoint = True
+            elif isinstance(sub, ast.Assign) and isinstance(sub.value, ast.Call):
+                # Track ``scan = scan_text_content(...)`` target names (plain
+                # Name targets only — see the convention note above).
+                if _call_name(sub.value) == "scan_text_content":
+                    for target in sub.targets:
+                        if isinstance(target, ast.Name):
+                            scan_vars.add(target.id)
+        if has_chokepoint:
+            return True
+        if scan_vars:
+            return _wrapper_scan_refused(node, scan_vars)
+        return False
     return False
 
 
@@ -448,21 +609,204 @@ def test_csrf_classification_covers_every_unsafe_route() -> None:
         pytest.fail("\n\n".join(msg))
 
 
-def test_redaction_protected_handlers_call_enforce_write_guard() -> None:
-    """Each ``_REDACTION_PROTECTED`` handler calls ``enforce_write_guard``."""
+def test_redaction_protected_handlers_scan_and_refuse() -> None:
+    """Each ``_REDACTION_PROTECTED`` handler scans user content — and, for the
+    thin ``scan_text_content`` wrapper, also refuses on the result (not merely
+    "a scan ran" — see ``_function_scans_and_refuses``)."""
     missing: list[str] = []
     for qualname in sorted(_REDACTION_PROTECTED):
         module, _, function = qualname.partition(".")
-        if not _function_calls_write_guard(module, function):
+        if not _function_scans_and_refuses(module, function):
             missing.append(qualname)
     if missing:
         pytest.fail(
-            "Handlers classified as _REDACTION_PROTECTED but lacking a "
-            "``privacy.enforce_write_guard(...)`` call in their body:\n  - "
+            "Handlers classified as _REDACTION_PROTECTED but not scanning "
+            "(and, for ``scan_text_content`` wrapper handlers, not refusing "
+            "on the result via ``raise_if_privacy_blocked`` / "
+            "``raise_or_collect`` / an inline ``.decision`` check that "
+            "raises):\n  - "
             + "\n  - ".join(missing)
-            + "\n\nEither add the guard call or move the handler to "
-            "_REDACTION_EXEMPT with a justification."
+            + "\n\nAdd the scan (+ refusal for wrapper handlers), or move the "
+            "handler to _REDACTION_EXEMPT with a justification. A wrapper scan "
+            "whose FileScan is dropped still writes the blocked content."
         )
+
+
+# --- Unit tests for the scan-and-refuse AST detector -----------------------
+#
+# These pin the exact false-pass the #1509 re-review (Codex) flagged: a
+# wrapper scan whose FileScan is dropped must NOT satisfy the invariant even
+# when an unrelated ``.decision`` check and a validation ``raise`` are present.
+
+
+def _one_handler(body: str) -> str:
+    return "async def handler():\n" + textwrap.indent(textwrap.dedent(body), "    ")
+
+
+def test_detector_rejects_wrapper_scan_without_any_refusal() -> None:
+    src = _one_handler(
+        """
+        scan = scan_text_content(body.content, scope="project_shared")
+        atomic_write_text(path, body.content)
+        """
+    )
+    assert not _source_scans_and_refuses(src, "handler")
+
+
+def test_detector_rejects_wrapper_scan_with_unrelated_decision_and_raise() -> None:
+    # The exact adversarial shape: scan result ignored, but an UNRELATED
+    # ``.decision`` check and an UNRELATED validation raise are present.
+    src = _one_handler(
+        """
+        scan = scan_text_content(body.content, scope="project_shared")
+        if other.decision == "x":
+            raise ValueError("unrelated validation")
+        atomic_write_text(path, body.content)
+        """
+    )
+    assert not _source_scans_and_refuses(src, "handler")
+
+
+def test_detector_accepts_wrapper_scan_with_helper_refusal() -> None:
+    src = _one_handler(
+        """
+        scan = scan_text_content(body.content, scope="project_shared")
+        raise_if_privacy_blocked(scan, kind="command", artifact_name=name)
+        atomic_write_text(path, body.content)
+        """
+    )
+    assert _source_scans_and_refuses(src, "handler")
+
+
+def test_detector_accepts_wrapper_scan_with_inline_decision_raise() -> None:
+    # The ``settings_sync.promote_target_rule`` shape.
+    src = _one_handler(
+        """
+        scan = scan_text_content(body.content, scope="project_shared")
+        if scan.decision in ("blocked", "blocked_project_shared"):
+            raise HTTPException(422, "blocked")
+        atomic_write_text(path, body.content)
+        """
+    )
+    assert _source_scans_and_refuses(src, "handler")
+
+
+def test_detector_accepts_direct_chokepoint_without_raise() -> None:
+    # Direct enforce_write_guard callers keep the old contract — a non-raising
+    # skip (``system.upload_files``) is a valid refusal we do not second-guess.
+    src = _one_handler(
+        """
+        guard = privacy.enforce_write_guard(text, surface="s")
+        if guard.decision == "blocked":
+            results.append(error)
+            return
+        dest.write_bytes(content)
+        """
+    )
+    assert _source_scans_and_refuses(src, "handler")
+
+
+def test_detector_rejects_refusal_in_uncalled_nested_def() -> None:
+    # #1509 re-review Blocker: a refusal buried in an uncalled nested def must
+    # not count — the write still happens in the handler's own scope.
+    src = _one_handler(
+        """
+        scan = scan_text_content(body.content, scope="project_shared")
+
+        async def refuse():
+            raise_if_privacy_blocked(scan, kind="command", artifact_name=name)
+
+        atomic_write_text(path, body.content)
+        """
+    )
+    assert not _source_scans_and_refuses(src, "handler")
+
+
+def test_detector_rejects_inline_raise_in_nested_def_under_if() -> None:
+    # #1509 re-review Nit: an ``if <scan>.decision`` whose raise lives inside a
+    # nested def in its body is not a real refusal.
+    src = _one_handler(
+        """
+        scan = scan_text_content(body.content, scope="project_shared")
+        if scan.decision in ("blocked", "blocked_project_shared"):
+            def _later():
+                raise HTTPException(422, "blocked")
+        atomic_write_text(path, body.content)
+        """
+    )
+    assert not _source_scans_and_refuses(src, "handler")
+
+
+def test_detector_rejects_inverted_decision_condition() -> None:
+    # #1509 re-review Blocker: the ``if`` test must compare against a BLOCKED
+    # decision. ``if scan.decision == "allowed": raise`` raises on the allowed
+    # case and writes blocked content — not a refusal.
+    src = _one_handler(
+        """
+        scan = scan_text_content(body.content, scope="project_shared")
+        if scan.decision == "allowed":
+            raise HTTPException(422, "nope")
+        atomic_write_text(path, body.content)
+        """
+    )
+    assert not _source_scans_and_refuses(src, "handler")
+
+
+def test_detector_rejects_raise_only_in_else_branch() -> None:
+    # #1509 re-review Blocker: the raise must be in the TRUE (blocked) branch.
+    # A raise only in ``else`` means the blocked branch falls through to write.
+    src = _one_handler(
+        """
+        scan = scan_text_content(body.content, scope="project_shared")
+        if scan.decision in ("blocked", "blocked_project_shared"):
+            atomic_write_text(path, body.content)
+        else:
+            raise HTTPException(422, "wrong branch")
+        """
+    )
+    assert not _source_scans_and_refuses(src, "handler")
+
+
+def test_detector_rejects_negated_not_equal_decision() -> None:
+    # #1509 re-review Blocker: ``!= "blocked"`` raises on the ALLOWED case and
+    # writes blocked content — negated polarity is not a refusal.
+    src = _one_handler(
+        """
+        scan = scan_text_content(body.content, scope="project_shared")
+        if scan.decision != "blocked":
+            raise HTTPException(422, "inverted")
+        atomic_write_text(path, body.content)
+        """
+    )
+    assert not _source_scans_and_refuses(src, "handler")
+
+
+def test_detector_rejects_negated_not_in_decision() -> None:
+    # #1509 re-review Blocker: ``not in (...)`` is the same inverted trap.
+    src = _one_handler(
+        """
+        scan = scan_text_content(body.content, scope="project_shared")
+        if scan.decision not in ("blocked", "blocked_project_shared"):
+            raise HTTPException(422, "inverted")
+        atomic_write_text(path, body.content)
+        """
+    )
+    assert not _source_scans_and_refuses(src, "handler")
+
+
+def test_detector_rejects_walrus_bound_scan() -> None:
+    # #1509 re-review Major: only plain ``scan = scan_text_content(...)`` is
+    # tracked. A walrus-bound scan is intentionally NOT tracked, so this
+    # fails closed — pinning the simple-assignment convention rather than
+    # silently accepting an untracked shape.
+    src = _one_handler(
+        """
+        if (scan := scan_text_content(body.content, scope="project_shared")):
+            raise_if_privacy_blocked(scan, kind="command", artifact_name=name)
+        atomic_write_text(path, body.content)
+        """
+    )
+    assert not _source_scans_and_refuses(src, "handler")
 
 
 def test_redaction_classification_covers_every_unsafe_route() -> None:

--- a/packages/memtomem/tests/test_web_invariants_registry.py
+++ b/packages/memtomem/tests/test_web_invariants_registry.py
@@ -151,6 +151,15 @@ _CSRF_EXEMPT: dict[str, str] = {
 _REDACTION_PROTECTED: frozenset[str] = frozenset(
     {
         "chunks.edit_chunk",
+        # The canonical editors write free-form user bytes into the
+        # git-tracked project_shared canonical — write-time Gate A scan
+        # in-route, before atomic_write_text (#1509).
+        "context_agents.create_agent",
+        "context_agents.update_agent",
+        "context_commands.create_command",
+        "context_commands.update_command",
+        "context_skills.create_skill",
+        "context_skills.update_skill",
         "scratch.promote_scratch",
         # Promote appends a private-tier hook rule (free-form command
         # strings + a free-string event key) into the git-tracked shared
@@ -175,23 +184,31 @@ _REDACTION_EXEMPT: dict[str, str] = {
         "rewrites cached LLM summaries from chunks already validated "
         "at index time"
     ),
-    # Structured artifacts (skills/commands/agents) — separate redaction
-    # policy lives in ``memtomem.context`` ingest path; the HTTP layer
-    # validates the schema only.
-    "context_agents.create_agent": "structured artifact; redaction at context-ingest layer",
-    "context_agents.update_agent": "structured artifact; see above",
+    # Structured artifact import/sync (skills/commands/agents) — redaction
+    # lives in the ``memtomem.context`` ingest path (import Gate A / sync
+    # tree scan); the HTTP layer validates the schema only. The create/update
+    # editors moved to ``_REDACTION_PROTECTED`` with an in-route Gate A scan
+    # (#1509).
     "context_agents.import_agent": "structured artifact import; redaction at context-ingest layer",
     "context_agents.import_agents": "bulk structured artifact import; see above",
     "context_agents.sync_agents": "filesystem-driven sync; redaction "
     "happens at file-write time inside the indexer",
-    "context_commands.create_command": "structured artifact; see above",
-    "context_commands.update_command": "structured artifact; see above",
     "context_commands.import_command": "structured artifact import; see above",
     "context_commands.import_commands": "bulk structured artifact import",
     "context_commands.sync_commands": "filesystem-driven sync; see above",
-    "context_mcp_servers.create_mcp_server": "structured artifact; redaction at context-ingest layer",
-    "context_mcp_servers.update_mcp_server": "structured artifact; see above",
-    "context_mcp_servers.patch_mcp_server": "structured artifact; see above",
+    # The mcp-servers editors DO scan in-route (Gate A before the write) via
+    # ``scan_mcp_server_text``, an engine wrapper around enforce_write_guard.
+    # They stay EXEMPT only because the AST guard does not recognize the
+    # wrapper name (and update/patch delegate to _update_mcp_server_impl);
+    # migrating them to _REDACTION_PROTECTED needs a guard extension — a
+    # tracked follow-up to #1509.
+    "context_mcp_servers.create_mcp_server": (
+        "scans in-route via scan_mcp_server_text; wrapper name not recognized by the AST guard"
+    ),
+    "context_mcp_servers.update_mcp_server": (
+        "scans in-route via scan_mcp_server_text inside _update_mcp_server_impl; see above"
+    ),
+    "context_mcp_servers.patch_mcp_server": "same _update_mcp_server_impl delegate; see above",
     "context_mcp_servers.delete_mcp_server": "delete-only, no payload",
     "context_mcp_servers.sync_mcp_servers": "filesystem-driven sync; see above",
     # Wiki install/update (ADR-0008 PR-E E-3): snapshots existing wiki canonical
@@ -205,8 +222,6 @@ _REDACTION_EXEMPT: dict[str, str] = {
         "no free-form content payload (body is just ``force``) — refreshes the "
         "project snapshot from wiki canonical; Gate A runs in-engine pre-copy"
     ),
-    "context_skills.create_skill": "structured artifact; see above",
-    "context_skills.update_skill": "structured artifact; see above",
     "context_skills.import_skill": "structured artifact import",
     "context_skills.import_skill_to_user": "structured artifact import (project runtime → user library)",
     "context_skills.import_skills": "bulk structured artifact import",

--- a/packages/memtomem/tests/test_web_routes_context_mcp_servers.py
+++ b/packages/memtomem/tests/test_web_routes_context_mcp_servers.py
@@ -179,6 +179,26 @@ def _seed_canonical(tmp_path: Path, name: str) -> Path:
 
 
 @pytest.mark.anyio
+async def test_update_rejects_secret_shaped_content(client: AsyncClient, tmp_path: Path) -> None:
+    """Update-side twin of test_create_rejects_secret_shaped_content — the
+    scan in _update_mcp_server_impl was previously untested (#1509)."""
+    secret = "sk-" + "a" * 30
+    path = _seed_canonical(tmp_path, "leaky")
+    before_bytes = path.read_bytes()
+    r = await client.put(
+        "/api/context/mcp-servers/leaky",
+        json={
+            "content": json.dumps({"command": "env", "env": {"OPENAI_API_KEY": secret}}),
+            "mtime_ns": str(path.stat().st_mtime_ns),
+        },
+    )
+    assert r.status_code == 422
+    assert "privacy pattern" in r.json()["detail"]
+    assert secret not in r.text
+    assert path.read_bytes() == before_bytes
+
+
+@pytest.mark.anyio
 async def test_PUT_force_bypasses_mtime_and_logs_warning(
     client: AsyncClient, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/packages/memtomem/tests/test_web_routes_context_mutators.py
+++ b/packages/memtomem/tests/test_web_routes_context_mutators.py
@@ -795,3 +795,90 @@ async def test_both_layouts_detail_prefers_dir_and_warns(
     assert "DIR BODY" in r.json()["content"]
     assert "FLAT BODY" not in r.json()["content"]
     assert adapter["warn_fragment"] in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Write-time Gate A (#1509) — secret-shaped content refused before any write
+# ---------------------------------------------------------------------------
+
+
+def _secret() -> str:
+    # Assembled at runtime so the test file itself never carries a
+    # committable token shape (GitHub push protection).
+    return "sk-" + "a" * 30
+
+
+@pytest.mark.parametrize("adapter", TYPE_MATRIX)
+@pytest.mark.anyio
+async def test_POST_rejects_secret_shaped_content(
+    adapter: dict,
+    client: AsyncClient,
+    gateway_root: Path,
+):
+    """A secret typed into the create editor is refused with the path-free
+    privacy 422 BEFORE any byte lands in the git-tracked canonical (#1509);
+    previously it was only caught at the next sync/import, after the damage."""
+    secret = _secret()
+    body = adapter["create_body"]("leaky")
+    body["content"] += f"\nOPENAI_API_KEY={secret}\n"
+    r = await client.post(adapter["list_url"], json=body)
+    assert r.status_code == 422, (adapter["type"], r.text)
+    detail = r.json()["detail"]
+    # Privacy-422 string-detail convention: count-only, never the matched
+    # bytes or an absolute path.
+    assert isinstance(detail, str), detail
+    assert "privacy pattern" in detail
+    assert secret not in r.text
+    assert str(gateway_root) not in detail
+    # Nothing landed: no working file and no artifact dir — which also
+    # proves the ADR-0022 create_version snapshot never fired.
+    assert not adapter["created_working"](gateway_root, "leaky").exists()
+    assert not (gateway_root / ".memtomem" / adapter["type"] / "leaky").exists()
+
+
+@pytest.mark.parametrize("adapter", TYPE_MATRIX)
+@pytest.mark.anyio
+async def test_PUT_rejects_secret_shaped_content_even_with_force(
+    adapter: dict,
+    client: AsyncClient,
+    gateway_root: Path,
+):
+    """The update editor refuses secret-shaped content with the same 422.
+    ``force: true`` only bypasses the mtime guard, never Gate A — and the
+    canonical bytes and mtime stay untouched after the refusal."""
+    secret = _secret()
+    manifest = adapter["make_canonical"](gateway_root, "hold-the-line")
+    before_bytes = manifest.read_bytes()
+    before_mtime_ns = manifest.stat().st_mtime_ns
+    r = await client.put(
+        adapter["detail"]("hold-the-line"),
+        json={
+            "content": f"updated\nOPENAI_API_KEY={secret}\n",
+            "mtime_ns": str(before_mtime_ns),
+            "force": True,
+        },
+    )
+    assert r.status_code == 422, (adapter["type"], r.text)
+    assert "privacy pattern" in r.json()["detail"]
+    assert secret not in r.text
+    assert manifest.read_bytes() == before_bytes
+    assert manifest.stat().st_mtime_ns == before_mtime_ns
+
+
+@pytest.mark.parametrize("adapter", TYPE_MATRIX)
+@pytest.mark.anyio
+async def test_POST_user_tier_secret_not_privacy_gated(
+    adapter: dict,
+    client: AsyncClient,
+    gateway_root: Path,
+):
+    """Deliberate asymmetry pin (#1509): the write-time Gate A guards only the
+    git-tracked project_shared tier. The same secret-shaped content on a
+    user-tier save proceeds through the allow_host_writes flow — that tier is
+    not git-tracked and keeps its reviewed sync-time force valve (ADR-0011 §5).
+    A later refactor must not silently universalize the block."""
+    body = adapter["create_body"]("private-ok")
+    body["content"] += f"\nOPENAI_API_KEY={_secret()}\n"
+    body["allow_host_writes"] = True
+    r = await client.post(adapter["list_url"], params={"target_scope": "user"}, json=body)
+    assert r.status_code == 200, (adapter["type"], r.text)


### PR DESCRIPTION
## Summary

Closes #1509 (maintainer decision: **Option 1 — add write-time Gate A**).

The web canonical create/update editors for **skills / commands / agents** wrote
user-supplied `body.content` into the git-tracked `project_shared` canonical with
no privacy scan — a pasted secret landed in git immediately and was only caught
at the next sync/import. Every sibling `project_shared` ingress already scans
(mcp-servers editor, import Gate A, sync tree scan, wiki install, settings
promote). This PR mirrors the mcp-servers precedent onto the six remaining
handlers.

## Changes

- **Routes** (`context_skills.py`, `context_commands.py`, `context_agents.py`):
  each create/update handler scans `body.content` via `scan_text_content` before
  delegating / writing — the exact in-memory string `atomic_write_text` will
  write, so there is no TOCTOU window. Surfaces:
  `web_context_{skills,commands,agents}_{create,update}`.
- **`_artifact_common.raise_if_privacy_blocked`**: shared 422 mapper so the
  refusal wording has one owner. The detail is the path-free, count-only Gate A
  string (`format_scan_block_message` with an editor-specific remediation hint);
  matched bytes and absolute paths never appear in the response.
- **Invariants registry** (`test_web_invariants_registry.py`): the six handlers
  moved from `_REDACTION_EXEMPT` to `_REDACTION_PROTECTED`, so the AST guard now
  *enforces* the in-route scan call. The stale mcp-servers justifications were
  corrected (they do scan in-route; see follow-up below).
- **AST guard hardened** (Codex review, 5 rounds): the redaction invariant no
  longer accepts "a scan ran" — a `scan_text_content` wrapper handler must also
  *refuse on the scan variable*. `_source_scans_and_refuses` walks only the
  handler's own lexical scope (no phantom pass from an uncalled nested `def`),
  ties the refusal to the variable bound from `scan_text_content`, and accepts
  an inline branch only as a **positive** blocked comparison
  (`== "blocked"` / `in (…blocked…)`) that raises in its true branch —
  rejecting `!=`, `not in`, `not (...)`, else-only raises, and walrus/tuple
  targets (all fail closed). The detector is unit-tested directly against every
  adversarial shape. Direct `enforce_write_guard` callers keep their existing
  contract (the audited chokepoint; refusal may be a non-raising skip).
- **Tests**: parametrized create/update secret-refusal tests across all three
  kinds (422, no echo, nothing written, mtime untouched, `force: true` does not
  bypass), a user-tier asymmetry pin, and the previously missing mcp-servers
  update-side secret test.
- **Docs**: CHANGELOG Security entry + ADR-0011 §5 dated amendment note (the
  "every first-party byte path scans before landing" claim is true again).

## Behavior notes

- **Ordering**: for `project_shared` requests the privacy 422 now precedes the
  409-duplicate / 409-stale-mtime / 404-missing / 400-UTF-8 responses — same
  posture as `create_mcp_server` (refuse before confirming or disclosing
  anything). `force: true` still bypasses only the mtime guard.
- **Deliberate asymmetry**: user-tier editor saves are *not* scanned — that tier
  is not git-tracked, is gated by the `allow_host_writes` confirm round-trip,
  and keeps its reviewed sync-time force valve (ADR-0011 §5). Pinned by
  `test_POST_user_tier_secret_not_privacy_gated`.
- No SPA change needed: the editors' save-error path already renders string
  details (same shape the mcp editor produces).

## Verification

- `ruff check` / `ruff format --check` clean; full suite
  `pytest -m "not ollama"`: 7584 passed, 11 skipped.
- Pin-validated: reverting only the route changes turns the new secret tests and
  `test_redaction_protected_handlers_call_enforce_write_guard` red.
- E2E against a live isolated `mm web`: secret-shaped command create → 422 with
  count-only detail, nothing written to disk; benign create → 200.

## Follow-up

- #1579 — extend the AST guard to recognize engine scan wrappers
  (`scan_mcp_server_text`, `_update_mcp_server_impl` delegation) and move the
  mcp-servers editors to `_REDACTION_PROTECTED` as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
