### PR TITLE
fix(mcp): serialize memory-CRUD read-modify-write across processes (#1587)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -4504,11 +4504,16 @@ async def _memory_migrate_run(
     before.
     """
     import shutil
-    from contextlib import ExitStack
+    import time
+    from contextlib import AsyncExitStack
 
     from memtomem import privacy
     from memtomem.cli._bootstrap import cli_components
-    from memtomem.context._atomic import _file_lock, _lock_path_for
+    from memtomem.context._atomic import (
+        _MIGRATE_SIDECAR_LOCK_BUDGET_S,
+        _lock_path_for,
+        async_file_lock,
+    )
     from memtomem.memory_scope import (
         MemoryScopeError,
         is_project_tier_registered,
@@ -4730,20 +4735,40 @@ async def _memory_migrate_run(
         completed: list[tuple[Path, Path, int]] = []
         # Codex review round 1, Major 1: acquire locks in a globally
         # stable order (sorted by string path) rather than plan order.
-        # ``_file_lock`` uses blocking ``portalocker.LOCK_EX`` with no
-        # timeout (see ``context/_atomic.py``), so two concurrent batch
-        # migrations that share files in opposite orders would deadlock
-        # indefinitely. ``context/migrate.py`` sorts lock paths for the
-        # same reason. The unique set is built first so plan-order
-        # duplicates (same source dir matched twice) don't try to
-        # re-acquire the same lock on this thread.
+        # ``async_file_lock`` uses a bounded ``portalocker.LOCK_EX`` poll, so
+        # two concurrent batch migrations that share files in opposite orders
+        # cannot deadlock indefinitely; the sort keeps the acquisition order
+        # stable so they can't livelock either. ``context/migrate.py`` sorts
+        # lock paths for the same reason. The unique set is built first so
+        # plan-order duplicates (same source dir matched twice) don't try to
+        # re-acquire the same lock.
+        #
+        # #1587: acquire the sidecars via the ASYNC bounded primitive, not the
+        # synchronous blocking ``_file_lock``. This function is awaited by the
+        # MCP ``mem_context_memory_migrate`` tool, so a blocking ``LOCK_EX`` on
+        # the event loop would freeze the whole server if a watcher held one of
+        # these sidecars while suspended on an embed await (the sidecar is now
+        # held across CRUD spans too). ONE shared deadline bounds the WHOLE
+        # batch — per-lock timeouts would sum to N×budget (#1145) — so each lock
+        # gets only the remaining budget.
         all_lock_paths: set[Path] = set()
         for entry in plan:
             all_lock_paths.add(_lock_path_for(entry["source"]))
             all_lock_paths.add(_lock_path_for(entry["target"]))
-        with ExitStack() as stack:
+        deadline = time.monotonic() + _MIGRATE_SIDECAR_LOCK_BUDGET_S
+        async with AsyncExitStack() as stack:
             for lp in sorted(all_lock_paths, key=str):
-                stack.enter_context(_file_lock(lp))
+                remaining = deadline - time.monotonic()
+                try:
+                    if remaining <= 0:
+                        raise TimeoutError
+                    await stack.enter_async_context(async_file_lock(lp, timeout=remaining))
+                except TimeoutError:
+                    raise click.ClickException(
+                        f"could not acquire memory-migrate locks within "
+                        f"{_MIGRATE_SIDECAR_LOCK_BUDGET_S:g}s — a CRUD writer or another "
+                        "migrate is holding a memory file; retry."
+                    ) from None
 
             for i, entry in enumerate(plan, 1):
                 src, tgt = entry["source"], entry["target"]

--- a/packages/memtomem/src/memtomem/context/_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_atomic.py
@@ -20,15 +20,16 @@ module and covers ``~/.memtomem/config.json`` specifically.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
 import os
 import tempfile
 import time
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
-from typing import Iterator
+from typing import AsyncIterator, Iterator
 
 import portalocker
 
@@ -37,6 +38,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "COPY_SKIP_NAMES",
     "DIRTY_SKIP_SUFFIXES",
+    "async_file_lock",
     "atomic_write_bytes",
     "atomic_write_text",
     "copy_tree_atomic",
@@ -148,6 +150,143 @@ def _file_lock(lock_path: Path, *, timeout: float | None = None) -> Iterator[Non
 def _lock_path_for(data_path: Path) -> Path:
     """Sidecar lockfile path for *data_path* (``.{name}.lock`` next to it)."""
     return data_path.parent / f".{data_path.name}.lock"
+
+
+# --- Memory-file cross-process CRUD serialization (issue #1587) -------------
+#
+# Lock-ordering invariant for the memory-file domain. Levels are acquired
+# low→high; NEVER acquire a lower level while holding a higher one; within a
+# level, multi-acquires MUST use sorted key order.
+#
+#   L0  debounce queue _Lock (indexing/debounce.py) — CLI hook path only.
+#   L1  per-file asyncio.Lock — AppContext.get_memory_file_lock. Multi: sorted
+#       keys. In-process, MCP-server-scope only.
+#   L2  cross-process sidecar lock — ``async_file_lock(_lock_path_for(f))``.
+#       Multi: sorted by str(lock_path) (memory-migrate). From ANY event loop
+#       acquire ONLY via ``async_file_lock`` (never the blocking ``_file_lock``
+#       synchronously on a loop): a sync ``LOCK_EX`` here can block the loop
+#       while the current holder is a *suspended task on the same loop*
+#       (portalocker/flock contends between fds within one process) = permanent
+#       deadlock. ``async_file_lock`` is itself two-layered — an in-process
+#       asyncio guard THEN the cross-process flock — because Windows
+#       ``LockFileEx`` does not reliably block a second handle from one process
+#       (same reason ``debounce._Lock`` #759 pairs a threading.Lock with the
+#       flock). #1566: if the parent dir is gone, the sidecar is SKIPPED (never
+#       mkdir-resurrect it); that decision is made once by the outermost
+#       acquirer and flows down as ``index_file(lock_held=True)``.
+#   L3  IndexEngine._index_lock. ``index_file(lock_held=True)`` asserts the
+#       caller already holds (or #1566-skipped) this file's L2 sidecar and
+#       enters at L3 directly; the sidecar is HOISTED above ``_index_lock`` so
+#       no path ever acquires L2 while holding L3.
+#   L4  storage / embedder / LLM — leaves; must never acquire L0–L3.
+#
+# Disjoint domains (config.json sidecar, context-gateway sidecars for
+# settings/skills/versions/wiki, web _gateway_lock/_config_lock) never nest
+# with this domain.
+
+# Per-hold-span acquisition budgets (seconds). Monkeypatchable by dotted path
+# in tests, matching the ``config._CONFIG_LOCK_BUDGET_S`` convention. Fail-fast
+# for interactive CRUD, longer for the internal reindex acquire (which may wait
+# behind one CRUD span), longest for a whole migrate batch.
+_CRUD_SIDECAR_LOCK_BUDGET_S: float = 5.0
+_MEMORY_SIDECAR_LOCK_BUDGET_S: float = 10.0
+_MIGRATE_SIDECAR_LOCK_BUDGET_S: float = 30.0
+
+# Layer-1 (in-process) guard for ``async_file_lock``: per-lockfile-path, keyed
+# by event loop. A bare module-level ``asyncio.Lock`` binds to the first loop
+# that acquires it and then raises "bound to a different event loop" when reused
+# from another loop — production runs one loop, but pytest gives each async test
+# its own. Keying by (path, loop) keeps same-loop callers sharing one lock while
+# distinct loops get distinct locks; closed loops are pruned on the new-loop
+# path (a WeakKeyDictionary can't reclaim them — a contended lock strongly refs
+# its bound loop). Mirrors ``web/routes/_locks._LoopLocalLock``, inlined here to
+# keep ``context`` free of a ``web`` import.
+_intra_async_locks: dict[str, dict[asyncio.AbstractEventLoop, asyncio.Lock]] = {}
+
+
+def _intra_async_lock_for(lock_path: Path) -> asyncio.Lock:
+    """Return the in-process asyncio guard for *lock_path* on the running loop."""
+    loop = asyncio.get_running_loop()
+    per_loop = _intra_async_locks.setdefault(str(lock_path), {})
+    lock = per_loop.get(loop)
+    if lock is None:
+        for dead in [lp for lp in per_loop if lp.is_closed()]:
+            del per_loop[dead]
+        lock = asyncio.Lock()
+        per_loop[loop] = lock
+    return lock
+
+
+@asynccontextmanager
+async def async_file_lock(lock_path: Path, *, timeout: float) -> AsyncIterator[None]:
+    """Async, bounded, two-layer sidecar lock — the L2 primitive of the
+    memory-file lock order above.
+
+    Unlike :func:`_file_lock`, this never blocks the event loop: the
+    cross-process ``portalocker`` acquire polls ``LOCK_NB`` and yields with
+    ``await asyncio.sleep`` between attempts, so a task waiting here (or another
+    process holding the sidecar) can never freeze the loop that a suspended
+    lock-holder needs to make progress on. The whole acquisition is bounded by a
+    single ``timeout`` budget shared across both layers; on expiry it raises
+    ``TimeoutError`` having acquired nothing.
+
+    Two layers, released in reverse order:
+
+    1. **In-process** per-path ``asyncio.Lock`` (``_intra_async_lock_for``).
+       Acquired first with the shared deadline. Required because Windows
+       ``LockFileEx`` does not reliably block a second handle from the same
+       process, so the flock alone would let two concurrent in-process handlers
+       (e.g. two ``mm web`` chunk-edit requests) race. This is also what gives
+       web/CLI callers — which hold no L1 ``AppContext`` lock — in-process
+       serialization.
+    2. **Cross-process** ``portalocker.LOCK_EX`` on the sidecar. Acquired
+       second; serializes against other processes (a second server, the CLI,
+       ``memory-migrate``).
+
+    The caller passes the sidecar path (``_lock_path_for(data_file)``), not the
+    data file. ``**Never**`` unlink the sidecar — deleting it reintroduces the
+    ``os.replace`` inode race (see
+    ``feedback_sidecar_lockfile_for_replaced_files``).
+    """
+    deadline = time.monotonic() + timeout
+    intra = _intra_async_lock_for(lock_path)
+    try:
+        await asyncio.wait_for(intra.acquire(), timeout=timeout)
+    except (asyncio.TimeoutError, TimeoutError):
+        raise TimeoutError(
+            f"could not acquire {lock_path} within {timeout:g}s (in-process contention)"
+        ) from None
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fp = os.fdopen(fd, "rb+")
+        except BaseException:
+            os.close(fd)
+            raise
+        try:
+            delay = 0.05
+            while True:
+                try:
+                    portalocker.lock(fp, portalocker.LOCK_EX | portalocker.LOCK_NB)
+                    break
+                except portalocker.LockException:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise TimeoutError(
+                            f"could not acquire {lock_path} within {timeout:g}s "
+                            f"(held by another process)"
+                        ) from None
+                    await asyncio.sleep(min(delay, remaining))
+                    delay = min(delay * 2, 0.5)
+            try:
+                yield
+            finally:
+                portalocker.unlock(fp)
+        finally:
+            fp.close()
+    finally:
+        intra.release()
 
 
 def atomic_write_bytes(path: Path, data: bytes, mode: int = 0o600) -> None:

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -426,7 +426,11 @@ class IndexEngine:
                 ReStructuredTextChunker(),
             ]
         )
-        self._index_lock = asyncio.Lock()  # prevent concurrent indexing of same files
+        # Prevent concurrent indexing of the same files. This is level L3 of the
+        # memory-file lock order (see ``context._atomic`` module docstring): the
+        # per-file sidecar (L2) is acquired ABOVE this lock, never below, so no
+        # path ever waits on a sidecar while holding ``_index_lock`` (#1587).
+        self._index_lock = asyncio.Lock()
         # Observability counter for ``GET /api/indexing/active`` — independent
         # of ``_index_lock`` because ``index_path_stream`` runs outside the
         # lock and ``asyncio.Lock.locked()`` is racy. Incremented on entry
@@ -596,8 +600,21 @@ class IndexEngine:
         *,
         force_unsafe: bool = False,
         already_scanned: bool = False,
+        lock_held: bool = False,
     ) -> IndexingStats:
         """Index a single file. Convenience wrapper for external callers.
+
+        ``lock_held=True`` tells this method the caller already holds this
+        file's cross-process sidecar lock (L2) for the whole read→rewrite→
+        reindex span — the memory-CRUD tools, web chunk edit/delete, web/CLI
+        add, all of which mutate the file and then reindex under one
+        ``async_file_lock`` (issue #1587). Re-acquiring the sidecar here would
+        self-deadlock (portalocker contends between fds within one process), so
+        this path skips straight to ``_index_lock`` (L3). It also stands in for
+        the #1566 "parent dir gone" case, whose outermost acquirer likewise
+        skips the sidecar (see below). Un-serialized callers (watcher, backfill,
+        ``mm index <file>``, importers) leave it ``False`` and this method takes
+        the sidecar itself, off the event loop, bounded.
 
         ``already_scanned=True`` skips the ADR-0006 redaction gate for callers
         that already ran ``privacy.enforce_write_guard`` on the new content at
@@ -651,42 +668,34 @@ class IndexEngine:
             )
         self._active_runs += 1
         try:
-            async with self._index_lock:
-                start = time.monotonic()
-                # ADR-0011 PR-D round 11 (B2): cross-process advisory
-                # lock so the sibling sidecar lock taken by
-                # ``mm context memory-migrate`` is honored on this
-                # path too. Without this, a watcher firing
-                # ``index_file(target)`` mid-migrate races with
-                # migrate's ``shutil.move`` + DB UPDATE pair —
-                # migrate's lock alone is one-sided. The lock is
-                # ``portalocker.LOCK_EX`` (blocking); the typical
-                # window is sub-millisecond so brief event-loop
-                # blocking is acceptable. Migrate holds the lock for
-                # at most the duration of one DB UPDATE, so watcher
-                # contention is bounded.
-                from memtomem.context._atomic import _file_lock, _lock_path_for
+            # ADR-0011 PR-D round 11 (B2): cross-process advisory lock so the
+            # sibling sidecar lock taken by ``mm context memory-migrate`` is
+            # honored on this path too. Without it, a watcher firing
+            # ``index_file(target)`` mid-migrate races with migrate's
+            # ``shutil.move`` + DB UPDATE pair (migrate's lock alone is
+            # one-sided). #1587 hoists this sidecar acquire ABOVE ``_index_lock``
+            # (L2 before L3) and makes it async + bounded, so it can never freeze
+            # the loop while a suspended holder needs it — and lets CRUD callers
+            # hold the sidecar across their whole read→rewrite→reindex span and
+            # reach here with ``lock_held=True`` instead of self-deadlocking.
+            from memtomem.context._atomic import (
+                _MEMORY_SIDECAR_LOCK_BUDGET_S,
+                _lock_path_for,
+                async_file_lock,
+            )
 
-                resolved_path = file_path.resolve()
-                if resolved_path.parent.is_dir():
-                    with _file_lock(_lock_path_for(resolved_path)):
-                        result = await self._index_file(
-                            resolved_path,
-                            force,
-                            namespace=namespace,
-                            force_unsafe=force_unsafe,
-                            already_scanned=already_scanned,
-                        )
-                else:
-                    # #1566: the parent dir is gone (deleted subtree / unmounted
-                    # volume), so this is a delete-by-source pass for a vanished
-                    # file. Taking the sidecar lock would ``mkdir`` the deleted
-                    # parent back into existence (``_file_lock`` recreates
-                    # ``lock_path.parent``) just to hold a lock over a delete —
-                    # resurrecting the directory the user removed. ``_index_lock``
-                    # still serializes in-process; migrate's sidecar lock for this
-                    # path lives in the same missing parent, so no live pair-op
-                    # can be mid-flight on it.
+            resolved_path = file_path.resolve()
+            # Skip the sidecar when the caller already holds it (lock_held) or
+            # when the parent dir is gone (#1566: a delete-by-source pass for a
+            # vanished file — taking the sidecar would ``mkdir`` the deleted
+            # parent back into existence just to lock a delete, resurrecting the
+            # directory the user removed). ``_index_lock`` still serializes
+            # in-process; a migrate sidecar for a missing-parent path lives in
+            # that same missing parent, so no live pair-op can be mid-flight.
+            skip_sidecar = lock_held or not resolved_path.parent.is_dir()
+            if skip_sidecar:
+                async with self._index_lock:
+                    start = time.monotonic()
                     result = await self._index_file(
                         resolved_path,
                         force,
@@ -694,7 +703,22 @@ class IndexEngine:
                         force_unsafe=force_unsafe,
                         already_scanned=already_scanned,
                     )
-                duration = (time.monotonic() - start) * 1000
+                    duration = (time.monotonic() - start) * 1000
+            else:
+                async with async_file_lock(
+                    _lock_path_for(resolved_path),
+                    timeout=_MEMORY_SIDECAR_LOCK_BUDGET_S,
+                ):
+                    async with self._index_lock:
+                        start = time.monotonic()
+                        result = await self._index_file(
+                            resolved_path,
+                            force,
+                            namespace=namespace,
+                            force_unsafe=force_unsafe,
+                            already_scanned=already_scanned,
+                        )
+                        duration = (time.monotonic() - start) * 1000
         finally:
             self._active_runs -= 1
         return IndexingStats(

--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -240,27 +240,51 @@ class FileWatcher:
             try:
                 file_path = await asyncio.wait_for(self._queue.get(), timeout=self._debounce_s)
                 if file_path == _STOP_SENTINEL:
-                    # Flush remaining pending files before exiting
+                    # Flush remaining pending files before exiting. A file whose
+                    # reindex times out on the sidecar is dropped here (we are
+                    # shutting down; the next start's backfill will catch it).
                     if pending:
-                        batch = list(pending)
-                        pending.clear()
-                        await asyncio.gather(
-                            *(self._reindex(p) for p in batch),
-                            return_exceptions=True,
-                        )
+                        await self._flush_batch(pending)
                     return
                 pending.add(file_path)
             except TimeoutError:
                 if pending:
-                    batch = list(pending)
-                    pending.clear()
-                    await asyncio.gather(
-                        *(self._reindex(p) for p in batch),
-                        return_exceptions=True,
-                    )
+                    # Reindex the batch and carry forward any file whose sidecar
+                    # acquire timed out, so the next debounce window retries it.
+                    pending = await self._flush_batch(pending)
                 continue
 
-    async def _reindex(self, file_path: Path) -> None:
+    async def _flush_batch(self, pending: set[Path]) -> set[Path]:
+        """Reindex every file in *pending*; return the set to retry next window.
+
+        ``_reindex`` returns a path when its sidecar acquire timed out (a CRUD
+        span or ``memory-migrate`` held the file past the budget) and ``None``
+        otherwise. Timed-out paths are re-queued by merging them back into the
+        in-memory ``pending`` set — NOT by ``put_nowait`` onto the bounded
+        watchdog queue, which drops under pressure and would silently lose the
+        event (#1587). The next ``_debounce_s`` timeout is the natural retry
+        backoff.
+        """
+        batch = list(pending)
+        results = await asyncio.gather(
+            *(self._reindex(p) for p in batch),
+            return_exceptions=True,
+        )
+        retry: set[Path] = set()
+        for path, result in zip(batch, results):
+            if isinstance(result, Path):
+                retry.add(result)
+            elif isinstance(result, BaseException) and not isinstance(result, Exception):
+                # Re-raise CancelledError / KeyboardInterrupt / SystemExit —
+                # ``return_exceptions=True`` captured them but they must not be
+                # swallowed as an ordinary reindex failure.
+                raise result
+        return retry
+
+    async def _reindex(self, file_path: Path) -> Path | None:
+        """Reindex one changed file. Returns ``file_path`` when the reindex
+        timed out acquiring the file's cross-process sidecar (so the caller can
+        retry it next window), else ``None``."""
         from memtomem.indexing.engine import PrivacyRejection
 
         try:
@@ -290,5 +314,17 @@ class FileWatcher:
                 file_path.name,
                 exc.hit_count,
             )
+        except TimeoutError:
+            # #1587: a CRUD span or ``memory-migrate`` held this file's sidecar
+            # past the bounded acquire budget. The change is NOT lost — return
+            # the path so ``_process_events`` retries it next debounce window
+            # (the debounce interval is the natural backoff). Warn, not error:
+            # this is expected contention, not a failure.
+            logger.warning(
+                "Auto-reindex deferred for %s: file locked by another writer; will retry",
+                file_path.name,
+            )
+            return file_path
         except Exception as exc:
             logger.error("Auto-reindex failed for %s: %s", file_path, exc)
+        return None

--- a/packages/memtomem/src/memtomem/server/context.py
+++ b/packages/memtomem/src/memtomem/server/context.py
@@ -143,13 +143,15 @@ class AppContext:
     # each snapshot the same pre-image and stale line range, then clobber
     # each other or splice over an unrelated entry (issue #1570).
     #
-    # In-process ONLY, by design. This serializes concurrent CRUD within a
-    # single MCP server process/event loop — the issue's realistic vector
-    # (several agents sharing one server). Cross-process races (a second
-    # MCP server, the CLI, ``mm web``) and CRUD-vs-``memory-migrate`` are
-    # NOT covered here — the tool layer cannot hold the engine's sidecar
-    # ``_file_lock`` across the whole span without self-deadlocking on the
-    # nested acquisition inside ``index_file`` (see ``get_memory_file_lock``).
+    # This is level L1 of the memory-file lock order (see the ``context._atomic``
+    # module docstring): in-process, serializing concurrent CRUD within a single
+    # MCP server process/event loop. Cross-process races (a second MCP server,
+    # the CLI, ``mm web``) and CRUD-vs-``memory-migrate`` are closed by L2 — the
+    # per-file cross-process sidecar, held across the whole span via
+    # ``async_file_lock`` and passed down to ``index_file(lock_held=True)`` so
+    # the nested engine acquire is skipped instead of self-deadlocking (#1587).
+    # The CRUD tools acquire L1 then L2; this L1 lock is still needed on its own
+    # for the DB-only bulk ``mem_delete`` namespace branch (no sidecar there).
     #
     # A plain ``dict`` (not the ``web/routes/_locks.py`` per-loop proxy) is
     # correct because an ``AppContext`` never outlives one event loop —
@@ -224,13 +226,12 @@ class AppContext:
         Get-or-create is race-free: a single event loop never suspends
         between the ``dict`` read and write below.
 
-        Do NOT additionally hold the engine's sidecar ``_file_lock`` for
-        the same path across a span that calls ``index_file`` — that lock
-        is re-acquired inside ``index_file`` and ``portalocker`` contends
-        between file descriptors even in one process, so nesting it here
-        would self-deadlock. This in-process lock is the only serialization
-        the tool layer takes; cross-process safety is out of scope (see the
-        ``_memory_file_locks`` field comment).
+        This is L1 in the memory-file lock order (``context._atomic``). L2 —
+        the cross-process sidecar — is acquired *inside* this lock via
+        ``async_file_lock`` (never the blocking ``_file_lock`` on the loop) and
+        passed to ``index_file(lock_held=True)`` so the engine's own sidecar
+        acquire is skipped rather than self-deadlocking (#1587). Acquire order
+        is always L1 → L2 → L3 (``_index_lock``); never the reverse.
         """
         key = path if isinstance(path, str) else self.memory_file_lock_key(path)
         lock = self._memory_file_locks.get(key)

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -37,43 +37,65 @@ _CHUNK_LOCK_MOVE_RETRIES = 3
 async def _locked_chunk(
     app: AppContext, uid: UUID, chunk_id: str
 ) -> AsyncIterator[tuple[Chunk | None, str | None]]:
-    """Yield ``(chunk, None)`` with the per-source-file lock held and the
-    chunk re-fetched fresh under it, or ``(None, error_message)``.
+    """Yield ``(chunk, None)`` with the source file's L1+L2 locks held and the
+    chunk re-fetched fresh under them, or ``(None, error_message)``.
 
-    Two-step acquire (issue #1570): the lock key is the chunk's resolved
-    ``source_file``, which we only learn by fetching the chunk — so fetch
-    once *unlocked* to learn the path, acquire that file's lock, then
-    re-fetch *under* the lock so ``start_line`` / ``end_line`` reflect any
-    CRUD write that committed on the same file while we waited (chunk UUIDs
-    are stable across ``index_file(force=True)``, ADR-0005). If the file was
-    moved (``mm context memory-migrate``) between the two fetches, re-key
-    onto the new path and retry, bounded by ``_CHUNK_LOCK_MOVE_RETRIES``.
+    Three-step acquire (issues #1570, #1587):
 
-    Scope: serializes only same-process MCP CRUD. ``memory-migrate`` takes
-    the engine's sidecar lock, not this one, so the re-key covers a migrate
-    that *finished* before we locked — not one racing the edit span. Other
-    processes and a user's editor are likewise unguarded (out of scope for
-    #1570; tracked separately). Exactly one ``yield`` runs on every path so
-    the ``@asynccontextmanager`` protocol holds.
+    1. Fetch the chunk *unlocked* to learn its ``source_file`` — the lock key,
+       which we can only get by reading the chunk.
+    2. Acquire that file's in-process per-file lock (L1,
+       ``get_memory_file_lock``) *and* its cross-process sidecar (L2,
+       ``async_file_lock``). L2 is held for the whole span, so a second MCP
+       server, the CLI, or ``memory-migrate`` cannot mutate or move the file
+       under us — this is what closes the cross-process hole #1570 left open.
+    3. Re-fetch *under both locks* so ``start_line`` / ``end_line`` reflect any
+       CRUD write that committed while we waited (chunk UUIDs are stable across
+       ``index_file(force=True)``, ADR-0005).
+
+    If ``memory-migrate`` grabbed L2 first and moved the file between the
+    unlocked fetch and our re-fetch, the fresh chunk's ``source_file`` differs;
+    re-key onto the new path and retry, bounded by ``_CHUNK_LOCK_MOVE_RETRIES``.
+    A sidecar acquire that times out (another process holds it past the budget)
+    surfaces a retryable error instead of blocking. Exactly one ``yield`` runs
+    on every path so the ``@asynccontextmanager`` protocol holds.
     """
+    from memtomem.context._atomic import (
+        _CRUD_SIDECAR_LOCK_BUDGET_S,
+        _lock_path_for,
+        async_file_lock,
+    )
+
     chunk = await app.storage.get_chunk(uid)
     if chunk is None:
         yield None, f"Error: chunk {chunk_id} not found."
         return
-    key = AppContext.memory_file_lock_key(chunk.metadata.source_file)
+    source_file = chunk.metadata.source_file
     for _ in range(_CHUNK_LOCK_MOVE_RETRIES):
-        async with app.get_memory_file_lock(key):
-            fresh = await app.storage.get_chunk(uid)
-            if fresh is None:
-                yield None, f"Error: chunk {chunk_id} not found."
-                return
-            fresh_key = AppContext.memory_file_lock_key(fresh.metadata.source_file)
-            if fresh_key == key:
-                yield fresh, None
-                return
-        # Moved out from under us (migrate finished between fetches): re-key
-        # onto the new path and retry the fresh read there.
-        key = fresh_key
+        key = AppContext.memory_file_lock_key(source_file)
+        sidecar = _lock_path_for(source_file.expanduser().resolve())
+        try:
+            async with app.get_memory_file_lock(key):
+                async with async_file_lock(sidecar, timeout=_CRUD_SIDECAR_LOCK_BUDGET_S):
+                    fresh = await app.storage.get_chunk(uid)
+                    if fresh is None:
+                        yield None, f"Error: chunk {chunk_id} not found."
+                        return
+                    if AppContext.memory_file_lock_key(fresh.metadata.source_file) == key:
+                        yield fresh, None
+                        return
+                    # Moved out from under us (migrate re-scoped the chunk before
+                    # we took L2): re-key onto the new path and retry there.
+                    source_file = fresh.metadata.source_file
+        except TimeoutError:
+            yield (
+                None,
+                (
+                    f"Error: chunk {chunk_id} source file is locked by another process "
+                    "(migration in flight?); retry."
+                ),
+            )
+            return
     yield None, f"Error: chunk {chunk_id} source file is being moved concurrently; retry."
 
 
@@ -87,9 +109,12 @@ async def _mutate_file_and_reindex(
 
     Shared tail of ``mem_edit`` and ``mem_delete``'s chunk branch so the
     rollback contract lives in exactly one place. The caller MUST hold the
-    file's memory-file lock: under it, no other locked CRUD writer can
-    commit between the backup read and the rollback ``write_text``, so
-    restoring ``original`` reverts only this call's own mutation.
+    file's L1 *and* L2 locks (via ``_locked_chunk``): under them, no other
+    CRUD writer — in this process or any other, and no ``memory-migrate`` —
+    can commit between the backup read and the rollback ``write_text``, so
+    restoring ``original`` reverts only this call's own mutation. Because L2
+    is already held, both ``index_file`` calls pass ``lock_held=True`` to skip
+    the nested sidecar acquire that would otherwise self-deadlock (#1587).
 
     Returns ``(stats, None)`` on success or ``(None, error_message)`` after
     a rollback; ``op`` ("edit"/"delete") only shapes the messages.
@@ -97,13 +122,17 @@ async def _mutate_file_and_reindex(
     original = await asyncio.to_thread(source_file.read_text, encoding="utf-8")
     try:
         await asyncio.to_thread(mutate)
-        stats = await app.index_engine.index_file(source_file, force=True, already_scanned=True)
+        stats = await app.index_engine.index_file(
+            source_file, force=True, already_scanned=True, lock_held=True
+        )
         app.search_pipeline.invalidate_cache()
         return stats, None
     except Exception as exc:
         await asyncio.to_thread(source_file.write_text, original, encoding="utf-8")
         try:
-            await app.index_engine.index_file(source_file, force=True, already_scanned=True)
+            await app.index_engine.index_file(
+                source_file, force=True, already_scanned=True, lock_held=True
+            )
         except Exception:
             logger.warning("Rollback re-index also failed", exc_info=True)
         app.search_pipeline.invalidate_cache()
@@ -391,21 +420,41 @@ async def _mem_add_core(
 
     assert target is not None
 
-    # Serialize append + re-index under the per-file lock (issue #1570): a
-    # concurrent mem_edit/mem_delete rollback restores its own pre-image, so
-    # an append landing mid-span would be silently erased without this.
-    async with app.get_memory_file_lock(target):
-        # Resolve the session-derived namespace *inside* the lock: waiting on
-        # the lock is a suspension point, and the active session can change
-        # during it — the entry must land under the namespace active at write
-        # time, not one captured before the wait.
-        effective_ns = namespace or _resolve_agent_namespace(app, None)
-        target.parent.mkdir(parents=True, exist_ok=True)
-        await asyncio.to_thread(append_entry, target, content, title=title, tags=tags)
-        # Re-index the whole file via the standard pipeline so the watcher
-        # (which also calls index_file) produces identical hashes → no duplicates.
-        stats = await app.index_engine.index_file(
-            target, namespace=effective_ns, already_scanned=True
+    # Serialize append + re-index under the per-file lock (issue #1570) plus the
+    # cross-process sidecar (issue #1587): a concurrent mem_edit/mem_delete
+    # rollback — in this process OR another server/CLI — restores its own
+    # pre-image, so an append landing mid-span would be silently erased without
+    # both. ``lock_held=True`` skips index_file's nested sidecar acquire.
+    from memtomem.context._atomic import (
+        _CRUD_SIDECAR_LOCK_BUDGET_S,
+        _lock_path_for,
+        async_file_lock,
+    )
+
+    try:
+        async with (
+            app.get_memory_file_lock(target),
+            async_file_lock(
+                _lock_path_for(target.expanduser().resolve()),
+                timeout=_CRUD_SIDECAR_LOCK_BUDGET_S,
+            ),
+        ):
+            # Resolve the session-derived namespace *inside* the lock: waiting on
+            # the lock is a suspension point, and the active session can change
+            # during it — the entry must land under the namespace active at write
+            # time, not one captured before the wait.
+            effective_ns = namespace or _resolve_agent_namespace(app, None)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            await asyncio.to_thread(append_entry, target, content, title=title, tags=tags)
+            # Re-index the whole file via the standard pipeline so the watcher
+            # (which also calls index_file) produces identical hashes → no dups.
+            stats = await app.index_engine.index_file(
+                target, namespace=effective_ns, already_scanned=True, lock_held=True
+            )
+    except TimeoutError:
+        return (
+            f"Error: {target} is locked by another process (migration in flight?); retry.",
+            None,
         )
     app.search_pipeline.invalidate_cache()
 
@@ -718,24 +767,42 @@ async def mem_delete(
         if sf_err:
             return sf_err
         assert sf_path is not None
-        # Same per-file lock as the chunk branch (issue #1570): without it a
-        # concurrent locked CRUD span's ``index_file(force=True)`` lands after
+        # Same per-file lock as the chunk branch (issue #1570) plus the
+        # cross-process sidecar (#1587): without both, a locked CRUD span's
+        # ``index_file(force=True)`` — in this process or another — lands after
         # this delete and re-upserts the whole file, silently resurrecting the
-        # rows just removed. The Gate-B scope probe runs under the lock too so
+        # rows just removed. The Gate-B scope probe runs under the locks too so
         # it sees the same state the delete acts on.
-        async with app.get_memory_file_lock(sf_path):
-            scopes = await app.storage.list_scopes_by_source(sf_path)
-            if "project_shared" in scopes and not confirm_project_shared:
-                logger.info(
-                    "mem_delete rejected bulk project_shared source without confirmation",
-                    extra={"source_file": str(sf_path), "scopes": sorted(scopes)},
-                )
-                return (
-                    "Error: source_file delete would remove scope='project_shared' chunks; "
-                    "pass confirm_project_shared=True to proceed. Bulk source deletes are "
-                    "all-or-nothing; use chunk_id for per-chunk control."
-                )
-            deleted = await app.storage.delete_by_source(sf_path)
+        from memtomem.context._atomic import (
+            _CRUD_SIDECAR_LOCK_BUDGET_S,
+            _lock_path_for,
+            async_file_lock,
+        )
+
+        try:
+            async with (
+                app.get_memory_file_lock(sf_path),
+                async_file_lock(
+                    _lock_path_for(sf_path.expanduser().resolve()),
+                    timeout=_CRUD_SIDECAR_LOCK_BUDGET_S,
+                ),
+            ):
+                scopes = await app.storage.list_scopes_by_source(sf_path)
+                if "project_shared" in scopes and not confirm_project_shared:
+                    logger.info(
+                        "mem_delete rejected bulk project_shared source without confirmation",
+                        extra={"source_file": str(sf_path), "scopes": sorted(scopes)},
+                    )
+                    return (
+                        "Error: source_file delete would remove scope='project_shared' chunks; "
+                        "pass confirm_project_shared=True to proceed. Bulk source deletes are "
+                        "all-or-nothing; use chunk_id for per-chunk control."
+                    )
+                deleted = await app.storage.delete_by_source(sf_path)
+        except TimeoutError:
+            return (
+                f"Error: {source_file} is locked by another process (migration in flight?); retry."
+            )
         app.search_pipeline.invalidate_cache()
         return f"Removed {deleted} chunks from index for {source_file}"
 
@@ -748,6 +815,13 @@ async def mem_delete(
         # one of these locks without acquiring more — no cycle is possible.
         # A file that gains namespace chunks after this snapshot is not
         # locked (same point-in-time semantics the unlocked delete had).
+        #
+        # This branch stays L1-only (no L2 sidecar) by design (#1587): it is a
+        # DB-only bulk delete over N files with no file read/rewrite, and taking
+        # N sidecars would add a shared-deadline multi-resource acquire for a
+        # race whose only cross-process outcome — a concurrent add re-inserting
+        # rows for a file that still exists on disk — is coherent
+        # file-is-source-of-truth behavior, not corruption.
         sources = await app.storage.list_sources_by_namespace(namespace)
         lock_keys = sorted({AppContext.memory_file_lock_key(p) for p in sources})
         async with AsyncExitStack() as stack:
@@ -1012,18 +1086,34 @@ async def mem_batch_add(
             append_entry(target, value, title=key or None, tags=entry_tags)
         return skipped
 
-    # Serialize the batch append + re-index under the per-file lock so a
-    # concurrent mem_edit/mem_delete rollback cannot erase these entries
-    # (issue #1570), same as the single-entry mem_add path above.
-    async with app.get_memory_file_lock(target):
-        # Inside the lock for the same write-time-namespace reason as
-        # ``_mem_add_core`` — the session can change during the lock wait.
-        effective_ns = namespace or _resolve_agent_namespace(app, None)
-        target.parent.mkdir(parents=True, exist_ok=True)
-        skipped = await asyncio.to_thread(_append_entries)
-        stats = await app.index_engine.index_file(
-            target, namespace=effective_ns, already_scanned=True
-        )
+    # Serialize the batch append + re-index under the per-file lock (issue
+    # #1570) plus the cross-process sidecar (#1587) so a concurrent
+    # mem_edit/mem_delete rollback — in this process or another — cannot erase
+    # these entries, same as the single-entry mem_add path above.
+    from memtomem.context._atomic import (
+        _CRUD_SIDECAR_LOCK_BUDGET_S,
+        _lock_path_for,
+        async_file_lock,
+    )
+
+    try:
+        async with (
+            app.get_memory_file_lock(target),
+            async_file_lock(
+                _lock_path_for(target.expanduser().resolve()),
+                timeout=_CRUD_SIDECAR_LOCK_BUDGET_S,
+            ),
+        ):
+            # Inside the lock for the same write-time-namespace reason as
+            # ``_mem_add_core`` — the session can change during the lock wait.
+            effective_ns = namespace or _resolve_agent_namespace(app, None)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            skipped = await asyncio.to_thread(_append_entries)
+            stats = await app.index_engine.index_file(
+                target, namespace=effective_ns, already_scanned=True, lock_held=True
+            )
+    except TimeoutError:
+        return f"Error: {target} is locked by another process (migration in flight?); retry."
     app.search_pipeline.invalidate_cache()
 
     display_ns = effective_ns or app.config.namespace.default_namespace

--- a/packages/memtomem/tests/test_context_memory_migrate.py
+++ b/packages/memtomem/tests/test_context_memory_migrate.py
@@ -313,39 +313,36 @@ async def test_engine_index_file_acquires_sidecar_lock_for_watcher_cooperation(
     migrate's ``shutil.move`` and the DB UPDATE still produces
     duplicate chunks at the destination.
 
-    Spy on ``memtomem.context._atomic._file_lock`` to confirm
-    ``index_file`` enters the lock for the resolved file path. The
-    presence assertion is sufficient — the lock primitive itself
-    is exercised by ``test_memory_migrate_compensation_*`` and the
-    sidecar lockfile pattern's own pin in
-    ``test_atomic_lockfile.py`` (#548 line of work).
+    Spy on ``memtomem.context._atomic.async_file_lock`` to confirm
+    ``index_file`` enters the lock for the resolved file path. #1587 hoisted
+    the sidecar acquire above ``_index_lock`` and switched it to the async,
+    bounded ``async_file_lock`` primitive; the presence assertion is still
+    sufficient — the lock primitive itself is exercised by
+    ``test_memory_migrate_compensation_*`` and the sidecar lockfile pattern's
+    own pin in ``test_atomic_lockfile.py`` (#548 line of work).
     """
     comp, mem_dir = bm25_only_components
 
     src = mem_dir / "rule.md"
     src.write_text("## Rule\n\nbody.\n", encoding="utf-8")
 
-    # Capture every (lock_path, kind) pair entering ``_file_lock``.
-    from contextlib import contextmanager
+    # Capture every lock_path entering ``async_file_lock``.
+    from contextlib import asynccontextmanager
 
     from memtomem.context import _atomic as atomic_mod
 
-    real_file_lock = atomic_mod._file_lock
+    real_async_file_lock = atomic_mod.async_file_lock
     lock_calls: list[Path] = []
 
-    @contextmanager
-    def _spy_file_lock(lock_path):
+    @asynccontextmanager
+    async def _spy_async_file_lock(lock_path, *, timeout):
         lock_calls.append(lock_path)
-        with real_file_lock(lock_path):
+        async with real_async_file_lock(lock_path, timeout=timeout):
             yield
 
-    monkeypatch.setattr(atomic_mod, "_file_lock", _spy_file_lock)
-    # The engine imports lazily inside ``index_file`` so the symbol
-    # we want to patch is the module-attribute view there too.
-    monkeypatch.setattr(
-        "memtomem.context._atomic._file_lock",
-        _spy_file_lock,
-    )
+    # The engine imports lazily inside ``index_file`` so patching the module
+    # attribute is enough (that lazy import reads it back off the module).
+    monkeypatch.setattr(atomic_mod, "async_file_lock", _spy_async_file_lock)
 
     # ``index_file`` is the canonical entry the watcher uses
     # (``watcher.py:230`` calls ``self._engine.index_file(file_path)``).
@@ -359,6 +356,73 @@ async def test_engine_index_file_acquires_sidecar_lock_for_watcher_cooperation(
         f"engine.index_file did not acquire {expected_lock} — the migrate "
         f"sidecar lock is one-sided. Captured locks: {lock_calls}"
     )
+
+
+@pytest.mark.asyncio
+async def test_memory_migrate_times_out_when_crud_holds_sidecar(
+    bm25_only_components, monkeypatch, tmp_path
+):
+    """#1587: a CRUD span holding a source file's sidecar makes ``memory-migrate``
+    fail with a bounded, friendly ``ClickException`` instead of freezing.
+
+    Before #1587 the MCP migrate tool acquired sidecars with a *blocking*
+    ``LOCK_EX`` synchronously on the event loop; a same-loop holder (a CRUD span
+    now holds the sidecar across its whole span) would freeze the server forever.
+    The async, bounded, shared-deadline acquisition breaks that: it gives up
+    within the budget and reports a retryable error. Holding the lock on THIS
+    loop also drives the in-process (layer-1) guard, so the test is deterministic
+    without a second process.
+    """
+    import time
+
+    import click
+
+    from memtomem.cli.context_cmd import _memory_migrate_run
+    from memtomem.context import _atomic as atomic_mod
+    from memtomem.context._atomic import _lock_path_for, async_file_lock
+
+    comp, mem_dir = bm25_only_components
+    project_root = tmp_path / "proj_lock"
+    proj_shared = project_root / ".memtomem" / "memories"
+    proj_shared.mkdir(parents=True)
+    (project_root / ".git").mkdir()
+    comp.config.indexing.project_memory_dirs = [proj_shared]
+
+    src = mem_dir / "rule.md"
+    src.write_text("## Rule\n\nharmless body.\n", encoding="utf-8")
+    await comp.storage.upsert_chunks(
+        [
+            Chunk(
+                content="harmless body.",
+                metadata=ChunkMetadata(source_file=src, scope="user", start_line=3, end_line=3),
+                embedding=[0.1] * 1024,
+            )
+        ]
+    )
+
+    _patch_cli_components(monkeypatch, comp)
+    monkeypatch.chdir(project_root)
+    monkeypatch.setattr(atomic_mod, "_MIGRATE_SIDECAR_LOCK_BUDGET_S", 0.2)
+
+    # Stand in for an in-flight CRUD span owning the source file's sidecar.
+    async with async_file_lock(_lock_path_for(src.resolve()), timeout=5.0):
+        start = time.monotonic()
+        with pytest.raises(click.ClickException) as excinfo:
+            await _memory_migrate_run(
+                [src.resolve()],
+                from_scope="user",
+                to_scope="project_shared",
+                apply_=True,
+                yes=True,
+                confirm_project_shared=True,
+            )
+        # Bounded (no permanent freeze), and names the contention.
+        assert time.monotonic() - start < 5.0
+        assert "could not acquire memory-migrate locks" in str(excinfo.value)
+
+    # The move never happened — source is intact, target absent.
+    assert src.exists()
+    assert not (proj_shared / "rule.md").exists()
 
 
 @pytest.mark.asyncio

--- a/packages/memtomem/tests/test_memory_crud_concurrency.py
+++ b/packages/memtomem/tests/test_memory_crud_concurrency.py
@@ -376,6 +376,11 @@ class TestLockedChunkHelper:
             assert chunk.metadata.source_file == p2
             assert app.get_memory_file_lock(p2).locked()
             assert not app.get_memory_file_lock(p1).locked()
+            # #1587: the span now also holds the cross-process sidecar (L2) for
+            # the settled path — its lockfile exists while we hold it.
+            from memtomem.context._atomic import _lock_path_for
+
+            assert _lock_path_for(p2).exists()
 
     @pytest.mark.asyncio
     async def test_perpetually_moving_file_returns_retryable_error(self, bm25_only_components):

--- a/packages/memtomem/tests/test_memory_crud_cross_process.py
+++ b/packages/memtomem/tests/test_memory_crud_cross_process.py
@@ -1,0 +1,344 @@
+"""Cross-process serialization of the memory-CRUD read-modify-write span
+(issue #1587, follow-up to #1570).
+
+#1570 held an in-process ``asyncio.Lock`` across each CRUD span — enough for
+several agents sharing ONE MCP server, but a second server, the CLI, or
+``memory-migrate`` still raced the read→rewrite→reindex window. #1587 holds the
+cross-process sidecar (``async_file_lock``, level L2 of the lock order in
+``context._atomic``) across the whole span too, and hoists the engine's own
+sidecar acquire above ``_index_lock`` so a CRUD caller can reach ``index_file``
+with ``lock_held=True`` instead of self-deadlocking.
+
+Test groups:
+* **A** — cross-process (``multiprocessing`` spawn, like ``test_config_write_lock``):
+  the sidecar serializes real appends across processes; times out cleanly.
+* **B** — lock ordering: the sidecar is acquired while ``_index_lock`` is free;
+  ``lock_held=True`` and the #1566 parent-gone case skip it.
+* **C** — timeout surfacing: a held sidecar makes a CRUD span / migrate return a
+  friendly retryable error rather than blocking (also pins the Windows-safe
+  in-process guard — two contenders on one loop serialize via layer 1).
+* **D** — watcher: a timed-out reindex is re-queued, not dropped.
+* **E** — sidecar-lockfile hygiene: ``.*.lock`` files are never indexed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import multiprocessing as mp
+import time
+from pathlib import Path
+
+import pytest
+
+from helpers import StubCtx
+from memtomem.context import _atomic as atomic_mod
+from memtomem.context._atomic import _lock_path_for, async_file_lock
+from memtomem.server.context import AppContext
+from memtomem.server.tools import memory_crud
+
+# spawn: uniform semantics across the CI matrix (Windows/macOS default), and the
+# only context that genuinely gives distinct-process flock contention.
+_CTX = mp.get_context("spawn")
+
+
+# ----------------------------------------------------------------- helpers
+
+
+def _locked_append(md_path_str: str, entry: str, q) -> None:
+    """Locked read→append→write of one distinct line under ``async_file_lock``,
+    with a widened read→write window so an unlocked version would reliably lose
+    updates (mirrors ``test_config_write_lock._locked_add_section``). Runs in a
+    child process, so serialization here comes purely from the cross-process
+    flock — the in-process guard is per-process and cannot help across them."""
+
+    async def run() -> None:
+        path = Path(md_path_str)
+        async with async_file_lock(_lock_path_for(path), timeout=20.0):
+            existing = path.read_text(encoding="utf-8") if path.exists() else ""
+            await asyncio.sleep(0.02)
+            path.write_text(existing + entry + "\n", encoding="utf-8")
+
+    asyncio.run(run())
+    q.put(entry)
+
+
+def _hold_sidecar(lock_path_str: str, ready_q, release_evt) -> None:
+    """Hold the sidecar until signalled — stands in for another process owning
+    the memory file's lock so same-file writers must time out."""
+
+    async def run() -> None:
+        async with async_file_lock(Path(lock_path_str), timeout=20.0):
+            ready_q.put("acquired")
+            await asyncio.to_thread(release_evt.wait, 30)
+
+    asyncio.run(run())
+
+
+# ============================================================ A. cross-process
+
+
+def test_cross_process_appends_do_not_lose_updates(tmp_path: Path):
+    """Positive pin: 8 processes each append a distinct line under the sidecar;
+    all 8 survive. Without the lock the widened window loses updates."""
+    md = tmp_path / "notes.md"
+    entries = [f"entry-{i}" for i in range(8)]
+
+    procs, queues = [], []
+    for entry in entries:
+        q = _CTX.Queue()
+        p = _CTX.Process(target=_locked_append, args=(str(md), entry, q))
+        queues.append(q)
+        procs.append(p)
+        p.start()
+
+    for q in queues:
+        assert q.get(timeout=30) in entries
+    for p in procs:
+        p.join(timeout=15)
+        assert p.exitcode == 0
+
+    survived = set(md.read_text(encoding="utf-8").split())
+    assert survived == set(entries), (
+        f"lost updates: expected all of {entries}, got {sorted(survived)}"
+    )
+
+
+def test_async_file_lock_uses_dot_prefixed_sidecar(tmp_path: Path):
+    """The lock is a ``.{name}.lock`` sibling, never the data file — locking the
+    data file wouldn't survive the ``os.replace`` inode swap."""
+
+    async def run() -> None:
+        md = tmp_path / "notes.md"
+        async with async_file_lock(_lock_path_for(md), timeout=5.0):
+            pass
+        assert (tmp_path / ".notes.md.lock").exists()
+
+    asyncio.run(run())
+
+
+def test_async_file_lock_times_out_when_held_by_another_process(tmp_path: Path):
+    """A separate process holding the sidecar makes an acquire raise
+    ``TimeoutError`` (acquiring nothing) within the budget."""
+    md = tmp_path / "notes.md"
+    lock_path = _lock_path_for(md)
+
+    ready_q = _CTX.Queue()
+    release_evt = _CTX.Event()
+    holder = _CTX.Process(target=_hold_sidecar, args=(str(lock_path), ready_q, release_evt))
+    holder.start()
+    try:
+        assert ready_q.get(timeout=15) == "acquired"
+
+        async def run() -> None:
+            start = time.monotonic()
+            with pytest.raises(TimeoutError):
+                async with async_file_lock(lock_path, timeout=0.3):
+                    pass
+            # Bounded: gave up near the budget, did not hang on the holder.
+            assert time.monotonic() - start < 5.0
+
+        asyncio.run(run())
+    finally:
+        release_evt.set()
+        holder.join(timeout=10)
+        assert holder.exitcode == 0
+
+
+# ============================================================ B. lock ordering
+
+
+@pytest.mark.asyncio
+async def test_index_file_acquires_sidecar_while_index_lock_free(bm25_only_components, monkeypatch):
+    """The sidecar (L2) is acquired ABOVE ``_index_lock`` (L3): when the spy
+    records the sidecar acquire, ``_index_lock`` must still be free. This is the
+    reorder that removes the reverse-order cycle #1587 fixes."""
+    comp, mem_dir = bm25_only_components
+    src = mem_dir / "rule.md"
+    src.write_text("## Rule\n\nbody.\n", encoding="utf-8")
+
+    engine = comp.index_engine
+    index_lock_held_at_acquire: list[bool] = []
+    real = atomic_mod.async_file_lock
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def spy(lock_path, *, timeout):
+        index_lock_held_at_acquire.append(engine._index_lock.locked())
+        async with real(lock_path, timeout=timeout):
+            yield
+
+    monkeypatch.setattr(atomic_mod, "async_file_lock", spy)
+    await engine.index_file(src.resolve())
+
+    assert index_lock_held_at_acquire == [False], (
+        "sidecar must be taken before _index_lock (L2 → L3), never while it is held"
+    )
+
+
+@pytest.mark.asyncio
+async def test_index_file_lock_held_skips_sidecar(bm25_only_components, monkeypatch):
+    """``lock_held=True`` skips the sidecar acquire entirely — the CRUD caller
+    already holds it, and re-acquiring would self-deadlock."""
+    comp, mem_dir = bm25_only_components
+    src = mem_dir / "rule.md"
+    src.write_text("## Rule\n\nbody.\n", encoding="utf-8")
+
+    calls: list[Path] = []
+    real = atomic_mod.async_file_lock
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def spy(lock_path, *, timeout):
+        calls.append(lock_path)
+        async with real(lock_path, timeout=timeout):
+            yield
+
+    monkeypatch.setattr(atomic_mod, "async_file_lock", spy)
+    await comp.index_engine.index_file(src.resolve(), force=True, lock_held=True)
+
+    assert calls == [], "lock_held=True must not acquire the sidecar"
+
+
+@pytest.mark.asyncio
+async def test_index_file_parent_gone_skips_sidecar_without_mkdir(
+    bm25_only_components, monkeypatch, tmp_path
+):
+    """#1566: when the parent dir is gone, the sidecar is skipped so we never
+    ``mkdir``-resurrect the directory the user removed."""
+    comp, _mem_dir = bm25_only_components
+    missing = tmp_path / "gone" / "orphan.md"  # parent 'gone/' never created
+
+    calls: list[Path] = []
+    real = atomic_mod.async_file_lock
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def spy(lock_path, *, timeout):
+        calls.append(lock_path)
+        async with real(lock_path, timeout=timeout):
+            yield
+
+    monkeypatch.setattr(atomic_mod, "async_file_lock", spy)
+    await comp.index_engine.index_file(missing)  # delete-by-source pass
+
+    assert calls == [], "parent-gone path must skip the sidecar"
+    assert not (tmp_path / "gone").exists(), "sidecar acquire resurrected the deleted parent dir"
+
+
+# ============================================================ C. timeout surface
+
+
+@pytest.mark.asyncio
+async def test_mem_edit_times_out_when_sidecar_held(bm25_only_components, monkeypatch):
+    """A held sidecar makes ``mem_edit`` return a friendly retryable error
+    instead of blocking. Holding the lock on THIS loop also exercises the
+    in-process (layer-1) guard that keeps same-process handlers serialized on
+    Windows, where the flock alone would not (Codex #1587 review)."""
+    comp, mem_dir = bm25_only_components
+    app = AppContext.from_components(comp)
+    ctx = StubCtx(app)
+
+    await memory_crud.mem_add(content="Alpha body", title="Alpha", file="d.md", ctx=ctx)
+    f = mem_dir / "d.md"
+    (alpha,) = sorted(
+        await comp.storage.list_chunks_by_source(f.resolve()),
+        key=lambda c: c.metadata.start_line,
+    )
+
+    monkeypatch.setattr(atomic_mod, "_CRUD_SIDECAR_LOCK_BUDGET_S", 0.2)
+    sidecar = _lock_path_for(f.resolve())
+
+    async with async_file_lock(sidecar, timeout=5.0):
+        out = await memory_crud.mem_edit(chunk_id=str(alpha.id), new_content="NEW BODY", ctx=ctx)
+
+    assert "locked by another process" in out
+    # File untouched — the edit never ran.
+    assert "Alpha body" in f.read_text(encoding="utf-8")
+    assert "NEW BODY" not in f.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_mem_add_times_out_when_sidecar_held(bm25_only_components, monkeypatch):
+    """``mem_add`` surfaces the same retryable error under a held sidecar."""
+    comp, mem_dir = bm25_only_components
+    app = AppContext.from_components(comp)
+    ctx = StubCtx(app)
+
+    monkeypatch.setattr(atomic_mod, "_CRUD_SIDECAR_LOCK_BUDGET_S", 0.2)
+    target = (mem_dir / "d.md").resolve()
+    (mem_dir / "d.md").write_text("## Seed\n\nseed.\n", encoding="utf-8")
+
+    async with async_file_lock(_lock_path_for(target), timeout=5.0):
+        out = await memory_crud.mem_add(content="new entry", title="New", file="d.md", ctx=ctx)
+
+    assert "locked by another process" in out
+
+
+# ============================================================ D. watcher requeue
+
+
+@pytest.mark.asyncio
+async def test_watcher_reindex_returns_path_on_timeout(monkeypatch):
+    """``_reindex`` returns the path (not ``None``) when the reindex times out
+    on the sidecar, so the caller can retry it — the change is not lost."""
+    from memtomem.config import IndexingConfig
+    from memtomem.indexing.watcher import FileWatcher
+
+    class _Engine:
+        async def index_file(self, path):
+            raise TimeoutError("sidecar held")
+
+    watcher = FileWatcher(_Engine(), IndexingConfig(memory_dirs=[]))
+    result = await watcher._reindex(Path("/some/notes.md"))
+    assert result == Path("/some/notes.md")
+
+
+@pytest.mark.asyncio
+async def test_watcher_flush_batch_requeues_only_timed_out(monkeypatch):
+    """``_flush_batch`` returns exactly the files whose reindex timed out (to be
+    retried next window) and drops the ones that succeeded."""
+    from memtomem.config import IndexingConfig
+    from memtomem.indexing.watcher import FileWatcher
+
+    ok = Path("/mem/ok.md")
+    stuck = Path("/mem/stuck.md")
+
+    class _Engine:
+        async def index_file(self, path):
+            if path == stuck:
+                raise TimeoutError("sidecar held")
+
+            class _Stats:
+                indexed_chunks = 1
+                skipped_chunks = 0
+                deleted_chunks = 0
+
+            return _Stats()
+
+    watcher = FileWatcher(_Engine(), IndexingConfig(memory_dirs=[]))
+    retry = await watcher._flush_batch({ok, stuck})
+    assert retry == {stuck}
+
+
+# ============================================================ E. sidecar hygiene
+
+
+@pytest.mark.asyncio
+async def test_sidecar_lockfiles_are_not_indexed(bm25_only_components):
+    """A ``.{name}.md.lock`` sidecar living beside memory files is never picked
+    up by a directory index — only the real markdown gets chunks."""
+    comp, mem_dir = bm25_only_components
+    (mem_dir / "real.md").write_text("## Real\n\nbody.\n", encoding="utf-8")
+    # A sidecar lock as ``async_file_lock``/migrate leave behind.
+    (mem_dir / ".real.md.lock").write_text("", encoding="utf-8")
+
+    await comp.index_engine.index_path(mem_dir, recursive=True)
+
+    sources = {p.name for p in await comp.storage.get_all_source_files()}
+    assert "real.md" in sources
+    assert not any(name.endswith(".lock") for name in sources), (
+        f"a sidecar lockfile was indexed: {sorted(sources)}"
+    )


### PR DESCRIPTION
## What & why

Follow-up to #1570/#1586. Those PRs held an **in-process** `asyncio.Lock` across each memory-CRUD read → rewrite → reindex span — enough to serialize several agents sharing one MCP server, but a **second server, the CLI, and `memory-migrate`** still raced that window (stale line ranges, lost updates, a rollback erasing a concurrent write).

This PR closes that hole for the **MCP CRUD + migrate + watcher** surfaces by holding the cross-process sidecar lock across the whole span, and fixes a **live deadlock on `main`** along the way.

### The deadlock that exists on `main` today

The MCP `mem_context_memory_migrate` tool awaits `_memory_migrate_run`, which acquired its sidecars with a **blocking `LOCK_EX`, no timeout, synchronously on the event loop**. If the watcher held one of those sidecars while suspended on an embed `await` (`index_file` holds the sidecar across `await _index_file`), the whole server loop froze permanently. A new pin reproduces this and confirms it no longer freezes.

## Design — the memory-file lock order

Stated as an invariant in `context/_atomic` and referenced from `engine.index_file` / `server/context`:

```
L0  debounce queue lock (CLI hook path only)
L1  per-file asyncio.Lock  (AppContext.get_memory_file_lock; in-process)
L2  cross-process sidecar  (async_file_lock; multi = sorted)
L3  IndexEngine._index_lock
L4  storage / embedder / LLM  (leaves)
```

- **`async_file_lock` (new)** — two layers, released in reverse: an in-process per-path `asyncio` guard (Windows `LockFileEx` does **not** reliably block a second same-process handle — same reason `debounce._Lock` #759 pairs a threading lock with the flock) then a **bounded `portalocker LOCK_NB` poll with `await asyncio.sleep`**. Never blocks the loop; raises `TimeoutError` on budget expiry having acquired nothing.
- **`index_file(lock_held=True)`** — hoists the sidecar acquire **above** `_index_lock`, so no path ever acquires L2 while holding L3 (the reverse-order cycle is removed structurally). `lock_held=True` and the #1566 parent-gone case skip the sidecar and enter at L3.
- **MCP CRUD spans** (`mem_add` / `mem_edit` / `mem_delete` chunk+source_file / `mem_batch_add`) take L2 after L1, before any read/mutate, and pass `lock_held=True` downstream; a held sidecar returns a friendly retryable error instead of blocking. The DB-only `mem_delete` **namespace** branch stays L1-only by design.
- **`memory-migrate`** acquires its src+tgt sidecars via `async_file_lock`, sorted, under **one shared deadline** (per-item timeouts would sum to N×budget — #1145), which also fixes the on-loop freeze above.
- **Watcher** re-queues a file whose reindex times out by merging it back into the in-memory `pending` set (not the bounded queue, which drops under pressure) so the change is retried next debounce window.

Budgets are monkeypatchable module constants (5 s CRUD / 10 s engine / 30 s migrate).

## Scope — what this PR does NOT cover

This is **PR 1 of 2** for #1587. The remaining markdown-mutating surfaces — **web chunk PATCH/DELETE/add** (`web/routes/chunks.py`, `web/routes/system.py`) and **CLI `mm mem add`** (`cli/memory.py`) — still write outside the sidecar, exactly as they do on `main` today (no regression). They are handled in the follow-up PR, which will `Closes #1587`. This PR intentionally does **not** close the issue.

## Tests

- `test_memory_crud_cross_process.py` (new): 8-writer cross-process lost-update pin (spawn), sidecar-name pin, cross-process timeout, lock-ordering (sidecar acquired while `_index_lock` free; `lock_held=True` skips it; #1566 parent-gone never `mkdir`s), CRUD timeout surfacing, watcher requeue, sidecar-lockfile hygiene.
- `test_context_memory_migrate.py`: new pin that a CRUD-held sidecar makes migrate fail with a bounded `ClickException` instead of freezing (the deadlock repro).
- `test_memory_crud_concurrency.py`: asserts the span now also holds the L2 sidecar.
- Full suite green (`uv run pytest -m "not ollama"`), ruff clean, mypy clean on changed files.

Design was gated by Codex before implementation; the committed diff was reviewed by Codex (no findings within this PR's scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
