### PR TITLE
chore: #1520 code-health batch — drop dead user_tier_enabled flag, redact MCP success-path paths, sync-doctor ls-files -z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   count as credentials — they are read by the SDK itself and are never copied
   into memtomem config. `LANGFUSE_ENABLED` alone never turns tracing on.
 
+### Removed
+
+- **The reserved config flag `context_gateway.user_tier_enabled` is gone**
+  (#1520 item 3). It was declared forward-compat for the multi-project
+  context UI RFC's PR3, which never shipped — the flag had zero read sites,
+  so it never gated anything. A stale key left in `~/.memtomem/config.json`
+  or a `config.d` fragment is skipped silently (both loaders guard unknown
+  field names); the one breaking edge is the env var
+  `MEMTOMEM_CONTEXT_GATEWAY__USER_TIER_ENABLED`, which now fails startup
+  validation — unset it. If PR3 lands, the flag returns wired to real
+  read sites.
+
 ### Fixed
 
 - **`mm upgrade` now stops a running `mm web` too, not just the MCP server**

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -894,7 +894,8 @@ project root the gateway knows about — the server's current working
 directory, any roots registered via the Web UI, and (opt-in) decoded paths
 from `~/.claude/projects/`. These project roots populate `project_shared`
 and `project_local` tier entries; the `user` tier (per ADR-0011 §1) is a
-separate axis gated by `USER_TIER_ENABLED` below.
+separate, always-visible axis whose canonical lives under
+`~/.memtomem/<artifact>/`.
 
 > For a task-first walkthrough of the Store → Sync → Runtime model, see the
 > [Context Gateway](context-gateway.md) guide. This section is the
@@ -926,7 +927,6 @@ registry and stores local absolute paths.
 |----------|---------|-------------|
 | `MEMTOMEM_CONTEXT_GATEWAY__KNOWN_PROJECTS_PATH` | `~/.memtomem/known_projects.json` | Where the Web UI persists "Add Project" registrations. The Sources, Skills, Custom Commands, and Subagents tabs render one collapsible group per registered project root. |
 | `MEMTOMEM_CONTEXT_GATEWAY__EXPERIMENTAL_CLAUDE_PROJECTS_SCAN` | `false` | When `true`, the gateway also reverse-decodes `~/.claude/projects/<encoded>` directory names into project roots and surfaces them as discovered roots. Off by default — the encoding is fragile around dash-containing paths, so this stays gated behind explicit consent. |
-| `MEMTOMEM_CONTEXT_GATEWAY__USER_TIER_ENABLED` | `false` | Forward-compat flag for the `user`-tier canonical artifact surface (ADR-0011 §1; canonical lives under `~/.memtomem/<artifact>/`). While `false`, `user`-tier entries are hidden from discovery responses entirely. |
 | `MEMTOMEM_CONTEXT_GATEWAY__AUTO_DISPLAY_CONFIGURED_PROJECTS` | `true` | Auto-surface `~/.claude/projects/` scan candidates that already carry a runtime marker, without an explicit Add Project step |
 
 ## Hooks

--- a/packages/memtomem/src/memtomem/cli/sync_doctor_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/sync_doctor_cmd.py
@@ -128,6 +128,15 @@ def _git_ls_files(start: Path) -> list[str] | None:
     Plain ``git ls-files`` from a nested dir only yields paths *under* that
     dir, which would let the doctor miss a tracked root-level
     ``config.json`` or ``*.db``.
+
+    ``-z`` + NUL-split bytes (#1520 quotePath fold-in, mirroring
+    ``wiki/store.py:asset_files_at_commit``): git's default
+    ``core.quotePath=true`` C-quotes non-ASCII pathnames in line-oriented
+    porcelain (a Korean-named ``스냅샷.db`` renders ``"\\354\\212\\244…"``
+    with a trailing ``"``), which evades the callers' ``endswith`` checks.
+    Undecodable names decode with ``errors="replace"`` rather than being
+    skipped — the suffix checks are ASCII, so replacement never breaks
+    detection, while skipping would false-pass a staged db.
     """
     git = shutil.which("git")
     if git is None:
@@ -137,17 +146,16 @@ def _git_ls_files(start: Path) -> list[str] | None:
         return None
     try:
         proc = subprocess.run(
-            [git, "ls-files"],
+            [git, "ls-files", "-z"],
             cwd=str(repo_root),
             capture_output=True,
-            text=True,
             check=False,
         )
     except OSError:
         return None
     if proc.returncode != 0:
         return None
-    return [line for line in proc.stdout.splitlines() if line]
+    return [entry.decode("utf-8", errors="replace") for entry in proc.stdout.split(b"\0") if entry]
 
 
 def check_no_db_staged(cwd: Path) -> CheckResult:

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -791,9 +791,7 @@ class ContextGatewayConfig(ConfigModel):
 
     See ``memtomem-docs/memtomem/planning/multi-project-context-ui-rfc.md`` —
     PR2 lands the read-only fields (``known_projects_path``,
-    ``experimental_claude_projects_scan``); ``user_tier_enabled`` reserved
-    here so PR3's mutating routes can wire onto a stable schema without a
-    second config bump.
+    ``experimental_claude_projects_scan``).
     """
 
     # Where ``Add Project`` registrations are persisted. Sibling to the
@@ -813,9 +811,6 @@ class ContextGatewayConfig(ConfigModel):
     # name changes (no validation_alias infra) and the unfiltered default is
     # untouched.
     auto_display_configured_projects: bool = True
-    # PR3 surface — listed here for forward-compat. While ``False`` the user
-    # scope is hidden from discovery responses entirely (RFC §Decision 5).
-    user_tier_enabled: bool = False
 
 
 class SessionTraceConfig(ConfigModel):

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -1374,12 +1374,20 @@ def _run_artifact_flat_apply(project_root: Path, rows: list[MigrateRow], *, forc
 
 def _format_artifact_scope_result(result: MigrateScopeResult, *, apply_: bool) -> str:
     """Plain-text summary for one scope-tier move (mirrors the CLI's
-    ``_print_migrate_scope_result``)."""
+    ``_print_migrate_scope_result`` content, not its verbatim paths).
+
+    Every echoed path is ``$HOME``-collapsed via ``_redact_reason`` (#1520
+    item 7) — the absolute src/dst/fan-out paths embed the username on the
+    MCP wire. Redaction is per path, not per line, so the 200-char cap can't
+    bite surrounding text (#1550 precedent). No root-stripping: root-relative
+    from/to lines would render identically for same-named artifacts in
+    different projects.
+    """
     layout_note = " (flat layout)" if result.layout == "flat" else ""
     lines = [
         f"Plan: migrate {result.kind}/{result.name}{layout_note}",
-        f"  from {result.from_scope}: {result.src_path}",
-        f"  to   {result.to_scope}: {result.dst_path}",
+        f"  from {result.from_scope}: {_redact_reason(str(result.src_path))}",
+        f"  to   {result.to_scope}: {_redact_reason(str(result.dst_path))}",
     ]
     if not apply_:
         if result.fanout_planned:
@@ -1389,7 +1397,7 @@ def _format_artifact_scope_result(result: MigrateScopeResult, *, apply_: bool) -
                 f"that diverges from the canonical render is snapshotted to "
                 f"a .bak first):"
             )
-            lines.extend(f"    - {path}" for path in result.fanout_planned)
+            lines.extend(f"    - {_redact_reason(str(path))}" for path in result.fanout_planned)
         lines.append("\nRe-call with apply=True to execute.")
         lines.append(
             f"After apply, run mem_context_sync(scope='{result.to_scope}') "
@@ -1400,14 +1408,14 @@ def _format_artifact_scope_result(result: MigrateScopeResult, *, apply_: bool) -
     lines.append(f"\n✓ moved {result.kind}/{result.name}: {result.from_scope} → {result.to_scope}")
     if result.fanout_cleaned:
         lines.append(f"  cleaned {len(result.fanout_cleaned)} stale runtime fan-out target(s):")
-        lines.extend(f"    - {path}" for path in result.fanout_cleaned)
+        lines.extend(f"    - {_redact_reason(str(path))}" for path in result.fanout_cleaned)
     if result.fanout_backed_up:
         lines.append(
             f"  {len(result.fanout_backed_up)} target(s) diverged from the "
             f"canonical render — snapshotted before removal (review and "
             f"delete manually):"
         )
-        lines.extend(f"    - {path}" for path in result.fanout_backed_up)
+        lines.extend(f"    - {_redact_reason(str(path))}" for path in result.fanout_backed_up)
     lines.append(
         f"\nNext: run mem_context_sync(scope='{result.to_scope}') "
         "to regenerate runtime fan-out at the new tier."
@@ -1650,6 +1658,15 @@ def _format_transfer_result(result: TransferResult | McpServerCopyResult, *, app
     The dry-run footer additionally names the confirmation flag(s) the
     destination tier will require at apply time, so an agent learns the
     full re-call shape from the preview.
+
+    Unlike the CLI mirror, every echoed path and engine note is
+    ``$HOME``-collapsed via ``_redact_reason`` (#1520 item 7) — absolute
+    src/dst/fan-out paths embed the username on the MCP wire. Per path,
+    not per line, so the 200-char cap can't bite surrounding text (#1550
+    precedent); no root-stripping because a transfer straddles two
+    projects and root-relative lines would render identically for
+    same-named artifacts. ``sync_command``/``sync_hint`` stay verbatim —
+    they are runnable remediation commands (``error_redact`` doctrine).
     """
     layout_note = (
         " (flat layout)" if result.layout == "flat" and result.kind != "mcp-servers" else ""
@@ -1657,8 +1674,8 @@ def _format_transfer_result(result: TransferResult | McpServerCopyResult, *, app
     rename_note = f" as {result.dst_name}" if result.dst_name != result.name else ""
     lines = [
         f"Plan: {result.mode} {result.kind}/{result.name}{rename_note}{layout_note}",
-        f"  from {result.from_scope}: {result.src_path}",
-        f"  to   {result.to_scope}: {result.dst_path}",
+        f"  from {result.from_scope}: {_redact_reason(str(result.src_path))}",
+        f"  to   {result.to_scope}: {_redact_reason(str(result.dst_path))}",
     ]
     if not apply_:
         if result.fanout_planned:
@@ -1668,20 +1685,24 @@ def _format_transfer_result(result: TransferResult | McpServerCopyResult, *, app
                 f"that diverges from the canonical render is snapshotted to "
                 f"a .bak first):"
             )
-            lines.extend(f"    - {path}" for path in result.fanout_planned)
+            lines.extend(f"    - {_redact_reason(str(path))}" for path in result.fanout_planned)
         if result.provenance == "carried":
             lines.append(
                 "  will carry the wiki install provenance (lock.json entry) to the destination"
             )
         elif result.provenance == "not_carried":
+            # provenance_reason can wrap an OSError from the lock.json write
+            # (absolute path inside) — same $HOME collapse as the notes.
             lines.append(
                 f"  install provenance will not be carried — the artifact "
-                f"lands untracked: {result.provenance_reason}"
+                f"lands untracked: {_redact_reason(result.provenance_reason)}"
             )
         # Engine caveats render in the PLAN too (CLI _print_transfer_result
         # mirror) — a caveat the agent only learns post-apply is not a plan
-        # it confirmed.
-        lines.extend(f"  note: {note}" for note in result.notes)
+        # it confirmed. Notes can embed absolute paths (e.g. the copy-rename
+        # overrides note carries dst_path/overrides), so they get the same
+        # $HOME collapse as the path lines.
+        lines.extend(f"  note: {_redact_reason(note)}" for note in result.notes)
         confirm_note = ""
         if result.to_scope == "project_shared":
             confirm_note = " and confirm_project_shared=True"
@@ -1704,22 +1725,22 @@ def _format_transfer_result(result: TransferResult | McpServerCopyResult, *, app
             f"  cleaned {len(result.fanout_cleaned)} stale runtime fan-out "
             f"target(s) at scope='{result.from_scope}':"
         )
-        lines.extend(f"    - {path}" for path in result.fanout_cleaned)
+        lines.extend(f"    - {_redact_reason(str(path))}" for path in result.fanout_cleaned)
     if result.fanout_backed_up:
         lines.append(
             f"  {len(result.fanout_backed_up)} target(s) diverged from the "
             f"canonical render — snapshotted before removal (review and "
             f"delete manually):"
         )
-        lines.extend(f"    - {path}" for path in result.fanout_backed_up)
+        lines.extend(f"    - {_redact_reason(str(path))}" for path in result.fanout_backed_up)
     if result.provenance == "carried":
         lines.append("  carried the wiki install provenance (lock.json entry) to the destination")
     elif result.provenance == "not_carried":
         lines.append(
             f"  install provenance not carried — the artifact lands "
-            f"untracked at the destination: {result.provenance_reason}"
+            f"untracked at the destination: {_redact_reason(result.provenance_reason)}"
         )
-    lines.extend(f"  note: {note}" for note in result.notes)
+    lines.extend(f"  note: {_redact_reason(note)}" for note in result.notes)
     if result.needs_sync and result.sync_command:
         lines.append(
             f"\nNext: run `{result.sync_command}` to generate runtime fan-out at the destination."

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -76,6 +76,35 @@ def test_config_json_applies_when_no_env(
     assert str(cfg.storage.sqlite_path) == "/from/config.db"
 
 
+def test_config_json_stale_removed_field_skipped_not_fatal(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stale key for a since-removed field loads clean (skipped, not fatal).
+
+    Regression for #1520 item 3: ``context_gateway.user_tier_enabled`` was
+    removed without ever gaining a read site. A persisted config.json that
+    still carries it must not break startup — the ``hasattr`` guard in
+    ``load_config_overrides`` skips unknown field names within a known
+    section, and sibling valid fields still apply.
+    """
+    _clear_all_memtomem_env(monkeypatch)
+    override_path.write_text(
+        json.dumps(
+            {
+                "context_gateway": {
+                    "user_tier_enabled": True,
+                    "experimental_claude_projects_scan": True,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    cfg = Mem2MemConfig()
+    load_config_overrides(cfg)
+    assert not hasattr(cfg.context_gateway, "user_tier_enabled")
+    assert cfg.context_gateway.experimental_claude_projects_scan is True
+
+
 def test_env_var_wins_over_config_json_scalar(
     override_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/packages/memtomem/tests/test_server_tools_context_redaction.py
+++ b/packages/memtomem/tests/test_server_tools_context_redaction.py
@@ -551,3 +551,158 @@ class TestWebParityGuard:
                     msg,
                     root,
                 )
+
+
+# ── #1520 item 7: migrate/transfer success-path formatters collapse $HOME ────
+
+
+class TestSuccessPathFormattersCollapseHome:
+    """The migrate/transfer result formatters must ``~``-collapse every echoed
+    path (src/dst headers, fan-out lists, engine notes) — those absolute paths
+    embed the username on the MCP wire. Redaction is per path, not per line
+    (#1550: a line-level pass lets the 200-char cap bite surrounding text).
+    ``sync_command`` stays verbatim by doctrine — it is a runnable remediation
+    command. Formatters are exercised directly with fabricated results whose
+    paths sit under a patched ``error_redact._HOME``.
+
+    Cross-platform (#838 discipline): the fabricated paths are ``Path``
+    objects, so ``str(path)`` renders with ``os.sep`` (``\\`` on Windows) —
+    the patched ``_HOME`` must therefore be ``str(Path(HOME))`` too, or the
+    collapse's literal ``replace`` would miss on Windows exactly as
+    production would not (there ``_HOME = str(Path.home())`` already carries
+    ``os.sep``). Assertions compare in POSIX space via ``_norm``.
+    """
+
+    HOME = "/Users/alice"
+
+    @staticmethod
+    def _norm(out: str) -> str:
+        return out.replace("\\", "/")
+
+    @pytest.fixture(autouse=True)
+    def _pin_home(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from memtomem.context import error_redact
+
+        # os.sep-native so the literal $HOME replace fires on Windows too.
+        monkeypatch.setattr(error_redact, "_HOME", str(Path(self.HOME)))
+
+    def _migrate_result(self, *, moved: bool):
+        from memtomem.context.migrate import MigrateScopeResult
+
+        home = Path(self.HOME)
+        return MigrateScopeResult(
+            kind="skills",
+            name="demo",
+            from_scope="user",
+            to_scope="project_shared",
+            src_path=home / ".memtomem" / "skills" / "demo",
+            dst_path=home / "proj" / ".memtomem" / "skills" / "demo",
+            layout="dir",
+            moved=moved,
+            fanout_cleaned=[home / ".claude" / "skills" / "demo" / "SKILL.md"],
+            fanout_backed_up=[home / ".claude" / "skills" / "demo" / "SKILL.md.bak"],
+            fanout_planned=[home / ".claude" / "skills" / "demo" / "SKILL.md"],
+        )
+
+    def _transfer_result(self, *, transferred: bool, **overrides):
+        from memtomem.context.transfer import TransferResult
+
+        home = Path(self.HOME)
+        kwargs = dict(
+            kind="skills",
+            name="demo",
+            dst_name="demo-copy",
+            mode="copy",
+            from_scope="project_shared",
+            to_scope="user",
+            src_project_root=home / "proj",
+            dst_project_root=None,
+            src_path=home / "proj" / ".memtomem" / "skills" / "demo",
+            dst_path=home / ".memtomem" / "skills" / "demo-copy",
+            layout="dir",
+            transferred=transferred,
+            fanout_cleaned=[home / ".claude" / "skills" / "demo" / "SKILL.md"],
+            fanout_backed_up=[home / ".claude" / "skills" / "demo" / "SKILL.md.bak"],
+            fanout_planned=[home / ".claude" / "skills" / "demo" / "SKILL.md"],
+            needs_sync=True,
+            sync_command="mm context sync --include=skills",
+            notes=(
+                "overrides travel verbatim: "
+                + str(home / ".memtomem" / "skills" / "demo-copy" / "overrides"),
+            ),
+        )
+        kwargs.update(overrides)
+        return TransferResult(**kwargs)
+
+    def test_migrate_dry_run_collapses_all_paths(self) -> None:
+        from memtomem.server.tools.context import _format_artifact_scope_result
+
+        norm = self._norm(
+            _format_artifact_scope_result(self._migrate_result(moved=False), apply_=False)
+        )
+
+        assert self.HOME not in norm, norm  # native home gone (both sep forms)
+        assert "from user: ~/.memtomem/skills/demo" in norm
+        assert "    - ~/" in norm  # fanout_planned entries
+        assert "Re-call with apply=True" in norm  # tail survives — no cap bite
+
+    def test_migrate_apply_collapses_all_paths(self) -> None:
+        from memtomem.server.tools.context import _format_artifact_scope_result
+
+        norm = self._norm(
+            _format_artifact_scope_result(self._migrate_result(moved=True), apply_=True)
+        )
+
+        assert self.HOME not in norm, norm
+        assert "✓ moved skills/demo" in norm
+        assert norm.count("    - ~/") == 2  # fanout_cleaned + fanout_backed_up
+
+    def test_transfer_dry_run_collapses_paths_and_notes(self) -> None:
+        from memtomem.server.tools.context import _format_transfer_result
+
+        norm = self._norm(
+            _format_transfer_result(self._transfer_result(transferred=False), apply_=False)
+        )
+
+        assert self.HOME not in norm, norm
+        assert "  note: overrides travel verbatim: ~/" in norm
+        # sync_command renders verbatim (runnable remediation command).
+        assert "`mm context sync --include=skills`" in norm
+
+    def test_transfer_apply_collapses_paths_and_notes(self) -> None:
+        from memtomem.server.tools.context import _format_transfer_result
+
+        norm = self._norm(
+            _format_transfer_result(self._transfer_result(transferred=True), apply_=True)
+        )
+
+        assert self.HOME not in norm, norm
+        assert "✓ copied skills/demo" in norm
+        assert "  note: overrides travel verbatim: ~/" in norm
+        assert norm.count("    - ~/") == 2  # fanout_cleaned + fanout_backed_up
+
+    @pytest.mark.parametrize("apply_", [False, True])
+    def test_transfer_provenance_reason_collapses_home(self, apply_: bool) -> None:
+        # Codex review on the #1520 item 7 round: ``provenance_reason`` can
+        # wrap an OSError from the destination lock.json write (absolute path
+        # inside) and rendered verbatim on both the dry-run and apply legs.
+        from memtomem.server.tools.context import _format_transfer_result
+
+        # Native str(Path(...)), NOT repr — an os.sep path so the collapse
+        # fires under the os-native _HOME on every platform (a repr would
+        # double the Windows backslashes and dodge the literal replace).
+        lock_path = str(Path(self.HOME) / ".memtomem" / "lock.json")
+        result = self._transfer_result(
+            transferred=apply_,
+            provenance="not_carried",
+            provenance_reason=(
+                f"destination lock.json could not be written "
+                f"([Errno 13] Permission denied: {lock_path})"
+            ),
+        )
+
+        norm = self._norm(_format_transfer_result(result, apply_=apply_))
+
+        assert self.HOME not in norm, norm
+        assert "destination lock.json could not be written" in norm
+        assert "~/.memtomem/lock.json" in norm  # collapsed, diagnostic survives

--- a/packages/memtomem/tests/test_sync_doctor_cli.py
+++ b/packages/memtomem/tests/test_sync_doctor_cli.py
@@ -124,6 +124,19 @@ class TestCheckNoDbStaged:
         assert r.status == "fail"
         assert "snapshot.db" in (r.detail or "")
 
+    def test_non_ascii_name_staged_fails_under_quotepath(self, tmp_path: Path) -> None:
+        # Under git's default ``core.quotePath=true`` a non-ASCII pathname is
+        # C-quoted in line-oriented porcelain (``"\354\212\244…"`` with a
+        # trailing ``"``), which evaded the pre-#1520 ``splitlines`` parse's
+        # ``endswith(".db")`` check. ``ls-files -z`` round-trips it exactly.
+        _git_init(tmp_path)
+        subprocess.run(["git", "config", "core.quotepath", "true"], cwd=tmp_path, check=True)
+        (tmp_path / "스냅샷.db").write_bytes(b"")
+        _git_add(tmp_path, "스냅샷.db")
+        r = check_no_db_staged(tmp_path)
+        assert r.status == "fail"
+        assert "스냅샷.db" in (r.detail or "")
+
 
 # ---- check_config_json_absent ----------------------------------------------
 
@@ -147,6 +160,19 @@ class TestCheckConfigJsonAbsent:
         sub.mkdir()
         (sub / "config.json").write_text("{}")
         _git_add(tmp_path, "sub/config.json")
+        r = check_config_json_absent(tmp_path)
+        assert r.status == "fail"
+
+    def test_staged_under_non_ascii_dir_fails_under_quotepath(self, tmp_path: Path) -> None:
+        # A config.json under a non-ASCII directory is C-quoted whole under
+        # ``core.quotePath=true`` (trailing ``"`` defeats ``endswith``) —
+        # pinned against the ``-z`` parse (#1520 quotePath fold-in).
+        _git_init(tmp_path)
+        subprocess.run(["git", "config", "core.quotepath", "true"], cwd=tmp_path, check=True)
+        sub = tmp_path / "설정"
+        sub.mkdir()
+        (sub / "config.json").write_text("{}")
+        _git_add(tmp_path, "설정/config.json")
         r = check_config_json_absent(tmp_path)
         assert r.status == "fail"
 


### PR DESCRIPTION
## Summary

Code-health batch from #1520 — the three decided items that touch `packages/memtomem` without adding CLI surface. One commit per item; each was adversarially reviewed (Codex gate) before push.

### Item 3 — remove dead `context_gateway.user_tier_enabled`

Reserved for the multi-project-context-ui RFC's PR3, which never shipped: **zero read sites**, so it never gated anything — the user tier is (and stays) always visible. Wiring it instead would flip that default (`False` = hidden), a behavior change nobody asked for.

- Stale keys in persisted `config.json` / `config.d` stay harmless (both loaders `hasattr`-guard field names) — pinned by a new regression test.
- Breaking edge called out in the CHANGELOG: a set `MEMTOMEM_CONTEXT_GATEWAY__USER_TIER_ENABLED` env var now fails `extra="forbid"` validation.
- The docs guard (`test_docs_guards.py`) caught `docs/guides/configuration.md` documenting the flag as if it gated the user tier — it never did; the env-var row is dropped and the prose corrected to match reality.

### Item 7 — `$HOME → ~` on MCP migrate/transfer success paths

`_format_artifact_scope_result` / `_format_transfer_result` echoed raw absolute src/dst/fan-out paths (plus engine `notes` and `provenance_reason`, which can embed paths) on the MCP wire, while every error/skip surface in the same module already routes through `_redact_reason`.

- Each path/note/reason is wrapped **individually** (per-path, not per-line, so the 200-char cap can't bite surrounding text — #1550 precedent).
- No root-stripping: a transfer straddles two projects; root-relative `from:`/`to:` lines would render identically for same-named artifacts in different projects.
- `sync_command`/`sync_hint` stay verbatim (runnable remediation command, `error_redact` doctrine). CLI formatters stay verbatim by design (loopback terminal, not a wire).
- The `provenance_reason` legs were a Codex-review catch on this PR's first round, folded with a parametrized regression test.

### quotePath fold-in — sync doctor `git ls-files -z`

From the issue comment: under git's default `core.quotePath=true`, a non-ASCII tracked pathname is C-quoted in line-oriented porcelain — the trailing quote defeats the `endswith(".db")` / `config.json` checks, so `mm sync-doctor` silently passed exactly the machine-local files it exists to catch. Switched to `ls-files -z` + NUL-split bytes (mirroring `wiki/store.py:asset_files_at_commit`); undecodable names decode with `errors="replace"` (the suffix checks are ASCII — a skip would false-pass a staged db). New pins were verified RED against the pre-fix parse.

## Testing

- `uv run pytest -m "not ollama"` — 7810 passed, 11 skipped
- `uv run ruff check` + `ruff format --check` — clean
- quotePath pins verified RED against the pre-fix implementation

Part of #1520 (items 3, 7, quotePath). Items 4/5 and 6 follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
