### PR TITLE
feat(web): prod affordance for wiki install instead of a silent dead-end

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1772,7 +1772,7 @@
   <script src="/context-gateway-detail.js?v=1"></script>
   <script src="/context-gateway-actions.js?v=1"></script>
   <script src="/context-portal.js?v=7"></script>
-  <script src="/wiki.js?v=8"></script>
+  <script src="/wiki.js?v=9"></script>
   <script src="/path-picker.js?v=4"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -528,6 +528,7 @@
   "settings.ctx.wiki_update": "Update",
   "settings.ctx.wiki_install_project": "Project",
   "settings.ctx.wiki_install_hint": "Wiki edits change ~/.memtomem-wiki, a separate git library shared across projects. Install snapshots this asset into the current project's .memtomem/ store; it does not edit ~/.memtomem/config.json or the user-level ~/.memtomem/<artifact>/ store. Update refreshes an installed one to wiki HEAD.",
+  "settings.ctx.wiki_install_prod_note": "Installing into a project is available only when the server runs in dev mode. Restart it with `mm web --dev` to install or update this asset, or use `mm context install` from the CLI.",
   "settings.ctx.wiki_force_confirm_title": "Overwrite local edits?",
   "settings.ctx.wiki_force_confirm_msg": "{type} \"{name}\" has local edits in {project}. Force-update overwrites them — each edited file is kept as a .bak sibling.",
   "settings.ctx.wiki_force_confirm_ok": "Overwrite",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -528,6 +528,7 @@
   "settings.ctx.wiki_update": "업데이트",
   "settings.ctx.wiki_install_project": "프로젝트",
   "settings.ctx.wiki_install_hint": "위키 편집은 모든 프로젝트가 참조할 수 있는 별도 git 라이브러리 ~/.memtomem-wiki 를 바꿉니다. 설치는 이 자산을 현재 프로젝트의 .memtomem/ 으로 스냅샷하며, ~/.memtomem/config.json 설정이나 사용자 레벨 ~/.memtomem/<artifact>/ 저장소는 수정하지 않습니다. 업데이트는 설치된 자산을 위키 HEAD 로 갱신합니다.",
+  "settings.ctx.wiki_install_prod_note": "프로젝트로의 설치는 서버가 dev 모드로 실행 중일 때만 가능합니다. 이 자산을 설치하거나 업데이트하려면 `mm web --dev` 로 서버를 다시 시작하거나, CLI 에서 `mm context install` 을 사용하세요.",
   "settings.ctx.wiki_force_confirm_title": "로컬 수정을 덮어쓸까요?",
   "settings.ctx.wiki_force_confirm_msg": "{project} 의 {type} \"{name}\" 에 로컬 수정이 있습니다. 강제 업데이트는 이를 덮어씁니다 — 수정된 각 파일은 .bak 으로 보존됩니다.",
   "settings.ctx.wiki_force_confirm_ok": "덮어쓰기",

--- a/packages/memtomem/src/memtomem/web/static/wiki.js
+++ b/packages/memtomem/src/memtomem/web/static/wiki.js
@@ -950,11 +950,36 @@ async function _wikiEnsureProjects() {
   }
 }
 
+function _renderWikiInstallProdNote() {
+  // Prod tier (#1511): the install/update POST routes mount only in dev
+  // (context_mutations.py, ADR-0008 E-3), so in prod the browse-only wiki
+  // would otherwise be a silent dead-end — a user reads the asset with no
+  // hint that installing it needs a differently-started server. Render an
+  // INERT affordance (disabled buttons + a note naming the `--dev`
+  // remediation) instead of nothing. Deliberately carries NO `wiki-install-btn`
+  // id and binds no handler: _bindWikiInstallAction stays a no-op here, so the
+  // "no functional install in prod" contract is unchanged — the buttons only
+  // make the missing capability discoverable.
+  return '<div class="wiki-section wiki-install-action wiki-install-action-prod">'
+    + '<div class="wiki-install-buttons">'
+    + `<button type="button" class="btn-ghost" disabled>`
+    + `${escapeHtml(t('settings.ctx.wiki_install'))}</button>`
+    + `<button type="button" class="btn-ghost" disabled>`
+    + `${escapeHtml(t('settings.ctx.wiki_update'))}</button>`
+    + '</div>'
+    + `<p class="wiki-seed-hint" id="wiki-install-prod-note" role="note">`
+    + `${escapeHtml(t('settings.ctx.wiki_install_prod_note'))}</p>`
+    + '</div>';
+}
+
 function _renderWikiInstallAction() {
-  // Dev-tier only: install/update writes into a project's git-tracked tree (the
-  // POST routes only mount in dev). Asset-level (vendor-independent), so this
-  // renders in the detail head, NOT the per-vendor view.
-  if (!_wikiDevMode() || !_wikiActive) return '';
+  // Asset-level (vendor-independent), so this renders in the detail head, NOT
+  // the per-vendor view.
+  if (!_wikiActive) return '';
+  // Install/update writes into a project's git-tracked tree; the POST routes
+  // only mount in dev. In prod, show the discoverability note (#1511) instead
+  // of an empty string.
+  if (!_wikiDevMode()) return _renderWikiInstallProdNote();
   let scopes = _wikiScopeList().filter((s) => !s.missing);
   if (!scopes.some((s) => (s.scope_id || '') === '')) {
     // Always offer Server-CWD (the CLI default target) even with an empty roster.

--- a/packages/memtomem/tests-js/wiki.test.mjs
+++ b/packages/memtomem/tests-js/wiki.test.mjs
@@ -281,13 +281,17 @@ describe('wiki.js install/update (E-3, dev tier)', () => {
     return posts;
   }
 
-  it('shows install/update buttons in dev and hides them in prod', async () => {
+  it('shows functional install/update buttons in dev', async () => {
     const dev = await bootDev();
     await dev.window.loadWiki();
     await dev.window.loadWikiDetail('skills', 'alpha');
     expect(dev.window.document.getElementById('wiki-install-btn')).not.toBeNull();
     expect(dev.window.document.getElementById('wiki-update-btn')).not.toBeNull();
+    // Dev shows no prod discoverability note.
+    expect(dev.window.document.getElementById('wiki-install-prod-note')).toBeNull();
+  });
 
+  it('shows a disabled affordance + --dev note in prod, not a silent dead-end (#1511)', async () => {
     const prod = await boot({
       '/api/wiki': WIKI_LIST,
       '/api/wiki/skills/alpha/diff': ALPHA_DIFF_NONE,
@@ -295,7 +299,17 @@ describe('wiki.js install/update (E-3, dev tier)', () => {
     });
     await prod.window.loadWiki();
     await prod.window.loadWikiDetail('skills', 'alpha');
-    expect(prod.window.document.getElementById('wiki-install-btn')).toBeNull();
+    const doc = prod.window.document;
+    // No FUNCTIONAL install button in prod (the POST route is dev-only), so
+    // the id bound by _bindWikiInstallAction is still absent.
+    expect(doc.getElementById('wiki-install-btn')).toBeNull();
+    // But the capability is now discoverable: a note names the remediation...
+    const note = doc.getElementById('wiki-install-prod-note');
+    expect(note).not.toBeNull();
+    expect(note.textContent).toContain('--dev');
+    // ...alongside inert (disabled) Install/Update buttons.
+    const buttons = doc.querySelectorAll('.wiki-install-action-prod button[disabled]');
+    expect(buttons.length).toBe(2);
   });
 
   it('project <select> lists the roster and defaults to the active scope', async () => {


### PR DESCRIPTION
## Summary

The prod web tier can **browse** the wiki (catalog, per-vendor diff/lint) but cannot **install** any asset into a project — the install/update routes mount dev-only (`context_mutations` is in `_DEV_ONLY_ROUTERS`, ADR-0008 E-3). In prod, `_renderWikiInstallAction()` returned `''`, so a user reading an asset saw no hint that installing it needs a differently-started server: browsing with no way to act, a silent dead-end (#1511).

Per the maintainer decision, this keeps the dev-only mount (writing into a project's git-tracked tree stays gated) and adds a **prod affordance** so the browse-only surface stops being a silent absence.

## Change

In prod, render an **inert** affordance instead of nothing:

- Two **disabled** Install/Update buttons (the capability is now visible, just unavailable here).
- A note naming the remediation: restart with `mm web --dev`, or use `mm context install` from the CLI.

The prod render deliberately carries **no `wiki-install-btn` id and binds no handler**, so `_bindWikiInstallAction` stays a no-op and the "no functional install in prod" contract is unchanged — nothing new can POST.

Uses the existing server-driven tier mechanism (`/api/system/ui-mode` → `body.dev-mode` class → `_wikiDevMode()`); no new tier plumbing.

- New i18n key `settings.ctx.wiki_install_prod_note` (en + ko; locale key parity verified).
- `wiki.js` cache-bust bumped `v8` → `v9`.

## Verification

- `wiki.test.mjs` — the former "hides them in prod" test is split into a **dev** test (functional buttons, no note) and a **prod** test (disabled affordance + `--dev` note, still no functional `wiki-install-btn`). Full tests-js suite: **59 files / 406 tests pass**.
- Python web-static / locale-key / i18n guards pass (36 + 97 tests).
- **End-to-end**: drove a real prod-mode `mm web` with Playwright — `/api/system/ui-mode` returns `{"mode":"prod"}`, `wiki.js?v=9` served, and the wiki detail for a real asset renders the disabled 설치/업데이트 buttons + the localized `--dev` note, with no functional install button.

Closes #1511

🤖 Generated with [Claude Code](https://claude.com/claude-code)
