### PR TITLE
fix(search): make rescue-leg failures loud and single-source the rescue weight

### DIFF
--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -6,6 +6,15 @@ per ADR-0011 §6) → RRF fusion → cross-encoder rerank (optional) →
 source/tag filter → validity filter → time-decay → MMR → access-freq
 boost → importance boost → context-window expansion.
 
+Stage 1 enrichment (session-summary rescue, RFC P1 Phase C): between
+retrieval and fusion, when ``namespace is None`` and a
+``SessionSummaryConfig`` with ``expansion_lookup_top_k > 0`` is wired,
+an ``archive:session:*`` summary lookup + ``summarizes`` chunk-links
+walk builds a boost-source set and a retrieval restricted to those
+sources joins RRF as a third input list weighted by
+``expansion_rescue_weight``. Failures degrade to two-leg fusion (loud
+once — see ``_log_rescue_failure``).
+
 The scope-context filter is applied **at the BM25 + dense storage
 calls** (not as a post-fusion stage) because the SQL fragment is the
 single chokepoint that prevents cross-project leak; running it at the
@@ -51,6 +60,25 @@ from memtomem.models import ContextInfo, NamespaceFilter, ScopeFilter, SearchRes
 from memtomem.search.fusion import reciprocal_rank_fusion
 
 logger = logging.getLogger(__name__)
+
+# Fallback for the rescue leg's RRF weight when no SessionSummaryConfig
+# is wired. Mirrors ``SessionSummaryConfig.expansion_rescue_weight``'s
+# default (config.py) — keep the two in sync.
+_DEFAULT_RESCUE_WEIGHT = 0.5
+
+# Rescue-leg failures silently degrade search to two-leg fusion, which
+# is invisible in production — loud (warning, not debug) on the first
+# occurrence per site per feedback_silent_except_log_level (reference
+# pattern: storage/mixins/schedules.py), DEBUG afterwards so a
+# persistently failing dependency doesn't spam the log on every query.
+_RESCUE_WARNED: set[str] = set()
+
+
+def _log_rescue_failure(site: str, msg: str, *args: object) -> None:
+    """warn-once-per-process logger for rescue-leg swallow sites."""
+    level = logging.DEBUG if site in _RESCUE_WARNED else logging.WARNING
+    _RESCUE_WARNED.add(site)
+    logger.log(level, msg, *args, exc_info=True)
 
 
 def _bg_task_error_cb(task: asyncio.Task) -> None:
@@ -313,7 +341,7 @@ class SearchPipeline:
                 project_context_root=project_context_root,
             )
         except Exception:
-            logger.debug("session-summary lookup failed; skipping rescue", exc_info=True)
+            _log_rescue_failure("summary_lookup", "session-summary lookup failed; skipping rescue")
             return set()
 
         threshold = cfg.expansion_score_threshold
@@ -332,8 +360,8 @@ class SearchPipeline:
                     r.chunk.id, link_type="summarizes"
                 )
             except Exception:
-                logger.debug(
-                    "get_chunks_shared_from failed for summary %s", r.chunk.id, exc_info=True
+                _log_rescue_failure(
+                    "links_walk", "get_chunks_shared_from failed for summary %s", r.chunk.id
                 )
                 continue
             for link in links:
@@ -345,7 +373,7 @@ class SearchPipeline:
         try:
             chunks_map = await self._storage.get_chunks_batch(target_chunk_ids)
         except Exception:
-            logger.debug("get_chunks_batch failed for rescue targets", exc_info=True)
+            _log_rescue_failure("chunks_batch", "get_chunks_batch failed for rescue targets")
             return set()
 
         return {str(c.metadata.source_file) for c in chunks_map.values()}
@@ -393,7 +421,7 @@ class SearchPipeline:
                     project_context_root=project_context_root,
                 )
             except Exception:
-                logger.debug("rescue bm25 leg failed", exc_info=True)
+                _log_rescue_failure("bm25_leg", "rescue bm25 leg failed")
                 return []
             return [r for r in hits if str(r.chunk.metadata.source_file) in boost_sources]
 
@@ -409,7 +437,7 @@ class SearchPipeline:
                     project_context_root=project_context_root,
                 )
             except Exception:
-                logger.debug("rescue dense leg failed", exc_info=True)
+                _log_rescue_failure("dense_leg", "rescue dense leg failed")
                 return []
             return [r for r in hits if str(r.chunk.metadata.source_file) in boost_sources]
 
@@ -801,7 +829,7 @@ class SearchPipeline:
                     )
                     rescue_chunk_ids = {r.chunk.id for r in rescue_results}
             except Exception:
-                logger.debug("session-summary rescue leg failed", exc_info=True)
+                _log_rescue_failure("rescue_wiring", "session-summary rescue leg failed")
 
         # Stage 3: fusion (or single-retriever passthrough)
         # When reranking is active, widen the candidate pool so the
@@ -825,17 +853,21 @@ class SearchPipeline:
                 dataclass_replace(r, via_session_summary=True) for r in rescue_results
             ]
 
+        # Single source for the rescue leg's RRF weight — the fallback is
+        # effectively unreachable (rescue only fires when the config is
+        # wired) but keeps the three fusion branches total.
+        rescue_w = (
+            self._session_summary_config.expansion_rescue_weight
+            if self._session_summary_config is not None
+            else _DEFAULT_RESCUE_WEIGHT
+        )
+
         if use_bm25 and use_dense:
             fusion_lists = [bm25_results, dense_results]
             fusion_weights = list(effective_weights)
             fusion_labels = ["bm25", "dense"]
             if rescue_results:
                 fusion_lists.append(rescue_results)
-                rescue_w = (
-                    self._session_summary_config.expansion_rescue_weight
-                    if self._session_summary_config is not None
-                    else 0.5
-                )
                 fusion_weights.append(rescue_w)
                 fusion_labels.append("session_rescue")
             fused = reciprocal_rank_fusion(
@@ -847,11 +879,6 @@ class SearchPipeline:
             )
         elif use_bm25:
             if rescue_results:
-                rescue_w = (
-                    self._session_summary_config.expansion_rescue_weight
-                    if self._session_summary_config is not None
-                    else 0.5
-                )
                 fused = reciprocal_rank_fusion(
                     [bm25_results, rescue_results],
                     k=self._config.rrf_k,
@@ -863,11 +890,6 @@ class SearchPipeline:
                 fused = bm25_results[:rerank_pool]
         elif use_dense:
             if rescue_results:
-                rescue_w = (
-                    self._session_summary_config.expansion_rescue_weight
-                    if self._session_summary_config is not None
-                    else 0.5
-                )
                 fused = reciprocal_rank_fusion(
                     [dense_results, rescue_results],
                     k=self._config.rrf_k,

--- a/packages/memtomem/tests/test_session_summary_rescue.py
+++ b/packages/memtomem/tests/test_session_summary_rescue.py
@@ -13,11 +13,13 @@ Covers the new path that runs alongside BM25 + dense:
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock
 import pytest
 
+import memtomem.search.pipeline as pipeline_module
 from memtomem.config import SearchConfig, SessionSummaryConfig
 from memtomem.models import Chunk, ChunkLink, ChunkMetadata, SearchResult
 from memtomem.search.fusion import reciprocal_rank_fusion
@@ -498,6 +500,111 @@ class TestPipelineEndToEndRescue:
         pipeline = _make_pipeline(storage, session_summary_config=cfg)
         await pipeline.search("q", top_k=10, namespace="agent-runtime:planner")
         assert archive_lookup_called is False
+
+
+# ---------------------------------------------------------------------------
+# 3b. Rescue-leg failure loudness (#1610/#1611)
+# ---------------------------------------------------------------------------
+
+
+class TestRescueLegLoudness:
+    """A rescue-leg failure degrades search to two-leg fusion, which is
+    invisible in production — the swallow sites must log WARNING on the
+    first occurrence (``feedback_silent_except_log_level``) and DEBUG
+    afterwards, and the search itself must still succeed.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_warn_once(self):
+        """The warn-once registry is process-global; isolate each test."""
+        pipeline_module._RESCUE_WARNED.clear()
+        yield
+        pipeline_module._RESCUE_WARNED.clear()
+
+    def _failing_rescue_setup(self) -> tuple[AsyncMock, Chunk]:
+        """Storage where the archive lookup succeeds but the chunk-links
+        walk raises — the rescue leg dies mid-flight while the organic
+        leg stays healthy."""
+        cfg_summary = _chunk("summary body", namespace="archive:session:abc")
+        organic = _chunk("organic chunk")
+        storage = _async_storage()
+
+        async def bm25_dispatch(
+            query, top_k, namespace_filter=None, scope_filter=None, project_context_root=None
+        ):
+            if getattr(namespace_filter, "pattern", None) == "archive:session:*":
+                return [_sr(cfg_summary, score=0.9, rank=1, source="bm25")]
+            return [_sr(organic, score=1.0, rank=1, source="bm25")]
+
+        storage.bm25_search = AsyncMock(side_effect=bm25_dispatch)
+        storage.get_chunks_shared_from = AsyncMock(side_effect=RuntimeError("links table gone"))
+        return storage, organic
+
+    @pytest.mark.asyncio
+    async def test_failure_degrades_to_organic_and_warns(self, caplog):
+        cfg = SessionSummaryConfig(expansion_lookup_top_k=3, expansion_score_threshold=0.3)
+        storage, organic = self._failing_rescue_setup()
+        pipeline = _make_pipeline(storage, session_summary_config=cfg)
+
+        with caplog.at_level(logging.DEBUG, logger="memtomem.search.pipeline"):
+            results, _ = await pipeline.search("q", top_k=10)
+
+        # Search must survive the rescue failure on organic results alone.
+        assert {r.chunk.id for r in results} == {organic.id}
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "get_chunks_shared_from failed" in r.message
+        ]
+        assert len(warnings) == 1, "first rescue failure must be loud (WARNING, not DEBUG)"
+
+    @pytest.mark.asyncio
+    async def test_repeat_failure_downgrades_to_debug(self, caplog):
+        """warn-once: a persistently failing dependency must not spam
+        WARNING on every query — repeats log at DEBUG."""
+        cfg = SessionSummaryConfig(expansion_lookup_top_k=3, expansion_score_threshold=0.3)
+        storage, _ = self._failing_rescue_setup()
+        pipeline = _make_pipeline(storage, session_summary_config=cfg)
+
+        with caplog.at_level(logging.DEBUG, logger="memtomem.search.pipeline"):
+            await pipeline.search("q", top_k=10)
+            await pipeline.search("q2", top_k=10)
+
+        records = [r for r in caplog.records if "get_chunks_shared_from failed" in r.message]
+        assert [r.levelno for r in records] == [logging.WARNING, logging.DEBUG]
+
+    @pytest.mark.asyncio
+    async def test_summary_lookup_failure_warns_and_degrades(self, caplog):
+        """The very first rescue stage (archive lookup) failing must also
+        be loud and leave organic retrieval intact."""
+        cfg = SessionSummaryConfig(expansion_lookup_top_k=3, expansion_score_threshold=0.3)
+        organic = _chunk("organic chunk")
+        storage = _async_storage()
+
+        async def bm25_dispatch(
+            query, top_k, namespace_filter=None, scope_filter=None, project_context_root=None
+        ):
+            if getattr(namespace_filter, "pattern", None) == "archive:session:*":
+                raise RuntimeError("archive namespace unreadable")
+            return [_sr(organic, score=1.0, rank=1, source="bm25")]
+
+        storage.bm25_search = AsyncMock(side_effect=bm25_dispatch)
+        pipeline = _make_pipeline(storage, session_summary_config=cfg)
+
+        with caplog.at_level(logging.DEBUG, logger="memtomem.search.pipeline"):
+            results, _ = await pipeline.search("q", top_k=10)
+
+        assert {r.chunk.id for r in results} == {organic.id}
+        assert any(
+            r.levelno == logging.WARNING and "session-summary lookup failed" in r.message
+            for r in caplog.records
+        )
+
+
+def test_default_rescue_weight_mirrors_config_default():
+    """#1610: the module fallback must stay in sync with the
+    ``SessionSummaryConfig.expansion_rescue_weight`` default it mirrors."""
+    assert pipeline_module._DEFAULT_RESCUE_WEIGHT == SessionSummaryConfig().expansion_rescue_weight
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The session-summary rescue leg swallowed every failure at DEBUG across six sites (`search/pipeline.py` — summary lookup, chunk-links walk, batch fetch, both rescue retrieval legs, outer wiring). A broken dependency silently degraded every search to two-leg fusion with nothing visible in production logs. The rescue-weight fallback literal `0.5` was also written out at three fusion branches, and the rescue leg was the only stage missing from the module docstring's fixed stage list.

## Change

- **Warn-once loudness**: all six swallow sites route through `_log_rescue_failure(site, msg)` — first failure per site per process logs WARNING (per the `feedback_silent_except_log_level` convention referenced from `storage/mixins/schedules.py`), repeats log DEBUG to avoid per-query spam. Search still degrades gracefully to organic results.
- **Single-source weight**: `_DEFAULT_RESCUE_WEIGHT = 0.5` hoisted; `rescue_w` computed once above the fusion branches. Recon correction (see issue comment): 3 fallback sites, not 4 — the 4th was a different dense-weight fallback. A pin test ties the module constant to `SessionSummaryConfig.expansion_rescue_weight`'s default so they can't drift.
- **Docs**: the Stage-1 enrichment rescue leg is now described in the module docstring's stage list (description only — no stage reordering; CLAUDE.md invariant untouched).
- **Coverage (#1611)**: new `TestRescueLegLoudness` covers the previously-untested failure paths on the `namespace=None` branch — archive-lookup failure and links-walk failure both keep the search alive on organic results with exactly one WARNING; repeat failures downgrade to DEBUG. (The happy-path `namespace=None` rescue flow and `via_session_summary` re-stamp survival through downstream stages were already pinned by `TestPipelineEndToEndRescue::test_rescue_chunk_surfaces_with_flag`.)

## Verification

- `uv run pytest packages/memtomem/tests/test_session_summary_rescue.py packages/memtomem/tests/test_pipeline.py` — 78 passed.
- Adjacent pipeline suites (`test_e2e_pipeline`, `test_expansion`, `test_qa_audit_pins`, `test_context_window`, `test_temporal_validity`) — 139 passed.
- `ruff check` + `ruff format --check` clean.

Closes #1610
Closes #1611

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
