### PR TITLE
feat(cli): mm context init --only NAME (single-artifact import) + document skills-only import-to-user (#1520 items 4,5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **`mm context init --only NAME`** (#1520 item 4) imports a single named
+  runtime artifact — the CLI twin of the web's per-artifact Import action.
+  Requires exactly one `--include` kind (skills, agents, or commands) and
+  runs import-only: `context.md`, sibling directory seeding, and the
+  `.gitignore` append are skipped. Exits 1 with a clear message when no
+  runtime artifact matches; `--scope=project_local` is rejected (the draft
+  tier has no runtime fan-out to import from); Gate A/B apply unchanged. The
+  engine already supported single-name narrowing (`only_name=`) for the
+  web routes — this wires it into the CLI.
+
 ### Security
 
 - **The web canonical create/update editors for skills / commands / agents

--- a/docs/guides/reference/data-config-cli.md
+++ b/docs/guides/reference/data-config-cli.md
@@ -317,6 +317,7 @@ mm context init --scope user           # seed user-tier canonical (~/.memtomem/{
 mm context init --scope project_local  # seed gitignored draft tier + auto-append .gitignore
 mm context init --scope project_shared --confirm-project-shared       # Gate B: explicit opt-in
 mm context init --include=agents --scope user --force-unsafe-import   # bypass Gate A on existing leaks
+mm context init --include=skills --only my-skill   # import ONE named runtime artifact (skips context.md + dir seeding)
 mm context generate --agent all        # generate all agent files
 mm context generate --include=agents --label production # generate files using the 'production' labeled snapshot (agents/commands only)
 mm context diff                        # check sync status

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -334,10 +334,16 @@ def _print_artifact_init(
     *,
     scope: TargetScope = "project_shared",
     force_unsafe_import: bool = False,
-) -> None:
+    only_name: str | None = None,
+) -> Any:
+    """Run one kind's runtime import and print the outcome; returns the
+    engine result so ``init --only`` can detect the not-found case
+    (empty ``imported`` + ``skipped`` — the engine silently skips
+    non-matching stems)."""
     result = spec.extract_fn(
         root,
         overwrite=overwrite,
+        only_name=only_name,
         scope=scope,
         force_unsafe_import=force_unsafe_import,
     )
@@ -356,6 +362,7 @@ def _print_artifact_init(
         click.echo(f"  (no runtime {spec.import_plural} imported into {scope})")
     for name, reason, code in result.skipped:
         click.secho(f"    skipped {name}: {reason}", fg=_skip_color(code))
+    return result
 
 
 def _print_artifact_generate(
@@ -802,12 +809,24 @@ def detect_cmd(include: tuple[str, ...]) -> None:
         "hard-refuses (ADR-0011 §5)."
     ),
 )
+@click.option(
+    "--only",
+    "only_name",
+    metavar="NAME",
+    default=None,
+    help=(
+        "Import only the runtime artifact with this exact name (import-only "
+        "mode: skips context.md and directory seeding). Requires exactly one "
+        "--include kind of skills, agents, or commands."
+    ),
+)
 def init_cmd(
     include: tuple[str, ...],
     overwrite: bool,
     scope_flag: str | None,
     confirm_project_shared: bool,
     force_unsafe_import: bool,
+    only_name: str | None,
 ) -> None:
     """Seed canonical artifact dirs and (optionally) import existing runtime files.
 
@@ -818,8 +837,39 @@ def init_cmd(
     ``--scope=project_local`` to seed at the user or local-draft tier
     instead. ADR-0011 §5 Gate A scans every imported file's bytes for
     secrets; project_shared hard-refuses on any hit.
+
+    ``--only NAME`` (#1520 item 4) narrows the runtime import to one named
+    artifact — the CLI twin of the web's single-name import route. It is
+    import-only: context.md, directory seeding, and the .gitignore append
+    are skipped; the scope gates above still apply because they guard the
+    import write itself. ``--scope=project_local`` is rejected — the draft
+    tier has no runtime fan-out to import from, so the command could only
+    ever no-op. Exits 1 when no runtime artifact matches (the engine
+    contract reports not-found as empty ``imported`` + ``skipped``).
     """
     inc = _parse_include(include)
+    if only_name is not None:
+        # Fail fast, before any prompt or filesystem write. ``settings`` is
+        # parse-accepted for init but has no import branch at all, and the
+        # engine ``only_name=`` narrowing exists only for the three artifact
+        # kinds — so exactly one of skills/agents/commands is required.
+        if len(inc) != 1 or "settings" in inc:
+            raise click.UsageError(
+                "--only requires exactly one --include kind (skills, agents, or commands)."
+            )
+        try:
+            validate_name(only_name)
+        except InvalidNameError as exc:
+            raise click.ClickException(str(exc)) from exc
+        # Codex review: project_local has no runtime fan-out to import FROM
+        # (ADR-0011 §3 — the engines short-circuit to a skip), and --only
+        # disables every seeding side effect, so the command would exit 0
+        # having done literally nothing. Reject up front instead.
+        if scope_flag == "project_local":
+            raise click.UsageError(
+                "--only cannot import into --scope=project_local: the draft "
+                "tier has no runtime fan-out to import from (ADR-0011 §3)."
+            )
     root = _find_project_root()
     scope_explicit = scope_flag is not None
     scope = _resolve_artifact_cli_scope(scope_flag)
@@ -874,7 +924,7 @@ def init_cmd(
     #   - explicit ``--scope project_shared`` AND a project context
     #     exists (Gate B already opted in upstream of this branch).
     artifact_only_scope = scope_explicit and scope in ("user", "project_local")
-    write_context_md = has_project_signal and not artifact_only_scope
+    write_context_md = has_project_signal and not artifact_only_scope and only_name is None
     if write_context_md:
         ctx_path = _context_path(root)
         if ctx_path.exists() and not click.confirm(
@@ -926,14 +976,18 @@ def init_cmd(
         click.echo("  Edit this file, then run 'mm context generate' to sync.")
 
     # Seed canonical sub-artifact dirs at the resolved scope (idempotent).
-    for kind in ("agents", "skills", "commands"):
-        d = canonical_artifact_dir(kind, scope, root)
-        d.mkdir(parents=True, exist_ok=True)
-        click.secho(f"  Created {d}", fg="green")
+    # Skipped in --only import-only mode: the extract engines mkdir their
+    # own destination parents, and a single-name import should not seed
+    # sibling kinds' directories.
+    if only_name is None:
+        for kind in ("agents", "skills", "commands"):
+            d = canonical_artifact_dir(kind, scope, root)
+            d.mkdir(parents=True, exist_ok=True)
+            click.secho(f"  Created {d}", fg="green")
 
     # project_local — auto-append the .gitignore block so the local-draft
     # tier and staging dir never end up tracked by accident.
-    if scope == "project_local":
+    if only_name is None and scope == "project_local":
         wrote, msg = _append_gitignore_marker(root)
         if wrote:
             click.secho(
@@ -962,13 +1016,21 @@ def init_cmd(
     for spec in _ARTIFACT_PRINT_SPECS:
         if spec.kind in inc:
             click.echo("")
-            _print_artifact_init(
+            result = _print_artifact_init(
                 spec,
                 root,
                 overwrite=overwrite,
                 scope=scope,
                 force_unsafe_import=force_unsafe_import,
+                only_name=only_name,
             )
+            # Engine contract: non-matching stems are silently skipped, so
+            # "no such runtime artifact" surfaces as empty imported+skipped
+            # (mirrors the web single-name import's 404).
+            if only_name and not result.imported and not result.skipped:
+                raise click.ClickException(
+                    f"No runtime {spec.kind} entry named {only_name!r} to import at scope='{scope}'"
+                )
 
 
 def _read_agent_file(path: Path) -> str:

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -822,6 +822,12 @@ def extract_agents_to_canonical(
     single-item import route) can detect "no such runtime artifact" by
     inspecting an empty ``imported`` + ``skipped``.
 
+    No ``source_scope`` parameter by design (#1520 item 5): the decoupled
+    project-runtime → user-library import (the web ``/import-to-user``
+    route) is skills-only — see ``extract_skills_to_canonical``'s
+    ``source_scope`` docstring. Here the runtime source root always
+    follows ``scope``.
+
     Layout policy: new agents (no existing canonical) land in directory
     layout per ADR-0008. Existing flat-layout entries are preserved by
     PR-C — migration to directory layout is a separate command (PR-D).

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -564,6 +564,12 @@ def extract_commands_to_canonical(
     When ``only_name`` is set, every runtime file with a different stem is
     silently skipped before any validation/dedupe work.
 
+    No ``source_scope`` parameter by design (#1520 item 5): the decoupled
+    project-runtime → user-library import (the web ``/import-to-user``
+    route) is skills-only — see ``extract_skills_to_canonical``'s
+    ``source_scope`` docstring. Here the runtime source root always
+    follows ``scope``.
+
     Layout policy: new commands (no existing canonical) land in directory
     layout per ADR-0008. Existing flat-layout entries are preserved by
     PR-C — migration to directory layout is a separate command (PR-D).

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -912,6 +912,10 @@ async def import_skill_to_user(
     Writes land outside any project root (``~/.memtomem/``), so the user-tier
     host-write disclosure (``allow_host_writes`` round-trip) applies — same as
     the user-tier ``/import``. 404 when no PROJECT runtime skill matches.
+
+    Skills-only by design (#1520 item 5): the agents/commands extract
+    engines have no ``source_scope`` variant, so there is no
+    ``import-to-user`` route for those kinds until one exists.
     """
     try:
         validate_name(name, kind="skill name")

--- a/packages/memtomem/tests/test_context_init_scope.py
+++ b/packages/memtomem/tests/test_context_init_scope.py
@@ -906,3 +906,157 @@ def test_extract_surface_kwarg_reaches_gate_a_for_all_kinds(
     surfaces.clear()
     extract_commands_to_canonical(proj, scope="user", surface="probe_commands")
     assert surfaces == ["probe_commands", "probe_commands"]  # claude + gemini branches
+
+
+# ── `mm context init --only NAME` (#1520 item 4) ────────────────────────
+
+
+class TestInitOnly:
+    """Single-name import-only mode: the CLI twin of the web single-name
+    import route. Engine ``only_name=`` narrowing already existed; these
+    pin the CLI wiring — option validation, side-effect skipping, and the
+    not-found exit (empty ``imported`` + ``skipped`` per engine contract).
+    """
+
+    def _proj_with_two_skills(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        proj = _make_project(tmp_path)
+        monkeypatch.chdir(proj)
+        set_home(monkeypatch, str(tmp_path / "home"))
+        for name in ("alpha", "beta"):
+            skill = proj / ".claude" / "skills" / name
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text(f"---\nname: {name}\n---\nbody\n", encoding="utf-8")
+        return proj
+
+    def test_only_imports_named_skill_and_skips_seeding(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+    ) -> None:
+        proj = self._proj_with_two_skills(tmp_path, monkeypatch)
+
+        result = runner.invoke(cli, ["context", "init", "--include", "skills", "--only", "alpha"])
+
+        assert result.exit_code == 0, result.output
+        assert (proj / ".memtomem" / "skills" / "alpha" / "SKILL.md").is_file()
+        # Sibling skill not imported; import-only mode: no context.md, no
+        # sibling-kind dir seeding.
+        assert not (proj / ".memtomem" / "skills" / "beta").exists()
+        assert not (proj / ".memtomem" / "context.md").exists()
+        assert not (proj / ".memtomem" / "agents").exists()
+        assert not (proj / ".memtomem" / "commands").exists()
+
+    def test_only_not_found_exits_1_with_kind_and_scope(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+    ) -> None:
+        self._proj_with_two_skills(tmp_path, monkeypatch)
+
+        result = runner.invoke(cli, ["context", "init", "--include", "skills", "--only", "ghost"])
+
+        assert result.exit_code == 1, result.output
+        assert "No runtime skills entry named 'ghost'" in result.output
+        assert "scope='project_shared'" in result.output
+
+    @pytest.mark.parametrize(
+        "include_args",
+        [
+            [],  # zero kinds
+            ["--include", "skills,agents"],  # two kinds
+            ["--include", "settings"],  # settings has no import branch
+        ],
+    )
+    def test_only_requires_exactly_one_artifact_kind(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        runner: CliRunner,
+        include_args: list[str],
+    ) -> None:
+        proj = self._proj_with_two_skills(tmp_path, monkeypatch)
+
+        result = runner.invoke(cli, ["context", "init", *include_args, "--only", "alpha"])
+
+        assert result.exit_code == 2, result.output
+        assert "--only requires exactly one --include kind" in result.output
+        # Fail-fast: nothing written.
+        assert not (proj / ".memtomem").exists()
+
+    def test_only_invalid_name_rejected_before_any_write(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+    ) -> None:
+        proj = self._proj_with_two_skills(tmp_path, monkeypatch)
+
+        result = runner.invoke(cli, ["context", "init", "--include", "skills", "--only", "../evil"])
+
+        assert result.exit_code == 1, result.output
+        assert not (proj / ".memtomem").exists()
+
+    def test_only_rejects_project_local_scope(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+    ) -> None:
+        """Codex review: project_local has no runtime fan-out to import from
+        and --only disables all seeding side effects — reject up front rather
+        than exiting 0 having done nothing."""
+        proj = self._proj_with_two_skills(tmp_path, monkeypatch)
+
+        result = runner.invoke(
+            cli,
+            [
+                "context",
+                "init",
+                "--include",
+                "skills",
+                "--only",
+                "alpha",
+                "--scope",
+                "project_local",
+            ],
+        )
+
+        assert result.exit_code == 2, result.output
+        assert "--only cannot import into --scope=project_local" in result.output
+        assert not (proj / ".memtomem").exists()
+
+    def test_only_agents_happy_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+    ) -> None:
+        proj = _make_project(tmp_path)
+        monkeypatch.chdir(proj)
+        set_home(monkeypatch, str(tmp_path / "home"))
+        _seed_project_runtime_agents(proj, "helper", "---\nname: helper\n---\nbody\n")
+        _seed_project_runtime_agents(proj, "other", "---\nname: other\n---\nbody\n")
+
+        result = runner.invoke(cli, ["context", "init", "--include", "agents", "--only", "helper"])
+
+        assert result.exit_code == 0, result.output
+        assert (proj / ".memtomem" / "agents" / "helper").exists()
+        assert not (proj / ".memtomem" / "agents" / "other").exists()
+
+    def test_only_commands_happy_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+    ) -> None:
+        proj = _make_project(tmp_path)
+        monkeypatch.chdir(proj)
+        set_home(monkeypatch, str(tmp_path / "home"))
+        cmds = proj / ".claude" / "commands"
+        cmds.mkdir(parents=True)
+        (cmds / "ship.md").write_text("Ship it.\n", encoding="utf-8")
+        (cmds / "hold.md").write_text("Hold it.\n", encoding="utf-8")
+
+        result = runner.invoke(cli, ["context", "init", "--include", "commands", "--only", "ship"])
+
+        assert result.exit_code == 0, result.output
+        assert (proj / ".memtomem" / "commands" / "ship").exists()
+        assert not (proj / ".memtomem" / "commands" / "hold").exists()
+
+    def test_only_without_flag_preserves_full_init(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+    ) -> None:
+        """No --only → pre-#1520 behavior intact (context.md + dir seeding)."""
+        proj = self._proj_with_two_skills(tmp_path, monkeypatch)
+
+        result = runner.invoke(cli, ["context", "init", "--include", "skills"], input="")
+
+        assert result.exit_code == 0, result.output
+        assert (proj / ".memtomem" / "context.md").exists()
+        assert (proj / ".memtomem" / "skills" / "alpha").exists()
+        assert (proj / ".memtomem" / "skills" / "beta").exists()
+        assert (proj / ".memtomem" / "agents").exists()


### PR DESCRIPTION
## Summary

#1520 items 4 + 5 — CLI single-artifact import parity, and recording why `import-to-user` is skills-only.

### Item 4 — `mm context init --only NAME`

The web has had per-artifact import routes since #1380; the CLI could only import a whole kind. The extract engines already support single-name narrowing (`only_name=`) for those routes — this PR wires it into `init`:

```bash
mm context init --include skills --only my-skill
```

- **Validation up front** (before any prompt or write): exactly one `--include` kind of skills/agents/commands (`settings` is parse-accepted by init but has no import branch), `validate_name` on the name, and `--scope=project_local` rejected (the draft tier has no runtime fan-out to import *from* — the engines short-circuit to a skip, and with seeding disabled the command could only ever no-op; a Codex-review catch on this PR's first round).
- **Import-only mode**: `context.md`, sibling-kind dir seeding, and the `.gitignore` append are skipped — the engines mkdir their own destination parents. Scope gates (Gate A/B, project-root check) stay active; they guard the import write itself.
- **Not-found exits 1** with `No runtime <kind> entry named '<name>' to import at scope='<scope>'` — the engine contract reports not-found as empty `imported`+`skipped` (non-matching stems are silently skipped), mirroring the web single-name import's 404.
- Plain `init` without `--only` is byte-identical (pinned by existing CLI tests; a new regression test also pins the full-init shape).

### Item 5 — `import-to-user` skills-only, documented (doc-only)

`POST /context/skills/{name}/import-to-user` (#1380) has no agents/commands equivalent although its docstring rationale generalizes. The blocker is structural: `extract_skills_to_canonical` grew a `source_scope` parameter to decouple the project-runtime source from the user-canonical destination; the agents/commands engines always derive the source root from the destination scope. Recorded on all three surfaces (both extract docstrings + the route) so the asymmetry reads as a decision, not an oversight.

## Testing

- New `TestInitOnly` suite in `test_context_init_scope.py`: single-skill import leaves siblings/context.md/other dirs untouched; agents/commands happy paths; not-found exit 1; 0/2-kind and `settings` → exit 2; invalid name rejected pre-write; `project_local` rejected; full-init regression without `--only`.
- E2E in an isolated worktree + isolated `HOME`: `uv run mm context init --include skills --only demo` imported exactly one skill (no `context.md`, no sibling dirs); not-found leg exits 1.
- `uv run pytest -m "not ollama"` — full suite green; `ruff check` + `format --check` clean.

Part of #1520 (items 4, 5). Items 3/7/quotePath: #1599. Item 6: #1601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
