### PR TITLE
fix(storage): make upsert_entities atomic — no orphaned DELETE on failure

### DIFF
--- a/packages/memtomem/src/memtomem/storage/mixins/entities.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/entities.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from memtomem.errors import StorageError
+
 
 class EntityMixin:
-    """Mixin providing entity extraction storage methods. Requires self._get_db()."""
+    """Mixin providing entity extraction storage methods.
+
+    Requires ``self._get_db()`` and ``self._in_transaction`` from the backend:
+    the write methods gate their commit/rollback on ``_in_transaction`` so they
+    compose under the backend's ``transaction()`` context manager.
+    """
 
     async def upsert_entities(self, chunk_id: str, entities: list[dict]) -> int:
         """Insert entities for a chunk. Replaces existing entities if any."""
@@ -15,31 +22,50 @@ class EntityMixin:
         db = self._get_db()
         now = datetime.now(timezone.utc).isoformat(timespec="seconds")
 
-        # Delete existing entities for this chunk (overwrite mode)
-        db.execute("DELETE FROM chunk_entities WHERE chunk_id = ?", (chunk_id,))
+        # Build params before touching the DB: a malformed entity dict (missing a
+        # required key) must raise BEFORE the DELETE, never mid-transaction (#1572).
+        rows = [
+            (
+                chunk_id,
+                e["entity_type"],
+                e["entity_value"],
+                e.get("confidence", 1.0),
+                e.get("position", 0),
+                now,
+            )
+            for e in entities
+        ]
 
-        db.executemany(
-            "INSERT INTO chunk_entities (chunk_id, entity_type, entity_value, confidence, position, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            [
-                (
-                    chunk_id,
-                    e["entity_type"],
-                    e["entity_value"],
-                    e.get("confidence", 1.0),
-                    e.get("position", 0),
-                    now,
-                )
-                for e in entities
-            ],
-        )
-        db.commit()
+        try:
+            # Overwrite mode: replace this chunk's entities atomically.
+            db.execute("DELETE FROM chunk_entities WHERE chunk_id = ?", (chunk_id,))
+            db.executemany(
+                "INSERT INTO chunk_entities (chunk_id, entity_type, entity_value, "
+                "confidence, position, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+                rows,
+            )
+            if not self._in_transaction:
+                db.commit()
+        except Exception as exc:
+            # Roll back the pending DELETE instead of leaving it to be flushed by
+            # the next unrelated commit on the shared writer connection (#1572).
+            if not self._in_transaction:
+                db.rollback()
+            raise StorageError(f"upsert_entities failed, transaction rolled back: {exc}") from exc
         return len(entities)
 
     async def delete_entities_for_chunk(self, chunk_id: str) -> int:
         db = self._get_db()
-        cur = db.execute("DELETE FROM chunk_entities WHERE chunk_id = ?", (chunk_id,))
-        db.commit()
+        try:
+            cur = db.execute("DELETE FROM chunk_entities WHERE chunk_id = ?", (chunk_id,))
+            if not self._in_transaction:
+                db.commit()
+        except Exception as exc:
+            if not self._in_transaction:
+                db.rollback()
+            raise StorageError(
+                f"delete_entities_for_chunk failed, transaction rolled back: {exc}"
+            ) from exc
         return cur.rowcount
 
     async def search_entities(

--- a/packages/memtomem/tests/test_entities.py
+++ b/packages/memtomem/tests/test_entities.py
@@ -3,6 +3,8 @@
 import pytest
 from helpers import make_chunk
 
+from memtomem.errors import StorageError
+
 
 class TestEntityMixin:
     @pytest.mark.asyncio
@@ -49,6 +51,56 @@ class TestEntityMixin:
     async def test_upsert_empty(self, storage):
         count = await storage.upsert_entities("nonexistent", [])
         assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_upsert_rolls_back_on_insert_failure(self, storage):
+        chunk = make_chunk("Alice met Bob")
+        await storage.upsert_chunks([chunk])
+        await storage.upsert_entities(
+            str(chunk.id),
+            [
+                {"entity_type": "person", "entity_value": "Alice"},
+                {"entity_type": "person", "entity_value": "Bob"},
+            ],
+        )
+
+        # A second upsert whose INSERT fails on an unbindable value, AFTER the
+        # DELETE has run. The pending DELETE must be rolled back — not left for a
+        # later unrelated commit on the shared writer connection to flush (#1572).
+        with pytest.raises(StorageError):
+            await storage.upsert_entities(
+                str(chunk.id),
+                [{"entity_type": "person", "entity_value": object()}],
+            )
+
+        # Unrelated commit on the shared writer connection: would flush an
+        # orphaned DELETE if one were left pending.
+        await storage.increment_access([chunk.id])
+
+        result = await storage.get_entities_for_chunk(str(chunk.id))
+        assert {r["entity_value"] for r in result} == {"Alice", "Bob"}
+
+    @pytest.mark.asyncio
+    async def test_upsert_malformed_entity_preserves_existing(self, storage):
+        chunk = make_chunk("keep me")
+        await storage.upsert_chunks([chunk])
+        await storage.upsert_entities(
+            str(chunk.id),
+            [{"entity_type": "person", "entity_value": "Keep"}],
+        )
+
+        # A batch with a missing required key is rejected before the DELETE, so
+        # the existing entity is preserved rather than silently wiped (#1572).
+        with pytest.raises(KeyError):
+            await storage.upsert_entities(
+                str(chunk.id),
+                [{"entity_type": "person"}],  # no entity_value
+            )
+
+        await storage.increment_access([chunk.id])
+
+        result = await storage.get_entities_for_chunk(str(chunk.id))
+        assert [r["entity_value"] for r in result] == ["Keep"]
 
     @pytest.mark.asyncio
     async def test_delete_entities(self, storage):


### PR DESCRIPTION
## Summary

`upsert_entities` (`storage/mixins/entities.py`) ran **DELETE → build INSERT
params → executemany → commit** with no `try/except`. The shared writer
connection is in sqlite3's default *deferred* mode (no `isolation_level`), so
the `DELETE` opens an implicit transaction that lingers until an explicit
`commit()`. If the INSERT failed — or building the params inline raised a
`KeyError` mid-transaction — the `DELETE` stayed **pending** on the shared
connection, and the next unrelated commit on that same connection
(`increment_access`, `save_query_history`, session/scratch ops) flushed it. The
chunk's entities were silently wiped even though the "upsert" raised, with
nothing logged. Entities are re-derivable on reindex, so severity is moderate —
but the failure is invisible.

## Fix

Match the backend's guarded-commit idiom (`delete_chunks`, `reset_all`, …):

- **Build the INSERT params before the `DELETE`** so a malformed entity dict
  raises before any DB mutation (existing entities preserved, for free).
- **Wrap DELETE+INSERT in `try/except`** with `_in_transaction`-gated
  commit/rollback, re-raising as `StorageError`. On failure the pending `DELETE`
  is rolled back instead of being left for a later piggyback commit. Gating on
  `_in_transaction` keeps the method composable under the backend's
  `transaction()` context manager.
- Apply the same idiom to the sibling outlier **`delete_entities_for_chunk`**,
  which also committed unconditionally and ignored `_in_transaction`.

No callers change: the production caller (`server/tools/entity.py`) always
supplies all keys, so the happy path is byte-for-byte identical — only the
failure path is now safe.

## Test plan

Two regression tests in `test_entities.py`, both pinned to **fail on the
pre-fix code and pass after** (the `increment_access` call is the unrelated
piggyback commit that would flush an orphaned DELETE):

- `test_upsert_rolls_back_on_insert_failure` — INSERT fails on an unbindable
  value *after* the DELETE → asserts `StorageError` and that the original
  entities survive the subsequent commit.
- `test_upsert_malformed_entity_preserves_existing` — a dict missing
  `entity_value` is rejected *before* the DELETE → existing entity preserved.

```
uv run pytest packages/memtomem/tests/test_entities.py -q          # 10 passed
uv run pytest packages/memtomem/tests/test_entity_extraction.py \
    packages/memtomem/tests/test_server_tools_advanced.py -q       # 101 passed
uv run ruff check … && uv run ruff format --check …                # clean
uv run mypy …/storage/mixins/entities.py                           # clean
```

Closes #1572

🤖 Generated with [Claude Code](https://claude.com/claude-code)
