### PR TITLE
docs(mcp): pin CLI/web-only posture for context install/update/projects

### DIFF
--- a/docs/adr/0008-wiki-layer.md
+++ b/docs/adr/0008-wiki-layer.md
@@ -167,6 +167,33 @@ files (no lockfile entry) and orphan lockfile entries (entry but no
 files on disk) are surfaced as `skip` rows and left untouched — those
 are out of scope for the install/upgrade lifecycle.
 
+### Surface coverage: no MCP verb for install/update/projects (by design)
+
+Most `mm context` verbs have a `mem_context_*` MCP counterpart — the MCP
+tool, CLI, and web app share one engine definition (the parity invariant
+in `server/tools/context.py`). `install`, `update`, and the projects
+registry (`mm context projects {list, add, resume}`) intentionally break
+that parity and are **CLI + dev-tier-web only, with no MCP verb**:
+
+- `install` / `update` read the host-global wiki but *write* into a
+  project's `.memtomem/` tree, so on the web they mount only in
+  `mode=dev` (PR-E row E-3, `context_mutations.py`). Exposing them
+  headless would let an agent snapshot wiki bytes into arbitrary
+  registered projects without the operator-in-the-loop the dev tier and
+  interactive CLI confirm prompts assume.
+- The projects registry mutates cross-project enrollment state
+  (`known_projects.json`), a host-scope trust boundary the MCP surface
+  does not own.
+
+Because of this, `mem_context_artifact_transfer`'s destination refusals
+(unknown / paused / discovery-only project) name the `mm context
+projects …` remediation *and* state explicitly that it has no MCP verb —
+a headless agent must escalate to a terminal rather than retry. If a
+future workflow needs headless install/update, adding the verbs means
+replicating the sync-eligibility gate (today a web-route-layer check,
+not an engine-layer one) at the MCP boundary; the tool-registry parity
+test pins the current absence so that becomes a conscious decision.
+
 ## Lockfile schema
 
 `<project>/.memtomem/lock.json`:

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -120,6 +120,8 @@ The `mem_context_*` tools (CLI: `mm context`) sync canonical artifacts — skill
 - **`artifact_migrate`** migrates agents/commands/skills — flat→dir layout when `to_scope` is omitted, or a scope-tier move when it is set (`apply=True` to execute, `force=True` for a dirty flat→dir, `confirm_project_shared=True` for the git-tracked tier).
 - **`artifact_transfer`** moves or copies one canonical artifact between tiers and/or registered projects — `mode="move"|"copy"`, `to_project_scope_id` (from `mm context projects list`), `as_name` for a renamed copy, and `asset_type="mcp-servers"` for cross-project MCP-server definition copies (`apply=True` to execute, `confirm_project_shared=True` for the git-tracked tier, `allow_host_writes=True` for a user-tier landing).
 
+> **CLI/web-only (no MCP verb).** Wiki→project install/update (`mm context install`/`update`) and the projects registry (`mm context projects {list, add, resume}`) are intentionally not exposed as `mem_context_*` tools — they write into a project's `.memtomem/` tree or mutate cross-project enrollment state, so they run from the CLI or the dev-tier Web UI only (ADR-0008). A headless agent that hits an `artifact_transfer` refusal naming one of these (unknown / paused / discovery-only destination) must run the printed `mm context projects …` command at a terminal; there is no MCP equivalent to retry with.
+
 ---
 
 ## Next Steps

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -1757,8 +1757,9 @@ def _resolve_transfer_destination(to_project: str, src_root: Path) -> tuple[Path
     if scope is None:
         return None, (
             f"error: unknown to_project_scope_id: '{to_project}'. Destinations "
-            f"are restricted to registered projects — list them with "
-            f"`mm context projects list`."
+            f"are restricted to registered projects. The projects registry has "
+            f"no MCP verb — list registered projects at a terminal with "
+            f"`mm context projects list`, then retry with a scope_id it prints."
         )
     if scope.root is None or scope.missing:
         return None, (f"error: scope '{to_project}' is registered but its root is missing.")
@@ -1767,14 +1768,16 @@ def _resolve_transfer_destination(to_project: str, src_root: Path) -> tuple[Path
             return None, (
                 f"refused: destination project {scope.scope_id} ({scope.root}) is "
                 f"paused — sync enrollment is disabled, so the transferred "
-                f"artifact would not fan out there. Run `mm context projects "
-                f"resume {scope.scope_id}` first, or pick another destination."
+                f"artifact would not fan out there. Resuming enrollment has no "
+                f"MCP verb: run `mm context projects resume {scope.scope_id}` at "
+                f"a terminal first, or pick another destination."
             )
         return None, (
             f"refused: destination project {scope.scope_id} ({scope.root}) is "
             f"discovery-only (never enrolled for sync), so the transferred "
-            f"artifact would not fan out there. Enroll it first with "
-            f"`mm context projects add {scope.root}`, or pick another destination."
+            f"artifact would not fan out there. Enrolling has no MCP verb: run "
+            f"`mm context projects add {scope.root}` at a terminal first, or "
+            f"pick another destination."
         )
     return scope.root, ""
 

--- a/packages/memtomem/tests/test_meta_tool.py
+++ b/packages/memtomem/tests/test_meta_tool.py
@@ -156,6 +156,57 @@ class TestScheduleActions:
         assert "params" in info.params
 
 
+class TestContextSurfacePosture:
+    """#1510: context install/update and the projects registry are intentionally
+    CLI + dev-tier-web only, with NO ``mem_context_*`` MCP verb (ADR-0008
+    "Surface coverage" section).
+
+    The web routes exist (``context_mutations.install_asset``/``update_asset``,
+    ``context_projects.{add,delete,update}_known_project`` — see
+    ``test_web_invariants_registry.py``); the CLI verbs exist
+    (``mm context install|update|projects``). Only the MCP surface omits them.
+    This pins both the exact registered-context action set and the deliberate
+    absence, so adding a verb later must consciously flip this test rather than
+    slip in unnoticed."""
+
+    # The 10 @register("context") actions. mem_context_migrate is @mcp.tool()
+    # only (a deprecated alias, not @register-ed), so it is not in ACTIONS.
+    _EXPECTED_CONTEXT_ACTIONS = frozenset(
+        {
+            "context_init",
+            "context_detect",
+            "context_generate",
+            "context_diff",
+            "context_sync",
+            "context_memory_migrate",
+            "context_artifact_migrate",
+            "context_artifact_transfer",
+            "context_version",
+            "context_promote",
+        }
+    )
+
+    def test_registered_context_actions_are_exactly_the_expected_set(self):
+        registered = {name for name, info in ACTIONS.items() if info.category == "context"}
+        assert registered == self._EXPECTED_CONTEXT_ACTIONS
+
+    def test_no_install_update_or_projects_mcp_verb(self):
+        """The posture pin: these three surfaces write into a project tree or
+        mutate cross-project enrollment, so they stay CLI/web-only. If you are
+        adding one, update _EXPECTED_CONTEXT_ACTIONS, ADR-0008, and
+        docs/guides/reference.md in the same change — and replicate the
+        sync-eligibility gate (today a web-route-layer check) at the MCP
+        boundary."""
+        forbidden = {
+            name
+            for name in ACTIONS
+            if name.startswith(("context_install", "context_update", "context_projects"))
+        }
+        assert forbidden == set(), (
+            f"unexpected CLI/web-only context verb(s) exposed on MCP: {sorted(forbidden)}"
+        )
+
+
 class TestMemVersion:
     """Tests for mem_version (mem_do action='version')."""
 


### PR DESCRIPTION
## Summary

The MCP context surface has no `install`/`update` verbs and no `projects` registry verb, so a headless agent cannot perform the ADR-0008 wiki→project flow — and worse, `mem_context_artifact_transfer`'s own destination refusals instructed the caller to run `mm context projects list|resume|add` CLI commands it *cannot execute*. Per the maintainer decision on #1510, this documents CLI/web-only as the deliberate posture (rather than adding the verbs), and makes the refusals honest about it.

## Why CLI/web-only, not new MCP verbs

- `install` / `update` read the host-global wiki but **write into a project's `.memtomem/` tree**, so on the web they mount only in `mode=dev` (PR-E row E-3, `context_mutations.py`). Headless exposure would let an agent snapshot wiki bytes into arbitrary registered projects without the operator-in-the-loop the dev tier / interactive CLI prompts assume.
- The projects registry mutates cross-project enrollment (`known_projects.json`) — a host-scope trust boundary the MCP surface does not own.
- Adding the verbs later means replicating the **sync-eligibility gate** (today a web-route-layer check via `resolve_project_shared_writable_scope_root`, not an engine-layer one) at the MCP boundary. The parity test pins the current absence so that becomes a conscious decision.

## Changes

- **Reword the 3 `artifact_transfer` destination refusals** (unknown / paused / discovery-only) in `_resolve_transfer_destination` to state explicitly that the projects registry **has no MCP verb** — the agent must escalate to a terminal. Existing substring assertions (`mm context projects list/resume/add`, `discovery-only`, `paused`) are preserved, so `test_server_tools_context_artifact_transfer.py` stays green.
- **ADR-0008** — new *"Surface coverage: no MCP verb for install/update/projects (by design)"* subsection under `## Subcommands`, cross-referencing the PR-E dev-tier row.
- **`docs/guides/reference.md`** — CLI/web-only callout at the end of the context tools section.
- **New parity test** `TestContextSurfacePosture` (`test_meta_tool.py`) — pins the exact registered `context` action set **and** asserts `context_install`/`context_update`/`context_projects*` are absent from `ACTIONS`.

## Verification

- `test_meta_tool.py::TestContextSurfacePosture` + `test_server_tools_context_artifact_transfer.py` — 45 passed.
- Docs guard suite (17 passed), `ruff check` + `ruff format --check` clean.
- CLI subcommands `mm context projects {list, add, resume}` confirmed to exist against source (doc claims verified).

Closes #1510

🤖 Generated with [Claude Code](https://claude.com/claude-code)
