### PR TITLE
perf(web,mcp): offload remaining blocking read-path work off the event loop (#1518)

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -397,7 +397,10 @@ async def mem_context_init(
 
     if "agents" in inc:
         try:
-            agent_result = extract_agents_to_canonical(
+            # Same offload as skills above (#1518 uniformity): the engine
+            # scans runtime dirs and writes canonical files synchronously.
+            agent_result = await asyncio.to_thread(
+                extract_agents_to_canonical,
                 root,
                 overwrite=overwrite,
                 scope=artifact_scope,
@@ -416,7 +419,8 @@ async def mem_context_init(
 
     if "commands" in inc:
         try:
-            command_result = extract_commands_to_canonical(
+            command_result = await asyncio.to_thread(
+                extract_commands_to_canonical,
                 root,
                 overwrite=overwrite,
                 scope=artifact_scope,
@@ -669,7 +673,10 @@ async def mem_context_generate(
 
     if "agents" in inc:
         try:
-            agent_result = generate_all_agents(
+            # Same offload as skills above (#1518 uniformity): the engine
+            # scans canonical dirs and writes runtime fan-out synchronously.
+            agent_result = await asyncio.to_thread(
+                generate_all_agents,
                 root,
                 strict=strict,
                 on_drop=on_drop,
@@ -697,7 +704,8 @@ async def mem_context_generate(
 
     if "commands" in inc:
         try:
-            command_result = generate_all_commands(
+            command_result = await asyncio.to_thread(
+                generate_all_commands,
                 root,
                 strict=strict,
                 on_drop=on_drop,
@@ -734,8 +742,8 @@ async def mem_context_generate(
         # Surface cross-tier duplicate-hook warnings, matching the CLI
         # ``_print_settings_generate`` which prints them before the results.
         results.extend(_settings_dup_tier_warnings(root, settings_scope))
-        settings_results = generate_all_settings(
-            root, scope=settings_scope, allow_host_writes=allow_host_writes
+        settings_results = await asyncio.to_thread(
+            generate_all_settings, root, scope=settings_scope, allow_host_writes=allow_host_writes
         )
         # Settings reasons embed absolute ``canonical_path`` / ``target_path``
         # values (context/settings.py f-strings), and the ok-row target is an
@@ -817,7 +825,9 @@ async def mem_context_diff(
         lines.append(f"({CONTEXT_FILENAME} missing — skipping project memory)")
 
     if "skills" in inc:
-        rows = diff_skills(root, scope=artifact_scope)
+        # Diff engines scan canonical + N runtime dirs per kind — off the
+        # event loop like the per-file reads above (#1518 uniformity).
+        rows = await asyncio.to_thread(diff_skills, root, scope=artifact_scope)
         if rows:
             if lines:
                 lines.append("")
@@ -831,7 +841,7 @@ async def mem_context_diff(
             lines.append("No skills to compare.")
 
     if "agents" in inc:
-        rows = diff_agents(root, scope=artifact_scope)
+        rows = await asyncio.to_thread(diff_agents, root, scope=artifact_scope)
         if rows:
             if lines:
                 lines.append("")
@@ -845,7 +855,7 @@ async def mem_context_diff(
             lines.append("No sub-agents to compare.")
 
     if "commands" in inc:
-        rows = diff_commands(root, scope=artifact_scope)
+        rows = await asyncio.to_thread(diff_commands, root, scope=artifact_scope)
         if rows:
             if lines:
                 lines.append("")
@@ -871,7 +881,7 @@ async def mem_context_diff(
         # Cross-tier duplicate-hook warnings, matching the CLI
         # ``_print_settings_diff`` which prints them before the rows.
         dup_warnings = _settings_dup_tier_warnings(root, settings_scope)
-        settings_results = _diff_settings(root, scope=settings_scope)
+        settings_results = await asyncio.to_thread(_diff_settings, root, scope=settings_scope)
         if settings_results or dup_warnings:
             if lines:
                 lines.append("")
@@ -1015,7 +1025,9 @@ async def mem_context_sync(
 
     if "agents" in inc:
         try:
-            agent_result = generate_all_agents(
+            # Same offload as skills above (#1518 uniformity).
+            agent_result = await asyncio.to_thread(
+                generate_all_agents,
                 root,
                 strict=strict,
                 on_drop=on_drop,
@@ -1044,7 +1056,8 @@ async def mem_context_sync(
 
     if "commands" in inc:
         try:
-            command_result = generate_all_commands(
+            command_result = await asyncio.to_thread(
+                generate_all_commands,
                 root,
                 strict=strict,
                 on_drop=on_drop,
@@ -1082,8 +1095,8 @@ async def mem_context_sync(
         # Surface cross-tier duplicate-hook warnings, matching the CLI
         # ``_print_settings_generate`` which prints them before the results.
         results.extend(_settings_dup_tier_warnings(root, settings_scope))
-        settings_results = generate_all_settings(
-            root, scope=settings_scope, allow_host_writes=allow_host_writes
+        settings_results = await asyncio.to_thread(
+            generate_all_settings, root, scope=settings_scope, allow_host_writes=allow_host_writes
         )
         # Same MCP wire-boundary redaction as the generate settings loop —
         # reasons embed absolute canonical/target paths, the ok-row target is

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -327,120 +327,128 @@ async def context_overview(
     from memtomem.context.mcp_servers import diff_mcp_servers, list_canonical_mcp_servers
     from memtomem.context.skills import diff_skills, list_canonical_skills
 
-    result: dict[str, dict[str, int | bool | str]] = {}
+    def _collect() -> dict:
+        result: dict[str, dict[str, int | bool | str]] = {}
 
-    try:
-        result["skills"] = summarize_diff_with_canonical(
-            diff_skills(project_root, scope=target_scope),
-            {p.name for p in list_canonical_skills(project_root, scope=target_scope)},
-        )
-    except Exception as exc:
-        logger.exception("diff_skills failed")
-        result["skills"] = _error_payload(exc, shape="total")
-
-    try:
-        result["commands"] = summarize_diff_with_canonical(
-            diff_commands(project_root, scope=target_scope),
-            {
-                canonical_command_name(p, layout)
-                for p, layout in list_canonical_commands(project_root, scope=target_scope)
-            },
-        )
-    except Exception as exc:
-        logger.exception("diff_commands failed")
-        result["commands"] = _error_payload(exc, shape="total")
-
-    try:
-        result["agents"] = summarize_diff_with_canonical(
-            diff_agents(project_root, scope=target_scope),
-            {
-                canonical_agent_name(p, layout)
-                for p, layout in list_canonical_agents(project_root, scope=target_scope)
-            },
-        )
-    except Exception as exc:
-        logger.exception("diff_agents failed")
-        result["agents"] = _error_payload(exc, shape="total")
-
-    try:
-        if target_scope == "project_shared":
-            result["mcp_servers"] = summarize_diff_with_canonical(
-                diff_mcp_servers(project_root),
-                {p.stem for p in list_canonical_mcp_servers(project_root)},
+        try:
+            result["skills"] = summarize_diff_with_canonical(
+                diff_skills(project_root, scope=target_scope),
+                {p.name for p in list_canonical_skills(project_root, scope=target_scope)},
             )
-        else:
-            result["mcp_servers"] = {"total": 0, "local_draft": 0}
-    except Exception as exc:
-        logger.exception("diff_mcp_servers failed")
-        result["mcp_servers"] = _error_payload(exc, shape="total")
+        except Exception as exc:
+            logger.exception("diff_skills failed")
+            result["skills"] = _error_payload(exc, shape="total")
 
-    try:
-        settings_diff = diff_settings(project_root, scope=target_scope)
-        # In-band `error` is a COUNT (per-file failures already classified by
-        # diff_settings — no error_kind, which would conflate distinct per-file
-        # causes), NOT the bool flag `_error_payload(shape="status")` emits
-        # when the whole call raises. The two shapes are on disjoint code
-        # paths. The frontend uses truthiness on `d.error` (any positive int
-        # OR the bool `true` reaches the danger render at
-        # context-gateway.js:136-145), so `error: 0` correctly skips the
-        # danger branch and `error: >=1` reaches it — both shapes work.
-        result["settings"] = summarize_settings_statuses([r.status for r in settings_diff.values()])
-    except Exception as exc:
-        logger.exception("diff_settings failed")
-        result["settings"] = _error_payload(exc, shape="status")
+        try:
+            result["commands"] = summarize_diff_with_canonical(
+                diff_commands(project_root, scope=target_scope),
+                {
+                    canonical_command_name(p, layout)
+                    for p, layout in list_canonical_commands(project_root, scope=target_scope)
+                },
+            )
+        except Exception as exc:
+            logger.exception("diff_commands failed")
+            result["commands"] = _error_payload(exc, shape="total")
 
-    # Wiki-install staleness axis (0629 backlog c/d): the count of installed
-    # assets whose lockfile pin sits behind wiki HEAD ("update available").
-    # This is the lockfile↔wiki axis — none of the canonical→runtime tiles
-    # above carry it, and the cross-project /context/status-all route that
-    # does has zero web consumers by design. ``None`` (not zeros) on failure:
-    # the badge is a pure header enhancement, but "0 behind" is a clean-state
-    # claim we can't back when the classifier itself raised.
-    wiki_installs: dict[str, int] | None
-    try:
-        if target_scope == "project_shared":
-            # classify_status shells out to git per lockfile entry
-            # (HEAD probe + per-pin reachability), so it runs off the event
-            # loop (#1145 discipline); the diff blocks above are filesystem
-            # reads only.
-            _wiki_head, status_rows = await asyncio.to_thread(classify_status, project_root)
-            tracked = [
-                row
-                for row in status_rows
-                if row.tier == "project_shared" and row.state != "untracked"
-            ]
-            wiki_installs = {
-                "total": len(tracked),
-                "behind": sum(1 for row in tracked if row.state == "behind"),
-            }
-        else:
-            # Wiki installs are lockfile-tracked project_shared snapshots
-            # only — mirror the mcp_servers single-tier placeholder.
-            wiki_installs = {"total": 0, "behind": 0}
-    except Exception:
-        logger.exception("classify_status failed")
-        wiki_installs = None
+        try:
+            result["agents"] = summarize_diff_with_canonical(
+                diff_agents(project_root, scope=target_scope),
+                {
+                    canonical_agent_name(p, layout)
+                    for p, layout in list_canonical_agents(project_root, scope=target_scope)
+                },
+            )
+        except Exception as exc:
+            logger.exception("diff_agents failed")
+            result["agents"] = _error_payload(exc, shape="total")
 
-    try:
-        detected_runtimes = _compute_detected_runtimes(project_root)
-    except Exception:
-        logger.exception("_compute_detected_runtimes failed")
-        detected_runtimes = []
+        try:
+            if target_scope == "project_shared":
+                result["mcp_servers"] = summarize_diff_with_canonical(
+                    diff_mcp_servers(project_root),
+                    {p.stem for p in list_canonical_mcp_servers(project_root)},
+                )
+            else:
+                result["mcp_servers"] = {"total": 0, "local_draft": 0}
+        except Exception as exc:
+            logger.exception("diff_mcp_servers failed")
+            result["mcp_servers"] = _error_payload(exc, shape="total")
 
-    try:
-        last_synced_at = _compute_last_synced_at(project_root, target_scope)
-    except Exception:
-        logger.exception("_compute_last_synced_at failed")
-        last_synced_at = None
+        try:
+            settings_diff = diff_settings(project_root, scope=target_scope)
+            # In-band `error` is a COUNT (per-file failures already classified
+            # by diff_settings — no error_kind, which would conflate distinct
+            # per-file causes), NOT the bool flag `_error_payload(shape="status")`
+            # emits when the whole call raises. The two shapes are on disjoint
+            # code paths. The frontend uses truthiness on `d.error` (any
+            # positive int OR the bool `true` reaches the danger render at
+            # context-gateway.js:136-145), so `error: 0` correctly skips the
+            # danger branch and `error: >=1` reaches it — both shapes work.
+            result["settings"] = summarize_settings_statuses(
+                [r.status for r in settings_diff.values()]
+            )
+        except Exception as exc:
+            logger.exception("diff_settings failed")
+            result["settings"] = _error_payload(exc, shape="status")
 
-    return {
-        "target_scope": target_scope,
-        "project_root": str(project_root),
-        "detected_runtimes": detected_runtimes,
-        "last_synced_at": last_synced_at,
-        "wiki_installs": wiki_installs,
-        **result,
-    }
+        # Wiki-install staleness axis (0629 backlog c/d): the count of
+        # installed assets whose lockfile pin sits behind wiki HEAD ("update
+        # available"). This is the lockfile↔wiki axis — none of the
+        # canonical→runtime tiles above carry it, and the cross-project
+        # /context/status-all route that does has zero web consumers by
+        # design. ``None`` (not zeros) on failure: the badge is a pure header
+        # enhancement, but "0 behind" is a clean-state claim we can't back
+        # when the classifier itself raised.
+        wiki_installs: dict[str, int] | None
+        try:
+            if target_scope == "project_shared":
+                _wiki_head, status_rows = classify_status(project_root)
+                tracked = [
+                    row
+                    for row in status_rows
+                    if row.tier == "project_shared" and row.state != "untracked"
+                ]
+                wiki_installs = {
+                    "total": len(tracked),
+                    "behind": sum(1 for row in tracked if row.state == "behind"),
+                }
+            else:
+                # Wiki installs are lockfile-tracked project_shared snapshots
+                # only — mirror the mcp_servers single-tier placeholder.
+                wiki_installs = {"total": 0, "behind": 0}
+        except Exception:
+            logger.exception("classify_status failed")
+            wiki_installs = None
+
+        try:
+            detected_runtimes = _compute_detected_runtimes(project_root)
+        except Exception:
+            logger.exception("_compute_detected_runtimes failed")
+            detected_runtimes = []
+
+        try:
+            last_synced_at = _compute_last_synced_at(project_root, target_scope)
+        except Exception:
+            logger.exception("_compute_last_synced_at failed")
+            last_synced_at = None
+
+        return {
+            "target_scope": target_scope,
+            "project_root": str(project_root),
+            "detected_runtimes": detected_runtimes,
+            "last_synced_at": last_synced_at,
+            "wiki_installs": wiki_installs,
+            **result,
+        }
+
+    # The whole aggregation — per-kind diffs (filesystem scans), the
+    # classify_status git probes (#1145 discipline), and the runtime/mtime
+    # sweeps — runs off the event loop in one hop, mirroring status-all
+    # (#1280). Per-kind failures are converted to error payloads inside the
+    # closure, so this await only raises on a defect in the shaping itself.
+    # No gateway lock: read-only path (#1518).
+    return await asyncio.to_thread(_collect)
 
 
 @router.get("/context/runtimes")

--- a/packages/memtomem/src/memtomem/web/routes/context_projects.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_projects.py
@@ -20,6 +20,7 @@ exactly one implementation.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 
@@ -431,9 +432,9 @@ async def list_projects(
     with_counts = "counts" in include_tokens
     with_coverage = "runtime_coverage" in include_tokens
     scopes = _discover_for(request)
-    return {
-        "target_scope": target_scope,
-        "scopes": [
+
+    def _build() -> list[dict]:
+        return [
             _scope_to_dict(
                 s,
                 with_counts=with_counts,
@@ -441,7 +442,17 @@ async def list_projects(
                 target_scope=target_scope,
             )
             for s in scopes
-        ],
+        ]
+
+    # counts/runtime_coverage cost N-scope artifact scans / config probes
+    # (see _counts_for), so the opt-in path runs off the event loop like
+    # status-all (#1280, #1518); the default path is pure dict shaping and
+    # stays inline ("cheap by default", ADR-0021 PR2). Per-kind failures are
+    # already handled inside _counts_for.
+    scope_dicts = await asyncio.to_thread(_build) if (with_counts or with_coverage) else _build()
+    return {
+        "target_scope": target_scope,
+        "scopes": scope_dicts,
     }
 
 

--- a/packages/memtomem/src/memtomem/web/routes/wiki_mutations.py
+++ b/packages/memtomem/src/memtomem/web/routes/wiki_mutations.py
@@ -118,11 +118,8 @@ async def seed_wiki_override(asset_type: AssetType, name: str, body: OverrideSee
     _require_vendor(asset_type, body.vendor)
     store = WikiStore.at_default()
 
-    def _seed() -> tuple[SeedResult, bool]:
-        result = seed_override(store, asset_type, name, body.vendor, force=body.force)
-        # Seeding always leaves the working tree dirty (new/changed file); read
-        # it back rather than assume so an identical-bytes re-seed reports clean.
-        return result, store.is_dirty()
+    def _seed() -> SeedResult:
+        return seed_override(store, asset_type, name, body.vendor, force=body.force)
 
     try:
         # Force-seed mutates ``overrides/<vendor>.<ext>`` (and a ``.bak`` on
@@ -139,7 +136,14 @@ async def seed_wiki_override(asset_type: AssetType, name: str, body: OverrideSee
         # can only fire while CONTENDING for the lock — never mid-write.
         async with asyncio.timeout(60):
             async with _gateway_lock:
-                result, wiki_dirty = _seed()
+                result = _seed()
+        # Seeding always leaves the working tree dirty (new/changed file); read
+        # it back rather than assume so an identical-bytes re-seed reports
+        # clean. The git-status subprocess runs off the event loop AFTER the
+        # lock releases (#1518) — the flag is advisory, so a concurrent mutator
+        # sneaking in between the write and this read is acceptable (the value
+        # still reflects a real repo state).
+        wiki_dirty = await asyncio.to_thread(store.is_dirty)
     except WikiNotFoundError as exc:
         raise _wiki_absent(exc) from exc
     except OverrideExistsError as exc:
@@ -342,7 +346,10 @@ async def edit_wiki_override(
                         reason_code="canonical_absent",
                     ) from exc
                 new_mtime_ns = target.stat().st_mtime_ns
-                wiki_dirty = store.is_dirty()
+        # Trailing dirty-read: a git-status subprocess, so it runs off the
+        # event loop after the lock releases (#1518). Advisory flag — a
+        # concurrent mutator between the write and this read is acceptable.
+        wiki_dirty = await asyncio.to_thread(store.is_dirty)
     except TimeoutError as exc:
         raise _error(
             503, "busy", "wiki override save timed out — another sync may be in progress"
@@ -515,7 +522,10 @@ async def edit_wiki_canonical(
                         reason_code="canonical_absent",
                     ) from exc
                 new_mtime_ns = target.stat().st_mtime_ns
-                wiki_dirty = store.is_dirty()
+        # Trailing dirty-read: a git-status subprocess, so it runs off the
+        # event loop after the lock releases (#1518). Advisory flag — a
+        # concurrent mutator between the write and this read is acceptable.
+        wiki_dirty = await asyncio.to_thread(store.is_dirty)
     except TimeoutError as exc:
         raise _error(
             503, "busy", "wiki canonical save timed out — another sync may be in progress"

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -150,6 +150,27 @@ class TestOverview:
         assert data["project_root"] == str(tmp_path)
 
     @pytest.mark.anyio
+    async def test_overview_scans_run_off_the_event_loop(self, client: AsyncClient, monkeypatch):
+        # #1518: the whole per-kind scan aggregation runs via asyncio.to_thread
+        # (mirroring status-all, #1280) — pinned deterministically by the
+        # executing thread of one representative diff engine.
+        import threading
+
+        from memtomem.context import skills as skills_mod
+
+        real_diff = skills_mod.diff_skills
+        ran_on_main: dict[str, bool] = {}
+
+        def _record_thread(*args, **kwargs):
+            ran_on_main["value"] = threading.current_thread() is threading.main_thread()
+            return real_diff(*args, **kwargs)
+
+        monkeypatch.setattr(skills_mod, "diff_skills", _record_thread)
+        r = await client.get("/api/context/overview")
+        assert r.status_code == 200
+        assert ran_on_main.get("value") is False  # offloaded (#1518)
+
+    @pytest.mark.anyio
     async def test_overview_detected_runtimes_shape(self, client: AsyncClient):
         r = await client.get("/api/context/overview")
         data = r.json()

--- a/packages/memtomem/tests/test_web_routes_wiki_mutations.py
+++ b/packages/memtomem/tests/test_web_routes_wiki_mutations.py
@@ -256,6 +256,32 @@ async def test_seed_runs_synchronously_inside_lock(
     assert ran_on_main.get("value") is True  # synchronous, inside the lock
 
 
+@pytest.mark.asyncio
+async def test_seed_dirty_read_runs_off_the_event_loop(
+    dev_client, seeded_wiki: Path, monkeypatch
+) -> None:
+    # #1518: the inverse pin of test_seed_runs_synchronously_inside_lock. The
+    # trailing is_dirty() is a git-status subprocess and must run via
+    # asyncio.to_thread AFTER the lock releases — i.e. on a pool worker, not
+    # the event loop's (main) thread. The write above it stays main-thread
+    # (previous test); only the advisory dirty-read moves off-loop.
+    import threading
+
+    real_is_dirty = WikiStore.is_dirty
+    ran_on_main: dict[str, bool] = {}
+
+    def _record_thread(self):
+        ran_on_main["value"] = threading.current_thread() is threading.main_thread()
+        return real_is_dirty(self)
+
+    monkeypatch.setattr(WikiStore, "is_dirty", _record_thread)
+    resp = await dev_client.post("/api/wiki/skills/alpha/override", json={"vendor": "claude"})
+
+    assert resp.status_code == 200, resp.text
+    assert ran_on_main.get("value") is False  # offloaded, post-lock
+    assert resp.json()["wiki_dirty"] is True  # value contract unchanged
+
+
 # ── tier gating ────────────────────────────────────────────────────────────
 
 
@@ -345,6 +371,35 @@ async def test_edit_override_happy_path(dev_client, seeded_wiki: Path) -> None:
     assert target.read_text(encoding="utf-8") == new
     # Editing an existing override keeps the prior bytes as a .bak sibling.
     assert target.with_suffix(".md.bak").read_text(encoding="utf-8") == _SKILL_BODY
+
+
+@pytest.mark.asyncio
+async def test_edit_dirty_read_runs_off_the_event_loop(
+    dev_client, seeded_wiki: Path, monkeypatch
+) -> None:
+    # #1518: same pin as test_seed_dirty_read_runs_off_the_event_loop for the
+    # editor PUT — the trailing git-status dirty-read runs on a pool worker
+    # after _gateway_lock releases; the write itself stays in-lock/main-thread.
+    import threading
+
+    real_is_dirty = WikiStore.is_dirty
+    ran_on_main: dict[str, bool] = {}
+
+    def _record_thread(self):
+        ran_on_main["value"] = threading.current_thread() is threading.main_thread()
+        return real_is_dirty(self)
+
+    monkeypatch.setattr(WikiStore, "is_dirty", _record_thread)
+    m = await _seed_and_commit(dev_client, seeded_wiki)
+    ran_on_main.clear()  # ignore the seed route's own dirty-read
+    resp = await dev_client.put(
+        "/api/wiki/skills/alpha/override",
+        json={"vendor": "claude", "content": "# edited\n", "mtime_ns": m},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert ran_on_main.get("value") is False  # offloaded, post-lock
+    assert resp.json()["wiki_dirty"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #1518. Offloads the four remaining read/post-write paths that still ran blocking filesystem/git work directly on the async event loop, matching the `asyncio.to_thread` pattern `/api/context/status-all` established in #1280. No lock is held in these paths, so this is stall-risk (a slow scan blocks every other coroutine on the loop), not deadlock-risk — CONFIRMED by the 2026-07-02 review.

## Sites

1. **`context_overview`** (`web/routes/context_gateway.py`) — the per-kind scan aggregation (skills/commands/agents/mcp/settings diffs + `classify_status` git probes + runtime/last-synced sweeps) is bundled into one `_collect()` closure and run in a single `to_thread` hop. Per-kind error payloads and response shape are byte-identical (the `try`/`except` blocks moved inside the closure verbatim); the previously separate `classify_status` offload is folded in.
2. **`list_projects?include=counts`** (`web/routes/context_projects.py`) — the per-scope dict build is offloaded when `counts`/`runtime_coverage` is requested (each scope costs N artifact scans / config probes). The default path stays inline — pure dict shaping, "cheap by default" (ADR-0021 PR2).
3. **Wiki editor PUT (override + canonical) + seed** (`web/routes/wiki_mutations.py`) — the trailing `store.is_dirty()` git-status subprocess moves out of `_gateway_lock` to a post-lock `to_thread` call. The write stays synchronous inside the lock, so the `_locks.py` invariant (no `await` between acquire and release) is preserved and the seed main-thread guard still holds. The seed return is split so `is_dirty()` no longer rides inside the in-lock `_seed()` closure.
4. **MCP context tools** (`server/tools/context.py`) — `generate`/`init`/`sync`/`diff` wrap the agents, commands, and settings engines in `to_thread`, matching skills (already offloaded, #1247 id 18). Thread-raised exceptions (`StrictDropError`/`PrivacyScanError`/`ClickException`) are re-raised by `to_thread` and still caught by the existing handlers.

## Behavior parity

- **Site 3 semantic note:** the dirty-read now runs after the lock releases, so a concurrent mutation could flip the flag between the write and the read. Acceptable — it's an advisory UI flag whose value still reflects a real repo state.
- No response shapes, error envelopes, or status codes change anywhere.

## Tests

- New thread-assertion pins: the wiki dirty-read runs **off** the main thread after `edit` and `seed` (the inverse of the existing seed-*write* main-thread guard, which still passes), and the overview scan aggregation runs off-loop.
- Full suite green: **7794 passed, 11 skipped**. `ruff check` + `format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
