### PR TITLE
chore(plugin): rename claude-plugin skill context → recall (#1520 item 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Changed
 
+- **Claude-plugin skill `/memtomem:context` is now `/memtomem:recall`**
+  (#1520 item 6). The skill injects relevant memories as context for the
+  current task; its old name collided with the context-gateway subsystem
+  (Skills / Commands / Agents / `mm context …`), which the plugin does not
+  drive — `recall` says what it actually does. Invoke `/memtomem:recall
+  [topic]` after updating the plugin; no gateway-driving plugin skill is
+  planned for now.
+
 - **Config sections no longer bind bare, unprefixed environment variables**
   (#1522). The 22 sub-config sections (`embedding`, `storage`, `llm`,
   `session_trace`, …) plus `NamespacePolicyRule` were `BaseSettings` classes

--- a/packages/memtomem-claude-plugin/skills/recall/SKILL.md
+++ b/packages/memtomem-claude-plugin/skills/recall/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: context
+name: recall
 description: Inject relevant memories as structured context for the current task. Use when starting complex work that may benefit from past decisions or notes.
 argument-hint: [topic or question]
 allowed-tools: mcp__memtomem__mem_search, mcp__memtomem__mem_do


### PR DESCRIPTION
## Summary

#1520 item 6 — the claude-plugin ships a `context` skill that is a **memory-injection** skill (`mem_search` + `mem_do` related-chain), but its name collided with the context-gateway subsystem (Skills / Commands / Agents, `mm context …`), which no plugin skill drives. Renamed to `recall`, which says what it actually does.

- `git mv skills/context → skills/recall` + frontmatter `name: recall`. Rename only — the body is untouched.
- Skills are auto-discovered by directory: the manifest, README, hooks, and tests carry no reference to the old name (swept `skills/context` / `memtomem:context` across the repo — zero hits post-rename).
- User-facing change: `/memtomem:context [topic]` → `/memtomem:recall [topic]` after a plugin update (CHANGELOG entry included).

**Decision recorded (item 6, second half):** no gateway-driving plugin skill for now. The gateway has full CLI/web/MCP surfaces; a plugin skill wrapping them adds a fourth surface to keep in sync without a demonstrated need. Revisit if demand shows up.

## Testing

- Repo-wide reference sweep: zero stale hits for `skills/context` / `memtomem:context`.
- Python package untouched; docs guards unaffected (they pin `hooks/hooks.json` only).

Part of #1520 (item 6). Items 3/7/quotePath: #1599. Items 4/5: separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
