### PR TITLE
fix(server): build instructions per tool mode so text matches the exposed surface

### DIFF
--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -34,8 +34,13 @@ from memtomem.server.helpers import (
     _parse_recall_date as _parse_recall_date,
     _set_config_key as _set_config_key,
 )
-from memtomem.server.instructions import INSTRUCTIONS as _INSTRUCTIONS
+from memtomem.server.instructions import build_instructions
 from memtomem.server.lifespan import app_lifespan
+
+# Tool mode must be resolved BEFORE the FastMCP instance exists: the
+# instructions text has to describe the tool surface this mode actually
+# exposes (#1608), and ``instructions=`` is only accepted at construction.
+_TOOL_MODE = os.environ.get("MEMTOMEM_TOOL_MODE", "core").lower()
 
 # ── mcp instance — must be created before tool-module imports ──────────
 # ``instructions=`` is auto-injected into every MCP client's session as
@@ -43,7 +48,7 @@ from memtomem.server.lifespan import app_lifespan
 # documentation surface most LLMs see before picking a tool. Source of
 # truth lives in ``memtomem/server/instructions.py``; pinned by
 # ``tests/test_server_instructions.py``.
-mcp = FastMCP("memtomem", instructions=_INSTRUCTIONS, lifespan=app_lifespan)
+mcp = FastMCP("memtomem", instructions=build_instructions(_TOOL_MODE), lifespan=app_lifespan)
 
 # Pin ``serverInfo.version`` in the MCP ``initialize`` response to the
 # memtomem package version (#383). ``FastMCP.__init__`` has no ``version``
@@ -167,27 +172,36 @@ _CORE_TOOLS = {
     "mem_do",
 }
 
-_TOOL_MODE = os.environ.get("MEMTOMEM_TOOL_MODE", "core").lower()
+# Action categories exposed as individual tools in ``standard`` mode.
+# Module-level so tests (instructions/pruning pins) can derive the
+# expected tool set from the same source the pruning uses.
+_STANDARD_PACKS = frozenset(
+    {
+        "crud",
+        "namespace",
+        "tags",
+        "sessions",
+        "scratch",
+        "relations",
+        "schedule",
+    }
+)
+
+# Snapshot of every tool registered by the imports above, taken BEFORE
+# pruning — the only place the full surface is still observable once a
+# non-full mode has pruned ``mcp``. Used by the per-mode pin tests.
+_ALL_REGISTERED_TOOLS = frozenset(t.name for t in mcp._tool_manager.list_tools())
 
 if _TOOL_MODE != "full":
     if _TOOL_MODE == "standard":
         from memtomem.server.tool_registry import ACTIONS
 
-        _standard_packs = {
-            "crud",
-            "namespace",
-            "tags",
-            "sessions",
-            "scratch",
-            "relations",
-            "schedule",
-        }
         _allowed = _CORE_TOOLS | {
-            f"mem_{name}" for name, info in ACTIONS.items() if info.category in _standard_packs
+            f"mem_{name}" for name, info in ACTIONS.items() if info.category in _STANDARD_PACKS
         }
     else:
         _allowed = _CORE_TOOLS
-    for name in list(mcp._tool_manager._tools):
+    for name in _ALL_REGISTERED_TOOLS:
         if name not in _allowed:
             mcp._tool_manager.remove_tool(name)
 

--- a/packages/memtomem/src/memtomem/server/instructions.py
+++ b/packages/memtomem/src/memtomem/server/instructions.py
@@ -1,4 +1,4 @@
-"""Server-level instructions string.
+"""Server-level instructions string, built per tool mode.
 
 Passed to ``FastMCP(instructions=...)`` and surfaced to every MCP client
 on the ``initialize`` response. This is the only documentation surface
@@ -6,21 +6,142 @@ most LLMs see before deciding which tool to call — keep it tight and
 focused on workflow recognition, not a full reference. Per-tool
 docstrings cover argument-level detail.
 
-When changing this string, also update the pin test
-``tests/test_server_instructions.py`` so that renamed tools or removed
-namespace conventions don't silently drift.
+The text MUST match the tool surface the client actually sees (#1608):
+``MEMTOMEM_TOOL_MODE=core`` (the default) exposes only the 9 core tools,
+so every multi-agent/session call is shown in its ``mem_do(action=...)``
+routed form there; ``standard`` exposes the session/crud packs directly
+but still routes ``multi_agent`` tools through ``mem_do``; ``full``
+shows direct calls for everything. Action name = tool name minus the
+``mem_`` prefix (see ``server/tool_registry.py``).
+
+When changing these strings, also update the pin test
+``tests/test_server_instructions.py`` so that renamed tools, removed
+namespace conventions, or mode/exposure mismatches don't silently drift.
 """
 
 from __future__ import annotations
 
-INSTRUCTIONS: str = """\
-memtomem — markdown-first long-term memory MCP server.
+VALID_TOOL_MODES: tuple[str, ...] = ("core", "standard", "full")
 
+_HEADER = """\
+memtomem — markdown-first long-term memory MCP server.
+"""
+
+_SINGLE_AGENT = """\
 Default usage (single-agent — the common case):
 - mem_add to record a note, mem_search to find one. That's it.
 - Notes go to the "default" namespace; agent_id and namespace=
   can be ignored unless you're orchestrating multiple agents.
+"""
 
+_NAMESPACES = """\
+Namespace conventions:
+  default                 single-agent / pre-multi-agent
+  agent-runtime:<id>      per-agent isolated scope
+  shared                  cross-agent shared scope
+Pass explicit namespace= only when overriding the derived value.
+"""
+
+_FOOTER = """\
+When in doubt, default to mem_add / mem_search with no extras.
+"""
+
+_CORE_MODE = """\
+This server runs in the default "core" tool mode: only the 9 core tools
+are exposed individually. Every other action is invoked through the
+mem_do dispatcher — mem_do(action="<name>", params={...}) where <name>
+is the tool name minus the "mem_" prefix. mem_do(action="help") lists
+every available action grouped by category (including actions that have
+no individual tool in any mode, e.g. "ingest"). Set
+MEMTOMEM_TOOL_MODE=standard|full on the server to expose more tools
+individually.
+
+Multi-agent workflow (only when the user asks for per-agent
+isolation or shared knowledge between agents):
+1. Register each agent once:
+     mem_do(action="agent_register", params={"agent_id": "planner"})
+2. Start a session per agent run:
+     mem_do(action="session_start", params={"agent_id": "planner"})
+   The session record's namespace auto-derives to
+   "agent-runtime:planner" — no explicit namespace= needed.
+3. Search / share inside the agent scope:
+     mem_do(action="agent_search", params={"query": "...", "include_shared": True})
+     mem_do(action="agent_share", params={"chunk_id": "...", "target": "shared"})
+4. End the session: mem_do(action="session_end", params={"summary": "..."})
+
+Per-project teams (multiple teams against one server): prefix the project
+onto the agent_id (agent_id="projA-planner") for private memory, and keep
+team-shared notes in a per-project bucket — write with
+mem_do(action="agent_share", params={"chunk_id": "...", "target": "shared:projA"}),
+read with
+mem_do(action="agent_search", params={"query": "...", "shared_namespace": "shared:projA"}).
+See ADR-0028.
+
+Session-bound write contract:
+- After mem_do(action="session_start", params={"agent_id": "..."}),
+  subsequent mem_add and mem_do(action="batch_add") calls without an
+  explicit namespace= argument automatically write to
+  "agent-runtime:<id>" — the session's agent scope. Pass namespace=
+  explicitly to write somewhere else (e.g. namespace="shared").
+- mem_search still reads from current_namespace by default; use
+  mem_do(action="agent_search") to read inside the agent scope.
+  (Symmetric search-side support is tracked separately.)
+
+Common pitfalls:
+- session_start without agent_id falls back to the "default"
+  namespace — pass agent_id whenever you want isolation.
+- agent_search needs an active session (or current_agent_id);
+  run the session_start action first.
+"""
+
+_STANDARD_MODE = """\
+This server runs in "standard" tool mode: core tools plus the session /
+crud / namespace / tags / scratch / relations / schedule packs are
+exposed individually. Multi-agent tools (agent_register, agent_search,
+agent_share) are NOT individual tools here — invoke them through
+mem_do(action="<name>", params={...}). mem_do(action="help") lists every
+available action. Set MEMTOMEM_TOOL_MODE=full to expose everything
+individually.
+
+Multi-agent workflow (only when the user asks for per-agent
+isolation or shared knowledge between agents):
+1. Register each agent once:
+     mem_do(action="agent_register", params={"agent_id": "planner"})
+2. Start a session per agent run:
+     mem_session_start(agent_id="planner")
+   The session record's namespace auto-derives to
+   "agent-runtime:planner" — no explicit namespace= needed.
+3. Search / share inside the agent scope:
+     mem_do(action="agent_search", params={"query": "...", "include_shared": True})
+     mem_do(action="agent_share", params={"chunk_id": "...", "target": "shared"})
+4. End the session: mem_session_end(summary="...")
+
+Per-project teams (multiple teams against one server): prefix the project
+onto the agent_id (agent_id="projA-planner") for private memory, and keep
+team-shared notes in a per-project bucket — write with
+mem_do(action="agent_share", params={"chunk_id": "...", "target": "shared:projA"}),
+read with
+mem_do(action="agent_search", params={"query": "...", "shared_namespace": "shared:projA"}).
+See ADR-0028.
+
+Session-bound write contract:
+- After mem_session_start(agent_id="..."), subsequent mem_add and
+  mem_batch_add calls without an explicit namespace= argument
+  automatically write to "agent-runtime:<id>" — the session's
+  agent scope. Pass namespace= explicitly to write somewhere
+  else (e.g. namespace="shared").
+- mem_search still reads from current_namespace by default; use
+  mem_do(action="agent_search") to read inside the agent scope.
+  (Symmetric search-side support is tracked separately.)
+
+Common pitfalls:
+- mem_session_start() without agent_id falls back to the "default"
+  namespace — pass agent_id whenever you want isolation.
+- agent_search needs an active session (or current_agent_id);
+  call mem_session_start first.
+"""
+
+_FULL_MODE = """\
 Multi-agent workflow (only when the user asks for per-agent
 isolation or shared knowledge between agents):
 1. Register each agent once: mem_agent_register(agent_id="planner")
@@ -29,21 +150,15 @@ isolation or shared knowledge between agents):
    The session record's namespace auto-derives to
    "agent-runtime:planner" — no explicit namespace= needed.
 3. Search / share inside the agent scope:
-     mem_agent_search(query=..., include_shared=True)
-     mem_agent_share(chunk_id=..., target="shared")   # copy chunk to shared scope
-4. End the session: mem_session_end(summary=...)
-
-Namespace conventions:
-  default                 single-agent / pre-multi-agent
-  agent-runtime:<id>      per-agent isolated scope
-  shared                  cross-agent shared scope
-Pass explicit namespace= only when overriding the derived value.
+     mem_agent_search(query="...", include_shared=True)
+     mem_agent_share(chunk_id="...", target="shared")   # copy chunk to shared scope
+4. End the session: mem_session_end(summary="...")
 
 Per-project teams (multiple teams against one server): prefix the project
 onto the agent_id (agent_id="projA-planner") for private memory, and keep
 team-shared notes in a per-project bucket — write with
-mem_agent_share(target="shared:projA"), read with
-mem_agent_search(shared_namespace="shared:projA"). See ADR-0028.
+mem_agent_share(chunk_id="...", target="shared:projA"), read with
+mem_agent_search(query="...", shared_namespace="shared:projA"). See ADR-0028.
 
 Session-bound write contract:
 - After mem_session_start(agent_id="..."), subsequent mem_add and
@@ -60,6 +175,29 @@ Common pitfalls:
   namespace — pass agent_id whenever you want isolation.
 - mem_agent_search needs an active session (or current_agent_id);
   call mem_session_start first.
-
-When in doubt, default to mem_add / mem_search with no extras.
 """
+
+_MODE_SECTIONS: dict[str, str] = {
+    "core": _CORE_MODE,
+    "standard": _STANDARD_MODE,
+    "full": _FULL_MODE,
+}
+
+
+def build_instructions(tool_mode: str) -> str:
+    """Return the instructions text matching ``tool_mode``'s tool surface.
+
+    Unknown modes fall back to ``core`` — mirroring the pruning logic in
+    ``server/__init__.py``, where anything that isn't ``standard`` or
+    ``full`` prunes down to the core tool set.
+    """
+    mode = tool_mode if tool_mode in _MODE_SECTIONS else "core"
+    return "\n".join(
+        (
+            _HEADER,
+            _SINGLE_AGENT,
+            _MODE_SECTIONS[mode],
+            _NAMESPACES,
+            _FOOTER,
+        )
+    )

--- a/packages/memtomem/tests/test_server_instructions.py
+++ b/packages/memtomem/tests/test_server_instructions.py
@@ -1,19 +1,21 @@
 """Pin tests for the FastMCP ``instructions=`` field.
 
-The instructions string set in ``memtomem/server/__init__.py`` is
+The instructions string built in ``memtomem/server/instructions.py`` is
 auto-injected into every MCP client's ``initialize`` response. For most
 LLMs this is the only workflow-level signal they get before deciding
 which memtomem tool to call — drift here means clients silently fall
 back to docstring-only inference and pick the wrong tool (e.g. plain
 ``mem_add`` when the user asked for per-agent isolation).
 
-Two layers, mirroring ``test_server_version_reporting.py``:
+Three layers:
 
-* A unit test asserts the constant is wired through to
-  ``mcp.instructions`` and mentions every workflow token an LLM has to
-  recognize. If a tool is renamed or a namespace convention changes,
-  both ``server/instructions.py`` and the ``REQUIRED_TOKENS`` tuple
-  below must move in lockstep.
+* Per-mode token pins assert each mode's text mentions every workflow
+  token an LLM has to recognize. If a tool is renamed or a namespace
+  convention changes, both ``server/instructions.py`` and the token
+  tables below must move in lockstep.
+* An exposure-parity pin asserts every ``mem_*`` tool named in a mode's
+  text is actually registered in that mode (#1608) — the default
+  ``core`` mode must never show a direct call to a pruned tool.
 * An end-to-end test drives the ``initialize`` RPC against a real
   subprocess and asserts the ``instructions`` field round-trips, so a
   future FastMCP release that drops the parameter (or strips it during
@@ -35,8 +37,16 @@ from typing import Any, Callable
 import pytest
 
 from memtomem.constants import SHARED_NAMESPACE
-from memtomem.server import mcp
-from memtomem.server.instructions import INSTRUCTIONS
+from memtomem.server import (
+    _ALL_REGISTERED_TOOLS,
+    _CORE_TOOLS,
+    _STANDARD_PACKS,
+    _TOOL_MODE,
+    mcp,
+)
+from memtomem.server.instructions import VALID_TOOL_MODES, build_instructions
+from memtomem.server.tool_registry import ACTIONS
+from memtomem.server.tools.meta import mem_do
 from memtomem.server.tools.multi_agent import (
     mem_agent_register,
     mem_agent_search,
@@ -44,19 +54,32 @@ from memtomem.server.tools.multi_agent import (
 )
 from memtomem.server.tools.session import mem_session_end, mem_session_start
 
-REQUIRED_TOKENS: tuple[str, ...] = (
-    # Single-agent quickstart — what 90% of users should reach for.
+
+def _expected_tools(mode: str) -> frozenset[str]:
+    """The individually-exposed tool set for ``mode`` — derived from the
+    same sources the pruning in ``server/__init__.py`` uses.
+
+    The standard set intersects with ``_ALL_REGISTERED_TOOLS`` because
+    ``ACTIONS`` also carries register-only actions (e.g. ``ingest``)
+    that never exist as individual MCP tools in any mode.
+    """
+    if mode == "full":
+        return _ALL_REGISTERED_TOOLS
+    if mode == "standard":
+        pack_tools = {
+            f"mem_{name}" for name, info in ACTIONS.items() if info.category in _STANDARD_PACKS
+        }
+        return frozenset(_CORE_TOOLS) | (pack_tools & _ALL_REGISTERED_TOOLS)
+    return frozenset(_CORE_TOOLS)
+
+
+# Tokens every mode's text must contain — the single-agent quickstart
+# plus the namespace vocabulary.
+# ``agent-runtime:`` is a prefix (colon + id); ``shared`` and ``default``
+# are exact namespaces with no colon (SHARED_NAMESPACE = "shared").
+_COMMON_TOKENS: tuple[str, ...] = (
     "mem_add",
     "mem_search",
-    # Multi-agent workflow — the recipe an LLM has to follow in order.
-    "mem_agent_register",
-    "mem_session_start",
-    "mem_agent_search",
-    "mem_agent_share",
-    "mem_session_end",
-    # Namespace conventions — the vocabulary the LLM needs to recognize.
-    # ``agent-runtime:`` is a prefix (colon + id); ``shared`` and ``default``
-    # are exact namespaces with no colon (SHARED_NAMESPACE = "shared").
     "agent-runtime:",
     "shared",
     "default",
@@ -64,98 +87,239 @@ REQUIRED_TOKENS: tuple[str, ...] = (
     "shared_namespace",
 )
 
+# Mode-specific tokens: the multi-agent recipe rendered in the calling
+# form that mode actually supports (#1608). ``core`` routes everything
+# through mem_do; ``standard`` exposes session/crud tools directly but
+# routes multi_agent actions; ``full`` shows direct calls.
+_MODE_TOKENS: dict[str, tuple[str, ...]] = {
+    "core": (
+        "mem_do",
+        'action="help"',
+        "MEMTOMEM_TOOL_MODE",
+        'action="agent_register"',
+        'action="session_start"',
+        'action="agent_search"',
+        'action="agent_share"',
+        'action="session_end"',
+        'action="batch_add"',
+    ),
+    "standard": (
+        "mem_do",
+        'action="help"',
+        "MEMTOMEM_TOOL_MODE",
+        "mem_session_start",
+        "mem_session_end",
+        "mem_batch_add",
+        'action="agent_register"',
+        'action="agent_search"',
+        'action="agent_share"',
+    ),
+    "full": (
+        "mem_agent_register",
+        "mem_session_start",
+        "mem_agent_search",
+        "mem_agent_share",
+        "mem_session_end",
+    ),
+}
+
 
 def test_instructions_is_wired_to_fastmcp() -> None:
-    """The constant from ``server/instructions.py`` reaches
+    """The mode-selected text from ``server/instructions.py`` reaches
     ``mcp.instructions`` (and therefore the ``initialize`` response).
     Without this, MCP clients have nothing but tool docstrings to go on.
     """
-    assert mcp.instructions == INSTRUCTIONS, (
-        "FastMCP(instructions=...) must be passed the INSTRUCTIONS "
-        "constant verbatim; see memtomem/server/__init__.py"
+    assert mcp.instructions == build_instructions(_TOOL_MODE), (
+        "FastMCP(instructions=...) must be passed build_instructions(_TOOL_MODE) "
+        "verbatim; see memtomem/server/__init__.py"
     )
 
 
-@pytest.mark.parametrize("token", REQUIRED_TOKENS)
-def test_instructions_mentions_workflow_token(token: str) -> None:
-    """Each token names a tool or convention an LLM must recognize to
-    route a user request correctly. If a tool is renamed, update both
-    ``INSTRUCTIONS`` and ``REQUIRED_TOKENS`` so this pin keeps working.
+def test_unknown_mode_falls_back_to_core() -> None:
+    """Pruning treats anything that isn't standard/full as core; the
+    instructions builder must mirror that so text and surface can't split.
     """
-    assert token in INSTRUCTIONS, (
-        f"instructions string lost reference to {token!r}; if the "
+    assert build_instructions("bogus") == build_instructions("core")
+
+
+@pytest.mark.parametrize("mode", VALID_TOOL_MODES)
+@pytest.mark.parametrize("token", _COMMON_TOKENS)
+def test_instructions_mentions_common_token(mode: str, token: str) -> None:
+    text = build_instructions(mode)
+    assert token in text, (
+        f"{mode} instructions lost reference to {token!r}; if the "
         f"workflow changed, update memtomem/server/instructions.py "
-        f"and the REQUIRED_TOKENS tuple in lockstep."
+        f"and the token tables in lockstep."
     )
 
 
-def test_shared_namespace_label_has_no_colon() -> None:
+@pytest.mark.parametrize(
+    ("mode", "token"),
+    [(m, t) for m, tokens in _MODE_TOKENS.items() for t in tokens],
+)
+def test_instructions_mentions_mode_token(mode: str, token: str) -> None:
+    """Each token names a tool, action, or escape hatch an LLM must
+    recognize to route a request correctly *in that mode*.
+    """
+    text = build_instructions(mode)
+    assert token in text, (
+        f"{mode} instructions lost reference to {token!r}; update "
+        f"memtomem/server/instructions.py and _MODE_TOKENS in lockstep."
+    )
+
+
+@pytest.mark.parametrize("mode", VALID_TOOL_MODES)
+def test_instructions_only_name_tools_exposed_in_mode(mode: str) -> None:
+    """Exposure parity (#1608): every ``mem_*`` name in a mode's text
+    must be an individually-registered tool in that mode. The shipping
+    default (core) previously walked clients into calling five
+    multi-agent tools that don't exist there.
+    """
+    text = build_instructions(mode)
+    allowed = _expected_tools(mode)
+    mentioned = set(re.findall(r"\bmem_\w+", text))
+    ghosts = mentioned - allowed
+    assert not ghosts, (
+        f"{mode} instructions reference tools not exposed in {mode} mode: "
+        f"{sorted(ghosts)}. Route them through mem_do(action=...) or move "
+        f"them to the right mode section in memtomem/server/instructions.py."
+    )
+
+
+@pytest.mark.parametrize("mode", VALID_TOOL_MODES)
+def test_shared_namespace_label_has_no_colon(mode: str) -> None:
     """The cross-agent namespace is exactly ``SHARED_NAMESPACE`` (``shared``),
     with no trailing colon — unlike the ``agent-runtime:`` *prefix*.
 
-    The substring ``REQUIRED_TOKENS`` pin can't guard this: ``"shared" in
-    "shared:"`` is True, so a regression to the ``shared:`` typo would slip
-    past it. Assert the exact namespace-conventions row and reject the colon
-    form explicitly. Derived from ``SHARED_NAMESPACE`` so the constant stays
-    the single source of truth.
+    The substring token pin can't guard this: ``"shared" in "shared:"`` is
+    True, so a regression to the ``shared:`` typo would slip past it. Assert
+    the exact namespace-conventions row and reject the colon form explicitly.
+    Derived from ``SHARED_NAMESPACE`` so the constant stays the single source
+    of truth.
     """
+    text = build_instructions(mode)
     ns = re.escape(SHARED_NAMESPACE)
-    assert re.search(rf"^  {ns}\s+cross-agent shared scope$", INSTRUCTIONS, re.MULTILINE), (
-        f"namespace-conventions table must list the shared namespace as the "
-        f"colon-free {SHARED_NAMESPACE!r} (SHARED_NAMESPACE); see "
+    assert re.search(rf"^  {ns}\s+cross-agent shared scope$", text, re.MULTILINE), (
+        f"namespace-conventions table ({mode}) must list the shared namespace "
+        f"as the colon-free {SHARED_NAMESPACE!r} (SHARED_NAMESPACE); see "
         f"memtomem/server/instructions.py"
     )
-    assert not re.search(rf"^  {ns}:", INSTRUCTIONS, re.MULTILINE), (
-        f"namespace-conventions table reintroduced the {SHARED_NAMESPACE + ':'!r} "
-        f"typo; the shared namespace has no colon (SHARED_NAMESPACE = "
-        f"{SHARED_NAMESPACE!r})."
+    assert not re.search(rf"^  {ns}:", text, re.MULTILINE), (
+        f"namespace-conventions table ({mode}) reintroduced the "
+        f"{SHARED_NAMESPACE + ':'!r} typo; the shared namespace has no colon "
+        f"(SHARED_NAMESPACE = {SHARED_NAMESPACE!r})."
     )
 
 
-# Tools whose ``foo(arg=...)`` example forms appear in INSTRUCTIONS. If a
-# parameter is renamed at the source, the example must move with it or the
-# string lies to the LLM (causes wrong-arg recovery round trips, observed
-# concretely on Haiku 4.5 in the v0.1.30-pre instructions where
+# Tools whose ``foo(arg=...)`` example forms appear in the instructions.
+# If a parameter is renamed at the source, the example must move with it
+# or the string lies to the LLM (causes wrong-arg recovery round trips,
+# observed concretely on Haiku 4.5 in the v0.1.30-pre instructions where
 # ``mem_agent_share(memory_id=...)`` was shown but the real signature is
-# ``chunk_id``).
+# ``chunk_id``). ``mem_do`` is included because the core/standard texts
+# render the multi-agent workflow through it.
 _DOCUMENTED_TOOLS: tuple[Callable[..., Any], ...] = (
     mem_agent_register,
     mem_agent_search,
     mem_agent_share,
     mem_session_start,
     mem_session_end,
+    mem_do,
 )
 
 
+@pytest.mark.parametrize("mode", VALID_TOOL_MODES)
 @pytest.mark.parametrize("fn", _DOCUMENTED_TOOLS, ids=lambda fn: fn.__name__)
-def test_instructions_kwargs_match_signature(fn: Callable[..., Any]) -> None:
-    """Any ``tool_name(arg=...)`` example in INSTRUCTIONS must use a
+def test_instructions_kwargs_match_signature(mode: str, fn: Callable[..., Any]) -> None:
+    """Any ``tool_name(arg=...)`` example in a mode's text must use a
     real parameter name from the function's actual signature. The MCP
     ``ctx`` parameter is excluded since it's framework-injected and
-    never appears in user-facing examples.
+    never appears in user-facing examples. Modes that don't show a given
+    tool simply have no matches and pass trivially.
     """
+    text = build_instructions(mode)
     sig = inspect.signature(fn)
     real_params = {p for p in sig.parameters if p != "ctx"}
     name = fn.__name__
 
     # Match each ``name(...)`` occurrence and pull out kwarg names.
     # The pattern stops at the first ``)`` so multi-line examples need
-    # to fit on one line — which all current INSTRUCTIONS examples do.
-    for match in re.finditer(rf"{re.escape(name)}\(([^)]*)\)", INSTRUCTIONS):
+    # to fit on one line — which all current examples do.
+    required = {
+        n for n, p in sig.parameters.items() if n != "ctx" and p.default is inspect.Parameter.empty
+    }
+    for match in re.finditer(rf"{re.escape(name)}\(([^)]*)\)", text):
         arglist = match.group(1)
-        for kwarg in re.findall(r"(\w+)\s*=", arglist):
+        kwargs = set(re.findall(r"(\w+)\s*=", arglist))
+        for kwarg in kwargs:
             assert kwarg in real_params, (
-                f"INSTRUCTIONS shows {name}({kwarg}=...) but the real "
+                f"{mode} instructions show {name}({kwarg}=...) but the real "
                 f"signature has parameters {sorted(real_params)}. Either "
                 f"fix the example in memtomem/server/instructions.py or "
                 f"rename the parameter on {fn.__module__}.{name}."
             )
+        if name != "mem_do" and arglist.strip():
+            # A non-empty direct-call example must be copy-paste runnable:
+            # all required (no-default) parameters have to appear. Empty
+            # ``name()`` forms are prose shorthand and stay exempt.
+            assert required <= kwargs, (
+                f"{mode} instructions show {name}(...) missing required "
+                f"parameters {sorted(required - kwargs)} — a client copying "
+                f"the example verbatim would hit a TypeError."
+            )
+
+
+@pytest.mark.parametrize("mode", VALID_TOOL_MODES)
+def test_mem_do_action_examples_exist_in_registry(mode: str) -> None:
+    """Every ``action="<name>"`` example must be a real registered action
+    (or the built-in ``help``) — a renamed action must not leave the
+    instructions steering clients into an unknown-action error.
+    """
+    text = build_instructions(mode)
+    for action in re.findall(r'action="(\w+)"', text):
+        assert action == "help" or action in ACTIONS, (
+            f'{mode} instructions show mem_do(action="{action}") but the '
+            f"registry has no such action; see server/tool_registry.py."
+        )
+
+
+@pytest.mark.parametrize("mode", VALID_TOOL_MODES)
+def test_mem_do_params_examples_match_action_signature(mode: str) -> None:
+    """Every full ``mem_do(action="X", params={...})`` example must use
+    real parameter names of the routed function AND include all of its
+    required (no-default) parameters — an example a client copies
+    verbatim must not route into a TypeError. Bare ``mem_do(action=...)``
+    name references (no ``params=``) are prose, not examples, and are
+    exempt from the required-params check.
+    """
+    text = build_instructions(mode)
+    for action, params_body in re.findall(r'mem_do\(action="(\w+)", params=\{([^}]*)\}', text):
+        assert action in ACTIONS, f'unknown action "{action}" in {mode} instructions'
+        sig = inspect.signature(ACTIONS[action].fn)
+        real_params = {p for p in sig.parameters if p != "ctx"}
+        required = {
+            n
+            for n, p in sig.parameters.items()
+            if n != "ctx" and p.default is inspect.Parameter.empty
+        }
+        keys = set(re.findall(r'"(\w+)":', params_body))
+        assert keys <= real_params, (
+            f'{mode} instructions show mem_do(action="{action}", params=...) with '
+            f"unknown keys {sorted(keys - real_params)}; real parameters are "
+            f"{sorted(real_params)}."
+        )
+        assert required <= keys, (
+            f'{mode} instructions show mem_do(action="{action}", params=...) missing '
+            f"required parameters {sorted(required - keys)} — a client copying the "
+            f"example verbatim would hit a TypeError."
+        )
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="server is POSIX-only")
 def test_initialize_response_carries_instructions(tmp_path: Path) -> None:
-    """End-to-end: drive the ``initialize`` RPC and assert the
-    ``instructions`` field on the response matches the wired constant.
+    """End-to-end: drive the ``initialize`` RPC in the default (core)
+    mode and assert the ``instructions`` field on the response matches
+    the core text.
 
     Isolates ``HOME`` + ``XDG_RUNTIME_DIR`` under ``tmp_path`` so the
     server doesn't touch the developer's real state during the probe
@@ -170,6 +334,9 @@ def test_initialize_response_carries_instructions(tmp_path: Path) -> None:
     env = os.environ.copy()
     env["HOME"] = str(home)
     env["XDG_RUNTIME_DIR"] = str(xdg)
+    # Pin the mode rather than inherit whatever the developer's shell
+    # exports — this test asserts the shipping-default text.
+    env["MEMTOMEM_TOOL_MODE"] = "core"
 
     initialize_request = {
         "jsonrpc": "2.0",
@@ -214,9 +381,9 @@ def test_initialize_response_carries_instructions(tmp_path: Path) -> None:
         response = json.loads(response_line)
         result = response.get("result", {})
         instructions = result.get("instructions")
-        assert instructions == INSTRUCTIONS, (
+        assert instructions == build_instructions("core"), (
             "initialize response's `instructions` field must round-trip "
-            "the wired constant; if this fails, FastMCP may have dropped "
+            "the core-mode text; if this fails, FastMCP may have dropped "
             "the parameter or stripped it during startup."
         )
     finally:


### PR DESCRIPTION
## Problem

The MCP `initialize` instructions walked every client through direct calls to `mem_agent_register`, `mem_session_start`, `mem_agent_search`, `mem_agent_share`, and `mem_batch_add` — but the shipping default `MEMTOMEM_TOOL_MODE=core` prunes the surface to 9 tools, none of which are these. The text never mentioned `mem_do` routing or the mode env var, so a client following the documented workflow verbatim called tools that don't exist.

## Change

- `server/instructions.py`: static `INSTRUCTIONS` constant → `build_instructions(tool_mode)`.
  - **core** (default): the multi-agent workflow renders as `mem_do(action=..., params={...})`; points at `mem_do(action="help")` for action discovery (also fixes discoverability of register-only actions like `ingest`) and `MEMTOMEM_TOOL_MODE=standard|full` for opting up.
  - **standard**: session/crud tools shown directly; `multi_agent` actions stay routed through `mem_do`.
  - **full**: direct calls, unchanged text shape.
  - Unknown modes fall back to core, mirroring the pruning logic.
- `server/__init__.py`: the `MEMTOMEM_TOOL_MODE` read moves above `FastMCP(...)` construction so the mode-matched text is wired at init. Adds a pre-prune `_ALL_REGISTERED_TOOLS` snapshot and hoists `_STANDARD_PACKS` to module level (shared source for the pin tests).
- `tests/test_server_instructions.py`: pins parametrized per mode, plus new guards —
  - **exposure parity**: every `mem_*` name in a mode's text must be individually registered in that mode (the #1608 regression class);
  - every `action="..."` example must exist in the registry;
  - every full example (direct call or `mem_do(..., params={...})`) must include all required parameters of the routed function, so a copy-pasted example can't route into a `TypeError` (Codex review finding — the old team examples omitted `chunk_id`/`query`).

## Verification

- `uv run pytest packages/memtomem/tests/test_server_instructions.py` — 74 passed (includes the subprocess `initialize` round-trip pinned to core mode).
- Full suite `uv run pytest -m "not ollama"` — 7881 passed, 11 skipped.
- Manual: `MEMTOMEM_TOOL_MODE=standard` import exposes 38 tools (core ⊂, `mem_agent_register` pruned, `mem_session_start`/`mem_batch_add` present) and serves the standard text; snapshot = 87 tools.

Closes #1608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
