### PR TITLE
fix(cli): warn when a non-pid-file writer still holds the DB after mm upgrade

### DIFF
--- a/packages/memtomem/src/memtomem/cli/upgrade_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/upgrade_cmd.py
@@ -9,8 +9,9 @@ issue #443. The same applies to a backgrounded ``mm web`` — it holds
 (#1569). ``mm upgrade`` wraps the reinstall with process-level hygiene:
 
     probe live server + web UI → SIGTERM (escalate to SIGKILL after
-    grace) → unlink stale pid files → ``uv tool install --refresh
-    --reinstall``.
+    grace) → unlink stale pid files → ``BEGIN IMMEDIATE`` DB probe for
+    writers the pid files can't see (#1606, warn-only) → ``uv tool
+    install --refresh --reinstall``.
 
 There is no ``--skip-pkill``: the kill-then-reinstall ordering is the
 whole reason this command exists. On Windows the kill stage is skipped
@@ -33,6 +34,7 @@ from pathlib import Path
 
 import click
 
+from memtomem.cli._db_lock import check_db_lock
 from memtomem.cli._liveness import (
     ServerState,
     check_server_liveness,
@@ -147,6 +149,28 @@ def _stop_server(state: ServerState, grace: float) -> tuple[list[int], list[Path
                 ) from exc
 
     return killed, removed
+
+
+def _resolve_db_path() -> Path | None:
+    """Best-effort DB path for the post-stop write-lock probe (#1606).
+
+    ``migrate=False`` for the same reason as ``mm reset``: this is a
+    read-only lookup and the auto-discover migration would rewrite
+    config.json (and create its lock sidecar) as a side effect.
+
+    Returns ``None`` on any failure — the probe is belt-and-braces, and
+    an upgrade must never be blocked by an unrelated config problem
+    (matching ``check_db_lock``'s own fail-open contract).
+    """
+    try:
+        from memtomem.config import Mem2MemConfig, load_config_d, load_config_overrides
+
+        cfg = Mem2MemConfig()
+        load_config_d(cfg)
+        load_config_overrides(cfg, migrate=False)
+        return Path(cfg.storage.sqlite_path).expanduser()
+    except Exception:
+        return None
 
 
 def _detect_installed_extras() -> list[str]:
@@ -370,6 +394,18 @@ def upgrade(
                 sys.exit(1)
             raise
 
+    # ----- post-stop DB probe (#1606) -----
+    # The pid-file probes only see processes that wrote server.pid /
+    # web.pid. A writer that never did (a user sqlite3 session, a process
+    # launched from another checkout) survives the stop stage and keeps
+    # running the old code after the byte swap. With the known processes
+    # down, a remaining write lock is by definition an unknown writer.
+    # Warn-and-proceed: the reinstall itself is safe, and the probe can't
+    # name a pid for us to stop (contrast mm reset, where the destructive
+    # wipe justifies refusing outright).
+    db_path = _resolve_db_path()
+    db_lock_warning = db_path is not None and check_db_lock(db_path).locked
+
     # ----- reinstall -----
     try:
         result = subprocess.run(install_cmd, capture_output=True, text=True, timeout=600)
@@ -417,6 +453,7 @@ def upgrade(
                     "reinstalled": pkg_target,
                     "extras": extras,
                     "version": version,
+                    "db_lock_warning": db_lock_warning,
                 }
             )
         )
@@ -430,3 +467,12 @@ def upgrade(
         for path in removed:
             click.echo(f"Removed {_format_path(path)}.")
     click.secho(f"Reinstalled {pkg_target}.", fg="green")
+    if db_lock_warning and db_path is not None:
+        db_repr = _format_path(db_path)
+        click.secho(
+            f"Warning: another process still holds a write lock on {db_repr} — "
+            "it keeps running the previous version until it exits. Find it with "
+            f"`lsof {db_repr}` (or `ps aux | grep memtomem`) and restart it to "
+            "pick up the upgrade.",
+            fg="yellow",
+        )

--- a/packages/memtomem/tests/test_upgrade_cmd.py
+++ b/packages/memtomem/tests/test_upgrade_cmd.py
@@ -28,6 +28,17 @@ def _no_extras_by_default(monkeypatch):
     monkeypatch.setattr(upgrade_cmd, "_detect_installed_extras", lambda: [])
 
 
+@pytest.fixture(autouse=True)
+def _no_db_probe_by_default(monkeypatch):
+    """Default tests skip the post-stop DB write-lock probe (#1606).
+
+    ``_resolve_db_path`` loads the real user config; returning None here
+    keeps every test off the real ``~/.memtomem``. Probe tests opt in by
+    re-patching ``_resolve_db_path`` + ``check_db_lock``.
+    """
+    monkeypatch.setattr(upgrade_cmd, "_resolve_db_path", lambda: None, raising=False)
+
+
 @pytest.fixture
 def fake_uv(monkeypatch):
     """Capture subprocess.run invocations and return scripted results."""
@@ -489,3 +500,95 @@ def _make_monotonic(values: list[float]):
         return values[-1]
 
     return _now
+
+
+# ------------------------------------------- post-stop DB probe (#1606)
+
+
+def _patch_db_probe(monkeypatch, tmp_path, *, locked: bool):
+    """Route the probe at a fake DB path with a scripted lock state."""
+    from memtomem.cli._db_lock import DbLockState
+
+    db_path = tmp_path / "memory.db"
+    monkeypatch.setattr(upgrade_cmd, "_resolve_db_path", lambda: db_path, raising=False)
+    monkeypatch.setattr(
+        upgrade_cmd,
+        "check_db_lock",
+        lambda _p: DbLockState(locked=locked, probe_error=None),
+        raising=False,
+    )
+    return db_path
+
+
+def test_db_lock_warns_but_proceeds(monkeypatch, tmp_path, fake_uv, force_tty):
+    """An unknown writer (no pid file) must produce a warning, not a refusal."""
+    calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, _DEAD)
+    _patch_db_probe(monkeypatch, tmp_path, locked=True)
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y"])
+    assert result.exit_code == 0, result.output
+    assert "write lock" in result.output
+    assert "previous version" in result.output
+    assert "lsof" in result.output
+    assert calls  # reinstall proceeded despite the lock
+
+
+def test_db_lock_warning_in_json_output(monkeypatch, tmp_path, fake_uv, force_tty):
+    _calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, _DEAD)
+    _patch_db_probe(monkeypatch, tmp_path, locked=True)
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["ok"] is True
+    assert payload["db_lock_warning"] is True
+
+
+def test_no_db_lock_no_warning(monkeypatch, tmp_path, fake_uv, force_tty):
+    _calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, _DEAD)
+    _patch_db_probe(monkeypatch, tmp_path, locked=False)
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["ok"] is True
+    assert payload["db_lock_warning"] is False
+
+    human = CliRunner().invoke(cli, ["upgrade", "-y"])
+    assert human.exit_code == 0, human.output
+    assert "write lock" not in human.output
+
+
+def test_config_failure_skips_probe(monkeypatch, fake_uv, force_tty):
+    """A broken config must not block the upgrade — the probe is skipped."""
+    calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, _DEAD)
+    monkeypatch.setattr(upgrade_cmd, "_resolve_db_path", lambda: None, raising=False)
+
+    def boom(_p):
+        raise AssertionError("check_db_lock must not run without a resolved db path")
+
+    monkeypatch.setattr(upgrade_cmd, "check_db_lock", boom, raising=False)
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y"])
+    assert result.exit_code == 0, result.output
+    assert "write lock" not in result.output
+    assert calls
+
+
+def test_dry_run_skips_db_probe(monkeypatch, tmp_path, fake_uv, force_tty):
+    """Dry-run never stops processes, so the post-stop probe must not run."""
+    calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, _DEAD)
+
+    def boom():
+        raise AssertionError("_resolve_db_path must not run on --dry-run")
+
+    monkeypatch.setattr(upgrade_cmd, "_resolve_db_path", boom, raising=False)
+
+    result = CliRunner().invoke(cli, ["upgrade", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert calls == []


### PR DESCRIPTION
## Summary

`mm upgrade` stops the processes it can see — the MCP server and, since PR #1590, a backgrounded `mm web` — but its liveness picture is pid-file-only. A live writer that never wrote a pid file (a user `sqlite3` session, a memtomem process launched from another checkout) survives the stop stage and keeps executing the **previous** version against the shared DB after the byte swap. PR #1590 explicitly deferred the belt-and-braces `BEGIN IMMEDIATE` probe as out of scope; the shared infrastructure has since landed in `cli/_db_lock.py` (#1574 item 7, PR #1595).

Closes #1606

## Changes

- **`cli/upgrade_cmd.py`**
  - New `_resolve_db_path()` — resolves `cfg.storage.sqlite_path` with `migrate=False` (same read-only-lookup rationale as `mm reset` / `mm uninstall`: the auto-discover migration would rewrite config.json and create its lock sidecar). Returns `None` on any config failure — an upgrade must never be blocked by an unrelated config problem, matching `check_db_lock`'s own fail-open contract.
  - Post-stop probe: once the known server/web processes are down, a remaining write lock is by definition an unknown writer. **Warn-and-proceed**, not refuse — the reinstall itself is safe, and the probe cannot name a pid for `mm upgrade` to stop (contrast `mm reset`, where the destructive wipe justifies refusing outright). The warning names the DB path and reuses the `mm reset` hint (`lsof` / `ps aux | grep memtomem`).
  - `--dry-run` never probes: the stop stage hasn't run, so a lock would be ambiguous with the still-running known processes.
  - `--json` success payload gains a stable `db_lock_warning` boolean.
  - The probe is read-only and platform-neutral, so it runs on Windows too — where the kill stage is skipped, making the warning more valuable.

- **`tests/test_upgrade_cmd.py`**
  - New autouse `_no_db_probe_by_default` seam keeps every existing test off the real `~/.memtomem` config.
  - Red-first regressions: locked → warning + `db_lock_warning: true` + reinstall still proceeds (exit 0); unlocked → no warning, `false` in JSON; config failure → probe skipped, upgrade unaffected; `--dry-run` → probe never invoked.

## Verification

- Red-first: the three semantic tests failed before the implementation (`KeyError: 'db_lock_warning'`, missing warning text).
- E2E in an isolated `HOME` + `XDG_RUNTIME_DIR`: with a real background `sqlite3` connection holding `BEGIN IMMEDIATE` on the configured DB, `mm upgrade -y` completed the reinstall and reported `db_lock_warning: true` (human run printed the yellow warning); after releasing the lock, `false` with no warning.
- `uv run pytest -m "not ollama"` on `test_upgrade_cmd.py` + `test_reset_cmd.py` + `test_uninstall_cmd.py`: 85 passed, 2 skipped.
- `ruff check` + `ruff format --check` clean; `mypy` clean on `upgrade_cmd.py`.
- Codex review: SHIP, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
