### PR TITLE
fix(cli): make mm init's .mcp.json writers atomic and guard the existing-file parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   metadata sidecar on the SIGKILL path, and reports every stopped pid;
   `--dry-run --json` lists the web pid in `would_kill`/`would_remove`. On
   Windows the manual-stop warning now names `mm web` as well.
+- **`mm init`'s `.mcp.json` / Kimi `mcp.json` writers are atomic and refuse
+  invalid pre-existing files with an actionable message** (#1568). Both
+  editor-config writers used truncate-then-write, so a crash mid-write could
+  corrupt the editor's MCP config for *every* configured server, and they
+  parsed a pre-existing file unguarded, so a hand-edited `.mcp.json`
+  (trailing comma, comment) aborted `mm init` at its final step with a raw
+  `JSONDecodeError` traceback — after `config.json` was already written,
+  leaving the run half-applied with no hint how to recover. The merge now
+  goes through the fsync-hardened `atomic_write_text` (tempfile +
+  `os.replace`, preserving the existing file's permission bits and writing
+  through a symlinked config to its resolved target instead of replacing
+  the link), and an unparseable existing file — or one whose top level or
+  `mcpServers` value is not a JSON object — is refused with a
+  "fix or remove it and re-run mm init" error, leaving it byte-for-byte
+  untouched.
 - **Concurrent MCP memory-CRUD calls on the same file no longer lose updates or
   corrupt an unrelated entry** (#1570). `mem_edit` / `mem_delete` did their
   read → rewrite (`replace_chunk_body` / `remove_lines`) → re-index → rollback

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -2608,41 +2608,80 @@ def _write_config_and_summary(
     click.echo()
 
 
-def _write_mcp_json(server_cmd: str, server_args: list[str], mcp_env: dict[str, str]) -> None:
-    """Write or update .mcp.json in current directory."""
+def _merge_mcp_server_entry(mcp_path: Path, server_entry: dict) -> None:
+    """Merge the memtomem entry into ``mcp_path``'s ``mcpServers``, atomically.
+
+    This runs as one of ``mm init``'s last steps — ``config.json`` is already
+    written — so failures here must not corrupt the editor's MCP config for
+    every configured server, and must surface as an actionable message
+    instead of a traceback that leaves the run half-applied (#1568):
+
+    - a hand-edited file that no longer parses (trailing comma, comment) or
+      has the wrong JSON shape is refused with a fix-or-remove hint, and
+      left byte-for-byte untouched;
+    - the write goes through ``atomic_write_text`` (tempfile + fsync +
+      ``os.replace``) so a crash mid-write can't truncate the file.
+    """
+    from memtomem.context._atomic import atomic_write_text
+
+    # ``os.replace`` would swap a symlinked config out for a regular file,
+    # silently disconnecting a dotfile-managed target — resolve and write
+    # through to the real file instead. Error messages keep the user-facing
+    # ``mcp_path`` spelling.
+    target = mcp_path.resolve()
+
+    existing: dict = {}
+    mode = 0o644
+    if target.exists():
+        try:
+            existing = json.loads(target.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise click.ClickException(
+                f"existing {mcp_path} is not valid JSON: {exc} — "
+                "fix or remove it and re-run mm init"
+            ) from exc
+        if not isinstance(existing, dict):
+            raise click.ClickException(
+                f"existing {mcp_path} is not a JSON object "
+                f"(got {type(existing).__name__}) — fix or remove it and re-run mm init"
+            )
+        # ``os.replace`` swaps the inode, so carry the current permissions
+        # over instead of silently loosening a user-tightened file to 0o644.
+        try:
+            mode = target.stat().st_mode & 0o777
+        except OSError:
+            pass
+    servers = existing.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        raise click.ClickException(
+            f'"mcpServers" in {mcp_path} is not a JSON object '
+            f"(got {type(servers).__name__}) — fix or remove it and re-run mm init"
+        )
+    servers["memtomem"] = server_entry
+    atomic_write_text(target, json.dumps(existing, indent=2), mode=mode)
+
+
+def _mcp_server_entry(server_cmd: str, server_args: list[str], mcp_env: dict[str, str]) -> dict:
     server_entry: dict = {
         "command": server_cmd,
         "args": server_args,
     }
     if mcp_env:
         server_entry["env"] = mcp_env
-    mcp_config: dict = {"mcpServers": {"memtomem": server_entry}}
-    mcp_path = Path(".mcp.json")
-    if mcp_path.exists():
-        existing = json.loads(mcp_path.read_text(encoding="utf-8"))
-        existing.setdefault("mcpServers", {})["memtomem"] = mcp_config["mcpServers"]["memtomem"]
-        mcp_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
-    else:
-        mcp_path.write_text(json.dumps(mcp_config, indent=2), encoding="utf-8")
+    return server_entry
+
+
+def _write_mcp_json(server_cmd: str, server_args: list[str], mcp_env: dict[str, str]) -> None:
+    """Write or update .mcp.json in current directory."""
+    _merge_mcp_server_entry(Path(".mcp.json"), _mcp_server_entry(server_cmd, server_args, mcp_env))
 
 
 def _write_kimi_mcp_json(server_cmd: str, server_args: list[str], mcp_env: dict[str, str]) -> Path:
     """Write or update Kimi CLI's MCP config file."""
-    server_entry: dict = {
-        "command": server_cmd,
-        "args": server_args,
-    }
-    if mcp_env:
-        server_entry["env"] = mcp_env
     base = Path(os.environ.get("KIMI_SHARE_DIR", "~/.kimi")).expanduser()
     mcp_path = base / "mcp.json"
     mcp_path.parent.mkdir(parents=True, exist_ok=True)
-    if mcp_path.exists():
-        existing = json.loads(mcp_path.read_text(encoding="utf-8"))
-    else:
-        existing = {}
-    existing.setdefault("mcpServers", {})["memtomem"] = server_entry
-    mcp_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    _merge_mcp_server_entry(mcp_path, _mcp_server_entry(server_cmd, server_args, mcp_env))
     return mcp_path
 
 

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -16,7 +16,14 @@ from typing import Literal
 
 import pytest
 
-from memtomem.cli.init_cmd import MmBinaryOrigin, RuntimeProfile, _write_mcp_json
+import click
+
+from memtomem.cli.init_cmd import (
+    MmBinaryOrigin,
+    RuntimeProfile,
+    _write_kimi_mcp_json,
+    _write_mcp_json,
+)
 from memtomem.config import Mem2MemConfig
 
 from .helpers import set_home
@@ -51,6 +58,149 @@ def test_write_mcp_json_preserves_valid_env(
 
     data = json.loads((tmp_path / ".mcp.json").read_text(encoding="utf-8"))
     assert data["mcpServers"]["memtomem"]["env"] == env
+
+
+def test_write_mcp_json_merges_preserving_other_servers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Updating an existing .mcp.json must keep the user's other MCP servers
+    and any unrelated top-level keys (#1568 merge branch, previously untested)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {"other": {"command": "other-server", "args": []}},
+                "unrelatedTopLevel": True,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    _write_mcp_json("uvx", ["--from", "memtomem", "memtomem-server"], {})
+
+    data = json.loads((tmp_path / ".mcp.json").read_text(encoding="utf-8"))
+    assert data["mcpServers"]["other"] == {"command": "other-server", "args": []}
+    assert data["unrelatedTopLevel"] is True
+    assert data["mcpServers"]["memtomem"]["command"] == "uvx"
+
+
+def test_write_mcp_json_corrupt_existing_is_actionable_and_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A hand-edited .mcp.json that no longer parses must surface a
+    fix-or-remove ClickException, not a JSONDecodeError traceback, and the
+    file must be left byte-for-byte intact (#1568)."""
+    monkeypatch.chdir(tmp_path)
+    corrupt = '{"mcpServers": {"other": {}},}'  # trailing comma
+    (tmp_path / ".mcp.json").write_text(corrupt, encoding="utf-8")
+
+    with pytest.raises(click.ClickException, match=r"not valid JSON(.|\n)*re-run mm init"):
+        _write_mcp_json("uvx", ["--from", "memtomem", "memtomem-server"], {})
+
+    assert (tmp_path / ".mcp.json").read_text(encoding="utf-8") == corrupt
+
+
+def test_write_mcp_json_non_object_existing_is_actionable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".mcp.json").write_text("[]", encoding="utf-8")
+
+    with pytest.raises(click.ClickException, match=r"not a JSON object"):
+        _write_mcp_json("uvx", ["--from", "memtomem", "memtomem-server"], {})
+
+    assert (tmp_path / ".mcp.json").read_text(encoding="utf-8") == "[]"
+
+
+def test_write_mcp_json_non_object_mcp_servers_is_actionable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Valid JSON whose ``mcpServers`` value has the wrong shape must be
+    refused actionably, not crash with a raw TypeError (review finding)."""
+    monkeypatch.chdir(tmp_path)
+    content = '{"mcpServers": []}'
+    (tmp_path / ".mcp.json").write_text(content, encoding="utf-8")
+
+    with pytest.raises(click.ClickException, match=r'"mcpServers".*not a JSON object'):
+        _write_mcp_json("uvx", ["--from", "memtomem", "memtomem-server"], {})
+
+    assert (tmp_path / ".mcp.json").read_text(encoding="utf-8") == content
+
+
+@pytest.mark.requires_symlinks
+def test_write_mcp_json_writes_through_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A symlinked .mcp.json (dotfile-managed) must stay a symlink; the
+    atomic replace goes to the resolved target, not over the link."""
+    real = tmp_path / "dotfiles" / "mcp.json"
+    real.parent.mkdir()
+    real.write_text(
+        json.dumps({"mcpServers": {"other": {"command": "other-server", "args": []}}}),
+        encoding="utf-8",
+    )
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".mcp.json").symlink_to(real)
+    monkeypatch.chdir(project)
+
+    _write_mcp_json("uvx", ["--from", "memtomem", "memtomem-server"], {})
+
+    assert (project / ".mcp.json").is_symlink()
+    data = json.loads(real.read_text(encoding="utf-8"))
+    assert data["mcpServers"]["other"] == {"command": "other-server", "args": []}
+    assert data["mcpServers"]["memtomem"]["command"] == "uvx"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX permission bits")
+def test_write_mcp_json_preserves_existing_permissions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The atomic rewrite swaps the inode; a user-tightened 0o600 file must
+    not silently come back 0o644."""
+    monkeypatch.chdir(tmp_path)
+    mcp_path = tmp_path / ".mcp.json"
+    mcp_path.write_text("{}", encoding="utf-8")
+    mcp_path.chmod(0o600)
+
+    _write_mcp_json("uvx", ["--from", "memtomem", "memtomem-server"], {})
+
+    assert mcp_path.stat().st_mode & 0o777 == 0o600
+
+
+def test_write_kimi_mcp_json_merges_preserving_other_servers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    share_dir = tmp_path / "kimi-share"
+    monkeypatch.setenv("KIMI_SHARE_DIR", str(share_dir))
+    share_dir.mkdir(parents=True)
+    (share_dir / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"other": {"command": "other-server", "args": []}}}),
+        encoding="utf-8",
+    )
+
+    written = _write_kimi_mcp_json("uvx", ["--from", "memtomem", "memtomem-server"], {})
+
+    assert written == share_dir / "mcp.json"
+    data = json.loads(written.read_text(encoding="utf-8"))
+    assert data["mcpServers"]["other"] == {"command": "other-server", "args": []}
+    assert data["mcpServers"]["memtomem"]["command"] == "uvx"
+
+
+def test_write_kimi_mcp_json_corrupt_existing_is_actionable_and_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    share_dir = tmp_path / "kimi-share"
+    monkeypatch.setenv("KIMI_SHARE_DIR", str(share_dir))
+    share_dir.mkdir(parents=True)
+    corrupt = "{not json"
+    (share_dir / "mcp.json").write_text(corrupt, encoding="utf-8")
+
+    with pytest.raises(click.ClickException, match=r"not valid JSON(.|\n)*re-run mm init"):
+        _write_kimi_mcp_json("uvx", ["--from", "memtomem", "memtomem-server"], {})
+
+    assert (share_dir / "mcp.json").read_text(encoding="utf-8") == corrupt
 
 
 def _make_test_profile(


### PR DESCRIPTION
## Summary

`mm init`'s editor-config writers (`.mcp.json`, Kimi `mcp.json`) used truncate-then-write (`Path.write_text`) and parsed a pre-existing file with an unguarded `json.loads`. Both failure modes hit at `mm init`'s **last** step, after `~/.memtomem/config.json` is already written: a crash mid-write corrupts the editor's MCP config for *every* configured server, and a hand-edited file (trailing comma, comment) aborts the run with a raw `JSONDecodeError` traceback, leaving init half-applied and failing identically on every re-run.

Closes #1568

## Changes

Both writers now converge on one `_merge_mcp_server_entry` helper in `cli/init_cmd.py`:

- **Atomic write** — routed through `context._atomic.atomic_write_text` (tempfile + fsync + `os.replace`; the fsync-hardened sibling of `config.py`'s `_atomic_write_json`, already imported outside `context/` by `web/routes/*` and `wiki/*`). A crash mid-write can no longer truncate the file.
- **Permission preservation** — `os.replace` swaps the inode, so the existing file's mode bits are carried over (a user-tightened `0o600` must not silently come back `0o644`); fresh files get `0o644`, matching the previous `write_text`/umask behavior.
- **Symlink write-through** — a symlinked `.mcp.json` (dotfile-managed) is resolved and the write goes to the real target instead of replacing the link with a regular file.
- **Guarded parse** — unparseable JSON, a non-object top level, or a non-object `mcpServers` value each raise an actionable `ClickException` (`… fix or remove it and re-run mm init`) and leave the file byte-for-byte untouched, consistent with the issue's suggestion (a warn-and-overwrite fallback à la `save_config_overrides` would destroy the user's *other* MCP server entries, so refusal is the right shape here).

These two writers are the complete set with this bug shape — the other editor flows only print paste hints, and the Claude-hooks `settings.json` writer is already guarded and delegates its merge to `context.settings`.

## Considered and declined

A cross-process lock around the read→merge→write (raised in internal review): `mm init` is a one-shot interactive writer of a file it does not own exclusively (editors rewrite `.mcp.json` themselves, unlocked), and a sidecar `.mcp.json.lock` would litter user project directories — the #1567 lesson — for a race with no realistic concurrent memtomem writer.

## Tests

New tests for both writers (merge preserves other servers + unrelated top-level keys — the merge branch was previously untested; corrupt existing file → actionable error, file untouched; non-object top level; non-object `mcpServers`; permission preservation; symlink write-through with the `requires_symlinks` marker).

Verified end-to-end with the real CLI in an isolated HOME: `mm init -y --preset minimal --mcp json` against a corrupt `.mcp.json` prints the one-line actionable error (no traceback) and leaves the file byte-identical; against a valid multi-server `.mcp.json` chmod'ed to `0600` it merges the memtomem entry, preserves the other server, and keeps `0600`.

`ruff check` + `ruff format --check` clean; `mypy` clean on `init_cmd.py`; `test_init_cmd.py`: 287 passed. The corrupt-file guard was mutation-tested (guard removed → new tests go red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
