### PR TITLE
fix(cli): mm upgrade stops a running mm web, not just the MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **`mm upgrade` now stops a running `mm web` too, not just the MCP server**
+  (#1569). The command exists to prevent the "on-disk bytes swapped but a live
+  process keeps running the old version" split-brain, but its liveness probe
+  only covered the server pid files — a backgrounded `mm web` (a live
+  SQLite/WAL writer holding `web.pid` under the same flock contract) survived
+  the reinstall and kept serving the previous version against the shared DB.
+  The upgrade plan now probes `web.pid` alongside `server.pid`, stops the web
+  UI with the same SIGTERM → grace → SIGKILL ladder, sweeps its `web.json`
+  metadata sidecar on the SIGKILL path, and reports every stopped pid;
+  `--dry-run --json` lists the web pid in `would_kill`/`would_remove`. On
+  Windows the manual-stop warning now names `mm web` as well.
 - **Concurrent MCP memory-CRUD calls on the same file no longer lose updates or
   corrupt an unrelated entry** (#1570). `mem_edit` / `mem_delete` did their
   read → rewrite (`replace_chunk_body` / `remove_lines`) → re-index → rollback

--- a/packages/memtomem/src/memtomem/cli/_liveness.py
+++ b/packages/memtomem/src/memtomem/cli/_liveness.py
@@ -1,7 +1,8 @@
-"""Server liveness probe shared by ``mm uninstall`` and ``mm upgrade``.
+"""Process liveness probes shared by ``mm uninstall`` and ``mm upgrade``.
 
-Both commands need to know whether a ``memtomem-server`` process is currently
-holding the pid lock file. The probe uses ``portalocker.lock(LOCK_EX | LOCK_NB)``
+Both commands need to know whether a ``memtomem-server`` (or ``mm web``)
+process is currently holding its pid lock file. The probe uses
+``portalocker.lock(LOCK_EX | LOCK_NB)``
 — if we can acquire it, no live writer is holding the file (it's a stale
 leftover or fresh and unowned). If we cannot, a writer is alive, regardless
 of whether the recorded PID is still valid or has been recycled.
@@ -18,7 +19,7 @@ from pathlib import Path
 
 import portalocker
 
-from memtomem._runtime_paths import legacy_server_pid_path, server_pid_path
+from memtomem._runtime_paths import legacy_server_pid_path, server_pid_path, web_pid_path
 
 
 @dataclass(frozen=True)
@@ -116,3 +117,16 @@ def check_server_liveness() -> ServerState:
         if state.alive:
             return state
     return ServerState(alive=False, pid=None, pid_file=None)
+
+
+def check_web_liveness() -> ServerState:
+    """Probe ``mm web``'s pid file (``web.pid``).
+
+    Same portalocker contract as the server probe: ``web._web_pid_lock``
+    holds ``LOCK_EX`` on the file for the UI process lifetime, and
+    ``_parse_pid_payload`` already understands its pid/port/started
+    payload. Kept separate from :func:`check_server_liveness` so callers
+    that only care about the MCP server (and their tests) are unaffected
+    (#1569).
+    """
+    return probe_pid_file(web_pid_path())

--- a/packages/memtomem/src/memtomem/cli/upgrade_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/upgrade_cmd.py
@@ -1,18 +1,22 @@
-"""CLI: ``mm upgrade`` — stop the running server, then reinstall.
+"""CLI: ``mm upgrade`` — stop running memtomem processes, then reinstall.
 
 ``uv tool install --reinstall memtomem`` only replaces the on-disk bytes;
 any ``memtomem-server`` process already imported by an MCP client keeps
 running the old code until it exits. That split-brain is exactly what
 caused the v0.1.25 → v0.1.26 stale ``.server.pid`` repro that motivated
-issue #443. ``mm upgrade`` wraps the reinstall with process-level hygiene:
+issue #443. The same applies to a backgrounded ``mm web`` — it holds
+``web.pid`` and keeps serving the previous version against the shared DB
+(#1569). ``mm upgrade`` wraps the reinstall with process-level hygiene:
 
-    probe live server → SIGTERM (escalate to SIGKILL after grace) →
-    unlink stale pid file → ``uv tool install --refresh --reinstall``.
+    probe live server + web UI → SIGTERM (escalate to SIGKILL after
+    grace) → unlink stale pid files → ``uv tool install --refresh
+    --reinstall``.
 
 There is no ``--skip-pkill``: the kill-then-reinstall ordering is the
 whole reason this command exists. On Windows the kill stage is skipped
 automatically (POSIX advisory flock + signals are unavailable) and the
-user is told to stop the server manually if they observe a split-brain.
+user is told to stop the processes manually if they observe a
+split-brain.
 """
 
 from __future__ import annotations
@@ -29,7 +33,12 @@ from pathlib import Path
 
 import click
 
-from memtomem.cli._liveness import ServerState, check_server_liveness, probe_pid_file
+from memtomem.cli._liveness import (
+    ServerState,
+    check_server_liveness,
+    check_web_liveness,
+    probe_pid_file,
+)
 
 # Bare PEP 440 release identifier — no operators, no whitespace. We pin
 # with ``memtomem==<version>``, so accepting a specifier like ``>=0.1.30``
@@ -74,10 +83,12 @@ def _pid_alive(pid: int) -> bool:
 
 
 def _stop_server(state: ServerState, grace: float) -> tuple[list[int], list[Path]]:
-    """SIGTERM the live server, escalate to SIGKILL after ``grace`` seconds.
+    """SIGTERM the live pid-file holder, escalate to SIGKILL after ``grace`` seconds.
 
-    Returns ``(killed_pids, removed_pid_files)``. Caller is responsible
-    for skipping this on Windows / when ``state.alive`` is False.
+    Works on any :class:`ServerState` — the MCP server and ``mm web``
+    both hold their pid file with the same flock contract. Returns
+    ``(killed_pids, removed_pid_files)``. Caller is responsible for
+    skipping this on Windows / when ``state.alive`` is False.
     """
     killed: list[int] = []
     removed: list[Path] = []
@@ -92,7 +103,7 @@ def _stop_server(state: ServerState, grace: float) -> tuple[list[int], list[Path
             pid = None
         except PermissionError as exc:
             raise click.ClickException(
-                f"cannot signal pid {pid}: {exc}. Stop the server manually and retry."
+                f"cannot signal pid {pid}: {exc}. Stop the process manually and retry."
             ) from exc
 
         # Poll for exit. server's ``_install_sigterm_handler`` (#439)
@@ -246,18 +257,23 @@ def upgrade(
     json_out: bool,
     dry_run: bool,
 ) -> None:
-    """Stop a running memtomem-server, then reinstall via ``uv tool``.
+    """Stop a running memtomem-server and Web UI, then reinstall via ``uv tool``.
 
     The canonical ``uv tool install --reinstall memtomem`` only swaps the
-    on-disk bytes; any server already imported by an MCP client keeps
-    running the previous version. ``mm upgrade`` adds the missing
-    process-level hygiene step around it.
+    on-disk bytes; any server already imported by an MCP client — and any
+    backgrounded ``mm web`` (#1569) — keeps running the previous version.
+    ``mm upgrade`` adds the missing process-level hygiene step around it.
     """
     is_windows = sys.platform == "win32"
     state = check_server_liveness()
+    web_state = check_web_liveness()
     extras, extras_auto = _resolve_extras(extras_flag)
     install_cmd = _build_install_cmd(version, extras)
     pkg_target = install_cmd[-1]
+    live_states = [s for s in (state, web_state) if s.alive]
+    # Windows skips the kill stage entirely, so a truthful plan/dry-run
+    # must not claim we would kill or remove anything there.
+    planned_stops = [] if is_windows else live_states
 
     # ----- plan -----
     if not json_out:
@@ -265,18 +281,21 @@ def upgrade(
         if is_windows:
             click.secho(
                 "  Detected Windows; skipping process termination. "
-                "Stop the server manually before rerunning if you see a "
-                "split-brain after upgrade.",
+                "Stop the server (and any `mm web`) manually before "
+                "rerunning if you see a split-brain after upgrade.",
                 fg="yellow",
             )
-        elif state.alive:
-            pid_repr = state.pid if state.pid is not None else "?"
-            pid_file_repr = _format_path(state.pid_file) if state.pid_file else "?"
-            click.echo(f"  Stop running server (pid {pid_repr}, lock {pid_file_repr})")
-            click.echo(f"  Wait up to {grace:g}s for graceful exit, then SIGKILL")
-            click.echo(f"  Remove stale {pid_file_repr}")
+        elif live_states:
+            for live, label in ((state, "server"), (web_state, "web UI")):
+                if not live.alive:
+                    continue
+                pid_repr = live.pid if live.pid is not None else "?"
+                pid_file_repr = _format_path(live.pid_file) if live.pid_file else "?"
+                click.echo(f"  Stop running {label} (pid {pid_repr}, lock {pid_file_repr})")
+                click.echo(f"  Wait up to {grace:g}s for graceful exit, then SIGKILL")
+                click.echo(f"  Remove stale {pid_file_repr}")
         else:
-            click.echo("  No running server detected — reinstall only")
+            click.echo("  No running server or web UI detected — reinstall only")
         if extras:
             source = "auto-detected from uv tool receipt" if extras_auto else "from --extras"
             click.echo(f"  Extras: [{','.join(extras)}] ({source})")
@@ -291,10 +310,10 @@ def upgrade(
                     {
                         "ok": True,
                         "dry_run": True,
-                        "would_kill": [state.pid] if (state.alive and state.pid) else [],
-                        "would_remove": (
-                            [str(state.pid_file)] if (state.alive and state.pid_file) else []
-                        ),
+                        "would_kill": [s.pid for s in planned_stops if s.pid is not None],
+                        "would_remove": [
+                            str(s.pid_file) for s in planned_stops if s.pid_file is not None
+                        ],
                         "would_install": install_cmd,
                         "extras": extras,
                         "version": version,
@@ -323,9 +342,28 @@ def upgrade(
     # ----- stop -----
     killed: list[int] = []
     removed: list[Path] = []
-    if state.alive and not is_windows:
+    if planned_stops:
         try:
-            killed, removed = _stop_server(state, grace=grace)
+            for live in planned_stops:
+                stopped, cleaned = _stop_server(live, grace=grace)
+                killed.extend(stopped)
+                removed.extend(cleaned)
+            if web_state.pid_file is not None and web_state.pid_file in removed:
+                # ``mm web`` unlinks its ``web.json`` metadata sidecar on a
+                # graceful SIGTERM but not on the SIGKILL path; sweep it so
+                # the next start doesn't inherit stale pid/port metadata.
+                # Re-probe right before the unlink (mirroring the pid-file
+                # guard in _stop_server): a web UI respawned after the pid
+                # file was cleaned must keep its fresh sidecar.
+                from memtomem.cli.web import _WEB_INFO_NAME
+
+                info_file = web_state.pid_file.with_name(_WEB_INFO_NAME)
+                if info_file.exists() and not probe_pid_file(web_state.pid_file).alive:
+                    try:
+                        info_file.unlink()
+                        removed.append(info_file)
+                    except OSError:
+                        pass
         except click.ClickException as exc:
             if json_out:
                 click.echo(_json.dumps({"ok": False, "error": str(exc)}))
@@ -385,7 +423,9 @@ def upgrade(
         return
 
     if killed:
-        click.secho(f"\nStopped pid {killed[0]}.", fg="green")
+        pids_repr = ", ".join(str(pid) for pid in killed)
+        noun = "pids" if len(killed) > 1 else "pid"
+        click.secho(f"\nStopped {noun} {pids_repr}.", fg="green")
     if removed:
         for path in removed:
             click.echo(f"Removed {_format_path(path)}.")

--- a/packages/memtomem/tests/test_upgrade_cmd.py
+++ b/packages/memtomem/tests/test_upgrade_cmd.py
@@ -341,6 +341,10 @@ def test_server_and_web_both_stopped(monkeypatch, tmp_path, fake_uv, force_tty):
     assert "Stopped pids 12345, 4242." in result.output
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Asserts the POSIX would_kill payload; Windows skips the kill stage so the arrays are empty (covered by test_windows_dry_run_json_reports_no_kills)",
+)
 def test_dry_run_json_includes_web(monkeypatch, tmp_path, fake_uv, force_tty):
     calls, _configure = fake_uv
     web_pid_file = tmp_path / "web.pid"

--- a/packages/memtomem/tests/test_upgrade_cmd.py
+++ b/packages/memtomem/tests/test_upgrade_cmd.py
@@ -57,8 +57,13 @@ def fake_uv(monkeypatch):
     return calls, configure
 
 
-def _patch_liveness(monkeypatch, state: ServerState) -> None:
+_DEAD = ServerState(alive=False, pid=None, pid_file=None)
+
+
+def _patch_liveness(monkeypatch, state: ServerState, web: ServerState = _DEAD) -> None:
+    """Patch both probes; web defaults to dead so tests never touch the real runtime dir."""
     monkeypatch.setattr(upgrade_cmd, "check_server_liveness", lambda: state)
+    monkeypatch.setattr(upgrade_cmd, "check_web_liveness", lambda: web)
 
 
 # ---------------------------------------------------------------- tests
@@ -74,7 +79,7 @@ def test_no_running_server_just_reinstalls(monkeypatch, fake_uv, force_tty):
 
     result = CliRunner().invoke(cli, ["upgrade", "-y"])
     assert result.exit_code == 0, result.output
-    assert "No running server detected" in result.output
+    assert "No running server or web UI detected" in result.output
     assert calls == [["uv", "tool", "install", "--refresh", "--reinstall", "memtomem"]]
 
 
@@ -273,6 +278,168 @@ def test_pid_file_unlink_skipped_if_respawned(monkeypatch, tmp_path, fake_uv, fo
     assert result.exit_code == 0, result.output
     assert pid_file.exists()
     assert "freshly started writer" in result.output
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only: web-UI kill path; Windows skips process termination entirely (covered by test_windows_skips_web_kill)",
+)
+def test_running_web_ui_is_stopped(monkeypatch, tmp_path, fake_uv, force_tty):
+    """#1569: a live ``mm web`` must be stopped, not survive the byte-swap."""
+    calls, _configure = fake_uv
+    web_pid_file = tmp_path / "web.pid"
+    web_pid_file.write_text("4242\n8080\n2026-07-03T00:00:00+00:00\n")
+    web_info_file = tmp_path / "web.json"
+    web_info_file.write_text('{"pid": 4242, "port": 8080}')
+    _patch_liveness(
+        monkeypatch,
+        _DEAD,
+        web=ServerState(alive=True, pid=4242, pid_file=web_pid_file, port=8080),
+    )
+
+    sent: list[tuple[int, int]] = []
+    monkeypatch.setattr(upgrade_cmd.os, "kill", lambda pid, sig: sent.append((pid, sig)))
+    monkeypatch.setattr(upgrade_cmd, "_pid_alive", lambda pid: False)
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y", "--grace", "1"])
+    assert result.exit_code == 0, result.output
+    assert "Stop running web UI (pid 4242" in result.output
+    assert (4242, upgrade_cmd.signal.SIGTERM) in sent
+    assert not web_pid_file.exists()
+    # SIGKILL-path leftover metadata sidecar is swept alongside the pid file.
+    assert not web_info_file.exists()
+    assert "Stopped pid 4242." in result.output
+    assert calls  # uv was invoked
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only: kill paths; Windows skips process termination entirely (covered by test_windows_skips_web_kill)",
+)
+def test_server_and_web_both_stopped(monkeypatch, tmp_path, fake_uv, force_tty):
+    _calls, _configure = fake_uv
+    server_pid_file = tmp_path / "server.pid"
+    server_pid_file.write_text("12345")
+    web_pid_file = tmp_path / "web.pid"
+    web_pid_file.write_text("4242\n8080\n2026-07-03T00:00:00+00:00\n")
+    _patch_liveness(
+        monkeypatch,
+        ServerState(alive=True, pid=12345, pid_file=server_pid_file),
+        web=ServerState(alive=True, pid=4242, pid_file=web_pid_file, port=8080),
+    )
+
+    sent: list[tuple[int, int]] = []
+    monkeypatch.setattr(upgrade_cmd.os, "kill", lambda pid, sig: sent.append((pid, sig)))
+    monkeypatch.setattr(upgrade_cmd, "_pid_alive", lambda pid: False)
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y", "--grace", "1"])
+    assert result.exit_code == 0, result.output
+    assert (12345, upgrade_cmd.signal.SIGTERM) in sent
+    assert (4242, upgrade_cmd.signal.SIGTERM) in sent
+    assert not server_pid_file.exists()
+    assert not web_pid_file.exists()
+    assert "Stopped pids 12345, 4242." in result.output
+
+
+def test_dry_run_json_includes_web(monkeypatch, tmp_path, fake_uv, force_tty):
+    calls, _configure = fake_uv
+    web_pid_file = tmp_path / "web.pid"
+    web_pid_file.write_text("4242\n8080\n2026-07-03T00:00:00+00:00\n")
+    _patch_liveness(
+        monkeypatch,
+        _DEAD,
+        web=ServerState(alive=True, pid=4242, pid_file=web_pid_file, port=8080),
+    )
+
+    result = CliRunner().invoke(cli, ["upgrade", "--dry-run", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["would_kill"] == [4242]
+    assert payload["would_remove"] == [str(web_pid_file)]
+    assert calls == []
+    assert web_pid_file.exists()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only: exercises the sidecar respawn-detection path; Windows skips kill entirely",
+)
+def test_web_sidecar_kept_if_respawned_after_pid_cleanup(monkeypatch, tmp_path, fake_uv, force_tty):
+    """A web UI respawned between the pid-file cleanup and the sidecar sweep
+    must keep its fresh ``web.json``."""
+    _calls, _configure = fake_uv
+    web_pid_file = tmp_path / "web.pid"
+    web_pid_file.write_text("4242\n8080\n2026-07-03T00:00:00+00:00\n")
+    web_info_file = tmp_path / "web.json"
+    web_info_file.write_text('{"pid": 99999, "port": 8080}')
+    _patch_liveness(
+        monkeypatch,
+        _DEAD,
+        web=ServerState(alive=True, pid=4242, pid_file=web_pid_file, port=8080),
+    )
+    monkeypatch.setattr(upgrade_cmd.os, "kill", lambda pid, sig: None)
+    monkeypatch.setattr(upgrade_cmd, "_pid_alive", lambda pid: False)
+
+    # First re-probe (pid-file unlink guard in _stop_server) sees no holder;
+    # second re-probe (sidecar sweep) sees the respawned web UI.
+    probes = iter(
+        [
+            ServerState(alive=False, pid=None, pid_file=web_pid_file),
+            ServerState(alive=True, pid=99999, pid_file=web_pid_file),
+        ]
+    )
+    monkeypatch.setattr(upgrade_cmd, "probe_pid_file", lambda p: next(probes))
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y", "--grace", "0.1"])
+    assert result.exit_code == 0, result.output
+    assert not web_pid_file.exists()
+    assert web_info_file.exists()
+
+
+def test_windows_dry_run_json_reports_no_kills(monkeypatch, tmp_path, fake_uv, force_tty):
+    """Windows skips the kill stage, so dry-run JSON must not claim otherwise."""
+    calls, _configure = fake_uv
+    server_pid_file = tmp_path / "server.pid"
+    server_pid_file.write_text("12345")
+    web_pid_file = tmp_path / "web.pid"
+    web_pid_file.write_text("4242\n8080\n2026-07-03T00:00:00+00:00\n")
+    _patch_liveness(
+        monkeypatch,
+        ServerState(alive=True, pid=12345, pid_file=server_pid_file),
+        web=ServerState(alive=True, pid=4242, pid_file=web_pid_file, port=8080),
+    )
+    monkeypatch.setattr(upgrade_cmd.sys, "platform", "win32")
+
+    result = CliRunner().invoke(cli, ["upgrade", "--dry-run", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["would_kill"] == []
+    assert payload["would_remove"] == []
+    assert calls == []
+
+
+def test_windows_skips_web_kill(monkeypatch, tmp_path, fake_uv, force_tty):
+    calls, _configure = fake_uv
+    web_pid_file = tmp_path / "web.pid"
+    web_pid_file.write_text("4242\n8080\n2026-07-03T00:00:00+00:00\n")
+    _patch_liveness(
+        monkeypatch,
+        _DEAD,
+        web=ServerState(alive=True, pid=4242, pid_file=web_pid_file, port=8080),
+    )
+    monkeypatch.setattr(upgrade_cmd.sys, "platform", "win32")
+
+    def boom(*_a, **_k):
+        raise AssertionError("os.kill must not be called on Windows")
+
+    monkeypatch.setattr(upgrade_cmd.os, "kill", boom)
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y"])
+    assert result.exit_code == 0, result.output
+    assert "Detected Windows" in result.output
+    assert "mm web" in result.output
+    assert calls  # uv still ran
+    assert web_pid_file.exists()
 
 
 def test_version_specifier_rejected(monkeypatch, fake_uv, force_tty):


### PR DESCRIPTION
## Summary

`mm upgrade` exists to prevent the "on-disk bytes swapped but a live process keeps running the old version" split-brain, but its liveness probe only covered the MCP server pid files (`server.pid` + legacy `.server.pid`). A backgrounded `mm web` — a live SQLite/WAL writer holding `web.pid` under the same portalocker flock contract — survived the reinstall untouched and kept serving the previous version against the shared DB.

Closes #1569

## Changes

- **`cli/_liveness.py`** — new `check_web_liveness()` probing `web_pid_path()` via the existing generic `probe_pid_file()` (`_parse_pid_payload` already understands `mm web`'s pid/port/started payload). Kept separate from `check_server_liveness()` so `mm uninstall`'s server-only semantics and existing test seams are unaffected.
- **`cli/upgrade_cmd.py`** — the web state is folded into every stage:
  - plan output lists `Stop running web UI (pid N, lock …)`;
  - `--dry-run --json` includes the web pid/pid-file in `would_kill` / `would_remove`;
  - the stop stage reuses the existing SIGTERM → grace → SIGKILL ladder (`_stop_server` is `ServerState`-driven and needed no changes beyond docstring/message genericization);
  - the `web.json` metadata sidecar — cleaned by `mm web` itself on graceful SIGTERM but left behind on the SIGKILL path — is swept only after a re-probe confirms no freshly respawned web UI holds the pid file (mirrors the existing pid-file respawn guard);
  - the success report names every stopped pid (previously only `killed[0]`);
  - Windows: the manual-stop warning now names `mm web`, and dry-run JSON no longer claims it would kill/remove anything there (the arrays previously reported the server pid even though the kill stage is skipped on Windows).

## Out of scope

The uninstall-style `BEGIN IMMEDIATE` DB probe suggested in the issue as belt-and-braces for non-pid-file writers is left as a follow-up, keeping this PR to the pid-probe gap named in the issue title. Like the server path, the stopped web UI is not restarted after the reinstall — the report tells the user what was stopped.

## Tests

- `_patch_liveness` now patches both probes (web defaults to dead) so no test touches the real runtime dir.
- New: web-only stop path (pid file + sidecar removed, pid reported), server+web both stopped (`Stopped pids 12345, 4242.`), dry-run JSON includes the web entries, sidecar kept when a web UI respawns between pid-file cleanup and the sidecar sweep, Windows skips the web kill, and Windows dry-run JSON reports empty `would_kill`/`would_remove`.
- Verified end-to-end in an isolated `HOME` + `XDG_RUNTIME_DIR` env: a real backgrounded `mm web` is listed by `--dry-run` and actually terminated (pid file and sidecar gone, process dead) by `mm upgrade -y` with the reinstall stubbed.
- `ruff check` + `ruff format --check` clean; `mypy` clean on the two changed source files; `test_upgrade_cmd.py` + `test_uninstall_cmd.py` + `test_web_cli.py`: 93 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
