### PR TITLE
fix(web,cli): serialize web + CLI memory writes across processes (#1587)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/memory.py
+++ b/packages/memtomem/src/memtomem/cli/memory.py
@@ -217,27 +217,50 @@ async def _add(
             if not _prompt_project_shared_confirm(target):
                 raise click.Abort()
 
-        target.parent.mkdir(parents=True, exist_ok=True)
-        append_entry(target, content, title=title, tags=tags)
-        # Guarded above (``enforce_write_guard``); skip the engine gate (ADR-0006 PR-A).
-        stats = await comp.index_engine.index_file(target, already_scanned=True)
+        from memtomem.context._atomic import (
+            _CRUD_SIDECAR_LOCK_BUDGET_S,
+            _lock_path_for,
+            async_file_lock,
+        )
 
-        # Apply tags to indexed chunks (chunker doesn't parse tag text from content)
-        if tags and stats.indexed_chunks > 0:
-            chunks = await comp.storage.list_chunks_by_source(target)
-            updated = []
-            for c in chunks:
-                merged = set(c.metadata.tags) | set(tags)
-                if merged != set(c.metadata.tags):
-                    c.metadata = c.metadata.__class__(
-                        **{
-                            **{f: getattr(c.metadata, f) for f in c.metadata.__dataclass_fields__},
-                            "tags": tuple(sorted(merged)),
-                        }
-                    )
-                    updated.append(c)
-            if updated:
-                await comp.storage.upsert_chunks(updated)
+        # #1587: hold the target file's cross-process sidecar (L2) across append
+        # + reindex + tag-merge so a concurrent MCP mem_edit/mem_delete rollback
+        # (this CLI runs in a separate process from the MCP server) cannot erase
+        # this appended entry. ``lock_held=True`` skips the nested engine acquire.
+        try:
+            async with async_file_lock(_lock_path_for(target), timeout=_CRUD_SIDECAR_LOCK_BUDGET_S):
+                target.parent.mkdir(parents=True, exist_ok=True)
+                await asyncio.to_thread(append_entry, target, content, title=title, tags=tags)
+                # Guarded above (``enforce_write_guard``); skip the engine gate (ADR-0006 PR-A).
+                stats = await comp.index_engine.index_file(
+                    target, already_scanned=True, lock_held=True
+                )
+
+                # Apply tags to indexed chunks (chunker doesn't parse tag text
+                # from content). Inside the lock — keyed to this file's chunks.
+                if tags and stats.indexed_chunks > 0:
+                    chunks = await comp.storage.list_chunks_by_source(target)
+                    updated = []
+                    for c in chunks:
+                        merged = set(c.metadata.tags) | set(tags)
+                        if merged != set(c.metadata.tags):
+                            c.metadata = c.metadata.__class__(
+                                **{
+                                    **{
+                                        f: getattr(c.metadata, f)
+                                        for f in c.metadata.__dataclass_fields__
+                                    },
+                                    "tags": tuple(sorted(merged)),
+                                }
+                            )
+                            updated.append(c)
+                    if updated:
+                        await comp.storage.upsert_chunks(updated)
+        except TimeoutError as exc:
+            raise click.ClickException(
+                f"{target} is locked by another process (another server or "
+                "migrate in flight); retry."
+            ) from exc
 
         click.echo(f"Added to {target} ({stats.indexed_chunks} chunks indexed)")
 

--- a/packages/memtomem/src/memtomem/tools/memory_mutation.py
+++ b/packages/memtomem/src/memtomem/tools/memory_mutation.py
@@ -1,0 +1,115 @@
+"""Surface-neutral helpers for the cross-process memory-CRUD write span (#1587).
+
+The MCP tools (``server/tools/memory_crud``) hold the per-file in-process lock
+(L1, ``AppContext.get_memory_file_lock``) plus the cross-process sidecar (L2).
+The web routes and CLI reach the same markdown files but have no ``AppContext``,
+so they take only L2 — and that is sufficient: ``async_file_lock``'s in-process
+guard serializes same-process web handlers (Windows ``LockFileEx`` alone would
+not) while the flock serializes across processes. See the lock-ordering
+invariant in :mod:`memtomem.context._atomic`.
+
+These helpers give the web/CLI edit paths the same fresh-re-fetch-under-lock and
+rollback contract the MCP tools already have, without threading an ``AppContext``
+through the web layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+from memtomem.context import _atomic
+from memtomem.context._atomic import _lock_path_for, async_file_lock
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
+    from pathlib import Path
+    from uuid import UUID
+
+    from memtomem.models import Chunk, IndexingStats
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def locked_source_chunk(
+    storage,
+    chunk_id: UUID,
+    *,
+    budget: float | None = None,
+) -> AsyncIterator[tuple[Chunk | None, str | None]]:
+    """Yield ``(chunk, None)`` with the chunk's source-file sidecar (L2) held and
+    the chunk re-fetched fresh under it, or ``(None, reason)`` where ``reason`` is
+    one of ``"not_found"`` / ``"moved"`` / ``"locked"``.
+
+    Two-step acquire (issue #1587): fetch once *unlocked* to learn the
+    ``source_file`` (the lock key), acquire that file's sidecar, then re-fetch
+    *under the lock* so ``start_line`` / ``end_line`` and ``scope`` reflect any
+    write committed while we waited. Unlike the MCP ``_locked_chunk`` (which
+    re-keys onto a moved file and holds the L1 lock too), a file moved by
+    ``memory-migrate`` between the two fetches is reported as ``"moved"`` for the
+    caller to retry — web/CLI callers re-issue the request rather than looping.
+    ``"locked"`` means the sidecar acquire timed out. Exactly one ``yield`` runs
+    on every path.
+    """
+    if budget is None:
+        # Resolve at call time so tests can monkeypatch the module constant.
+        budget = _atomic._CRUD_SIDECAR_LOCK_BUDGET_S
+    chunk = await storage.get_chunk(chunk_id)
+    if chunk is None:
+        yield None, "not_found"
+        return
+    resolved = chunk.metadata.source_file.expanduser().resolve()
+    # ``acquired`` distinguishes a timeout from the sidecar *acquire* (→ report
+    # "locked") from a ``TimeoutError`` raised by the caller's own body after we
+    # yielded — that must propagate, not be masked as a lock timeout or trigger
+    # a second yield (which would break the @asynccontextmanager protocol).
+    acquired = False
+    try:
+        async with async_file_lock(_lock_path_for(resolved), timeout=budget):
+            acquired = True
+            fresh = await storage.get_chunk(chunk_id)
+            if fresh is None:
+                yield None, "not_found"
+                return
+            if fresh.metadata.source_file.expanduser().resolve() != resolved:
+                yield None, "moved"
+                return
+            yield fresh, None
+    except TimeoutError:
+        if acquired:
+            raise
+        yield None, "locked"
+
+
+async def mutate_source_and_reindex(
+    index_engine,
+    source_file: Path,
+    mutate: Callable[[], None],
+) -> IndexingStats:
+    """Backup-read → ``mutate`` (in a worker thread) → force re-index with
+    ``lock_held=True``, restoring the pre-image and re-raising on failure.
+
+    The caller MUST already hold ``source_file``'s sidecar (via
+    :func:`locked_source_chunk`); ``lock_held=True`` skips the nested engine
+    acquire that would otherwise self-deadlock. Mirrors the MCP
+    ``_mutate_file_and_reindex`` rollback contract, giving the web edit path the
+    rollback it previously lacked.
+    """
+    original = await asyncio.to_thread(source_file.read_text, encoding="utf-8")
+    try:
+        await asyncio.to_thread(mutate)
+        return await index_engine.index_file(
+            source_file, force=True, already_scanned=True, lock_held=True
+        )
+    except Exception:
+        await asyncio.to_thread(source_file.write_text, original, encoding="utf-8")
+        try:
+            await index_engine.index_file(
+                source_file, force=True, already_scanned=True, lock_held=True
+            )
+        except Exception:
+            logger.warning("Rollback re-index also failed", exc_info=True)
+        raise

--- a/packages/memtomem/src/memtomem/web/routes/chunks.py
+++ b/packages/memtomem/src/memtomem/web/routes/chunks.py
@@ -63,68 +63,94 @@ async def edit_chunk(
     chunk = await storage.get_chunk(chunk_id)
     if chunk is None:
         raise HTTPException(status_code=404, detail="Chunk not found")
-
-    meta = chunk.metadata
-    if meta.source_file.is_symlink():
+    if chunk.metadata.source_file.is_symlink():
         raise HTTPException(status_code=403, detail="Cannot edit chunks from symlinked files.")
 
     from memtomem import privacy
+    from memtomem.tools.memory_mutation import locked_source_chunk, mutate_source_and_reindex
 
-    # ADR-0011 PR-D review round 7: infer scope from the loaded chunk's
-    # persisted metadata so Gate A's project_shared hard-refusal of
-    # ``force_unsafe=True`` fires on the web edit path too. Without
-    # ``scope=meta.scope``, ``enforce_write_guard`` defaults to user-tier
-    # treatment and a force_unsafe edit on a project_shared chunk
-    # returns ``bypassed`` instead of ``blocked_project_shared`` —
-    # mirrors the MCP ``mem_edit`` contract at memory_crud.py:406-413.
-    inferred_scope = meta.scope or "user"
-    guard = privacy.enforce_write_guard(
-        body.new_content,
-        surface="web_api_chunk_edit",
-        force_unsafe=body.force_unsafe,
-        scope=inferred_scope,
-        audit_context={"chunk_id": str(chunk_id), "scope": inferred_scope},
-    )
-    if guard.decision == "blocked":
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "detail": "redaction_blocked",
-                "hits": len(guard.hits),
-                "surface": "web_api_chunk_edit",
-            },
+    # #1587: hold the source file's cross-process sidecar (L2) across the whole
+    # read → rewrite → reindex → rollback span and re-fetch the chunk fresh under
+    # it, so a concurrent MCP CRUD / CLI write / memory-migrate cannot splice us
+    # with a stale line range or lose this edit. ``mm web`` has no AppContext L1
+    # lock; L2's in-process guard serializes concurrent web handlers too.
+    async with locked_source_chunk(storage, chunk_id) as (fresh, reason):
+        if reason == "not_found":
+            raise HTTPException(status_code=404, detail="Chunk not found")
+        if reason == "moved":
+            raise HTTPException(
+                status_code=409, detail="Chunk moved by a concurrent migration; retry."
+            )
+        if reason == "locked":
+            raise HTTPException(
+                status_code=503, detail="Memory file is locked by another writer; try again."
+            )
+        assert fresh is not None
+        meta = fresh.metadata
+
+        # Re-check the symlink refusal on the FRESH source under the lock: a
+        # concurrent reindex/migration could have re-pointed the row at a
+        # symlink resolving to the same target (so ``locked_source_chunk`` does
+        # not flag it as "moved"), and we must not edit through it.
+        if meta.source_file.is_symlink():
+            raise HTTPException(status_code=403, detail="Cannot edit chunks from symlinked files.")
+
+        # ADR-0011 PR-D review round 7: infer scope from the loaded chunk's
+        # persisted metadata so Gate A's project_shared hard-refusal of
+        # ``force_unsafe=True`` fires on the web edit path too. Evaluated on the
+        # fresh chunk (re-fetched under the lock) so a concurrent migrate cannot
+        # leave us validating a stale scope. Mirrors MCP ``mem_edit``.
+        inferred_scope = meta.scope or "user"
+        guard = privacy.enforce_write_guard(
+            body.new_content,
+            surface="web_api_chunk_edit",
+            force_unsafe=body.force_unsafe,
+            scope=inferred_scope,
+            audit_context={"chunk_id": str(chunk_id), "scope": inferred_scope},
         )
-    if guard.decision == "blocked_project_shared":
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "detail": "blocked_project_shared",
-                "hits": len(guard.hits),
-                "surface": "web_api_chunk_edit",
-                "message": (
-                    "force_unsafe is not permitted on scope='project_shared' "
-                    "chunks (git history is forever). Move the chunk to a "
-                    "different scope first, or hand-edit the canonical file."
+        if guard.decision == "blocked":
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "detail": "redaction_blocked",
+                    "hits": len(guard.hits),
+                    "surface": "web_api_chunk_edit",
+                },
+            )
+        if guard.decision == "blocked_project_shared":
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "detail": "blocked_project_shared",
+                    "hits": len(guard.hits),
+                    "surface": "web_api_chunk_edit",
+                    "message": (
+                        "force_unsafe is not permitted on scope='project_shared' "
+                        "chunks (git history is forever). Move the chunk to a "
+                        "different scope first, or hand-edit the canonical file."
+                    ),
+                },
+            )
+
+        try:
+            # ``replace_chunk_body`` keeps the heading + section-leading
+            # blockquote header (``> created:`` / ``> tags:``) intact when the
+            # caller passes body-only ``new_content``. The Web UI editor
+            # surfaces ``chunk.content`` (already header-stripped by the
+            # chunker), so saving without preservation would silently erase
+            # the metadata header on disk. Prefix ``new_content`` with ``## ``
+            # to override the heading explicitly. Guarded above; skip the engine
+            # gate (ADR-0006 PR-A). Rolls back the file on reindex failure.
+            await mutate_source_and_reindex(
+                index_engine,
+                meta.source_file,
+                lambda: replace_chunk_body(
+                    meta.source_file, meta.start_line, meta.end_line, body.new_content
                 ),
-            },
-        )
-
-    try:
-        # ``replace_chunk_body`` keeps the heading + section-leading
-        # blockquote header (``> created:`` / ``> tags:``) intact when the
-        # caller passes body-only ``new_content``. The Web UI editor
-        # surfaces ``chunk.content`` (already header-stripped by the
-        # chunker), so saving without preservation would silently erase
-        # the metadata header on disk. Prefix ``new_content`` with ``## ``
-        # to override the heading explicitly.
-        replace_chunk_body(meta.source_file, meta.start_line, meta.end_line, body.new_content)
-        # Guarded above (``enforce_write_guard``); skip the engine gate so the
-        # whole-file reindex doesn't re-litigate already-adjudicated content and
-        # the existing rollback contract stays intact (ADR-0006 PR-A).
-        await index_engine.index_file(meta.source_file, force=True, already_scanned=True)
-    except Exception as exc:
-        logger.error("Chunk edit failed for %s: %s", chunk_id, exc, exc_info=True)
-        raise HTTPException(status_code=500, detail="Edit failed. Check server logs.") from exc
+            )
+        except Exception as exc:
+            logger.error("Chunk edit failed for %s: %s", chunk_id, exc, exc_info=True)
+            raise HTTPException(status_code=500, detail="Edit failed. Check server logs.") from exc
 
     updated = await storage.get_chunk(chunk_id)
     return chunk_to_out(updated if updated is not None else chunk)
@@ -147,48 +173,67 @@ async def delete_chunk(
     if chunk is None:
         raise HTTPException(status_code=404, detail="Chunk not found")
 
-    meta = chunk.metadata
-    source = meta.source_file
+    import asyncio
 
-    # ADR-0011 PR-D review round 7: Gate B on the web delete path —
-    # mirrors the MCP ``mem_delete`` round-3 fix (8407d73). Without
-    # this, deleting a project_shared chunk via DELETE /api/chunks/{id}
-    # would silently rewrite git-tracked memory without an explicit
-    # confirm. The query param shape parallels the MCP
-    # ``confirm_project_shared`` kwarg.
-    inferred_scope = meta.scope or "user"
-    if inferred_scope == "project_shared" and not confirm_project_shared:
-        logger.info(
-            "web delete_chunk rejected project_shared chunk without confirmation",
-            extra={"chunk_id": str(chunk_id), "scope": inferred_scope},
-        )
-        raise HTTPException(
-            status_code=403,
-            detail={
-                "detail": "blocked_project_shared",
-                "surface": "web_api_chunk_delete",
-                "message": (
-                    "Deleting scope='project_shared' chunks requires "
-                    "confirm_project_shared=true. The chunk lives in the "
-                    "git-tracked memory tier; pass the query parameter to proceed."
-                ),
-            },
-        )
+    from memtomem.tools.memory_mutation import locked_source_chunk
 
-    # Remove lines from original source file, then re-index
-    if source.exists() and meta.start_line and meta.end_line:
-        try:
-            remove_lines(source, meta.start_line, meta.end_line)
-            # Delete (removal) of an already-adjudicated file — skip the engine
-            # gate; the ``except`` fallback below still relies on real indexing
-            # failures raising (ADR-0006 PR-A).
-            await index_engine.index_file(source, force=True, already_scanned=True)
-        except Exception as exc:
-            logger.warning("Source file edit failed for %s: %s", chunk_id, exc)
-            # Fall back to index-only delete
+    # #1587: hold the source file's cross-process sidecar (L2) across the
+    # remove-lines + reindex span (and the Gate-B probe, re-checked on the fresh
+    # chunk under the lock) so a concurrent write cannot resurrect or corrupt the
+    # rows we remove. ``mm web`` has no AppContext L1 lock; L2 covers it.
+    async with locked_source_chunk(storage, chunk_id) as (fresh, reason):
+        if reason == "not_found":
+            raise HTTPException(status_code=404, detail="Chunk not found")
+        if reason == "moved":
+            raise HTTPException(
+                status_code=409, detail="Chunk moved by a concurrent migration; retry."
+            )
+        if reason == "locked":
+            raise HTTPException(
+                status_code=503, detail="Memory file is locked by another writer; try again."
+            )
+        assert fresh is not None
+        meta = fresh.metadata
+        source = meta.source_file
+
+        # ADR-0011 PR-D review round 7: Gate B on the web delete path —
+        # mirrors the MCP ``mem_delete`` round-3 fix (8407d73). Re-checked on the
+        # fresh chunk so a concurrent re-scope cannot slip a project_shared
+        # delete past the confirm.
+        inferred_scope = meta.scope or "user"
+        if inferred_scope == "project_shared" and not confirm_project_shared:
+            logger.info(
+                "web delete_chunk rejected project_shared chunk without confirmation",
+                extra={"chunk_id": str(chunk_id), "scope": inferred_scope},
+            )
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "detail": "blocked_project_shared",
+                    "surface": "web_api_chunk_delete",
+                    "message": (
+                        "Deleting scope='project_shared' chunks requires "
+                        "confirm_project_shared=true. The chunk lives in the "
+                        "git-tracked memory tier; pass the query parameter to proceed."
+                    ),
+                },
+            )
+
+        # Remove lines from original source file, then re-index. No file
+        # rollback here (unlike edit): the intent is deletion, so on a reindex
+        # failure we fall back to an index-only delete rather than restoring the
+        # line. ``lock_held=True`` skips the nested sidecar acquire (#1587).
+        if source.exists() and meta.start_line and meta.end_line:
+            try:
+                await asyncio.to_thread(remove_lines, source, meta.start_line, meta.end_line)
+                await index_engine.index_file(
+                    source, force=True, already_scanned=True, lock_held=True
+                )
+            except Exception as exc:
+                logger.warning("Source file edit failed for %s: %s", chunk_id, exc)
+                await storage.delete_chunks([chunk_id])
+        else:
             await storage.delete_chunks([chunk_id])
-    else:
-        await storage.delete_chunks([chunk_id])
 
     return DeleteResponse(deleted=1)
 

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -1761,28 +1761,51 @@ async def add_memory(
         date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         target = (base / f"{date_str}.md").resolve()
 
-    target.parent.mkdir(parents=True, exist_ok=True)
-    tags = req.tags or []
-    append_entry(target, req.content, title=req.title, tags=tags)
-    # Compose/add route guarded this content above (``enforce_write_guard``);
-    # skip the engine gate (ADR-0006 PR-A).
-    stats = await index_engine.index_file(target, namespace=req.namespace, already_scanned=True)
+    from memtomem.context._atomic import (
+        _CRUD_SIDECAR_LOCK_BUDGET_S,
+        _lock_path_for,
+        async_file_lock,
+    )
 
-    # Apply tags to indexed chunks (the chunker doesn't parse tag text from content)
-    if tags and stats.indexed_chunks > 0:
-        chunks = await storage.list_chunks_by_source(target)
-        updated = []
-        for c in chunks:
-            merged = set(c.metadata.tags) | set(tags)
-            if merged != set(c.metadata.tags):
-                c.metadata = c.metadata.__class__(
-                    **{
-                        **{f: getattr(c.metadata, f) for f in c.metadata.__dataclass_fields__},
-                        "tags": tuple(sorted(merged)),
-                    }
-                )
-                updated.append(c)
-        if updated:
-            await storage.upsert_chunks(updated)
+    tags = req.tags or []
+    # #1587: hold the target file's cross-process sidecar (L2) across append +
+    # reindex + tag-merge so a concurrent MCP mem_edit/mem_delete rollback — in
+    # this process or another — cannot erase this appended entry. ``mm web`` has
+    # no AppContext L1 lock; L2's in-process guard serializes web handlers too.
+    # ``lock_held=True`` skips the nested engine acquire.
+    try:
+        async with async_file_lock(_lock_path_for(target), timeout=_CRUD_SIDECAR_LOCK_BUDGET_S):
+            target.parent.mkdir(parents=True, exist_ok=True)
+            # Guarded above (``enforce_write_guard``); skip the engine gate (ADR-0006 PR-A).
+            await _asyncio.to_thread(append_entry, target, req.content, title=req.title, tags=tags)
+            stats = await index_engine.index_file(
+                target, namespace=req.namespace, already_scanned=True, lock_held=True
+            )
+
+            # Apply tags to indexed chunks (the chunker doesn't parse tag text
+            # from content). Inside the lock — it upserts rows keyed to this
+            # file's just-indexed chunks.
+            if tags and stats.indexed_chunks > 0:
+                chunks = await storage.list_chunks_by_source(target)
+                updated = []
+                for c in chunks:
+                    merged = set(c.metadata.tags) | set(tags)
+                    if merged != set(c.metadata.tags):
+                        c.metadata = c.metadata.__class__(
+                            **{
+                                **{
+                                    f: getattr(c.metadata, f)
+                                    for f in c.metadata.__dataclass_fields__
+                                },
+                                "tags": tuple(sorted(merged)),
+                            }
+                        )
+                        updated.append(c)
+                if updated:
+                    await storage.upsert_chunks(updated)
+    except TimeoutError as exc:
+        raise HTTPException(
+            status_code=503, detail="Memory file is locked by another writer; try again."
+        ) from exc
 
     return AddMemoryResponse(file=str(target), indexed_chunks=stats.indexed_chunks)

--- a/packages/memtomem/tests/test_memory_mutation.py
+++ b/packages/memtomem/tests/test_memory_mutation.py
@@ -1,0 +1,144 @@
+"""PR2 surface pins for the cross-process memory-CRUD lock (issue #1587):
+the ``memtomem.tools.memory_mutation`` helpers and the CLI ``mm mem add`` path.
+
+The web PATCH/DELETE/add pins live in ``test_web_routes.py``
+(``TestChunkCrudCrossProcessLock``); these cover the surface-neutral helpers
+directly plus the CLI add timeout surface.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import click
+import pytest
+
+from memtomem.context import _atomic
+from memtomem.context._atomic import _lock_path_for, async_file_lock
+from memtomem.models import IndexingStats
+from memtomem.tools.memory_mutation import locked_source_chunk, mutate_source_and_reindex
+
+
+def _stats() -> IndexingStats:
+    return IndexingStats(
+        total_files=1,
+        total_chunks=1,
+        indexed_chunks=1,
+        skipped_chunks=0,
+        deleted_chunks=0,
+        duration_ms=1.0,
+    )
+
+
+# ------------------------------------------------------- locked_source_chunk
+
+
+@pytest.mark.asyncio
+async def test_locked_source_chunk_not_found():
+    storage = AsyncMock()
+    storage.get_chunk = AsyncMock(return_value=None)
+    async with locked_source_chunk(storage, uuid4()) as (chunk, reason):
+        assert chunk is None
+        assert reason == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_locked_source_chunk_times_out(tmp_path, monkeypatch):
+    """A held sidecar makes the helper report ``"locked"`` within the budget."""
+    from memtomem.models import Chunk, ChunkMetadata
+
+    src = tmp_path / "n.md"
+    src.write_text("## H\n\nbody\n", encoding="utf-8")
+    chunk = Chunk(content="body", metadata=ChunkMetadata(source_file=src, start_line=1, end_line=3))
+    storage = AsyncMock()
+    storage.get_chunk = AsyncMock(return_value=chunk)
+    monkeypatch.setattr(_atomic, "_CRUD_SIDECAR_LOCK_BUDGET_S", 0.2)
+
+    async with async_file_lock(_lock_path_for(src.resolve()), timeout=5.0):
+        async with locked_source_chunk(storage, uuid4()) as (fresh, reason):
+            assert fresh is None
+            assert reason == "locked"
+
+
+@pytest.mark.asyncio
+async def test_locked_source_chunk_propagates_body_timeout(tmp_path):
+    """A ``TimeoutError`` raised by the caller's body after the lock is acquired
+    must propagate, not be masked as a lock-acquire timeout (which would also
+    break the @asynccontextmanager protocol with a second yield)."""
+    from memtomem.models import Chunk, ChunkMetadata
+
+    src = tmp_path / "n.md"
+    src.write_text("body\n", encoding="utf-8")
+    chunk = Chunk(content="body", metadata=ChunkMetadata(source_file=src, start_line=1, end_line=1))
+    storage = AsyncMock()
+    storage.get_chunk = AsyncMock(return_value=chunk)
+
+    with pytest.raises(TimeoutError, match="from body"):
+        async with locked_source_chunk(storage, uuid4()) as (fresh, reason):
+            assert reason is None
+            raise TimeoutError("from body")
+
+
+# ------------------------------------------------- mutate_source_and_reindex
+
+
+@pytest.mark.asyncio
+async def test_mutate_source_and_reindex_success(tmp_path):
+    src = tmp_path / "n.md"
+    src.write_text("orig\n", encoding="utf-8")
+    engine = AsyncMock()
+    engine.index_file = AsyncMock(return_value=_stats())
+
+    def mutate():
+        src.write_text("mutated\n", encoding="utf-8")
+
+    stats = await mutate_source_and_reindex(engine, src, mutate)
+    assert stats.indexed_chunks == 1
+    assert src.read_text(encoding="utf-8") == "mutated\n"
+    # index_file was called with lock_held=True (caller owns the sidecar).
+    assert engine.index_file.await_args.kwargs["lock_held"] is True
+
+
+@pytest.mark.asyncio
+async def test_mutate_source_and_reindex_rolls_back_on_failure(tmp_path):
+    src = tmp_path / "n.md"
+    src.write_text("orig\n", encoding="utf-8")
+    engine = AsyncMock()
+    # Forward reindex raises; the rollback reindex (2nd call) succeeds.
+    engine.index_file = AsyncMock(side_effect=[RuntimeError("boom"), _stats()])
+
+    def mutate():
+        src.write_text("mutated\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await mutate_source_and_reindex(engine, src, mutate)
+    # File restored to its pre-image; both the forward and rollback reindex ran.
+    assert src.read_text(encoding="utf-8") == "orig\n"
+    assert engine.index_file.await_count == 2
+
+
+# ------------------------------------------------------------- CLI mm mem add
+
+
+@pytest.mark.asyncio
+async def test_cli_add_times_out_when_sidecar_held(bm25_only_components, monkeypatch):
+    """``mm mem add`` raises a friendly ``ClickException`` (not a traceback) when
+    another process holds the target file's sidecar."""
+    from memtomem.cli import memory as cli_memory
+
+    comp, mem_dir = bm25_only_components
+
+    @asynccontextmanager
+    async def _fake_components():
+        yield comp
+
+    monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _fake_components)
+    monkeypatch.setattr(_atomic, "_CRUD_SIDECAR_LOCK_BUDGET_S", 0.2)
+
+    target = (mem_dir / "notes.md").resolve()
+    async with async_file_lock(_lock_path_for(target), timeout=5.0):
+        with pytest.raises(click.ClickException) as excinfo:
+            await cli_memory._add("hello world", None, [], "notes.md")
+    assert "locked by another process" in str(excinfo.value)

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -4342,3 +4342,150 @@ class TestFsList:
         nfc_path = unicodedata.normalize("NFC", str(memdir / "한글노트"))
         resp2 = await client.get(f"/api/fs/list?path={nfc_path}")
         assert resp2.status_code == 200, resp2.text
+
+
+class TestChunkCrudCrossProcessLock:
+    """#1587: web chunk edit/delete and add hold the source file's cross-process
+    sidecar (L2) across the read → rewrite → reindex span. These pin the new
+    failure surfaces — timeout → 503, concurrent migration → 409, and the edit
+    rollback the web path previously lacked.
+    """
+
+    def _chunk_on(self, source: Path, cid: uuid.uuid4 | None = None) -> Chunk:
+        c = _make_test_chunk(chunk_id=cid, source=str(source))
+        return c.__class__(
+            content=c.content,
+            metadata=c.metadata.__class__(
+                source_file=source,
+                heading_hierarchy=("## H",),
+                tags=c.metadata.tags,
+                namespace=c.metadata.namespace,
+                start_line=1,
+                end_line=3,
+            ),
+            id=c.id,
+            content_hash=c.content_hash,
+            embedding=c.embedding,
+            created_at=c.created_at,
+            updated_at=c.updated_at,
+        )
+
+    async def test_edit_chunk_returns_503_when_sidecar_held(
+        self, app, client: AsyncClient, tmp_path: Path, monkeypatch
+    ):
+        from memtomem.context._atomic import _lock_path_for, async_file_lock
+
+        src = tmp_path / "note.md"
+        src.write_text("## H\n\nbody\n", encoding="utf-8")
+        chunk = self._chunk_on(src)
+        app.state.storage.get_chunk = AsyncMock(return_value=chunk)
+        monkeypatch.setattr("memtomem.context._atomic._CRUD_SIDECAR_LOCK_BUDGET_S", 0.2)
+
+        async with async_file_lock(_lock_path_for(src.resolve()), timeout=5.0):
+            resp = await client.patch(f"/api/chunks/{chunk.id}", json={"new_content": "updated"})
+        assert resp.status_code == 503
+        # File untouched — the edit never ran.
+        assert src.read_text(encoding="utf-8") == "## H\n\nbody\n"
+
+    @pytest.mark.requires_symlinks
+    async def test_edit_chunk_rechecks_symlink_on_fresh_chunk(
+        self, app, client: AsyncClient, tmp_path: Path
+    ):
+        """The symlink refusal is re-evaluated on the chunk re-fetched under the
+        lock: a concurrent re-point to a symlink (resolving to the same target,
+        so not reported as "moved") must still be refused with 403."""
+        real = tmp_path / "real.md"
+        real.write_text("## H\n\nbody\n", encoding="utf-8")
+        link = tmp_path / "link.md"
+        link.symlink_to(real)
+        cid = uuid.uuid4()
+        # Pre-check + unlocked fetch see the real (non-symlink) path; the
+        # under-lock re-fetch sees the symlink (resolves to the same target).
+        app.state.storage.get_chunk = AsyncMock(
+            side_effect=[
+                self._chunk_on(real, cid),
+                self._chunk_on(real, cid),
+                self._chunk_on(link, cid),
+            ]
+        )
+        resp = await client.patch(f"/api/chunks/{cid}", json={"new_content": "updated"})
+        assert resp.status_code == 403
+        # The real file was not edited.
+        assert real.read_text(encoding="utf-8") == "## H\n\nbody\n"
+
+    async def test_edit_chunk_returns_409_when_file_moved(
+        self, app, client: AsyncClient, tmp_path: Path
+    ):
+        srca = tmp_path / "a.md"
+        srcb = tmp_path / "b.md"
+        srca.write_text("## H\n\nbody\n", encoding="utf-8")
+        srcb.write_text("## H\n\nbody\n", encoding="utf-8")
+        cid = uuid.uuid4()
+        # Three fetches: the route's symlink/404 pre-check and locked_source_chunk's
+        # unlocked fetch both see a.md; the re-fetch under the lock sees b.md
+        # (a concurrent migrate moved it) → the route reports 409 retry.
+        app.state.storage.get_chunk = AsyncMock(
+            side_effect=[
+                self._chunk_on(srca, cid),
+                self._chunk_on(srca, cid),
+                self._chunk_on(srcb, cid),
+            ]
+        )
+        resp = await client.patch(f"/api/chunks/{cid}", json={"new_content": "updated"})
+        assert resp.status_code == 409
+
+    async def test_edit_chunk_rolls_back_file_on_reindex_failure(
+        self, app, client: AsyncClient, tmp_path: Path
+    ):
+        src = tmp_path / "note.md"
+        original = "## H\n\nold body\n"
+        src.write_text(original, encoding="utf-8")
+        chunk = self._chunk_on(src)
+        app.state.storage.get_chunk = AsyncMock(return_value=chunk)
+        # Forward reindex raises; the rollback reindex (2nd call) succeeds.
+        app.state.index_engine.index_file = AsyncMock(
+            side_effect=[
+                RuntimeError("boom"),
+                IndexingStats(
+                    total_files=1,
+                    total_chunks=1,
+                    indexed_chunks=1,
+                    skipped_chunks=0,
+                    deleted_chunks=0,
+                    duration_ms=1.0,
+                ),
+            ]
+        )
+
+        resp = await client.patch(f"/api/chunks/{chunk.id}", json={"new_content": "new body"})
+        assert resp.status_code == 500
+        # The failed edit was rolled back — original bytes restored.
+        assert src.read_text(encoding="utf-8") == original
+
+    async def test_delete_chunk_returns_503_when_sidecar_held(
+        self, app, client: AsyncClient, tmp_path: Path, monkeypatch
+    ):
+        from memtomem.context._atomic import _lock_path_for, async_file_lock
+
+        src = tmp_path / "note.md"
+        src.write_text("## H\n\nbody\n", encoding="utf-8")
+        chunk = self._chunk_on(src)
+        app.state.storage.get_chunk = AsyncMock(return_value=chunk)
+        monkeypatch.setattr("memtomem.context._atomic._CRUD_SIDECAR_LOCK_BUDGET_S", 0.2)
+
+        async with async_file_lock(_lock_path_for(src.resolve()), timeout=5.0):
+            resp = await client.delete(f"/api/chunks/{chunk.id}")
+        assert resp.status_code == 503
+
+    async def test_add_memory_returns_503_when_sidecar_held(
+        self, app, client: AsyncClient, tmp_path: Path, monkeypatch
+    ):
+        from memtomem.context._atomic import _lock_path_for, async_file_lock
+
+        app.state.config.indexing.memory_dirs = [tmp_path]
+        monkeypatch.setattr("memtomem.context._atomic._CRUD_SIDECAR_LOCK_BUDGET_S", 0.2)
+        target = (tmp_path / "pinned.md").resolve()
+
+        async with async_file_lock(_lock_path_for(target), timeout=5.0):
+            resp = await client.post("/api/add", json={"content": "hello", "file": "pinned.md"})
+        assert resp.status_code == 503


### PR DESCRIPTION
## What & why

**Stacked on #1589** (base branch `fix/cross-process-crud-lock-1587`) — this is **PR 2 of 2** for #1587 and **closes it**. Review/merge #1589 first.

PR #1589 held the cross-process sidecar (L2) across the MCP CRUD spans and `memory-migrate`. This closes the remaining markdown-mutating surfaces, which still wrote outside the lock exactly as they do on `main` today:

- **web chunk PATCH/DELETE** (`web/routes/chunks.py`) — read a chunk's line range from a row fetched at request entry, mutated the file with no lock and no re-fetch (stale-line-range / lost-update TOCTOU); PATCH had **no rollback** at all.
- **web add + CLI `mm mem add`** — appended + reindexed with no lock, so a concurrent MCP `mem_edit`/`mem_delete` rollback in another process could erase the append.

These surfaces have no `AppContext` (mm web keeps components on `app.state`; the CLI is a separate process), so they take **only the L2 sidecar** via `async_file_lock`. That is sufficient: the sidecar's in-process guard serializes concurrent web handlers (Windows `LockFileEx` alone would not) and the flock serializes across processes.

## Changes

- **New `tools/memory_mutation.py`** — two surface-neutral helpers so web/CLI get the same fresh-re-fetch-under-lock + rollback contract the MCP tools have, without threading an `AppContext` through the web layer:
  - `locked_source_chunk` — acquire the chunk's sidecar, re-fetch fresh under it, report `not_found` / `moved` (concurrent migrate) / `locked` (timeout).
  - `mutate_source_and_reindex` — backup → mutate → reindex(`lock_held=True`), restoring the pre-image on failure — the rollback web PATCH lacked.
- **web PATCH** — lock + fresh re-fetch (privacy/Gate-A **and the symlink refusal** re-evaluated on the fresh chunk under the lock) + rollback; **503** on lock timeout, **409** when the file was migrated mid-request, 500 on mutate/index failure (rolled back).
- **web DELETE** — lock + fresh Gate-B re-check + `remove_lines` + reindex(`lock_held=True`); keeps the index-only-delete fallback (no file rollback — deletion shouldn't restore the removed line).
- **web add + CLI `mm mem add`** — hold the target's sidecar across append + reindex + tag-merge, reindex with `lock_held=True`; **503** / `ClickException` on timeout.

## Review notes (Codex)

The committed diff was reviewed by Codex; two Major findings were fixed before push:
- `locked_source_chunk` narrows its `TimeoutError` catch with an `acquired` flag so a `TimeoutError` raised by the caller's body propagates instead of being masked as a lock-acquire timeout (and double-yield). Pinned by `test_locked_source_chunk_propagates_body_timeout`.
- web PATCH re-checks `is_symlink()` on the fresh (under-lock) chunk, so a concurrent re-point to a symlink resolving to the same target is still refused 403. Pinned by `test_edit_chunk_rechecks_symlink_on_fresh_chunk`.

## Tests

- `test_web_routes.py::TestChunkCrudCrossProcessLock` — PATCH/DELETE/add timeout → 503, PATCH moved → 409, PATCH reindex-failure rollback restores bytes, fresh-symlink → 403.
- `test_memory_mutation.py` — `locked_source_chunk` not_found / locked / body-timeout-propagation; `mutate_source_and_reindex` success + rollback; CLI `mm mem add` timeout → `ClickException`.
- Full suite green (`uv run pytest -m "not ollama"`), ruff clean, mypy clean on changed regions.

Closes #1587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
