### PR TITLE
fix(context): protect pre-digest legacy clean rows from silent swap under install --all --force

### DIFF
--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -1514,9 +1514,14 @@ def _apply_pinned_install(
     # recorded digests (== the clean dest) differ from the bytes the pin would
     # extract. When they MATCH (the dest already equals the pin), fall through
     # so --force's re-extraction can still reconcile away stale dest-only
-    # leftovers (#1247). A pre-digest entry has no comparable digests
-    # (``digests_from_entry`` → None) and keeps its legacy re-extract behavior;
-    # a VALID EMPTY map (``{}`` — a digest-bearing install that copied zero
+    # leftovers (#1247). A pre-digest entry (``digests_from_entry`` → None) has
+    # no recorded map, so the CLEAN DEST is hashed in its place (#1512): the
+    # row just classified clean, so the dest bytes ARE the bytes the install
+    # wrote — the same identity a recorded map would carry — and a legacy row
+    # gains the same no-op-on-divergence protection instead of the pre-#1479
+    # silent, .bak-less re-extract. (Its dest==pin fall-through then re-extracts
+    # identical bytes and upserts a digest-bearing entry, upgrading the row.)
+    # A VALID EMPTY map (``{}`` — a digest-bearing install that copied zero
     # files) is honored, so a pin that would extract files over it counts as a
     # divergence rather than a fall-through (``is not None``, not truthiness —
     # Codex gate). (Reachable only under --force: without it the caller skips
@@ -1531,7 +1536,26 @@ def _apply_pinned_install(
             for rel in wiki.asset_files_at_commit(pin, asset_type, name)
             if not is_copy_skipped_rel(rel)
         }
-        if recorded_digests is not None and recorded_digests != pin_digests:
+        if recorded_digests is not None:
+            effective_digests = recorded_digests
+        else:
+            try:
+                effective_digests = {
+                    f.relative_to(dest).as_posix(): hashlib.sha256(f.read_bytes()).hexdigest()
+                    for f in iter_installed_files(dest)
+                }
+            except OSError as exc:
+                # Fail-closed like the walk_failed gate above: an unhashable
+                # dest cannot be proven equal to the pin, and a wrong guess
+                # either destroys bytes (fall through) or silently masks a
+                # permissions problem (no-op) — refuse loud instead (the
+                # --all CLI loop degrades this to a red row, file intact).
+                raise StaleInstallError(
+                    f"{asset_type}/{name}: cannot hash installed files under "
+                    f"{dest} ({exc}) to compare against the pin — refusing to "
+                    f"re-extract even with --force; fix permissions and retry"
+                ) from exc
+        if effective_digests != pin_digests:
             return InstallResult(
                 asset_type=cast('Literal["skills", "agents", "commands"]', asset_type),
                 name=name,

--- a/packages/memtomem/tests/test_context_install_all.py
+++ b/packages/memtomem/tests/test_context_install_all.py
@@ -580,12 +580,33 @@ _ = pytest
 # ── B1: pinned re-extraction reconciles dest-only files (#1247) ──────────
 
 
-def test_force_reextraction_removes_stale_dest_only_file(
+def _strip_to_legacy_entry(project_root: Path, asset_type: str, name: str) -> Path:
+    """Strip the manifest + digest keys from a lockfile entry, simulating a
+    pre-#1268 (pre-digest, pre-manifest) legacy install record."""
+    lock_path = project_root / ".memtomem" / "lock.json"
+    doc = json.loads(lock_path.read_text(encoding="utf-8"))
+    doc[asset_type][name].pop("files", None)
+    doc[asset_type][name].pop("files_commit", None)
+    doc[asset_type][name].pop("digests", None)
+    doc[asset_type][name].pop("digests_installed_at", None)
+    lock_path.write_text(json.dumps(doc), encoding="utf-8")
+    return lock_path
+
+
+def test_legacy_row_with_stale_dest_only_file_noops_under_force(
     wiki_root: Path, tmp_path: Path, monkeypatch
 ) -> None:
-    """``install --all --force`` re-extracts at the pin; a dest-only file
-    whose mtime predates ``installed_at`` (a pre-B1 additive-update leftover)
-    must be reconciled away, not carried forever."""
+    """Re-pin (#1512, was the pre-B1 reconcile pin): a legacy clean row whose
+    dest carries a dest-only file now NO-OPS under ``install --all --force``
+    instead of re-extracting.
+
+    A pre-digest entry has no recorded map to prove which dest bytes the
+    install wrote, so the clean-dest hash stands in for it; the dest-only
+    ``leftover.md`` makes dest != pin, and re-extracting would silently drop
+    a file the pin never described with no ``.bak`` — the #1512 hole. The
+    stale-leftover reconcile (#1247 B1) is thereby reserved for rows that can
+    prove dest == pin; legacy remediation is a fresh ``install``/``update``,
+    which writes a digest-bearing entry."""
     _initialized_wiki(wiki_root)
     pin = _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"pinned\n"})
     install_skill(tmp_path, "foo")
@@ -593,34 +614,88 @@ def test_force_reextraction_removes_stale_dest_only_file(
     dest = tmp_path / ".memtomem" / "skills" / "foo"
     stale = dest / "leftover.md"
     stale.write_bytes(b"stale wiki bytes\n")
-    # Backdate so the file reads as old wiki bytes (mtime <= installed_at):
-    # the legacy-entry deletion rule, not the user-added keep rule.
+    # Backdate so the legacy mtime rule still classifies the row clean.
     past = datetime.now(timezone.utc).timestamp() - 3600
     os.utime(stale, (past, past))
-    # Pre-B1 entries carry no manifest and no digests — simulate one by
-    # stripping all four keys (with a valid digest pairing left in place,
-    # the unrecorded leftover would correctly classify user-added → keep;
-    # that digest-branch behavior is pinned in test_dirty_digest.py).
-    lock_path = tmp_path / ".memtomem" / "lock.json"
-    doc = json.loads(lock_path.read_text(encoding="utf-8"))
-    doc["skills"]["foo"].pop("files", None)
-    doc["skills"]["foo"].pop("files_commit", None)
-    doc["skills"]["foo"].pop("digests", None)
-    doc["skills"]["foo"].pop("digests_installed_at", None)
-    lock_path.write_text(json.dumps(doc), encoding="utf-8")
+    lock_path = _strip_to_legacy_entry(tmp_path, "skills", "foo")
 
     monkeypatch.chdir(tmp_path)
     runner = CliRunner()
     result = runner.invoke(context_group, ["install", "--all", "--yes", "--force"])
 
     assert result.exit_code == 0, result.output
-    assert not stale.exists()
+    # The row is left untouched: dest-only file survives, no .bak anywhere.
+    assert stale.exists()
+    assert stale.read_bytes() == b"stale wiki bytes\n"
+    assert (dest / "SKILL.md").read_bytes() == b"pinned\n"
+    assert not list(dest.rglob("*.bak"))
+    assert "1 installed" not in result.output
+    assert "skipped" in result.output
+    lock_doc = json.loads(lock_path.read_text(encoding="utf-8"))
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == pin
+    # No re-extraction → the legacy entry stays legacy (no manifest upsert).
+    assert "files" not in lock_doc["skills"]["foo"]
+    assert "digests" not in lock_doc["skills"]["foo"]
+
+
+def test_legacy_clean_install_off_dirty_wiki_survives_all_force(
+    wiki_root: Path, tmp_path: Path, monkeypatch
+) -> None:
+    """The #1512 harmful case: a PRE-DIGEST legacy clean row installed off a
+    dirty wiki working tree must not be silently swapped by
+    ``install --all --force``.
+
+    Same shape as ``test_clean_install_off_dirty_wiki_survives_all_force``,
+    but with the digest keys stripped: before #1512 the ``recorded_digests is
+    not None`` gate let exactly this row fall through to a silent, ``.bak``-less
+    re-extract. The clean-dest hash now stands in for the missing recorded map."""
+    _initialized_wiki(wiki_root)
+    pin = _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v1\n"})
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"working-tree-v2\n")
+    install_skill(tmp_path, "foo")
+    dest = tmp_path / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    assert dest.read_bytes() == b"working-tree-v2\n"
+    lock_path = _strip_to_legacy_entry(tmp_path, "skills", "foo")
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["install", "--all", "--yes", "--force"])
+
+    assert result.exit_code == 0, result.output
+    # The installed bytes are preserved — NOT silently swapped to the pin's v1.
+    assert dest.read_bytes() == b"working-tree-v2\n"
+    assert not dest.with_suffix(dest.suffix + ".bak").exists()
+    assert "1 installed" not in result.output
+    assert "skipped" in result.output
+    lock_doc = json.loads(lock_path.read_text(encoding="utf-8"))
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == pin
+
+
+def test_legacy_row_matching_pin_reextracts_and_upgrades_entry(
+    wiki_root: Path, tmp_path: Path, monkeypatch
+) -> None:
+    """A legacy clean row whose dest already equals the pin falls through
+    (#1512): the re-extraction writes identical bytes and the lockfile upsert
+    upgrades the entry to a digest-bearing one, so the row leaves the legacy
+    class entirely."""
+    _initialized_wiki(wiki_root)
+    pin = _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"pinned\n"})
+    install_skill(tmp_path, "foo")
+    lock_path = _strip_to_legacy_entry(tmp_path, "skills", "foo")
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["install", "--all", "--yes", "--force"])
+
+    assert result.exit_code == 0, result.output
+    dest = tmp_path / ".memtomem" / "skills" / "foo"
     assert (dest / "SKILL.md").read_bytes() == b"pinned\n"
     lock_doc = json.loads(lock_path.read_text(encoding="utf-8"))
     assert lock_doc["skills"]["foo"]["wiki_commit"] == pin
-    # Manifest recorded against the pin on re-extraction.
+    # Manifest + digests recorded against the pin on re-extraction.
     assert lock_doc["skills"]["foo"]["files"] == ["SKILL.md"]
     assert lock_doc["skills"]["foo"]["files_commit"] == pin
+    assert set(lock_doc["skills"]["foo"]["digests"]) == {"SKILL.md"}
 
 
 def test_classify_install_all_missing_only_dirty_reason(wiki_root: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`install --all --force` clean-row guard (added by #1479) protected against silent, `.bak`-less re-extraction over a clean row — but only for **digest-bearing** lockfile entries. The guard was gated on `recorded_digests is not None`, so a **pre-digest legacy entry** (installed before #1268 and never updated) fell straight through to `copy_asset_at_commit` with an empty `.bak` set: the exact silent destructive swap the fix was for. This was documented as intentional at `install.py`, which is why #1512 was filed as a re-decision rather than a bug.

## Change

A legacy row has no recorded digest map to prove which bytes the install wrote — but the row just re-classified **clean**, so the on-disk dest bytes *are* that identity. The guard now hashes the clean dest via `iter_installed_files` (the same key-space as the recorded map and the pin scan — the three rule carriers stay in lockstep by contract) and compares it to the pin's digests in place of the missing recorded map:

- **Digest-bearing rows**: unchanged — still compared recorded-vs-pin, byte-identical behavior.
- **Legacy rows**: gain the same no-op-on-divergence protection.
- **Unhashable dest**: refuses loud (`StaleInstallError`, degraded to a red row by the `--all` loop) rather than guessing in a direction that either destroys bytes or masks a permissions problem — mirroring the existing `walk_failed` gate.

### Intended behavior flip

A legacy clean row whose dest **diverges** from the pin — including the stale dest-only leftover case from #1247 B1 — now **no-ops** instead of re-extracting. The reconcile is reserved for rows that can prove `dest == pin`. Legacy remediation is a fresh `install`/`update`, which the `dest == pin` fall-through now performs in-place (the re-extract upserts a digest-bearing entry, upgrading the row out of the legacy class). The prior test `test_force_reextraction_removes_stale_dest_only_file` asserted the old benign re-extract; it is re-pinned to the new protective behavior.

## Tests

- **New** `test_legacy_clean_install_off_dirty_wiki_survives_all_force` — the harmful case (#1512): a legacy clean row installed off a *dirty* wiki survives `--force` untouched, no `.bak`. Fails against pre-fix `install.py`, passes after.
- **New** `test_legacy_row_with_stale_dest_only_file_noops_under_force` — the re-pinned reconcile case: a legacy dest-only leftover now no-ops (was the removed-away case).
- **New** `test_legacy_row_matching_pin_reextracts_and_upgrades_entry` — `dest == pin` legacy row still falls through and upgrades to a digest-bearing entry.
- #1479 digest-bearing + empty-map regressions stay green.

Closes #1512

🤖 Generated with [Claude Code](https://claude.com/claude-code)
