### PR TITLE
fix(scheduler): two-pass + mass-delete brake for orphan compaction (#1565)

### DIFF
--- a/packages/memtomem/src/memtomem/scheduler/jobs.py
+++ b/packages/memtomem/src/memtomem/scheduler/jobs.py
@@ -19,17 +19,23 @@ runner without passing schema validation.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal
 
 from pydantic import BaseModel, Field
 
 # expire_chunks lives in the search package; importing at module top is
-# safe — there is no scheduler ↔ search cycle.
+# safe — there is no scheduler ↔ search cycle. Likewise orphan_detect lives
+# in the leaf ``storage`` package, so this stays clear of the heavy
+# ``server`` import that would risk a scheduler ↔ server cycle.
 from memtomem.search.decay import expire_chunks
+from memtomem.storage.orphan_detect import is_suspected_mass_orphan, scan_orphans
 
 if TYPE_CHECKING:
     from memtomem.server.context import AppContext
+
+logger = logging.getLogger(__name__)
 
 
 JobRunStatus = Literal["ok", "error", "timeout", "running"]
@@ -88,21 +94,45 @@ class DedupScanParams(BaseModel):
 async def _run_compaction(app: AppContext) -> JobResult:
     """Delete orphan chunks (chunks whose source file no longer exists).
 
-    Loops orphans one-by-one rather than batching: orphan counts are
+    Orphans are confirmed with a two-pass scan (``scan_orphans``) so a
+    transient absence — a cloud-sync/network mount briefly unavailable when
+    the cron tick fires — is not mistaken for a deletion. As a second guard,
+    a suspected *mass* orphan event (many sources vanishing at once, the
+    tell-tale of a mount failure rather than a real deletion) is refused
+    outright: this job runs unattended with ``dry_run=False``, so skipping and
+    warning is far safer than wiping every chunk under the mount. See #1565.
+
+    Loops confirmed orphans one-by-one rather than batching: orphan counts are
     typically small, and ``delete_by_source`` already handles its own
     invalidation. If this turns into a bottleneck, add a bulk
     ``delete_by_sources`` to the storage layer (follow-up).
     """
-    sources = await app.storage.get_all_source_files()
-    orphaned = [sf for sf in sources if not sf.exists()]
+    result = await scan_orphans(app.storage)
+    if is_suspected_mass_orphan(result):
+        logger.warning(
+            "compaction: refusing to delete %d/%d orphaned sources (%.0f%%) — "
+            "exceeds mass-delete brake; likely a transient mount/permission "
+            "failure, not a real mass deletion. Re-run after verifying source "
+            "roots are mounted.",
+            len(result.confirmed_orphans),
+            result.total_sources,
+            100 * result.ratio,
+        )
+        return {
+            "sources_checked": result.total_sources,
+            "orphan_files": len(result.confirmed_orphans),
+            "chunks_deleted": 0,
+            "skipped_reason": "orphan_ratio_exceeded",
+        }
+
     deleted = 0
-    for sf in orphaned:
+    for sf in result.confirmed_orphans:
         deleted += await app.storage.delete_by_source(sf)
     if deleted > 0:
         app.search_pipeline.invalidate_cache()
     return {
-        "sources_checked": len(sources),
-        "orphan_files": len(orphaned),
+        "sources_checked": result.total_sources,
+        "orphan_files": len(result.confirmed_orphans),
         "chunks_deleted": deleted,
     }
 

--- a/packages/memtomem/src/memtomem/server/health_maintenance.py
+++ b/packages/memtomem/src/memtomem/server/health_maintenance.py
@@ -6,8 +6,9 @@ All operations are idempotent and non-destructive (only removes stale data).
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 from typing import TYPE_CHECKING
+
+from memtomem.storage.orphan_detect import is_suspected_mass_orphan, scan_orphans
 
 if TYPE_CHECKING:
     from memtomem.config import HealthWatchdogConfig
@@ -26,35 +27,43 @@ class MaintenanceExecutor:
     async def cleanup_orphans(self) -> dict:
         """Delete chunks whose source files no longer exist.
 
-        Uses a two-pass check to avoid false positives from temporarily
-        inaccessible files (e.g., network mounts, permission changes).
+        Uses a two-pass scan to avoid false positives from temporarily
+        inaccessible files (e.g., network mounts, permission changes), and
+        refuses a suspected *mass* orphan event (many sources vanishing at
+        once — the tell-tale of a mount failure, not a real deletion) rather
+        than wiping every chunk under the mount unattended. See #1565.
         """
-        import asyncio
+        result = await scan_orphans(self._app.storage)
 
-        source_files = await self._app.storage.get_all_source_files()
-        candidates: list[Path] = [sf for sf in source_files if not sf.exists()]
-
-        if not candidates:
+        if not result.confirmed_orphans:
             return {"orphaned": 0, "deleted_chunks": 0}
 
-        # Second check after short delay to avoid transient failures
-        await asyncio.sleep(0.5)
-        orphaned: list[Path] = [sf for sf in candidates if not sf.exists()]
-
-        if not orphaned:
-            return {"orphaned": 0, "deleted_chunks": 0}
+        if is_suspected_mass_orphan(result):
+            logger.warning(
+                "Auto-maintenance: skipping suspected mass orphan delete "
+                "(%d/%d sources, %.0f%%) — likely a transient mount/permission "
+                "failure. No chunks deleted.",
+                len(result.confirmed_orphans),
+                result.total_sources,
+                100 * result.ratio,
+            )
+            return {
+                "orphaned": len(result.confirmed_orphans),
+                "deleted_chunks": 0,
+                "skipped_reason": "orphan_ratio_exceeded",
+            }
 
         total_deleted = 0
-        for sf in orphaned:
+        for sf in result.confirmed_orphans:
             deleted = await self._app.storage.delete_by_source(sf)
             total_deleted += deleted
 
         logger.info(
             "Auto-maintenance: cleaned %d orphaned files (%d chunks)",
-            len(orphaned),
+            len(result.confirmed_orphans),
             total_deleted,
         )
-        return {"orphaned": len(orphaned), "deleted_chunks": total_deleted}
+        return {"orphaned": len(result.confirmed_orphans), "deleted_chunks": total_deleted}
 
     async def trim_search_cache(self, max_entries: int = 30) -> dict:
         """Evict oldest entries from the search pipeline cache."""

--- a/packages/memtomem/src/memtomem/server/tools/dedup_decay.py
+++ b/packages/memtomem/src/memtomem/server/tools/dedup_decay.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from uuid import UUID
 
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
+from memtomem.storage.orphan_detect import scan_orphans
 
 
 @mcp.tool()
@@ -182,15 +182,16 @@ async def mem_cleanup_orphans(
         dry_run: If True (default), only list orphaned files without deleting.
     """
     app = await _get_app_initialized(ctx)
-    source_files = await app.storage.get_all_source_files()
-
-    orphaned: list[Path] = []
-    for sf in source_files:
-        if not sf.exists():
-            orphaned.append(sf)
+    # Two-pass scan (scan_orphans) so a source that is only transiently
+    # inaccessible — a cloud-sync/network mount mid-reconnect — is not listed
+    # or deleted as an orphan. The mass-delete brake is intentionally *not*
+    # applied here: this tool is user-initiated and dry_run defaults to True,
+    # so an explicit large cleanup is the caller's call to make. See #1565.
+    result = await scan_orphans(app.storage)
+    orphaned = result.confirmed_orphans
 
     if not orphaned:
-        return f"No orphaned chunks found ({len(source_files)} source files checked)."
+        return f"No orphaned chunks found ({result.total_sources} source files checked)."
 
     if dry_run:
         lines = [f"Orphaned files: {len(orphaned)} (dry-run, no deletions)\n"]

--- a/packages/memtomem/src/memtomem/storage/orphan_detect.py
+++ b/packages/memtomem/src/memtomem/storage/orphan_detect.py
@@ -1,0 +1,118 @@
+"""Transient-safe orphan-source detection (issue #1565).
+
+An *orphan source* is an indexed ``source_file`` whose path no longer exists
+on disk — its chunks are candidates for deletion. Several call sites detect
+orphans the same way (``[sf for sf in get_all_source_files() if not sf.exists()]``)
+and then delete them: the scheduled ``compaction`` job, the health-watchdog
+auto-maintenance path, and the interactive ``mem_cleanup_orphans`` tool.
+
+A single ``exists()`` check is unsafe when sources live under a cloud-sync or
+network mount (Dropbox/iCloud reconnect, VPN blip, sleep/wake remount): if the
+mount is briefly absent at the moment the check runs, *every* source under it
+reports ``exists() == False`` and an unattended delete wipes all their chunks
+as "orphans". This module centralizes two independent guards:
+
+1. **Two-pass re-check** (:func:`scan_orphans`) — a path is only reported
+   orphaned if it fails ``exists()`` on an initial pass *and* again after a
+   short delay, filtering sub-second transient absences. Mirrors the guard
+   already living inline in ``health_maintenance.py``.
+2. **Mass-delete brake** (:func:`is_suspected_mass_orphan`) — even a stable
+   two-pass result can be a mount that stayed down past the re-check window,
+   so unattended callers additionally refuse to delete when the confirmed
+   orphans are both numerous (absolute floor) *and* a large fraction of all
+   sources. "Everything vanished at once" is far likelier a mount failure than
+   a real mass deletion; the safe move is to skip and warn, not delete.
+
+The thresholds are module constants (not config) — they mirror the previously
+hardcoded 0.5 s delay and add no new config/docs surface. Callers read them at
+call time, so tests can monkeypatch them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from memtomem.storage.base import StorageBackend
+
+# Delay between the two ``exists()`` passes. Matches the value that lived inline
+# in ``MaintenanceExecutor.cleanup_orphans`` before this module existed.
+ORPHAN_RECHECK_DELAY_SECONDS = 0.5
+
+# Mass-delete brake. The absolute floor keeps small corpora deleting normally
+# (deleting the only indexed file is a ratio of 1.0 but not a "mass" event);
+# the brake only engages once *both* thresholds are crossed.
+MASS_DELETE_MIN_ORPHANS = 10
+MASS_DELETE_RATIO = 0.5
+
+
+@dataclass(frozen=True)
+class OrphanScanResult:
+    """Outcome of a two-pass orphan scan.
+
+    ``confirmed_orphans`` are the paths that failed ``exists()`` on *both*
+    passes; ``first_pass_orphans`` records how many failed the initial pass
+    (``>= len(confirmed_orphans)``) for observability.
+    """
+
+    total_sources: int
+    first_pass_orphans: int
+    confirmed_orphans: list[Path] = field(default_factory=list)
+
+    @property
+    def ratio(self) -> float:
+        """Confirmed orphans as a fraction of all indexed sources (0.0 if none)."""
+        if self.total_sources <= 0:
+            return 0.0
+        return len(self.confirmed_orphans) / self.total_sources
+
+
+async def scan_orphans(
+    storage: StorageBackend,
+    *,
+    recheck_delay_seconds: float | None = None,
+) -> OrphanScanResult:
+    """Two-pass scan for indexed sources whose files no longer exist.
+
+    A source is only confirmed orphaned if it fails :meth:`pathlib.Path.exists`
+    on an initial pass *and* again after ``recheck_delay_seconds`` (defaults to
+    :data:`ORPHAN_RECHECK_DELAY_SECONDS`, read at call time). When the first
+    pass finds nothing there is no second pass and no delay.
+
+    Both passes run the (potentially slow, blocking) ``exists()`` stats off the
+    event loop via :func:`asyncio.to_thread`, matching ``check_orphan_count`` —
+    a hanging network mount must not stall the whole server.
+    """
+    delay = ORPHAN_RECHECK_DELAY_SECONDS if recheck_delay_seconds is None else recheck_delay_seconds
+
+    sources = await storage.get_all_source_files()
+    total = len(sources)
+
+    first_pass = await asyncio.to_thread(lambda: [sf for sf in sources if not sf.exists()])
+    if not first_pass:
+        return OrphanScanResult(total_sources=total, first_pass_orphans=0)
+
+    await asyncio.sleep(delay)
+    confirmed = await asyncio.to_thread(lambda: [sf for sf in first_pass if not sf.exists()])
+    return OrphanScanResult(
+        total_sources=total,
+        first_pass_orphans=len(first_pass),
+        confirmed_orphans=confirmed,
+    )
+
+
+def is_suspected_mass_orphan(result: OrphanScanResult) -> bool:
+    """Whether ``result`` looks like a mount failure rather than a real deletion.
+
+    True only when the confirmed orphans clear *both* the absolute floor
+    (:data:`MASS_DELETE_MIN_ORPHANS`) and the fraction-of-all-sources ratio
+    (:data:`MASS_DELETE_RATIO`). Unattended callers use this to skip the delete
+    and warn; the constants are read here so tests can monkeypatch them.
+    """
+    n = len(result.confirmed_orphans)
+    if n < MASS_DELETE_MIN_ORPHANS:
+        return False
+    return result.total_sources > 0 and result.ratio >= MASS_DELETE_RATIO

--- a/packages/memtomem/tests/test_health_watchdog.py
+++ b/packages/memtomem/tests/test_health_watchdog.py
@@ -233,8 +233,12 @@ class TestDeepChecks:
 
 class TestMaintenanceExecutor:
     @pytest.mark.asyncio
-    async def test_cleanup_orphans(self, mock_app, tmp_path):
+    async def test_cleanup_orphans(self, mock_app, tmp_path, monkeypatch):
         from memtomem.server.health_maintenance import MaintenanceExecutor
+        from memtomem.storage import orphan_detect
+
+        # Keep the #1565 two-pass re-check instant.
+        monkeypatch.setattr(orphan_detect, "ORPHAN_RECHECK_DELAY_SECONDS", 0.0)
 
         app, _db = mock_app
         config = HealthWatchdogConfig(enabled=True)
@@ -243,9 +247,33 @@ class TestMaintenanceExecutor:
         app.storage.delete_by_source = AsyncMock(return_value=5)
 
         executor = MaintenanceExecutor(app, config)
+        # One orphan is below the mass-delete brake, so it deletes normally.
         result = await executor.cleanup_orphans()
         assert result["orphaned"] == 1
         assert result["deleted_chunks"] == 5
+
+    @pytest.mark.asyncio
+    async def test_cleanup_orphans_skips_suspected_mass_delete(
+        self, mock_app, tmp_path, monkeypatch
+    ):
+        """#1565 — a mount blip vanishing every source is refused, not wiped."""
+        from memtomem.server.health_maintenance import MaintenanceExecutor
+        from memtomem.storage import orphan_detect
+
+        monkeypatch.setattr(orphan_detect, "ORPHAN_RECHECK_DELAY_SECONDS", 0.0)
+
+        app, _db = mock_app
+        config = HealthWatchdogConfig(enabled=True)
+        missing = {tmp_path / f"gone-{i}.md" for i in range(12)}
+        app.storage.get_all_source_files = AsyncMock(return_value=missing)
+        app.storage.delete_by_source = AsyncMock(return_value=5)
+
+        executor = MaintenanceExecutor(app, config)
+        result = await executor.cleanup_orphans()
+        assert result["orphaned"] == 12
+        assert result["deleted_chunks"] == 0
+        assert result["skipped_reason"] == "orphan_ratio_exceeded"
+        app.storage.delete_by_source.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_trim_search_cache(self, mock_app):

--- a/packages/memtomem/tests/test_orphan_detect.py
+++ b/packages/memtomem/tests/test_orphan_detect.py
@@ -1,0 +1,164 @@
+"""Tests for the shared two-pass orphan detector (issue #1565).
+
+``scan_orphans`` confirms an indexed source is orphaned only when it fails
+``exists()`` on two passes, filtering transient absences (a cloud-sync/network
+mount briefly unavailable). ``is_suspected_mass_orphan`` is the belt-and-braces
+brake for unattended callers: it flags "everything vanished at once" as a likely
+mount failure rather than a real deletion.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from memtomem.storage.orphan_detect import (
+    OrphanScanResult,
+    is_suspected_mass_orphan,
+    scan_orphans,
+)
+
+
+class _FakeSource:
+    """A source path whose ``exists()`` returns a scripted True/False sequence.
+
+    The first pass calls ``exists()`` on every source; the second pass calls it
+    again only on first-pass failures. Once the scripted sequence is exhausted
+    the last value repeats, so ``[True]`` = always present, ``[False, False]`` =
+    stable orphan, ``[False, True]`` = transient (absent then back).
+    """
+
+    def __init__(self, name: str, exists_seq: list[bool]) -> None:
+        self._name = name
+        self._seq = list(exists_seq)
+        self._last = self._seq[-1]
+
+    def exists(self) -> bool:
+        if self._seq:
+            self._last = self._seq.pop(0)
+        return self._last
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"<src {self._name}>"
+
+
+def _storage(sources) -> MagicMock:
+    st = MagicMock()
+    st.get_all_source_files = AsyncMock(return_value=set(sources))
+    return st
+
+
+class TestScanOrphans:
+    @pytest.mark.asyncio
+    async def test_empty_sources(self):
+        result = await scan_orphans(_storage([]), recheck_delay_seconds=0)
+        assert result.total_sources == 0
+        assert result.first_pass_orphans == 0
+        assert result.confirmed_orphans == []
+        assert result.ratio == 0.0
+
+    @pytest.mark.asyncio
+    async def test_all_present_no_second_pass(self):
+        # No first-pass failures -> function returns before the delay/second
+        # pass. ``first_pass_orphans == 0`` proves the early-return branch.
+        sources = [_FakeSource("a", [True]), _FakeSource("b", [True])]
+        result = await scan_orphans(_storage(sources), recheck_delay_seconds=0)
+        assert result.total_sources == 2
+        assert result.first_pass_orphans == 0
+        assert result.confirmed_orphans == []
+
+    @pytest.mark.asyncio
+    async def test_transient_absence_excluded(self):
+        transient = _FakeSource("flaky", [False, True])
+        present = _FakeSource("ok", [True])
+        result = await scan_orphans(_storage([transient, present]), recheck_delay_seconds=0)
+        assert result.total_sources == 2
+        assert result.first_pass_orphans == 1  # seen absent on pass 1
+        assert result.confirmed_orphans == []  # but present on pass 2
+
+    @pytest.mark.asyncio
+    async def test_stable_orphan_confirmed(self):
+        stable = _FakeSource("gone", [False, False])
+        present = _FakeSource("ok", [True])
+        result = await scan_orphans(_storage([stable, present]), recheck_delay_seconds=0)
+        assert result.total_sources == 2
+        assert result.first_pass_orphans == 1
+        assert result.confirmed_orphans == [stable]
+
+    @pytest.mark.asyncio
+    async def test_mixed_transient_and_stable(self):
+        stable = _FakeSource("gone", [False, False])
+        transient = _FakeSource("flaky", [False, True])
+        present = _FakeSource("ok", [True])
+        result = await scan_orphans(_storage([stable, transient, present]), recheck_delay_seconds=0)
+        assert result.total_sources == 3
+        assert result.first_pass_orphans == 2
+        assert result.confirmed_orphans == [stable]
+        assert result.ratio == pytest.approx(1 / 3)
+
+
+class TestMassOrphanBrake:
+    def _result(self, confirmed: int, total: int) -> OrphanScanResult:
+        return OrphanScanResult(
+            total_sources=total,
+            first_pass_orphans=confirmed,
+            confirmed_orphans=[_FakeSource(str(i), [False, False]) for i in range(confirmed)],
+        )
+
+    def test_single_orphan_below_floor(self):
+        # 1/1 is ratio 1.0 but below the absolute floor -> deleting the only
+        # indexed file is normal, not a mass event.
+        assert is_suspected_mass_orphan(self._result(1, 1)) is False
+
+    def test_many_and_high_ratio_trips(self):
+        assert is_suspected_mass_orphan(self._result(12, 12)) is True
+
+    def test_many_but_low_ratio_ok(self):
+        # 12 orphans but only 24% of a large corpus -> plausible real cleanup.
+        assert is_suspected_mass_orphan(self._result(12, 50)) is False
+
+    def test_exactly_at_thresholds_trips(self):
+        # count == floor (10) and ratio == 0.5 -> both boundaries inclusive.
+        assert is_suspected_mass_orphan(self._result(10, 20)) is True
+
+    def test_below_floor_even_at_full_ratio(self):
+        assert is_suspected_mass_orphan(self._result(9, 9)) is False
+
+
+class TestInteractiveToolSkipsBrake:
+    """#1565 policy pin: the mass-delete brake is unattended-path only.
+
+    ``mem_cleanup_orphans`` is user-initiated and defaults to ``dry_run=True``,
+    so an explicit ``dry_run=False`` cleanup of many orphans must still delete —
+    the two-pass guard applies, but the brake deliberately does not. This locks
+    in the asymmetry so a future refactor can't silently route the interactive
+    tool through ``is_suspected_mass_orphan`` (which the scheduler and health
+    paths use to skip).
+    """
+
+    @pytest.mark.asyncio
+    async def test_many_orphans_still_deleted(self, monkeypatch, tmp_path):
+        from memtomem.server.tools import dedup_decay
+        from memtomem.storage import orphan_detect
+
+        monkeypatch.setattr(orphan_detect, "ORPHAN_RECHECK_DELAY_SECONDS", 0.0)
+
+        # 12 stable orphans / 12 sources — well past the mass-delete brake that
+        # the unattended paths enforce.
+        missing = {tmp_path / f"gone-{i}.md" for i in range(12)}
+        app = MagicMock()
+        app.storage.get_all_source_files = AsyncMock(return_value=missing)
+        app.storage.delete_by_source = AsyncMock(return_value=1)
+        app.search_pipeline.invalidate_cache = MagicMock()
+
+        async def _fake_app(_ctx):
+            return app
+
+        monkeypatch.setattr(dedup_decay, "_get_app_initialized", _fake_app)
+
+        out = await dedup_decay.mem_cleanup_orphans(dry_run=False, ctx=None)
+
+        assert "Cleanup complete" in out
+        assert "Orphaned files: 12" in out
+        assert app.storage.delete_by_source.await_count == 12  # brake NOT applied

--- a/packages/memtomem/tests/test_scheduler_jobs.py
+++ b/packages/memtomem/tests/test_scheduler_jobs.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 from pydantic import ValidationError
 
 from memtomem.scheduler import JOB_KINDS, JobSpec
 from memtomem.server.context import AppContext
+from memtomem.storage import orphan_detect
 
 
 @pytest.fixture
@@ -120,3 +123,84 @@ class TestDeadLinkCleanupSemantics:
         # Live row survives.
         remaining = db.execute("SELECT link_type FROM chunk_links ORDER BY link_type").fetchall()
         assert [r[0] for r in remaining] == ["summarizes"]
+
+
+class _ScriptedSource:
+    """Source path whose ``exists()`` yields a scripted True/False sequence."""
+
+    def __init__(self, name: str, exists_seq: list[bool]) -> None:
+        self._name = name
+        self._seq = list(exists_seq)
+        self._last = self._seq[-1]
+
+    def exists(self) -> bool:
+        if self._seq:
+            self._last = self._seq.pop(0)
+        return self._last
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"<src {self._name}>"
+
+
+def _fake_app(sources, *, delete_return: int = 3) -> MagicMock:
+    app = MagicMock()
+    app.storage.get_all_source_files = AsyncMock(return_value=set(sources))
+    app.storage.delete_by_source = AsyncMock(return_value=delete_return)
+    app.search_pipeline.invalidate_cache = MagicMock()
+    return app
+
+
+class TestCompactionOrphanGuards:
+    """#1565 — compaction must not mass-delete on a transient/mount blip."""
+
+    @pytest.fixture(autouse=True)
+    def _no_delay(self, monkeypatch):
+        # Keep the two-pass re-check instant in tests.
+        monkeypatch.setattr(orphan_detect, "ORPHAN_RECHECK_DELAY_SECONDS", 0.0)
+
+    @pytest.mark.asyncio
+    async def test_transient_absence_not_deleted(self):
+        """A source absent on pass 1 but back on pass 2 is never deleted."""
+        transient = _ScriptedSource("flaky", [False, True])
+        present = _ScriptedSource("ok", [True])
+        app = _fake_app([transient, present])
+
+        result = await JOB_KINDS["compaction"].runner(app)
+
+        assert result["chunks_deleted"] == 0
+        assert result["orphan_files"] == 0
+        assert result["sources_checked"] == 2
+        assert "skipped_reason" not in result
+        app.storage.delete_by_source.assert_not_awaited()
+        app.search_pipeline.invalidate_cache.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mass_orphan_event_skips_delete(self):
+        """Many sources vanishing at once is refused, not deleted."""
+        sources = [_ScriptedSource(f"gone-{i}", [False, False]) for i in range(12)]
+        app = _fake_app(sources)
+
+        result = await JOB_KINDS["compaction"].runner(app)
+
+        assert result["chunks_deleted"] == 0
+        assert result["orphan_files"] == 12
+        assert result["sources_checked"] == 12
+        assert result["skipped_reason"] == "orphan_ratio_exceeded"
+        app.storage.delete_by_source.assert_not_awaited()
+        app.search_pipeline.invalidate_cache.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_small_stable_orphan_is_deleted(self):
+        """A confirmed orphan below the mass-delete brake deletes normally."""
+        gone = _ScriptedSource("gone", [False, False])
+        present = [_ScriptedSource(f"ok-{i}", [True]) for i in range(4)]
+        app = _fake_app([gone, *present], delete_return=3)
+
+        result = await JOB_KINDS["compaction"].runner(app)
+
+        assert result["chunks_deleted"] == 3
+        assert result["orphan_files"] == 1
+        assert result["sources_checked"] == 5
+        assert "skipped_reason" not in result
+        app.storage.delete_by_source.assert_awaited_once_with(gone)
+        app.search_pipeline.invalidate_cache.assert_called_once()


### PR DESCRIPTION
## Summary

The scheduled `compaction` cron job deleted every chunk whose source file failed a **single** `sf.exists()` check — unattended, with `dry_run=False`. When sources live under a cloud-sync or network mount (Dropbox/iCloud reconnect, VPN blip, sleep/wake remount), a brief absence at the moment the tick fires makes every source report `exists() == False`, and compaction silently wipes all their chunks + embeddings as "orphans" until a full manual re-index.

The health-watchdog sibling (`MaintenanceExecutor.cleanup_orphans`) already guarded this exact mode with an inline two-pass check, but the scheduled path had no such guard and the logic was duplicated.

## What changed

New leaf-layer helper **`storage/orphan_detect.py`** (kept in `storage/` to avoid a `scheduler → server` import cycle) with two independent guards:

- **`scan_orphans`** — two-pass re-check (0.5 s apart, `exists()` stats run off the event loop via `asyncio.to_thread`). A source is confirmed orphaned only if absent on *both* passes, filtering sub-second transient absences.
- **`is_suspected_mass_orphan`** — a mount can stay down past the re-check window, so unattended callers additionally refuse to delete when confirmed orphans clear *both* an absolute floor (10) *and* a fraction-of-all-sources ratio (0.5). "Everything vanished at once" is far likelier a mount failure than a real deletion; the safe move is to skip and warn (surfaced via `skipped_reason`).

All three single-check sites now route through the helper:

| Site | Change |
|------|--------|
| `scheduler/jobs.py::_run_compaction` (the bug) | two-pass **+** mass-delete brake |
| `server/health_maintenance.py::cleanup_orphans` | drops the duplicated inline two-pass; gains the brake |
| `server/tools/dedup_decay.py::mem_cleanup_orphans` (interactive, `dry_run=True` default) | two-pass only — the brake is **deliberately not** applied to a cleanup a present user explicitly requested (asymmetry pinned by a regression test) |

Thresholds are named module constants (not config): they mirror the previously hardcoded 0.5 s and add no config/docs surface.

## Test plan

- New `tests/test_orphan_detect.py`: two-pass semantics (transient excluded, stable confirmed), brake boundaries (1/1 below floor, 12/12 trips, 12/50 ratio-ok, 10/20 at-threshold), and the interactive-tool no-brake pin.
- `tests/test_scheduler_jobs.py`: transient-not-deleted, mass-event-skipped (`skipped_reason`), small-stable-orphan-deleted.
- `tests/test_health_watchdog.py`: existing single-orphan delete still works; added a mass-event skip test.
- Full suite green (`pytest -m "not ollama"`: 7628 passed), `ruff check`/`format` clean, `mypy` clean on touched modules.

Found during the 2026-07-03 operational-stability audit (#1563–74).

Closes #1565

🤖 Generated with [Claude Code](https://claude.com/claude-code)
