### PR TITLE
docs(cli): document the two --all axes on context install vs update

### DIFF
--- a/docs/guides/context-gateway.md
+++ b/docs/guides/context-gateway.md
@@ -114,6 +114,15 @@ wiki (~/.memtomem-wiki)  ──install──▶  project Store (<project>/.memto
   unchanged / refuse preview without writing anything (also works with
   `--all`, where it prints the batch table and skips the confirm prompt).
 
+> **`--all` means different axes on `install` vs `update`.** They are not the
+> same batch. `mm context install --all` fixes the **project** and restores
+> *every asset* in this project's `lock.json` at its pinned commit — the
+> "fresh-machine restore" verb (it takes no `<type> <name>`). `mm context
+> update --all` fixes the **asset** (`<type> <name>` still required) and applies
+> that one asset across *every known project* that has it installed, advancing
+> each to wiki HEAD. Pick by what you're holding constant: one project (install)
+> or one asset (update).
+
 Install and Update only ever write the **project** Store. They do **not** edit
 `~/.memtomem/config.json` or the `~/.memtomem/<artifact>/` User tier — so a wiki
 install never changes your machine-wide settings or User-tier copies. Once

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -1763,7 +1763,11 @@ def version_enable_cmd(artifact_type: str, name: str, scope_flag: str | None) ->
     "--all",
     "all_assets",
     is_flag=True,
-    help="Re-install every entry from <project>/.memtomem/lock.json at its pinned commit.",
+    help=(
+        "Re-install every ASSET in THIS project's .memtomem/lock.json at its "
+        "pinned commit (fresh-machine restore). Note: `update --all` means a "
+        "different axis — ONE asset across every known PROJECT."
+    ),
 )
 @click.option(
     "--yes",
@@ -1846,7 +1850,11 @@ _WIKI_DIRTY_WARN = "warning: wiki has uncommitted changes; using HEAD which does
     "--all",
     "all_projects",
     is_flag=True,
-    help="Apply across every known project that has this asset installed.",
+    help=(
+        "Apply this ONE asset across every known PROJECT that has it installed. "
+        "Note: `install --all` means a different axis — every asset in a SINGLE "
+        "project, restored at its pin."
+    ),
 )
 @click.option(
     "--yes",


### PR DESCRIPTION
## Summary

`--all` means different axes on the sibling verbs `mm context install` and `mm context update`, which reads as an inconsistency to a user who learned one and reaches for the other (#1513):

- **`install --all`** fixes the **project** and restores *every asset* in this project's `lock.json` at its pinned commit — the fresh-machine restore verb (takes no `<type> <name>`; Python dest `all_assets`).
- **`update --all`** fixes the **asset** (`<type> <name>` still required) and applies it across *every known project* that has it installed (Python dest `all_projects`).

Flag-semantics changes are breaking for scripts, so per the maintainer decision on #1513 this **keeps both axes as-is and documents the difference** rather than renaming or deprecating.

## Change (docs/help only — no behavior change)

- Both `--all` help strings now name their axis explicitly and cross-reference the sibling verb ("Note: `update --all` means a different axis — ONE asset across every known PROJECT", and vice versa).
- `docs/guides/context-gateway.md` gains a callout under the Install/Update section contrasting the two axes ("Pick by what you're holding constant: one project (install) or one asset (update)").

## Verification

- `mm context install --help` / `mm context update --help` render the new axis-naming text (confirmed).
- No test or doc asserted the old help strings (grep clean).
- Docs guards + context install/update + CLI context suites: **209 passed**. `ruff check` + `ruff format --check` clean.

Closes #1513

🤖 Generated with [Claude Code](https://claude.com/claude-code)
