### PR TITLE
fix(indexing): watcher queue-full logging, debounce poison-entry cap, stream locking (#1574 items 1,3,6)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/indexing.py
+++ b/packages/memtomem/src/memtomem/cli/indexing.py
@@ -313,6 +313,7 @@ def _print_drain_result(result, *, as_json: bool, label: str) -> None:
                 {
                     "indexed": result.indexed,
                     "errors": [{"path": p, "message": m} for p, m in result.errors],
+                    "dropped": [{"path": p, "message": m} for p, m in result.dropped],
                     "remaining": result.remaining,
                 }
             )
@@ -324,4 +325,10 @@ def _print_drain_result(result, *, as_json: bool, label: str) -> None:
         click.echo(f"  Errors: {len(result.errors)}")
         for p, m in result.errors:
             click.echo(click.style(f"    {p}: {m}", fg="red"))
+    if result.dropped:
+        from memtomem.indexing.debounce import _MAX_DRAIN_ATTEMPTS
+
+        click.echo(f"  Dropped after {_MAX_DRAIN_ATTEMPTS} failed attempts:")
+        for p, m in result.dropped:
+            click.echo(click.style(f"    {p}: {m} — fix the cause, then: mm index {p}", fg="red"))
     click.echo(f"  Remaining in queue: {result.remaining}")

--- a/packages/memtomem/src/memtomem/indexing/debounce.py
+++ b/packages/memtomem/src/memtomem/indexing/debounce.py
@@ -52,6 +52,16 @@ logger = logging.getLogger(__name__)
 _DEFAULT_QUEUE_PATH = Path("~/.memtomem/index_debounce_queue.json").expanduser()
 _QUEUE_VERSION = 1
 
+# A deterministically-failing entry (permission error, parser bug, redaction
+# block) must not be retried forever — drain runs on every hook fire and every
+# ``Stop``-hook ``--flush``, so a poison entry turns each of those into a
+# guaranteed failure. After this many failed drain attempts the entry is
+# dropped loudly (logger.error + ``DrainResult.dropped``). A later re-enqueue
+# (i.e. a real new write to the file) resets the counter. This cap applies to
+# redaction-blocked files too — exempting them would reintroduce the
+# unbounded-retry class this exists to remove (#1574 item 3).
+_MAX_DRAIN_ATTEMPTS = 5
+
 
 @dataclass
 class QueueEntry:
@@ -62,6 +72,7 @@ class QueueEntry:
     last_seen: float
     namespace: str | None = None
     force: bool = False
+    attempts: int = 0  # failed drain attempts so far (see _MAX_DRAIN_ATTEMPTS)
 
     @classmethod
     def from_dict(cls, d: dict) -> "QueueEntry":
@@ -70,6 +81,7 @@ class QueueEntry:
             last_seen=float(d["last_seen"]),
             namespace=d.get("namespace"),
             force=bool(d.get("force", False)),
+            attempts=int(d.get("attempts", 0)),
         )
 
 
@@ -79,6 +91,7 @@ class DrainResult:
 
     indexed: list[str] = field(default_factory=list)
     errors: list[tuple[str, str]] = field(default_factory=list)  # (path, message)
+    dropped: list[tuple[str, str]] = field(default_factory=list)  # (path, message)
     remaining: int = 0
 
 
@@ -250,11 +263,41 @@ def enqueue(
             existing.last_seen = ts
             existing.namespace = namespace
             existing.force = force
+            # A re-enqueue is a real new write (the only caller is the
+            # PostToolUse[Write] hook), so give the entry a fresh retry
+            # budget — the failure may have been fixed by this write.
+            existing.attempts = 0
         _save(qp, entries)
 
 
 def _ready(entry: QueueEntry, window_seconds: float, now: float) -> bool:
     return (now - entry.last_seen) >= window_seconds
+
+
+def _record_failure(
+    entries: dict[str, QueueEntry],
+    path_str: str,
+    entry: QueueEntry,
+    exc: Exception,
+    result: DrainResult,
+) -> None:
+    """Count one failed drain attempt; keep the entry for retry until the
+    attempt cap is hit, then drop it loudly (log + ``result.dropped``)."""
+    message = repr(exc)
+    entry.attempts += 1
+    if entry.attempts < _MAX_DRAIN_ATTEMPTS:
+        result.errors.append((path_str, message))
+        return
+    del entries[path_str]
+    result.dropped.append((path_str, message))
+    logger.error(
+        "debounce queue: dropping %s after %d failed indexing attempts (%s); "
+        "fix the underlying cause and re-run: mm index %s",
+        path_str,
+        entry.attempts,
+        message,
+        path_str,
+    )
 
 
 async def drain_ready(
@@ -284,8 +327,9 @@ async def drain_ready(
                 result.indexed.append(p)
                 del entries[p]
             except Exception as e:
-                result.errors.append((p, repr(e)))
-                # Keep the entry so the next hook call retries.
+                # Keep the entry so the next hook call retries — until the
+                # attempt cap drops it (poison-entry guard, #1574 item 3).
+                _record_failure(entries, p, entry, e, result)
         result.remaining = len(entries)
         _save(qp, entries)
     return result
@@ -320,7 +364,10 @@ async def drain_all(
                 result.indexed.append(p)
                 del entries[p]
             except Exception as e:
-                result.errors.append((p, repr(e)))
+                # Same poison-entry cap as drain_ready — this path runs on
+                # every Stop-hook ``--flush``, the highest-frequency
+                # automated drain, so it must not bypass the cap.
+                _record_failure(entries, p, entry, e, result)
         result.remaining = len(entries)
         _save(qp, entries)
     return result

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -432,10 +432,11 @@ class IndexEngine:
         # path ever waits on a sidecar while holding ``_index_lock`` (#1587).
         self._index_lock = asyncio.Lock()
         # Observability counter for ``GET /api/indexing/active`` — independent
-        # of ``_index_lock`` because ``index_path_stream`` runs outside the
-        # lock and ``asyncio.Lock.locked()`` is racy. Incremented on entry
-        # and decremented in a ``finally`` block by every public entry point
-        # (``index_path``, ``index_file``, ``index_path_stream``).
+        # of ``_index_lock`` because runs also span discovery, gaps between
+        # files, and lock-wait periods where ``asyncio.Lock.locked()`` would
+        # misreport. Incremented on entry and decremented in a ``finally``
+        # block by every public entry point (``index_path``, ``index_file``,
+        # ``index_path_stream``).
         self._active_runs: int = 0
 
     @property
@@ -592,6 +593,80 @@ class IndexEngine:
             return self._discover_files(path, recursive)
         return []
 
+    async def _index_file_locked(
+        self,
+        resolved_path: Path,
+        force: bool,
+        *,
+        namespace: str | None = None,
+        on_chunk_progress: Callable[[int, int], None] | None = None,
+        force_unsafe: bool = False,
+        already_scanned: bool = False,
+        lock_held: bool = False,
+    ) -> tuple[IndexFileResult, float]:
+        """Run ``_index_file`` under the L2 sidecar → L3 ``_index_lock`` pair.
+
+        Single home for the per-file lock policy so ``index_file`` and
+        ``index_path_stream`` cannot drift (#1574 item 6). Returns the raw
+        per-file result plus the duration (ms) of the indexing work itself —
+        measured inside the locks, so lock-wait time is excluded.
+
+        ADR-0011 PR-D round 11 (B2): the cross-process sidecar means the
+        sibling lock taken by ``mm context memory-migrate`` is honored here
+        too. Without it, a watcher firing ``index_file(target)`` mid-migrate
+        races with migrate's ``shutil.move`` + DB UPDATE pair (migrate's lock
+        alone is one-sided). #1587 hoists this sidecar acquire ABOVE
+        ``_index_lock`` (L2 before L3) and makes it async + bounded, so it can
+        never freeze the loop while a suspended holder needs it — and lets
+        CRUD callers hold the sidecar across their whole read→rewrite→reindex
+        span and reach here with ``lock_held=True`` instead of
+        self-deadlocking.
+        """
+        # In-body import on purpose: tests monkeypatch the budget by dotted
+        # path (``memtomem.context._atomic._MEMORY_SIDECAR_LOCK_BUDGET_S``);
+        # a module-top ``from`` import would freeze the value.
+        from memtomem.context._atomic import (
+            _MEMORY_SIDECAR_LOCK_BUDGET_S,
+            _lock_path_for,
+            async_file_lock,
+        )
+
+        # Skip the sidecar when the caller already holds it (lock_held) or
+        # when the parent dir is gone (#1566: a delete-by-source pass for a
+        # vanished file — taking the sidecar would ``mkdir`` the deleted
+        # parent back into existence just to lock a delete, resurrecting the
+        # directory the user removed). ``_index_lock`` still serializes
+        # in-process; a migrate sidecar for a missing-parent path lives in
+        # that same missing parent, so no live pair-op can be mid-flight.
+        skip_sidecar = lock_held or not resolved_path.parent.is_dir()
+        if skip_sidecar:
+            async with self._index_lock:
+                start = time.monotonic()
+                result = await self._index_file(
+                    resolved_path,
+                    force,
+                    namespace=namespace,
+                    on_chunk_progress=on_chunk_progress,
+                    force_unsafe=force_unsafe,
+                    already_scanned=already_scanned,
+                )
+                return result, (time.monotonic() - start) * 1000
+        async with async_file_lock(
+            _lock_path_for(resolved_path),
+            timeout=_MEMORY_SIDECAR_LOCK_BUDGET_S,
+        ):
+            async with self._index_lock:
+                start = time.monotonic()
+                result = await self._index_file(
+                    resolved_path,
+                    force,
+                    namespace=namespace,
+                    on_chunk_progress=on_chunk_progress,
+                    force_unsafe=force_unsafe,
+                    already_scanned=already_scanned,
+                )
+                return result, (time.monotonic() - start) * 1000
+
     async def index_file(
         self,
         file_path: Path,
@@ -668,57 +743,14 @@ class IndexEngine:
             )
         self._active_runs += 1
         try:
-            # ADR-0011 PR-D round 11 (B2): cross-process advisory lock so the
-            # sibling sidecar lock taken by ``mm context memory-migrate`` is
-            # honored on this path too. Without it, a watcher firing
-            # ``index_file(target)`` mid-migrate races with migrate's
-            # ``shutil.move`` + DB UPDATE pair (migrate's lock alone is
-            # one-sided). #1587 hoists this sidecar acquire ABOVE ``_index_lock``
-            # (L2 before L3) and makes it async + bounded, so it can never freeze
-            # the loop while a suspended holder needs it — and lets CRUD callers
-            # hold the sidecar across their whole read→rewrite→reindex span and
-            # reach here with ``lock_held=True`` instead of self-deadlocking.
-            from memtomem.context._atomic import (
-                _MEMORY_SIDECAR_LOCK_BUDGET_S,
-                _lock_path_for,
-                async_file_lock,
+            result, duration = await self._index_file_locked(
+                file_path.resolve(),
+                force,
+                namespace=namespace,
+                force_unsafe=force_unsafe,
+                already_scanned=already_scanned,
+                lock_held=lock_held,
             )
-
-            resolved_path = file_path.resolve()
-            # Skip the sidecar when the caller already holds it (lock_held) or
-            # when the parent dir is gone (#1566: a delete-by-source pass for a
-            # vanished file — taking the sidecar would ``mkdir`` the deleted
-            # parent back into existence just to lock a delete, resurrecting the
-            # directory the user removed). ``_index_lock`` still serializes
-            # in-process; a migrate sidecar for a missing-parent path lives in
-            # that same missing parent, so no live pair-op can be mid-flight.
-            skip_sidecar = lock_held or not resolved_path.parent.is_dir()
-            if skip_sidecar:
-                async with self._index_lock:
-                    start = time.monotonic()
-                    result = await self._index_file(
-                        resolved_path,
-                        force,
-                        namespace=namespace,
-                        force_unsafe=force_unsafe,
-                        already_scanned=already_scanned,
-                    )
-                    duration = (time.monotonic() - start) * 1000
-            else:
-                async with async_file_lock(
-                    _lock_path_for(resolved_path),
-                    timeout=_MEMORY_SIDECAR_LOCK_BUDGET_S,
-                ):
-                    async with self._index_lock:
-                        start = time.monotonic()
-                        result = await self._index_file(
-                            resolved_path,
-                            force,
-                            namespace=namespace,
-                            force_unsafe=force_unsafe,
-                            already_scanned=already_scanned,
-                        )
-                        duration = (time.monotonic() - start) * 1000
         finally:
             self._active_runs -= 1
         return IndexingStats(
@@ -1259,10 +1291,14 @@ class IndexEngine:
           same loose shape as ``IndexingStats.errors`` so non-stream UI
           handlers reuse verbatim. Empty list when the run had no errors.
 
-        Note: this path runs **outside** ``_index_lock`` (unlike
-        ``index_path`` / ``index_file``). The ``_active_runs`` counter
-        is bumped here too so ``GET /api/indexing/active`` covers
-        stream runs uniformly.
+        Locking: each file is indexed under the same L2 sidecar →
+        L3 ``_index_lock`` pair as ``index_file`` (via
+        ``_index_file_locked``), taken **per file** so a stream run
+        serializes against watcher/CLI/CRUD reindexes of the same file
+        without holding a lock across the whole tree walk (#1574 item 6).
+        The ``_active_runs`` counter is still bumped once per stream run
+        so ``GET /api/indexing/active`` covers discovery and the gaps
+        between files, where no lock is held.
         """
         self._active_runs += 1
         try:
@@ -1342,13 +1378,20 @@ class IndexEngine:
                         )
 
                     try:
-                        return await self._index_file(
-                            fp,
+                        # Same L2 sidecar → L3 ``_index_lock`` policy as
+                        # ``index_file``, taken per file so streaming progress
+                        # survives (#1574 item 6). A sidecar timeout raises
+                        # ``TimeoutError``, which the ``except Exception``
+                        # below folds into this file's ``errors`` — the
+                        # stream continues with the next file.
+                        result, _ = await self._index_file_locked(
+                            fp.resolve(),
                             force,
                             namespace=namespace,
                             on_chunk_progress=cb,
                             force_unsafe=force_unsafe,
                         )
+                        return result
                     finally:
                         queue.put_nowait(DONE)
 

--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -45,10 +45,19 @@ class _MarkdownEventHandler(FileSystemEventHandler):
     def _enqueue(self, path: str) -> None:
         p = Path(path)
         if p.suffix in self._supported:
-            try:
-                self._loop.call_soon_threadsafe(self._queue.put_nowait, p)
-            except asyncio.QueueFull:
-                logger.warning("File watcher queue full, dropping event for %s", p.name)
+            # ``call_soon_threadsafe`` only *schedules* the put — a full queue
+            # raises ``QueueFull`` later, inside the event loop's callback
+            # runner, so the try/except must live in the callback itself
+            # (catching it here is dead code and drops surface as unhandled
+            # "Exception in callback" tracebacks instead of the warning).
+            self._loop.call_soon_threadsafe(self._put_or_warn, p)
+
+    def _put_or_warn(self, p: Path) -> None:
+        """Runs on the event loop thread; drop loudly when the queue is full."""
+        try:
+            self._queue.put_nowait(p)
+        except asyncio.QueueFull:
+            logger.warning("File watcher queue full, dropping event for %s", p.name)
 
     def on_modified(self, event: FileSystemEvent) -> None:
         if not event.is_directory:

--- a/packages/memtomem/tests/test_cli_index_noop_e2e.py
+++ b/packages/memtomem/tests/test_cli_index_noop_e2e.py
@@ -263,6 +263,60 @@ def test_debounce_flush_surfaces_blocked_file_as_error(tmp_path, monkeypatch):
     assert payload["remaining"] == 1
 
 
+def test_debounce_flush_drops_poison_entry_after_cap(tmp_path, monkeypatch):
+    """A queue entry that fails on every drain is dropped after
+    ``_MAX_DRAIN_ATTEMPTS`` flushes, loudly: the human output and the
+    ``--json`` payload both carry a ``dropped`` record and the queue is
+    empty afterwards (#1574 item 3). Uses a redaction-blocked file as the
+    deterministic failure — the recorded decision is that blocked files
+    are capped too, since exempting them reintroduces unbounded retry.
+    """
+    from memtomem.cli import _bootstrap
+    from memtomem.indexing.debounce import _MAX_DRAIN_ATTEMPTS
+
+    for var in [k for k in os.environ if k.startswith("MEMTOMEM_")]:
+        monkeypatch.delenv(var, raising=False)
+
+    home = tmp_path / "home"
+    home.mkdir()
+    set_home(monkeypatch, home)
+    monkeypatch.setattr(_bootstrap, "_CONFIG_PATH", home / ".memtomem" / "config.json")
+    monkeypatch.setenv("MEMTOMEM_INDEX_DEBOUNCE_QUEUE", str(tmp_path / "debounce_queue.json"))
+
+    mem_dir = tmp_path / "memories"
+    mem_dir.mkdir()
+    secret = "hf" + "_FAKEfake0123456789FAKEfake01234567"
+    leak = mem_dir / "leak.md"
+    leak.write_text(f"# Leak\n\napi token: {secret}\n")
+
+    runner = CliRunner()
+    r = runner.invoke(
+        cli,
+        ["init", "-y", "--provider", "none", "--memory-dir", str(mem_dir), "--mcp", "skip"],
+    )
+    assert r.exit_code == 0, f"init failed: {r.output}"
+    r = runner.invoke(cli, ["index", "--debounce-window", "999999", str(leak)])
+    assert r.exit_code == 0, f"enqueue failed: {r.output}"
+
+    for i in range(_MAX_DRAIN_ATTEMPTS - 1):
+        r = runner.invoke(cli, ["index", "--flush"])
+        assert r.exit_code == 0, f"flush {i + 1} failed: {r.output}"
+        assert "Remaining in queue: 1" in r.output, f"flush {i + 1}: {r.output}"
+
+    r = runner.invoke(cli, ["index", "--flush", "--json"])
+    assert r.exit_code == 0, f"final flush failed: {r.output}"
+    payload = json.loads(r.output.strip().splitlines()[-1])
+    assert payload["errors"] == []
+    assert len(payload["dropped"]) == 1
+    assert payload["dropped"][0]["path"] == str(leak)
+    assert payload["remaining"] == 0
+
+    # Genuinely gone — the next flush sees an empty queue.
+    r = runner.invoke(cli, ["index", "--flush", "--json"])
+    payload = json.loads(r.output.strip().splitlines()[-1])
+    assert payload["indexed"] == [] and payload["dropped"] == [] and payload["remaining"] == 0
+
+
 def test_debounce_flush_drains_terminal_skip_without_livelock(tmp_path, monkeypatch):
     """A terminal, non-security skip (binary / too-large file) enqueued via the
     hook path must still **drain** — it must not stick in the queue and

--- a/packages/memtomem/tests/test_index_debounce.py
+++ b/packages/memtomem/tests/test_index_debounce.py
@@ -223,6 +223,136 @@ class TestDrainAll:
         assert result.remaining == 0
 
 
+class TestPoisonEntryCap:
+    """A deterministically-failing entry is retried up to
+    ``_MAX_DRAIN_ATTEMPTS`` and then dropped loudly — logged, removed from
+    the queue, and reported via ``DrainResult.dropped`` (#1574 item 3).
+    Without the cap, every hook fire and every Stop-hook ``--flush`` retries
+    the poison entry forever."""
+
+    @staticmethod
+    def _failing_indexer():
+        async def indexer(p: str, ns: str | None, force: bool) -> None:
+            raise RuntimeError("synthetic permanent failure")
+
+        return indexer
+
+    def test_entry_dropped_after_max_attempts(self, queue_file: Path, caplog) -> None:
+        debounce.enqueue("/tmp/poison.py", now=100.0, queue_file=queue_file)
+        indexer = self._failing_indexer()
+
+        for attempt in range(1, debounce._MAX_DRAIN_ATTEMPTS):
+            result = asyncio.run(
+                debounce.drain_ready(
+                    window_seconds=5.0, indexer=indexer, now=110.0, queue_file=queue_file
+                )
+            )
+            assert result.dropped == []
+            assert result.remaining == 1
+            # ``attempts`` persists on disk between drains (survives process
+            # restarts — the queue outlives any one hook invocation).
+            assert _read_raw(queue_file)["entries"]["/tmp/poison.py"]["attempts"] == attempt
+
+        with caplog.at_level("ERROR", logger="memtomem.indexing.debounce"):
+            result = asyncio.run(
+                debounce.drain_ready(
+                    window_seconds=5.0, indexer=indexer, now=110.0, queue_file=queue_file
+                )
+            )
+        assert result.indexed == []
+        assert result.errors == []
+        assert len(result.dropped) == 1
+        assert result.dropped[0][0] == "/tmp/poison.py"
+        assert result.remaining == 0
+        assert "/tmp/poison.py" not in _read_raw(queue_file)["entries"]
+        dropped_logs = [r.getMessage() for r in caplog.records if r.levelname == "ERROR"]
+        assert any("mm index /tmp/poison.py" in m for m in dropped_logs), (
+            "the drop must be loud and name the remediation command"
+        )
+
+    def test_drain_all_applies_the_same_cap(self, queue_file: Path) -> None:
+        """``drain_all`` backs the Stop-hook ``mm index --flush`` — the
+        highest-frequency automated drain — so it must not bypass the cap."""
+        debounce.enqueue("/tmp/poison.py", now=100.0, queue_file=queue_file)
+        indexer = self._failing_indexer()
+
+        for _ in range(debounce._MAX_DRAIN_ATTEMPTS - 1):
+            result = asyncio.run(debounce.drain_all(indexer=indexer, queue_file=queue_file))
+            assert result.dropped == []
+        result = asyncio.run(debounce.drain_all(indexer=indexer, queue_file=queue_file))
+        assert [p for p, _ in result.dropped] == ["/tmp/poison.py"]
+        assert result.remaining == 0
+        assert _read_raw(queue_file)["entries"] == {}
+
+    def test_reenqueue_resets_attempts(self, queue_file: Path) -> None:
+        """A re-enqueue is a real new write (the only enqueue caller is the
+        PostToolUse[Write] hook), so the entry gets a fresh retry budget —
+        the write may have fixed the failure."""
+        debounce.enqueue("/tmp/flaky.py", now=100.0, queue_file=queue_file)
+        indexer = self._failing_indexer()
+        for _ in range(debounce._MAX_DRAIN_ATTEMPTS - 1):
+            asyncio.run(
+                debounce.drain_ready(
+                    window_seconds=5.0, indexer=indexer, now=110.0, queue_file=queue_file
+                )
+            )
+        entries = _read_raw(queue_file)["entries"]
+        assert entries["/tmp/flaky.py"]["attempts"] == debounce._MAX_DRAIN_ATTEMPTS - 1
+
+        debounce.enqueue("/tmp/flaky.py", now=120.0, queue_file=queue_file)
+        assert _read_raw(queue_file)["entries"]["/tmp/flaky.py"]["attempts"] == 0
+
+    def test_success_after_failures_clears_entry(self, queue_file: Path) -> None:
+        """An entry that eventually succeeds is drained normally — the cap
+        only ever drops entries that fail on their final attempt."""
+        debounce.enqueue("/tmp/flaky.py", now=100.0, queue_file=queue_file)
+        calls = {"n": 0}
+
+        async def indexer(p: str, ns: str | None, force: bool) -> None:
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise RuntimeError("transient")
+
+        for _ in range(3):
+            result = asyncio.run(
+                debounce.drain_ready(
+                    window_seconds=5.0, indexer=indexer, now=110.0, queue_file=queue_file
+                )
+            )
+        assert result.indexed == ["/tmp/flaky.py"]
+        assert result.dropped == []
+        assert _read_raw(queue_file)["entries"] == {}
+
+    def test_legacy_queue_file_without_attempts_loads_as_zero(self, queue_file: Path) -> None:
+        """Queue files written before the ``attempts`` field must round-trip:
+        missing key loads as 0 and the first failure counts from there."""
+        queue_file.parent.mkdir(parents=True, exist_ok=True)
+        queue_file.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "entries": {
+                        "/tmp/legacy.py": {
+                            "first_seen": 100.0,
+                            "last_seen": 100.0,
+                            "namespace": None,
+                            "force": False,
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        indexer = self._failing_indexer()
+        result = asyncio.run(
+            debounce.drain_ready(
+                window_seconds=5.0, indexer=indexer, now=110.0, queue_file=queue_file
+            )
+        )
+        assert result.dropped == []
+        assert _read_raw(queue_file)["entries"]["/tmp/legacy.py"]["attempts"] == 1
+
+
 class TestStatusSnapshot:
     """``status_snapshot`` is read-without-lock. Concurrent enqueues may
     race the read; the docstring on :func:`status_snapshot` flags this so

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -797,9 +797,11 @@ class TestActiveRunsCounter:
 
     The counter feeds ``GET /api/indexing/active`` so the web UI's header
     indicator (#582 item 4.11) survives page reloads and reaches second
-    tabs. It must cover all three public entry points — including
-    ``index_path_stream``, which runs **outside** ``_index_lock`` and is
-    therefore invisible to ``asyncio.Lock.locked()``.
+    tabs. It must cover all three public entry points. It stays independent
+    of ``_index_lock``: runs also span discovery, gaps between files, and
+    lock-wait periods where ``asyncio.Lock.locked()`` would misreport
+    (since #1574 item 6 the stream takes the lock per file, but the
+    counter contract is unchanged).
     """
 
     async def test_idle_engine_is_not_active(self, components):
@@ -840,10 +842,10 @@ class TestActiveRunsCounter:
             engine._index_file = orig  # type: ignore[method-assign]
 
     async def test_active_during_index_path_stream(self, components, memory_dir):
-        """``index_path_stream`` runs outside ``_index_lock`` — verify the
-        counter still tracks it. This is the critical path: a server-bound
-        active-state endpoint that read ``_index_lock.locked()`` would
-        miss every streaming run.
+        """The counter must track stream runs across discovery and the gaps
+        between files, where no lock is held — an active-state endpoint
+        that read ``_index_lock.locked()`` would flicker off there even
+        though the stream now takes the lock per file (#1574 item 6).
         """
         (memory_dir / "notes.md").write_text("# Keep\n\nContent.")
         engine = components.index_engine
@@ -889,6 +891,74 @@ class TestActiveRunsCounter:
             assert engine.is_active is False
         finally:
             engine._index_file = orig  # type: ignore[method-assign]
+
+    async def test_stream_serializes_against_index_path(self, components, memory_dir):
+        """The stream's per-file work parks on ``_index_lock`` while an
+        ``index_path`` run holds it (#1574 item 6) — before that fix the
+        stream interleaved freely with locked runs on the same files."""
+        (memory_dir / "notes.md").write_text("# Keep\n\nContent.")
+        engine = components.index_engine
+        gate = asyncio.Event()
+        orig = engine._index_file
+        calls = {"n": 0}
+
+        async def first_call_blocked(fp, force=False, namespace=None, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:  # only index_path's call parks, holding the lock
+                await gate.wait()
+            return await orig(fp, force, namespace=namespace)
+
+        engine._index_file = first_call_blocked  # type: ignore[method-assign]
+        try:
+            locked_run = asyncio.create_task(engine.index_path(memory_dir))
+            for _ in range(5):
+                await asyncio.sleep(0)
+            assert engine._index_lock.locked(), "index_path must be parked holding the lock"
+
+            gen = engine.index_path_stream(memory_dir, recursive=True)
+            ev = await gen.__anext__()
+            assert ev["type"] == "discovery"  # discovery needs no lock
+            nxt = asyncio.create_task(gen.__anext__())
+            for _ in range(10):
+                await asyncio.sleep(0)
+            assert not nxt.done(), (
+                "stream produced a per-file event while index_path held _index_lock"
+            )
+
+            gate.set()
+            await locked_run
+            ev = await nxt
+            assert ev["type"] in ("chunk_progress", "progress")
+            async for _ in gen:
+                pass
+        finally:
+            engine._index_file = orig  # type: ignore[method-assign]
+
+    async def test_stream_aclose_while_parked_on_index_lock(self, components, memory_dir):
+        """Cancelling a stream whose runner is waiting on ``_index_lock``
+        must unwind cleanly: counter back to 0 and the lock not leaked
+        (#1574 item 6 cancellation contract)."""
+        (memory_dir / "notes.md").write_text("# Keep\n\nContent.")
+        engine = components.index_engine
+
+        await engine._index_lock.acquire()  # stand in for a concurrent locked run
+        try:
+            gen = engine.index_path_stream(memory_dir, recursive=True)
+            ev = await gen.__anext__()
+            assert ev["type"] == "discovery"
+            nxt = asyncio.create_task(gen.__anext__())
+            for _ in range(5):
+                await asyncio.sleep(0)
+            assert not nxt.done()
+
+            nxt.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await nxt
+            assert engine._active_runs == 0
+            assert engine.is_active is False
+        finally:
+            engine._index_lock.release()
+        assert not engine._index_lock.locked(), "cancelled stream leaked _index_lock"
 
     async def test_decrements_on_stream_aclose(self, components, memory_dir):
         """Async-generator path relies on ``GeneratorExit`` triggering the

--- a/packages/memtomem/tests/test_memory_crud_cross_process.py
+++ b/packages/memtomem/tests/test_memory_crud_cross_process.py
@@ -228,6 +228,77 @@ async def test_index_file_parent_gone_skips_sidecar_without_mkdir(
     assert not (tmp_path / "gone").exists(), "sidecar acquire resurrected the deleted parent dir"
 
 
+@pytest.mark.asyncio
+async def test_stream_acquires_sidecar_while_index_lock_free(bm25_only_components, monkeypatch):
+    """``index_path_stream`` uses the same L2 → L3 order as ``index_file``
+    (via ``_index_file_locked``): the sidecar acquire happens while
+    ``_index_lock`` is free (#1574 item 6). Before that fix the stream
+    bypassed both locks entirely — ``calls`` would be empty."""
+    comp, mem_dir = bm25_only_components
+    src = mem_dir / "rule.md"
+    src.write_text("## Rule\n\nbody.\n", encoding="utf-8")
+
+    engine = comp.index_engine
+    index_lock_held_at_acquire: list[bool] = []
+    real = atomic_mod.async_file_lock
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def spy(lock_path, *, timeout):
+        index_lock_held_at_acquire.append(engine._index_lock.locked())
+        async with real(lock_path, timeout=timeout):
+            yield
+
+    monkeypatch.setattr(atomic_mod, "async_file_lock", spy)
+    async for _event in engine.index_path_stream(src, recursive=False):
+        pass
+
+    assert index_lock_held_at_acquire == [False], (
+        "the stream must take the sidecar (L2) before _index_lock (L3), once per file"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_sidecar_timeout_folds_into_errors_and_continues(
+    bm25_only_components, monkeypatch
+):
+    """A held sidecar on one file must not abort the stream: that file's
+    ``TimeoutError`` lands in ``complete.errors`` (no new event type) and
+    the remaining files still index (#1574 item 6)."""
+    comp, mem_dir = bm25_only_components
+    stuck = mem_dir / "a-stuck.md"
+    ok = mem_dir / "b-ok.md"
+    stuck.write_text("## Stuck\n\nheld.\n", encoding="utf-8")
+    ok.write_text("## Ok\n\nfree.\n", encoding="utf-8")
+
+    monkeypatch.setattr(atomic_mod, "_MEMORY_SIDECAR_LOCK_BUDGET_S", 0.2)
+
+    held = asyncio.Event()
+    release = asyncio.Event()
+
+    async def holder() -> None:
+        async with async_file_lock(_lock_path_for(stuck.resolve()), timeout=5.0):
+            held.set()
+            await release.wait()
+
+    holder_task = asyncio.create_task(holder())
+    await held.wait()
+    try:
+        events = [e async for e in comp.index_engine.index_path_stream(mem_dir, recursive=True)]
+    finally:
+        release.set()
+        await holder_task
+
+    complete = next(e for e in events if e["type"] == "complete")
+    assert len(complete["errors"]) == 1, f"expected 1 timeout error, got {complete['errors']}"
+    assert "a-stuck.md" in complete["errors"][0]
+    # The other file still indexed — the stream continued past the timeout.
+    sources = {p.name for p in await comp.storage.get_all_source_files()}
+    assert "b-ok.md" in sources
+    assert "a-stuck.md" not in sources
+
+
 # ============================================================ C. timeout surface
 
 

--- a/packages/memtomem/tests/test_watcher_deleted_files.py
+++ b/packages/memtomem/tests/test_watcher_deleted_files.py
@@ -22,6 +22,7 @@ from unittest import mock
 from watchdog.events import (
     DirDeletedEvent,
     FileDeletedEvent,
+    FileModifiedEvent,
     FileMovedEvent,
 )
 
@@ -102,6 +103,41 @@ class TestMarkdownEventHandlerDeleteMove:
         handler.on_moved(FileMovedEvent("/mem/old.txt", "/mem/new.md"))
         await asyncio.sleep(0)
         assert self._drain(queue) == {Path("/mem/new.md")}
+
+
+class TestQueueFullDrop:
+    """A full queue must drop the event via the one-line warning, not an
+    unhandled "Exception in callback" traceback (#1574 item 1).
+
+    ``call_soon_threadsafe`` only *schedules* the put, so a ``QueueFull``
+    fires later, inside the event loop's callback runner — the try/except
+    has to live in the callback itself for the warning path to be live.
+    """
+
+    async def test_full_queue_warns_instead_of_unhandled_callback_error(self, caplog):
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue[Path] = asyncio.Queue(maxsize=1)
+        queue.put_nowait(Path("/mem/occupied.md"))
+        handler = _MarkdownEventHandler(queue, loop, frozenset({".md"}))
+
+        unhandled: list[dict] = []
+        prev_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, ctx: unhandled.append(ctx))
+        try:
+            with caplog.at_level(logging.WARNING, logger="memtomem.indexing.watcher"):
+                handler.on_modified(FileModifiedEvent("/mem/dropped.md"))
+                await asyncio.sleep(0)  # run the scheduled callback on the loop
+        finally:
+            loop.set_exception_handler(prev_handler)
+
+        assert unhandled == [], (
+            "queue-full must be caught in the loop-side callback, not routed to "
+            "the loop exception handler as an unhandled callback error"
+        )
+        assert any("queue full" in r.getMessage().lower() for r in caplog.records)
+        # The event was dropped; the occupied slot is untouched.
+        assert queue.get_nowait() == Path("/mem/occupied.md")
+        assert queue.empty()
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Fixes items **1, 3, 6** of #1574 (small-batch operational-stability follow-ups, indexing subsystem).

### Item 1 — watcher queue-full handler was dead code
`_enqueue` runs on the watchdog observer thread; `call_soon_threadsafe(put_nowait, p)` only *schedules* the put, so `asyncio.QueueFull` fired later inside the event loop and the `try/except` never caught it — a burst surfaced as unhandled-callback tracebacks. The try/except now lives in a loop-side callback (`_put_or_warn`), so a drop is one warning line and never reaches the loop exception handler.

### Item 3 — debounce drain retried a poison entry forever
A deterministically-failing path was kept and re-attempted on every hook fire and every Stop-hook `--flush`, with no cap. Entries now carry a persisted `attempts` counter: after 5 failed drains the entry is dropped loudly (`logger.error` naming `mm index <path>` as remediation) and reported via `DrainResult.dropped`, which both `mm index` output shapes surface. A re-enqueue (a real new `Write`) resets the counter; legacy queue files without the field load as 0. Recorded decision: redaction-blocked files are capped too — exempting them would reintroduce the unbounded-retry class (drop log names the re-run command).

### Item 6 — `index_path_stream` ran outside the locks
The stream called `_index_file` directly, bypassing the L2 sidecar + L3 `_index_lock` that `index_file` has held since #1587 — a web stream-reindex could interleave with a watcher/CLI/CRUD reindex of the same file and lose a stale-chunk delete. The lock policy is extracted into `_index_file_locked` (single home for `index_file` and the stream runner, no drift) and taken **per file**, so streaming progress survives; a sidecar timeout folds into that file's `errors` and the stream continues. `_active_runs` accounting is unchanged.

## Tests

All red-first against the pre-fix source (verified by stash-revert run):
- watcher: full queue → warning logged, loop exception handler not invoked
- debounce: drop on Nth failure (+ loud log with remediation), `drain_all` uniformity, re-enqueue reset, success-after-failures, legacy-file round-trip, CLI e2e `--flush --json` `dropped` payload
- stream: sidecar acquired while `_index_lock` free, sidecar timeout continues the stream, serializes against `index_path`, `aclose`/cancel while parked on the lock unwinds cleanly

Full suite: 7736 passed, 11 skipped. Codex review: SHIP (no findings).

Part of #1574 (items 1, 3, 6 — items 2, 4, 5, 7, 8 follow in sibling PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
