### PR TITLE
fix(mcp): claim session handle at mem_session_end entry (at-most-once)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   descriptors even in one process, so nesting it would self-deadlock. Cross-
   process races (a second MCP server, the CLI, `mm web`) and CRUD-vs-`memory-
   migrate` remain out of scope and are tracked separately.
+- **`mem_session_end` no longer double-writes the summary on a retried or
+  concurrent call** (#1571). Only the final state reset was guarded by
+  `_session_lock`; the effectful phase — `end_session`, the billable
+  auto-summary LLM call, and the archive summary-chunk write+index — ran
+  unlocked before it, so a client retry (or two agents sharing the session)
+  re-read the same `current_session_id` and re-ran the whole phase. The active
+  handle is now *claimed* — read and nulled atomically under `_session_lock` at
+  entry — so the effectful phase runs at most once and the loser returns "No
+  active session." (matching the claim-then-run contract from #1564). The handle
+  is not restored on mid-phase failure; an orphaned active row is reaped by the
+  existing stale-session path.
 - **Deleting or renaming a watched markdown file now removes its chunks from
   the index immediately** (#1566). The file watcher had no `on_deleted`
   handler and `on_moved` enqueued only the new path, so a deleted or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,12 +199,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `_session_lock`; the effectful phase — `end_session`, the billable
   auto-summary LLM call, and the archive summary-chunk write+index — ran
   unlocked before it, so a client retry (or two agents sharing the session)
-  re-read the same `current_session_id` and re-ran the whole phase. The active
-  handle is now *claimed* — read and nulled atomically under `_session_lock` at
-  entry — so the effectful phase runs at most once and the loser returns "No
-  active session." (matching the claim-then-run contract from #1564). The handle
-  is not restored on mid-phase failure; an orphaned active row is reaped by the
-  existing stale-session path.
+  re-read the same `current_session_id` and re-ran the whole phase. The session
+  is now *claimed* under `_session_lock` at entry (its id recorded in
+  `_ending_session_ids`), so a second/retried end returns "No active session."
+  and the effectful phase runs at most once (matching the claim-then-run
+  contract from #1564); the claim is not released on mid-phase failure, and an
+  orphaned active row is reaped by the existing stale-session path. The public
+  `current_session_id` / `current_agent_id` handles stay set through the phase
+  and are cleared only when it completes — separating the claim from the handle
+  so a concurrent session-bound write during the multi-second teardown still
+  routes to `agent-runtime:<id>` and a concurrent `mem_scratch_set` still binds
+  to the ending session (and is reaped by its `scratch_cleanup`) instead of
+  silently falling back to the default/global scope.
 - **Deleting or renaming a watched markdown file now removes its chunks from
   the index immediately** (#1566). The file watcher had no `on_deleted`
   handler and `on_moved` enqueued only the new path, so a deleted or

--- a/packages/memtomem/src/memtomem/server/context.py
+++ b/packages/memtomem/src/memtomem/server/context.py
@@ -131,7 +131,8 @@ class AppContext:
     _dim_mismatch_announced: bool = False
     _config_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _init_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-    # Guards mutations of ``current_session_id`` + ``current_agent_id``.
+    # Guards mutations of ``current_session_id`` + ``current_agent_id`` and
+    # ``_ending_session_ids``.
     # Kept distinct from ``_config_lock`` so a long-running config write
     # cannot block a session start, and vice versa.
     _session_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
@@ -160,6 +161,17 @@ class AppContext:
     _memory_file_locks: dict[str, asyncio.Lock] = field(
         default_factory=dict, init=False, repr=False
     )
+    # Sessions whose ``mem_session_end`` effectful phase (billable LLM
+    # auto-summary, archive-chunk write) is in flight (issue #1571). This is
+    # the at-most-once *claim* — a second/retried end whose session id is
+    # already here returns "No active session." and does not re-run the
+    # phase. Kept separate from ``current_session_id`` so the claim does NOT
+    # null the public session handle at entry: nulling it early would make
+    # concurrent session-bound writes (``mem_add`` agent-namespace routing,
+    # ``mem_scratch_set`` binding) see no active session for the whole
+    # multi-second phase. The handle is nulled only when the phase completes.
+    # Guarded by ``_session_lock``.
+    _ending_session_ids: set[str] = field(default_factory=set, init=False, repr=False)
 
     # ── current_namespace (validated) ─────────────────────────────────────
     # Property + setter pair so every write — whether via ``mem_ns_set``,

--- a/packages/memtomem/src/memtomem/server/tools/session.py
+++ b/packages/memtomem/src/memtomem/server/tools/session.py
@@ -153,13 +153,18 @@ async def mem_session_end(
     Resets both ``current_session_id`` and ``current_agent_id`` so the
     next ``mem_agent_search`` falls back to ``current_namespace``.
 
-    The active-session handle is *claimed* (read and cleared) atomically
-    under ``_session_lock`` at entry, so a concurrent or client-retried
-    ``mem_session_end`` returns ``"No active session."`` instead of
-    re-running the effectful phase. The summarize/persist work therefore
-    runs **at most once** per session; the handle is not restored if that
-    phase fails part-way (a retry must not risk a duplicate billable
-    summary). An active DB row orphaned by a mid-phase crash is reaped by
+    The session is *claimed* atomically under ``_session_lock`` at entry by
+    recording its id in ``_ending_session_ids``, so a concurrent or
+    client-retried ``mem_session_end`` returns ``"No active session."``
+    instead of re-running the effectful phase — the summarize/persist work
+    runs **at most once** per session. The public ``current_session_id`` /
+    ``current_agent_id`` handles stay set through the phase and are cleared
+    only when it completes, so concurrent session-bound writes
+    (``mem_add`` agent-namespace routing, ``mem_scratch_set`` binding) still
+    resolve to the active session during teardown instead of silently
+    falling back to the default scope. The claim is not released on
+    mid-phase failure (a retry must not risk a duplicate billable summary);
+    an active DB row orphaned by a mid-phase crash is reaped by
     the stale-session path (``find_stale_active_sessions``).
 
     When ``summary`` is provided, the text is also promoted to a
@@ -187,108 +192,127 @@ async def mem_session_end(
     """
     app = await _get_app_initialized(ctx)
 
-    # Claim-then-work (issue #1571): atomically read AND null the active
-    # session handle under _session_lock so a retried or concurrent
+    # Claim-then-work (issue #1571): under _session_lock, record the active
+    # session id in _ending_session_ids so a retried or concurrent
     # mem_session_end cannot double-run the effectful phase (billable LLM
     # auto-summary, archive-chunk write + index, end_session UPDATE). The
-    # loser sees no active session and returns early. At-most-once: the
-    # handle is NOT restored on mid-phase failure — a retry after a partial
-    # failure must not risk a duplicate summary. Same contract as
-    # schedule_try_claim (issue #1564). agent_id is captured here too: the
-    # archive helper needs the tag after the handle has been cleared.
+    # loser (session already claimed) sees no active session and returns
+    # early. At-most-once: the finally below clears the public handle on
+    # both success and failure, so a retry after a partial failure sees no
+    # active session and does not re-run the phase — the summary is never
+    # duplicated. Same contract as schedule_try_claim (issue #1564).
+    #
+    # The public handle is deliberately left set here (unlike a naive
+    # null-at-entry): it is cleared only after the phase, in the finally, so
+    # concurrent session-bound writes during the multi-second phase still
+    # route to this session's scope (agent-namespace / scratch binding)
+    # instead of the default. agent_id is captured for the archive helper.
     async with app._session_lock:
         session_id = app.current_session_id
-        if not session_id:
+        if not session_id or session_id in app._ending_session_ids:
             return "No active session."
+        app._ending_session_ids.add(session_id)
         agent_id = app.current_agent_id
-        app.current_session_id = None
-        app.current_agent_id = None
 
-    # Gather session stats
-    events = await app.storage.get_session_events(session_id)
-    event_counts: dict[str, int] = {}
-    for e in events:
-        event_counts[e["event_type"]] = event_counts.get(e["event_type"], 0) + 1
+    try:
+        # Gather session stats
+        events = await app.storage.get_session_events(session_id)
+        event_counts: dict[str, int] = {}
+        for e in events:
+            event_counts[e["event_type"]] = event_counts.get(e["event_type"], 0) + 1
 
-    # Read the session row before end_session writes ended_at — we need
-    # ``started_at`` and ``namespace`` for the Phase B auto-summary
-    # chunk lookup. Tolerate missing rows defensively (the row was
-    # created in mem_session_start, so absence indicates external
-    # tampering or a backend bug; either way, fall back to skipping
-    # auto-summary rather than crashing the close path).
-    session_row = await app.storage.get_session(session_id)
+        # Read the session row before end_session writes ended_at — we need
+        # ``started_at`` and ``namespace`` for the Phase B auto-summary
+        # chunk lookup. Tolerate missing rows defensively (the row was
+        # created in mem_session_start, so absence indicates external
+        # tampering or a backend bug; either way, fall back to skipping
+        # auto-summary rather than crashing the close path).
+        session_row = await app.storage.get_session(session_id)
 
-    await app.storage.end_session(session_id, summary, {"event_counts": event_counts})
+        await app.storage.end_session(session_id, summary, {"event_counts": event_counts})
 
-    effective_summary = summary
-    auto_summary_skip_reason: str | None = None
-    auto_source_chunks: list = []
-    if not summary:
-        (
-            effective_summary,
-            auto_summary_skip_reason,
-            auto_source_chunks,
-        ) = await _maybe_auto_summarize(
-            app,
-            session_id=session_id,
-            session_row=session_row,
-        )
-
-    summary_chunk_line: str | None = None
-    summary_chunk_id = None
-    if effective_summary:
-        try:
-            summary_chunk_line, summary_chunk_id = await _persist_session_summary_chunk(
+        effective_summary = summary
+        auto_summary_skip_reason: str | None = None
+        auto_source_chunks: list = []
+        if not summary:
+            (
+                effective_summary,
+                auto_summary_skip_reason,
+                auto_source_chunks,
+            ) = await _maybe_auto_summarize(
                 app,
                 session_id=session_id,
-                agent_id=agent_id,
-                summary=effective_summary,
-                event_counts=event_counts,
-            )
-        except Exception:
-            logger.warning(
-                "session_summary_chunk_persist_failed session_id=%s",
-                session_id,
-                exc_info=True,
+                session_row=session_row,
             )
 
-    # Phase B-2: link the summary chunk back to the source chunks it
-    # summarized. Only runs on the auto path (manual ``summary=`` did
-    # not collect source chunks). Failures are best-effort: a broken
-    # link writer must not roll back the session-end DB write or the
-    # archive chunk that already landed.
-    if summary_chunk_id is not None and auto_source_chunks:
-        try:
-            await _write_summary_links(
-                app,
-                summary_chunk_id=summary_chunk_id,
-                source_chunks=auto_source_chunks,
-                cap=app.config.session_summary.max_summary_links,
-            )
-        except Exception:
-            logger.warning(
-                "session_summary_links_failed session_id=%s",
-                session_id,
-                exc_info=True,
-            )
+        summary_chunk_line: str | None = None
+        summary_chunk_id = None
+        if effective_summary:
+            try:
+                summary_chunk_line, summary_chunk_id = await _persist_session_summary_chunk(
+                    app,
+                    session_id=session_id,
+                    agent_id=agent_id,
+                    summary=effective_summary,
+                    event_counts=event_counts,
+                )
+            except Exception:
+                logger.warning(
+                    "session_summary_chunk_persist_failed session_id=%s",
+                    session_id,
+                    exc_info=True,
+                )
 
-    # Cleanup session-bound working memory
-    cleaned = await app.storage.scratch_cleanup(session_id)
+        # Phase B-2: link the summary chunk back to the source chunks it
+        # summarized. Only runs on the auto path (manual ``summary=`` did
+        # not collect source chunks). Failures are best-effort: a broken
+        # link writer must not roll back the session-end DB write or the
+        # archive chunk that already landed.
+        if summary_chunk_id is not None and auto_source_chunks:
+            try:
+                await _write_summary_links(
+                    app,
+                    summary_chunk_id=summary_chunk_id,
+                    source_chunks=auto_source_chunks,
+                    cap=app.config.session_summary.max_summary_links,
+                )
+            except Exception:
+                logger.warning(
+                    "session_summary_links_failed session_id=%s",
+                    session_id,
+                    exc_info=True,
+                )
 
-    lines = [
-        f"Session ended: {session_id}",
-        f"- Events: {len(events)} ({', '.join(f'{k}:{v}' for k, v in event_counts.items())})",
-    ]
-    if effective_summary:
-        prefix = "Summary" if summary else "Auto summary"
-        lines.append(f"- {prefix}: {effective_summary[:100]}...")
-    elif auto_summary_skip_reason:
-        lines.append(f"- Auto summary: skipped ({auto_summary_skip_reason})")
-    if summary_chunk_line:
-        lines.append(summary_chunk_line)
-    if cleaned:
-        lines.append(f"- Working memory cleaned: {cleaned} entries")
-    return "\n".join(lines)
+        # Cleanup session-bound working memory
+        cleaned = await app.storage.scratch_cleanup(session_id)
+
+        lines = [
+            f"Session ended: {session_id}",
+            f"- Events: {len(events)} ({', '.join(f'{k}:{v}' for k, v in event_counts.items())})",
+        ]
+        if effective_summary:
+            prefix = "Summary" if summary else "Auto summary"
+            lines.append(f"- {prefix}: {effective_summary[:100]}...")
+        elif auto_summary_skip_reason:
+            lines.append(f"- Auto summary: skipped ({auto_summary_skip_reason})")
+        if summary_chunk_line:
+            lines.append(summary_chunk_line)
+        if cleaned:
+            lines.append(f"- Working memory cleaned: {cleaned} entries")
+        return "\n".join(lines)
+    finally:
+        # Release the claim and clear the public handle now that the phase
+        # is over — on success OR failure. Running on failure too means a
+        # dead session is not left active for routing, and a retry then
+        # sees no active session and does not re-run the effectful phase
+        # (at-most-once). The identity guard leaves a *newer* session
+        # untouched: if a mem_session_start supervened during the phase it
+        # overwrote current_session_id with a fresh id.
+        async with app._session_lock:
+            app._ending_session_ids.discard(session_id)
+            if app.current_session_id == session_id:
+                app.current_session_id = None
+                app.current_agent_id = None
 
 
 async def _maybe_auto_summarize(

--- a/packages/memtomem/src/memtomem/server/tools/session.py
+++ b/packages/memtomem/src/memtomem/server/tools/session.py
@@ -153,6 +153,15 @@ async def mem_session_end(
     Resets both ``current_session_id`` and ``current_agent_id`` so the
     next ``mem_agent_search`` falls back to ``current_namespace``.
 
+    The active-session handle is *claimed* (read and cleared) atomically
+    under ``_session_lock`` at entry, so a concurrent or client-retried
+    ``mem_session_end`` returns ``"No active session."`` instead of
+    re-running the effectful phase. The summarize/persist work therefore
+    runs **at most once** per session; the handle is not restored if that
+    phase fails part-way (a retry must not risk a duplicate billable
+    summary). An active DB row orphaned by a mid-phase crash is reaped by
+    the stale-session path (``find_stale_active_sessions``).
+
     When ``summary`` is provided, the text is also promoted to a
     first-class chunk under ``archive:session:<session_id>`` (Phase A
     of the episodic-session-summary RFC). The chunk is hidden from
@@ -178,14 +187,22 @@ async def mem_session_end(
     """
     app = await _get_app_initialized(ctx)
 
-    if not app.current_session_id:
-        return "No active session."
-
-    session_id = app.current_session_id
-    # Capture before end_session and the lock-guarded reset below; the
-    # archive helper runs after end_session, so any later state
-    # mutation could clobber the tag we want to record.
-    agent_id = app.current_agent_id
+    # Claim-then-work (issue #1571): atomically read AND null the active
+    # session handle under _session_lock so a retried or concurrent
+    # mem_session_end cannot double-run the effectful phase (billable LLM
+    # auto-summary, archive-chunk write + index, end_session UPDATE). The
+    # loser sees no active session and returns early. At-most-once: the
+    # handle is NOT restored on mid-phase failure — a retry after a partial
+    # failure must not risk a duplicate summary. Same contract as
+    # schedule_try_claim (issue #1564). agent_id is captured here too: the
+    # archive helper needs the tag after the handle has been cleared.
+    async with app._session_lock:
+        session_id = app.current_session_id
+        if not session_id:
+            return "No active session."
+        agent_id = app.current_agent_id
+        app.current_session_id = None
+        app.current_agent_id = None
 
     # Gather session stats
     events = await app.storage.get_session_events(session_id)
@@ -257,10 +274,6 @@ async def mem_session_end(
 
     # Cleanup session-bound working memory
     cleaned = await app.storage.scratch_cleanup(session_id)
-
-    async with app._session_lock:
-        app.current_session_id = None
-        app.current_agent_id = None
 
     lines = [
         f"Session ended: {session_id}",

--- a/packages/memtomem/tests/test_sessions.py
+++ b/packages/memtomem/tests/test_sessions.py
@@ -284,6 +284,108 @@ class TestSessionEndClaim:
         assert "Session ended" in out1
         assert out2 == "No active session."
 
+    @pytest.mark.asyncio
+    async def test_handle_stays_live_during_teardown_for_agent_routing(self, components):
+        """The claim must not deactivate the session for *other* concurrent
+        tools: while ``mem_session_end``'s effectful phase runs, the public
+        ``current_agent_id`` must stay set so a concurrent session-bound write
+        still routes to ``agent-runtime:<id>`` instead of the default scope.
+        Regression pin for the claim-vs-handle separation (#1571 review): a
+        naive null-at-entry leaves this None for the whole multi-second phase.
+        """
+        from memtomem.server.tools.multi_agent import _resolve_agent_namespace
+
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+        await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        real_events = app.storage.get_session_events
+        first = True
+
+        async def gated(session_id):
+            nonlocal first
+            if first:
+                first = False
+                entered.set()
+                await release.wait()
+            return await real_events(session_id)
+
+        app.storage.get_session_events = gated  # type: ignore[method-assign]
+
+        t_end = asyncio.create_task(mem_session_end(ctx=ctx))  # type: ignore[arg-type]
+        await entered.wait()  # end is parked mid-phase
+        # A write racing the teardown must still resolve to the agent scope.
+        assert app.current_agent_id == "planner"
+        assert _resolve_agent_namespace(app, None) == "agent-runtime:planner"
+        release.set()
+        await t_end
+
+        assert app.current_agent_id is None  # cleared only after the phase
+
+    @pytest.mark.asyncio
+    async def test_scratch_set_during_teardown_is_cleaned_not_leaked(self, components):
+        """A ``mem_scratch_set`` racing the teardown must bind to the ending
+        session so the same call's ``scratch_cleanup(session_id)`` reaps it.
+        Regression pin: a null-at-entry claim would bind it to the global
+        (``session_id=None``) scope, escaping cleanup and leaking past close.
+        """
+        from memtomem.server.tools.scratch import mem_scratch_set
+
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+        await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        real_events = app.storage.get_session_events
+        first = True
+
+        async def gated(session_id):
+            nonlocal first
+            if first:
+                first = False
+                entered.set()
+                await release.wait()
+            return await real_events(session_id)
+
+        app.storage.get_session_events = gated  # type: ignore[method-assign]
+
+        t_end = asyncio.create_task(mem_session_end(ctx=ctx))  # type: ignore[arg-type]
+        await entered.wait()  # parked before the phase's scratch_cleanup
+        await mem_scratch_set(key="leaky", value="v", ctx=ctx)  # type: ignore[arg-type]
+        release.set()
+        await t_end
+
+        # Bound to the ending session → cleaned by scratch_cleanup, not leaked.
+        assert await app.storage.scratch_get("leaky") is None
+
+    @pytest.mark.asyncio
+    async def test_midphase_failure_clears_handle_and_is_at_most_once(self, components):
+        """If the effectful phase raises, the finally still releases the claim
+        and clears the handle, so the dead session isn't left active and a
+        retry returns "No active session." (at-most-once — the phase does not
+        re-run). Pins the failure path of the claim/handle separation.
+        """
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+        await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+
+        async def boom(_session_id):
+            raise RuntimeError("boom")
+
+        app.storage.get_session_events = boom  # type: ignore[method-assign]
+
+        out1 = await mem_session_end(ctx=ctx)  # type: ignore[arg-type]
+        assert "Error" in out1
+        assert app.current_session_id is None
+        assert app.current_agent_id is None
+        assert not app._ending_session_ids  # claim released even on failure
+
+        out2 = await mem_session_end(ctx=ctx)  # type: ignore[arg-type]
+        assert out2 == "No active session."
+
 
 class TestSessionNamespaceDerivation:
     """``mem_session_start`` derives the session record's namespace from

--- a/packages/memtomem/tests/test_sessions.py
+++ b/packages/memtomem/tests/test_sessions.py
@@ -1,5 +1,6 @@
 """Tests for episodic memory (sessions)."""
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -201,6 +202,87 @@ class TestSessionAgentInheritance:
         """
         app = AppContext.from_components(components)
         assert app._session_lock is not app._config_lock
+
+
+class TestSessionEndClaim:
+    """``mem_session_end`` claims the active-session handle atomically at
+    entry (issue #1571), so a retried or concurrent end runs the effectful
+    phase (end_session UPDATE, billable auto-summary, archive-chunk write)
+    **at most once**. Before the fix the guard/read of ``current_session_id``
+    ran unlocked and only the final reset held ``_session_lock``, so a second
+    caller entering before the first reached the reset re-ran the whole
+    phase and double-wrote the summary.
+    """
+
+    @pytest.mark.asyncio
+    async def test_concurrent_end_runs_effects_once(self, components):
+        """Two overlapping ``mem_session_end`` calls: the winner runs the
+        effectful phase, the loser returns "No active session." exactly
+        once. Regression pin — MUST fail before the claim-then-work fix.
+
+        The gate parks the first call inside ``get_session_events`` — the
+        first suspension point after the old unlocked guard — so the second
+        call provably reaches the entry check while the first is mid-phase.
+        ``end_session`` is wrapped to count how many times the effectful
+        phase actually ran.
+        """
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+        await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        real_events = app.storage.get_session_events
+        first = True
+
+        async def gated_events(session_id):
+            nonlocal first
+            if first:
+                first = False
+                entered.set()
+                await release.wait()
+            return await real_events(session_id)
+
+        end_calls: list[str] = []
+        real_end = app.storage.end_session
+
+        async def counting_end(session_id, summary, metadata):
+            end_calls.append(session_id)
+            return await real_end(session_id, summary, metadata)
+
+        # Instance attributes shadow the bound methods; ``components`` is
+        # function-scoped so no teardown/restore is needed.
+        app.storage.get_session_events = gated_events  # type: ignore[method-assign]
+        app.storage.end_session = counting_end  # type: ignore[method-assign]
+
+        t1 = asyncio.create_task(mem_session_end(summary="s", ctx=ctx))  # type: ignore[arg-type]
+        await entered.wait()  # t1 is now parked inside the effectful phase
+        out2 = await mem_session_end(summary="s", ctx=ctx)  # type: ignore[arg-type]
+        release.set()
+        out1 = await t1
+
+        assert out2 == "No active session."
+        assert "Session ended" in out1
+        assert len(end_calls) == 1  # effectful phase ran exactly once
+        assert app.current_session_id is None
+        assert app.current_agent_id is None
+
+    @pytest.mark.asyncio
+    async def test_sequential_retry_second_is_noop(self, components):
+        """Calling ``mem_session_end`` twice in a row: the second returns
+        exactly "No active session." This already held before the fix (the
+        old code reset the ids before returning) — it pins the retry
+        contract, it is not the concurrency regression above.
+        """
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+        await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+
+        out1 = await mem_session_end(ctx=ctx)  # type: ignore[arg-type]
+        out2 = await mem_session_end(ctx=ctx)  # type: ignore[arg-type]
+
+        assert "Session ended" in out1
+        assert out2 == "No active session."
 
 
 class TestSessionNamespaceDerivation:


### PR DESCRIPTION
## Summary

`mem_session_end` guarded only the final state *reset* with `_session_lock`; the whole effectful phase — `end_session`, the billable auto-summary LLM call, `_persist_session_summary_chunk` (writes + indexes `sessions/<YYYY-MM>/<session_id>.md`), and scratch cleanup — ran **unlocked** before it. A concurrent or client-retried `mem_session_end` re-read the same `current_session_id` and re-ran that phase, producing a duplicate billable summary and a double-written/indexed summary chunk. `mem_session_start` already mutates session state under the lock, so `end` was the asymmetric path.

Fixes #1571.

## Fix — claim-then-work (at-most-once)

Read **and null** `current_session_id` / `current_agent_id` atomically under `_session_lock` at entry, then run the effectful phase on the captured locals:

```python
async with app._session_lock:
    session_id = app.current_session_id
    if not session_id:
        return "No active session."
    agent_id = app.current_agent_id
    app.current_session_id = None
    app.current_agent_id = None
```

The loser sees no active session and returns early, so summarization runs **at most once**. The handle is not restored on mid-phase failure — a retry must not risk a duplicate summary; an orphaned active DB row is reaped by the existing stale-session path (`find_stale_active_sessions`). Same contract as `schedule_try_claim` (#1564 / #1578).

The rest of the body already operated on the captured locals (`session_id`, `agent_id`, `session_row`), so the trailing lock-guarded reset block was simply removed and nothing else changed.

### Why `_end_active_session_inline` is untouched
It runs only from `mem_session_start`, already under `_session_lock` (start holds the lock across the whole inline end). `asyncio.Lock` is not reentrant, so the claim logic deliberately lives only in `mem_session_end` — factoring it into a shared helper that inline-end also called would double-acquire and deadlock.

## Tests

`TestSessionEndClaim` in `test_sessions.py`:
- **`test_concurrent_end_runs_effects_once`** — gated interleave (parks the first call inside `get_session_events`, the first suspension point after the old unlocked guard) proves the effectful phase runs exactly once and the second caller gets `"No active session."`. Verified red-first: fails on the unpatched tree (second call returns "Session ended" + `end_session` runs twice).
- **`test_sequential_retry_second_is_noop`** — retry contract pin (already passed before the fix).

Full `test_sessions.py` (31) and `test_multi_agent_integration.py` (23) green; `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
