### PR TITLE
fix(indexing): watcher removes chunks for deleted/renamed files (#1566)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,28 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   count as credentials — they are read by the SDK itself and are never copied
   into memtomem config. `LANGFUSE_ENABLED` alone never turns tracing on.
 
+### Fixed
+
+- **Deleting or renaming a watched markdown file now removes its chunks from
+  the index immediately** (#1566). The file watcher had no `on_deleted`
+  handler and `on_moved` enqueued only the new path, so a deleted or
+  renamed-away file's chunks lingered in `chunks`/`chunks_fts`/`chunks_vec`
+  and stayed searchable until the opt-in orphan-compaction pass ran — with the
+  scheduler disabled (the default), effectively forever. This has a privacy
+  edge: "I deleted the file" did not mean "it left the memory index". The
+  watcher now enqueues deletes and both sides of a move; `IndexEngine.index_file`
+  treats a path that no longer exists — deleted, renamed away, or replaced by a
+  directory — as delete-by-source, reusing the same primitive as the
+  orphan-cleanup backstops. Cleanup is deliberately *not* blocked by exclude
+  patterns (the orphan sweep already purges excluded orphans, so the live path
+  matches — otherwise a deleted-and-newly-excluded file's content would persist
+  forever). Safety brakes: the delete fires only on a genuine missing-file
+  error, never a transient `EACCES`/`EIO` blip; a wholesale loss of a watched
+  root/volume is left to the periodic two-pass mass-orphan brake rather than
+  mass-deleted per event; and the delete pass never resurrects a removed parent
+  directory via the sidecar lock. Orphan compaction remains the backstop for
+  events missed while the watcher is down.
+
 ## [0.3.2] — 2026-06-30
 
 A security release. The Web UI now validates `Host`/`Origin` on every `/api/*`

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -7,6 +7,7 @@ import contextlib
 import dataclasses
 import logging
 import os
+import stat as stat_module
 import time
 from collections.abc import Callable, Iterable
 from datetime import datetime, timezone
@@ -615,13 +616,29 @@ class IndexEngine:
         for the contract and rationale. Callers that go through
         ``mem_edit`` / ``mem_delete`` / CLI ``mm index --force`` / web
         ``POST /reindex`` all use this path.
+
+        If ``file_path`` no longer exists on disk (deleted, renamed away, or
+        replaced by a directory), this removes that source's stale chunks via
+        ``delete_by_source``, regardless of exclude patterns (cleanup is never
+        blocked by exclude). The delete is skipped when the whole containing
+        index root has vanished, so a single missing file is purged but a
+        wholesale root/volume loss is left to the periodic mass-orphan brake
+        (#1565) instead of being mass-deleted per-event (#1566).
         """
         # Defense-in-depth: the primary guard lives at the top of
         # ``_index_file`` (covers every caller — watcher, stream endpoint,
-        # CLI, MCP tools). This public-entry check is kept so the call
-        # returns early with zeroed stats without entering the lock.
+        # CLI, MCP tools). This public-entry check is kept so an excluded,
+        # still-present *file* returns early with zeroed stats without entering
+        # the lock. A path that is no longer a regular file — missing, or
+        # replaced by a directory — falls through even when excluded, so its
+        # stale chunks are purged: exclude blocks indexing, not cleanup (see the
+        # missing-source branch in ``_index_file``). ``is_file`` (not
+        # ``exists``) is the right predicate — a same-named directory ``exists``
+        # but is not indexable, and its old chunks must still be cleaned. (#1566)
         user_spec = _build_exclude_spec(self._config.exclude_patterns)
-        if _path_is_excluded(file_path, self._config.all_index_roots(), user_spec):
+        if _path_is_excluded(file_path, self._config.all_index_roots(), user_spec) and (
+            file_path.is_file()
+        ):
             logger.debug("Skipping excluded file %s", file_path)
             return IndexingStats(
                 total_files=0,
@@ -651,7 +668,25 @@ class IndexEngine:
                 from memtomem.context._atomic import _file_lock, _lock_path_for
 
                 resolved_path = file_path.resolve()
-                with _file_lock(_lock_path_for(resolved_path)):
+                if resolved_path.parent.is_dir():
+                    with _file_lock(_lock_path_for(resolved_path)):
+                        result = await self._index_file(
+                            resolved_path,
+                            force,
+                            namespace=namespace,
+                            force_unsafe=force_unsafe,
+                            already_scanned=already_scanned,
+                        )
+                else:
+                    # #1566: the parent dir is gone (deleted subtree / unmounted
+                    # volume), so this is a delete-by-source pass for a vanished
+                    # file. Taking the sidecar lock would ``mkdir`` the deleted
+                    # parent back into existence (``_file_lock`` recreates
+                    # ``lock_path.parent``) just to hold a lock over a delete —
+                    # resurrecting the directory the user removed. ``_index_lock``
+                    # still serializes in-process; migrate's sidecar lock for this
+                    # path lives in the same missing parent, so no live pair-op
+                    # can be mid-flight on it.
                     result = await self._index_file(
                         resolved_path,
                         force,
@@ -792,26 +827,71 @@ class IndexEngine:
             parts.append(name)
         return "".join(parts)
 
-    def _is_within_memory_dirs(self, path: Path) -> bool:
-        """Check that *path* is within at least one configured index root.
+    def _containing_index_root(self, path: Path) -> Path | None:
+        """Return the *most-specific* resolved index root containing *path*.
 
         Covers user-tier ``memory_dirs`` and project-tier
-        ``project_memory_dirs`` (ADR-0011). Method name kept for
-        backward compatibility with callers; the semantic is
-        "any registered index root".
+        ``project_memory_dirs`` (ADR-0011). When roots are nested
+        (``~/mem`` and ``~/mem/project``), the longest-prefix match wins —
+        so the unmount brake in :meth:`_delete_missing_source` checks the
+        nested root that actually vanished rather than a surviving parent
+        that would mask it. Returns ``None`` when *path* is outside every
+        root.
         """
+        best: Path | None = None
         for d in self._config.all_index_roots():
             root = Path(d).expanduser().resolve()
             try:
-                if path.is_relative_to(root):
-                    return True
+                within = path.is_relative_to(root)
             except TypeError:
                 try:
                     path.relative_to(root)
-                    return True
+                    within = True
                 except ValueError:
-                    continue
-        return False
+                    within = False
+            if within and (best is None or len(root.parts) > len(best.parts)):
+                best = root
+        return best
+
+    def _is_within_memory_dirs(self, path: Path) -> bool:
+        """Check that *path* is within at least one configured index root.
+
+        Method name kept for backward compatibility with callers; the
+        semantic is "any registered index root".
+        """
+        return self._containing_index_root(path) is not None
+
+    async def _delete_missing_source(self, file_path: Path) -> IndexFileResult:
+        """Remove stale chunks for a source file that is gone from disk.
+
+        Reached when ``stat``/``read_text`` raise ``FileNotFoundError`` /
+        ``NotADirectoryError`` / ``IsADirectoryError`` (the file was deleted,
+        renamed away, or replaced by a directory).
+
+        Deletion is skipped when the most-specific containing index root has
+        itself disappeared: when a whole watched root/volume is unmounted or
+        removed, every path under it reports missing at once, and a per-event
+        purge of the entire tree is exactly the mass-delete we must not do.
+        Root gone → no-op; the two-pass mass-orphan brake (#1565, run by the
+        scheduler / health watchdog / ``mem_cleanup_orphans``) owns that bulk
+        case with a ratio check the per-event path can't replicate. This brake
+        catches whole-root loss; a mountpoint that survives *empty* still
+        passes ``is_dir()`` here, so that bulk case is deliberately left to the
+        periodic mass-orphan scan rather than guessed at per-event. Reuses the
+        same ``delete_by_source`` primitive as those backstops. (#1566)
+        """
+        root = self._containing_index_root(file_path)
+        if root is None or not root.is_dir():
+            return {"total": 0, "indexed": 0, "skipped": 0, "deleted": 0, "errors": []}
+        deleted = await self._storage.delete_by_source(file_path)
+        if deleted:
+            # Path + count only — never log file content on the delete path.
+            logger.info(
+                "Source file gone; removed %d stale chunk(s) from index: %s",
+                deleted,
+                file_path,
+            )
+        return {"total": 0, "indexed": 0, "skipped": 0, "deleted": deleted, "errors": []}
 
     async def _index_file(
         self,
@@ -827,22 +907,46 @@ class IndexEngine:
         # new_chunk_ids (list[UUID]). Early zero-result paths may omit
         # new_chunk_ids — consumers must tolerate missing keys.
 
+        # Existence check FIRST — before the exclude guard. A file that is gone
+        # from disk is a delete-by-source, and cleanup must never be blocked by
+        # an exclude pattern: the orphan sweep (#1565) already purges excluded
+        # orphans unconditionally, so the live path must match, else a deleted
+        # + newly-excluded file's chunks stay searchable forever. ``stat`` reads
+        # only metadata (no content), so statting an excluded file first is
+        # safe — its content is still never read below. (#1566)
+        try:
+            stat_result = file_path.stat()
+        except (FileNotFoundError, NotADirectoryError):
+            # File deleted/renamed away (NotADirectoryError: a parent component
+            # was replaced by a file, so the path cannot exist) — purge its
+            # stale chunks instead of a silent no-op.
+            return await self._delete_missing_source(file_path)
+        except OSError:
+            # Transient I/O (EACCES/EIO/ESTALE) — never delete on a blip.
+            return {"total": 0, "indexed": 0, "skipped": 0, "deleted": 0, "errors": []}
+
+        # The path exists but is no longer a regular file (replaced by a
+        # directory or special file) — gone *as an indexable source*, so purge
+        # its stale chunks. Checked from the stat result (no extra syscall, no
+        # content read) and BEFORE the exclude guard, so an excluded file that
+        # was swapped for a same-named directory is still cleaned up. (#1566)
+        if not stat_module.S_ISREG(stat_result.st_mode):
+            return await self._delete_missing_source(file_path)
+
         # Primary exclude guard — every caller (index_file, _index_path_inner
         # after _discover_files, index_path_stream single-file branch) funnels
         # through here, so a single check closes all entry points including
         # ones added later. ``_discover_files`` still filters upstream for
         # directory walks, but this guard ensures single-file callers like
-        # ``index_path_stream(file)`` cannot smuggle credentials or noise.
+        # ``index_path_stream(file)`` cannot smuggle credentials or noise. Only
+        # *indexing* (adding content) is gated here; the missing-file delete
+        # above runs regardless.
         user_spec = _build_exclude_spec(self._config.exclude_patterns)
         if _path_is_excluded(file_path, self._config.all_index_roots(), user_spec):
             logger.debug("Skipping excluded file %s", file_path)
             return {"total": 0, "indexed": 0, "skipped": 0, "deleted": 0, "errors": []}
 
-        try:
-            file_size = file_path.stat().st_size
-        except OSError:
-            return {"total": 0, "indexed": 0, "skipped": 0, "deleted": 0, "errors": []}
-
+        file_size = stat_result.st_size
         if file_size > _MAX_INDEX_FILE_BYTES:
             logger.warning("Skipping %s: file too large (%d bytes)", file_path.name, file_size)
             return {
@@ -861,6 +965,12 @@ class IndexEngine:
         except UnicodeDecodeError:
             logger.warning("Non-UTF-8 content in %s, replacing invalid bytes", file_path.name)
             content = file_path.read_text(encoding="utf-8", errors="replace")
+        except (FileNotFoundError, NotADirectoryError, IsADirectoryError):
+            # File is gone as a *file*: unlinked between stat and read (TOCTOU),
+            # or the leaf path was replaced by a directory (``IsADirectoryError``
+            # — ``stat`` succeeds on the dir, the read fails). Either way the old
+            # source no longer exists, so purge its stale chunks. (#1566)
+            return await self._delete_missing_source(file_path)
         except OSError:
             return {"total": 0, "indexed": 0, "skipped": 0, "deleted": 0, "errors": []}
 

--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -58,8 +58,23 @@ class _MarkdownEventHandler(FileSystemEventHandler):
         if not event.is_directory:
             self._enqueue(str(event.src_path))
 
-    def on_moved(self, event: FileSystemEvent) -> None:
+    def on_deleted(self, event: FileSystemEvent) -> None:
+        # #1566: a deleted .md is enqueued like any other path — the consumer
+        # sees it no longer exists on disk and ``index_file`` purges its stale
+        # chunks (delete-by-source). Without this a deleted file's content
+        # stayed searchable until the opt-in orphan-compaction pass ran.
         if not event.is_directory:
+            self._enqueue(str(event.src_path))
+
+    def on_moved(self, event: FileSystemEvent) -> None:
+        # #1566: enqueue BOTH paths. The old path no longer exists → its chunks
+        # are deleted-by-source; the new path is indexed. The suffix filter in
+        # ``_enqueue`` still admits a .md ``src`` even when the file was renamed
+        # away to a non-.md ``dest`` (rename-away), so the stale chunks are
+        # cleaned in that case too. Previously only ``dest`` was enqueued,
+        # orphaning the old path's chunks on every rename/move.
+        if not event.is_directory:
+            self._enqueue(str(event.src_path))
             self._enqueue(str(event.dest_path))
 
 
@@ -250,13 +265,23 @@ class FileWatcher:
 
         try:
             stats = await self._engine.index_file(file_path)
-            logger.info(
-                "Auto-reindexed %s: indexed=%d skipped=%d deleted=%d",
-                file_path.name,
-                stats.indexed_chunks,
-                stats.skipped_chunks,
-                stats.deleted_chunks,
-            )
+            if stats.deleted_chunks and not stats.indexed_chunks and not file_path.exists():
+                # #1566: pure delete pass (file gone from disk) — "Auto-reindexed
+                # ... indexed=0 ... deleted=N" reads as a no-op in logs a user
+                # greps during a privacy check. Name it for what it is.
+                logger.info(
+                    "Removed deleted file from index: %s (%d stale chunk(s))",
+                    file_path.name,
+                    stats.deleted_chunks,
+                )
+            else:
+                logger.info(
+                    "Auto-reindexed %s: indexed=%d skipped=%d deleted=%d",
+                    file_path.name,
+                    stats.indexed_chunks,
+                    stats.skipped_chunks,
+                    stats.deleted_chunks,
+                )
         except PrivacyRejection as exc:
             # ADR-0006 PR-A: a watched file gained secret-class content; it is
             # left un-indexed (not a failure — the boundary is doing its job).

--- a/packages/memtomem/tests/test_watcher_deleted_files.py
+++ b/packages/memtomem/tests/test_watcher_deleted_files.py
@@ -1,0 +1,322 @@
+"""Watcher delete/move handling: deleting or renaming a watched file must
+remove its chunks from the index (regression coverage for #1566).
+
+Two layers:
+
+* ``_MarkdownEventHandler`` — the watchdog handler correctly enqueues the
+  right path(s) for ``on_deleted`` / ``on_moved`` (with the suffix filter).
+* ``IndexEngine.index_file`` — a path that no longer exists on disk purges
+  its stale chunks via ``delete_by_source``, gated on the containing index
+  root still existing (mount-blip brake) and without resurrecting a deleted
+  parent directory.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+from pathlib import Path
+from unittest import mock
+
+from watchdog.events import (
+    DirDeletedEvent,
+    FileDeletedEvent,
+    FileMovedEvent,
+)
+
+from memtomem.indexing.watcher import _STOP_SENTINEL, FileWatcher, _MarkdownEventHandler
+
+
+def _mock_embedder(components):
+    """Wire a deterministic in-memory embedder onto the engine (no ONNX)."""
+    embedder = mock.AsyncMock()
+    embedder.embed_texts = mock.AsyncMock(
+        side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
+    )
+    embedder.dimension = 1024
+    components.index_engine._embedder = embedder
+    return embedder
+
+
+async def _index_content(components, path: Path, body: str = "# Note\n\nSome content.\n") -> None:
+    path.write_text(body, encoding="utf-8")
+    _mock_embedder(components)
+    await components.index_engine.index_file(path)
+
+
+# ===========================================================================
+# Handler-level: which path(s) get enqueued
+# ===========================================================================
+
+
+class TestMarkdownEventHandlerDeleteMove:
+    """``_MarkdownEventHandler`` enqueue behavior for delete/move events."""
+
+    def _handler(self):
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue[Path] = asyncio.Queue()
+        handler = _MarkdownEventHandler(queue, loop, frozenset({".md"}))
+        return handler, queue
+
+    def _drain(self, queue: asyncio.Queue[Path]) -> set[Path]:
+        out: set[Path] = set()
+        while not queue.empty():
+            out.add(queue.get_nowait())
+        return out
+
+    async def test_on_deleted_enqueues_md(self):
+        handler, queue = self._handler()
+        handler.on_deleted(FileDeletedEvent("/mem/gone.md"))
+        await asyncio.sleep(0)  # let call_soon_threadsafe run
+        assert self._drain(queue) == {Path("/mem/gone.md")}
+
+    async def test_on_deleted_filters_unsupported_suffix(self):
+        handler, queue = self._handler()
+        handler.on_deleted(FileDeletedEvent("/mem/gone.txt"))
+        await asyncio.sleep(0)
+        assert self._drain(queue) == set()
+
+    async def test_on_deleted_ignores_directory(self):
+        handler, queue = self._handler()
+        handler.on_deleted(DirDeletedEvent("/mem/subdir"))
+        await asyncio.sleep(0)
+        assert self._drain(queue) == set()
+
+    async def test_on_moved_enqueues_both_paths(self):
+        handler, queue = self._handler()
+        handler.on_moved(FileMovedEvent("/mem/old.md", "/mem/new.md"))
+        await asyncio.sleep(0)
+        assert self._drain(queue) == {Path("/mem/old.md"), Path("/mem/new.md")}
+
+    async def test_on_moved_rename_away_from_md_keeps_old_path(self):
+        # dest is a non-.md path (renamed away) — only the .md src survives the
+        # suffix filter, so the old path's stale chunks still get cleaned.
+        handler, queue = self._handler()
+        handler.on_moved(FileMovedEvent("/mem/old.md", "/mem/old.txt"))
+        await asyncio.sleep(0)
+        assert self._drain(queue) == {Path("/mem/old.md")}
+
+    async def test_on_moved_rename_into_md_keeps_new_path(self):
+        handler, queue = self._handler()
+        handler.on_moved(FileMovedEvent("/mem/old.txt", "/mem/new.md"))
+        await asyncio.sleep(0)
+        assert self._drain(queue) == {Path("/mem/new.md")}
+
+
+# ===========================================================================
+# Engine-level: missing file == delete-by-source
+# ===========================================================================
+
+
+class TestDeleteMissingSource:
+    """``index_file`` purges chunks for a source file that is gone from disk."""
+
+    async def test_deleted_file_removes_its_chunks(self, components, memory_dir):
+        md_path = memory_dir / "delete_me.md"
+        await _index_content(components, md_path)
+        assert len(await components.storage.get_chunk_hashes(md_path)) > 0
+
+        md_path.unlink()
+        stats = await components.index_engine.index_file(md_path)
+
+        assert stats.deleted_chunks > 0
+        assert len(await components.storage.get_chunk_hashes(md_path)) == 0
+
+    async def test_transient_oserror_does_not_delete(self, components, memory_dir):
+        """A non-ENOENT OSError (EACCES/EIO) must never delete — only a genuine
+        missing file does. Guards against a permission/mount blip mass-deleting."""
+        md_path = memory_dir / "blip.md"
+        await _index_content(components, md_path)
+        assert len(await components.storage.get_chunk_hashes(md_path)) > 0
+
+        original_stat = Path.stat
+
+        def fake_stat(self, *args, **kwargs):
+            if self.name == "blip.md":
+                raise PermissionError("simulated transient error")
+            return original_stat(self, *args, **kwargs)
+
+        with mock.patch.object(Path, "stat", autospec=True, side_effect=fake_stat):
+            stats = await components.index_engine.index_file(md_path)
+
+        assert stats.deleted_chunks == 0
+        assert len(await components.storage.get_chunk_hashes(md_path)) > 0
+
+    async def test_unmounted_root_does_not_delete(self, components, memory_dir):
+        """If the whole index root is gone (unmount), skip deletion — the
+        two-pass orphan scan adjudicates that case instead."""
+        md_path = memory_dir / "note.md"
+        await _index_content(components, md_path)
+        assert len(await components.storage.get_chunk_hashes(md_path)) > 0
+
+        # Remove the entire memory_dir root out from under the engine.
+        shutil.rmtree(memory_dir)
+        stats = await components.index_engine.index_file(md_path)
+
+        assert stats.deleted_chunks == 0
+        assert len(await components.storage.get_chunk_hashes(md_path)) > 0
+
+    async def test_subdir_deletion_removes_chunks_without_resurrecting_dir(
+        self, components, memory_dir
+    ):
+        """Deleting a file whose subdirectory was removed must clean its chunks
+        and must NOT recreate the deleted directory (the sidecar-lock mkdir
+        hazard)."""
+        subdir = memory_dir / "sub"
+        subdir.mkdir()
+        md_path = subdir / "nested.md"
+        await _index_content(components, md_path)
+        assert len(await components.storage.get_chunk_hashes(md_path)) > 0
+
+        shutil.rmtree(subdir)
+        stats = await components.index_engine.index_file(md_path)
+
+        assert stats.deleted_chunks > 0
+        assert len(await components.storage.get_chunk_hashes(md_path)) == 0
+        assert not subdir.exists(), "deleted subdirectory must not be resurrected by the lock mkdir"
+
+    async def test_rename_cleans_old_path_and_indexes_new(self, components, memory_dir):
+        old_path = memory_dir / "before.md"
+        new_path = memory_dir / "after.md"
+        await _index_content(components, old_path)
+        assert len(await components.storage.get_chunk_hashes(old_path)) > 0
+
+        old_path.rename(new_path)
+
+        del_stats = await components.index_engine.index_file(old_path)
+        assert del_stats.deleted_chunks > 0
+        assert len(await components.storage.get_chunk_hashes(old_path)) == 0
+
+        add_stats = await components.index_engine.index_file(new_path)
+        assert add_stats.indexed_chunks > 0
+        assert len(await components.storage.get_chunk_hashes(new_path)) > 0
+
+    async def test_deleted_excluded_path_is_still_purged(self, components, memory_dir):
+        """Cleanup is not blocked by exclude: a file indexed before an exclude
+        pattern was added, then deleted, must still have its stale chunks purged
+        — matching the exclude-agnostic orphan sweep (otherwise deleted-and-
+        excluded content would persist forever)."""
+        md_path = memory_dir / "was_indexed.md"
+        await _index_content(components, md_path)
+        assert len(await components.storage.get_chunk_hashes(md_path)) > 0
+
+        components.config.indexing.exclude_patterns = ["was_indexed.md"]
+        md_path.unlink()
+        stats = await components.index_engine.index_file(md_path)
+
+        assert stats.deleted_chunks > 0
+        assert len(await components.storage.get_chunk_hashes(md_path)) == 0
+
+    async def test_present_excluded_path_is_not_indexed_or_purged(self, components, memory_dir):
+        """A still-present excluded file is a no-op: its (pre-exclude) chunks are
+        left intact and no new content is indexed — exclude blocks *indexing*,
+        the delete path only fires for a missing file."""
+        md_path = memory_dir / "still_here.md"
+        await _index_content(components, md_path)
+        before = len(await components.storage.get_chunk_hashes(md_path))
+        assert before > 0
+
+        components.config.indexing.exclude_patterns = ["still_here.md"]
+        stats = await components.index_engine.index_file(md_path)
+
+        assert stats.deleted_chunks == 0
+        assert stats.indexed_chunks == 0
+        assert len(await components.storage.get_chunk_hashes(md_path)) == before
+
+    async def test_file_replaced_by_directory_purges_chunks(self, components, memory_dir):
+        """A source file swapped for a directory of the same name (stat succeeds,
+        read raises IsADirectoryError) is gone as a *file* — purge its chunks."""
+        md_path = memory_dir / "swap.md"
+        await _index_content(components, md_path)
+        assert len(await components.storage.get_chunk_hashes(md_path)) > 0
+
+        md_path.unlink()
+        md_path.mkdir()  # same name, now a directory
+        stats = await components.index_engine.index_file(md_path)
+
+        assert stats.deleted_chunks > 0
+        assert len(await components.storage.get_chunk_hashes(md_path)) == 0
+
+    async def test_excluded_file_replaced_by_directory_still_purges(self, components, memory_dir):
+        """Intersection of the two edges: a file that is both excluded AND
+        replaced by a same-named directory. ``exists()`` is true for the dir, so
+        keying cleanup off ``is_file`` (not ``exists``) and checking the stat
+        mode before the exclude guard is what lets the stale chunks be purged."""
+        md_path = memory_dir / "excluded_swap.md"
+        await _index_content(components, md_path)
+        assert len(await components.storage.get_chunk_hashes(md_path)) > 0
+
+        components.config.indexing.exclude_patterns = ["excluded_swap.md"]
+        md_path.unlink()
+        md_path.mkdir()  # excluded name, now a directory
+        stats = await components.index_engine.index_file(md_path)
+
+        assert stats.deleted_chunks > 0
+        assert len(await components.storage.get_chunk_hashes(md_path)) == 0
+
+    async def test_nested_root_removed_engages_brake(self, components, tmp_path):
+        """When nested roots are configured and the most-specific one is removed,
+        the brake keys off *that* root (not a surviving parent) and skips the
+        delete — leaving the bulk case to the two-pass mass-orphan scan."""
+        outer = tmp_path / "outer"
+        inner = outer / "inner"
+        inner.mkdir(parents=True)
+        components.config.indexing.memory_dirs = [outer, inner]
+
+        nested = inner / "nested.md"
+        await _index_content(components, nested)
+        assert len(await components.storage.get_chunk_hashes(nested)) > 0
+
+        shutil.rmtree(inner)  # inner root gone, outer survives
+        stats = await components.index_engine.index_file(nested)
+
+        assert stats.deleted_chunks == 0
+        assert len(await components.storage.get_chunk_hashes(nested)) > 0
+
+
+# ===========================================================================
+# Mid-level: the consumer drives the delete end-to-end (no real Observer)
+# ===========================================================================
+
+
+async def test_process_events_deletes_via_queue(components, memory_dir):
+    """Feed the deleted path + stop sentinel straight into the queue and run
+    the consumer — deterministic, no filesystem-event timing."""
+    md_path = memory_dir / "queued.md"
+    await _index_content(components, md_path)
+    assert len(await components.storage.get_chunk_hashes(md_path)) > 0
+
+    watcher = FileWatcher(
+        index_engine=components.index_engine,
+        config=components.config.indexing,
+        debounce_ms=100,
+    )
+    md_path.unlink()
+    watcher._queue.put_nowait(md_path)
+    watcher._queue.put_nowait(_STOP_SENTINEL)
+
+    await watcher._process_events()
+
+    assert len(await components.storage.get_chunk_hashes(md_path)) == 0
+
+
+async def test_reindex_logs_removed_not_reindexed(components, memory_dir, caplog):
+    """The delete pass logs 'Removed deleted file from index', not the
+    misleading 'Auto-reindexed ... indexed=0 ... deleted=N'."""
+    md_path = memory_dir / "logtest.md"
+    await _index_content(components, md_path)
+
+    watcher = FileWatcher(
+        index_engine=components.index_engine,
+        config=components.config.indexing,
+        debounce_ms=100,
+    )
+    md_path.unlink()
+
+    with caplog.at_level(logging.INFO, logger="memtomem.indexing.watcher"):
+        await watcher._reindex(md_path)
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("Removed deleted file from index" in m for m in messages)
+    assert not any("Auto-reindexed" in m for m in messages)


### PR DESCRIPTION
## Summary

Closes #1566. The file watcher had no `on_deleted` handler and `on_moved` enqueued only the new path, so deleting or renaming a watched markdown file left its chunks in `chunks`/`chunks_fts`/`chunks_vec` and still searchable. The only cleanup was the opt-in orphan-compaction pass (`mem_cleanup_orphans` / scheduler / health watchdog); with the scheduler disabled (the default) the deleted content persisted indefinitely. This is privacy-adjacent — "I deleted the file" did not mean "it left the memory index".

Note: the issue text assumed "the indexer already handles a missing file as delete-by-source" — it did **not**. `_index_file` returned zeroed stats on a `stat`/`read_text` `OSError` and did nothing; the only delete path was "file exists but yields zero chunks". This PR adds the missing-file → delete behavior.

## What changed

- **`indexing/watcher.py`** — `_MarkdownEventHandler` gains `on_deleted`; `on_moved` now enqueues **both** the old and new paths (the suffix filter still admits a `.md` src when a file is renamed away to a non-`.md` name). The reindex log names a pure delete pass (`Removed deleted file from index`) instead of the misleading `Auto-reindexed … indexed=0 … deleted=N`.
- **`indexing/engine.py`** — `index_file` / `_index_file` treat a source that is no longer a **regular file** (missing, renamed away, or replaced by a directory/special file) as delete-by-source, reusing the same `delete_by_source` primitive as the orphan-cleanup backstops. The existence/mode check runs **before** the exclude guard so cleanup is never blocked by an exclude pattern — matching the exclude-agnostic orphan sweep, otherwise a deleted-and-newly-excluded file's content would persist forever. Excluded regular-file *content* is still never read.
- **`CHANGELOG.md`** — `[Unreleased] › Fixed` entry.

## Safety brakes

- Only a genuine missing-file error deletes; a transient `EACCES`/`EIO` blip is a no-op (never mass-delete on a mount hiccup).
- Deletion is skipped when the **most-specific** containing index root has itself vanished — a wholesale root/volume loss is left to the periodic two-pass mass-orphan brake (#1565) rather than mass-deleted per event. Nested roots use longest-prefix matching so a surviving parent can't mask a removed child root. (A mountpoint that survives *empty* still passes `is_dir()` here — that bulk case is deliberately owned by the periodic scan, not guessed per-event.)
- The delete pass skips the sidecar advisory lock when the parent dir is gone, so it never resurrects a removed directory via the lock's `mkdir`.

## Tests

New `tests/test_watcher_deleted_files.py` (18 tests): handler-level enqueue behavior (`on_deleted`, `on_moved` both-paths, rename-away/into `.md`, suffix + directory filtering); engine-level delete-on-missing, `FileNotFoundError`-only gating (transient error preserves chunks), unmount brake, subdir deletion without directory resurrection, rename cleanup, deleted-excluded purge + present-excluded no-op, file→directory replacement, excluded file→directory intersection, nested-root brake; a deterministic mid-level `_process_events` drive via the queue; and the delete-pass log line.

Full suite: **7661 passed**. `ruff check` / `ruff format` / `mypy` clean.

## Review

Reviewed by Codex across three rounds (NEEDS-FIX → NEEDS-FIX → **SHIP**): the first two rounds surfaced the `IsADirectoryError` gap, the exclude-blocks-cleanup gap, the unmount-brake overclaim / first-match-root masking, and finally the excluded-file-replaced-by-directory intersection — all fixed here.

## Out of scope

- Search-pipeline cache: a deleted chunk can surface from cache for up to `cache_ttl` (default 30 s); the watcher doesn't invalidate cache on any path today (even modify). Wiring `invalidate_cache()` into `FileWatcher` needs constructor changes and is left to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
