### PR TITLE
chore(storage): audit except-Exception cluster — log, narrow, or justify

### DIFF
--- a/packages/memtomem/src/memtomem/storage/mixins/analytics.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/analytics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sqlite3
 
 logger = logging.getLogger(__name__)
 
@@ -131,8 +132,14 @@ class AnalyticsMixin:
                 (limit,),
             ).fetchall()
             return [{"query": r[0], "count": r[1]} for r in rows]
-        except Exception:
-            logger.debug("get_knowledge_gaps query failed", exc_info=True)
+        except sqlite3.OperationalError as exc:
+            # Only the expected "table not created yet on a fresh DB" case
+            # degrades to []. A real bug (bad column, SQL syntax) also
+            # raises OperationalError — re-raise those instead of hiding a
+            # regression behind an empty result.
+            if "no such table" not in str(exc).lower():
+                raise
+            logger.debug("get_knowledge_gaps: query_history table missing", exc_info=True)
             return []
 
     async def get_most_connected(self, limit: int = 5) -> list[dict]:
@@ -268,8 +275,13 @@ class AnalyticsMixin:
                 access_params,
             ).fetchall()
             accessed = {r[0]: r[1] for r in access_rows}
-        except Exception:
-            logger.debug("access_log query failed (table may not exist yet)", exc_info=True)
+        except sqlite3.OperationalError as exc:
+            # Only degrade for the expected missing-table case on a fresh
+            # DB; re-raise real query bugs (bad column, syntax) so they
+            # aren't hidden behind a partial timeline.
+            if "no such table" not in str(exc).lower():
+                raise
+            logger.debug("get_activity_summary: access_log table missing", exc_info=True)
 
         # Merge all days
         all_days = sorted(set(created) | set(updated) | set(accessed))

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -223,6 +224,10 @@ class SqliteBackend(
             try:
                 rconn.close()
             except Exception:
+                # Teardown best-effort: a connection that won't close is
+                # being discarded anyway. DEBUG (not WARNING) is deliberate
+                # per feedback_silent_except_log_level — this is expected
+                # noise on shutdown, not an operational footgun.
                 logger.debug("Failed to close read pool connection", exc_info=True)
         if hasattr(self, "_read_pool"):
             self._read_pool.clear()
@@ -230,6 +235,9 @@ class SqliteBackend(
             try:
                 self._db.execute("PRAGMA wal_checkpoint(TRUNCATE)")
             except Exception:
+                # Best-effort checkpoint on close; the DB closes regardless
+                # and the WAL is replayed on next open. DEBUG by design
+                # (feedback_silent_except_log_level): benign shutdown case.
                 logger.debug("WAL checkpoint failed during close", exc_info=True)
             self._db.close()
             self._db = None
@@ -1664,13 +1672,18 @@ class SqliteBackend(
         is corrupt — callers treat both as "no cache, regenerate".
         """
         assert self._meta is not None
-        raw = self._meta.get_meta(_ai_summary_key(source_file))
+        key = _ai_summary_key(source_file)
+        raw = self._meta.get_meta(key)
         if not raw:
             return None
         try:
             obj = json.loads(raw)
         except (json.JSONDecodeError, TypeError):
-            logger.warning("Corrupt ai_summary record for %s", source_file)
+            # Source paths can be secret-shaped, so log a fingerprint of
+            # the key rather than the path itself (matches the bulk
+            # get_all_ai_summaries path; feedback_canonical_path_leak_resolved_root).
+            fingerprint = hashlib.sha256(key.encode("utf-8", "replace")).hexdigest()[:12]
+            logger.warning("Corrupt ai_summary record (key %s)", fingerprint)
             return None
         if not isinstance(obj, dict):
             return None
@@ -1718,8 +1731,13 @@ class SqliteBackend(
 
         Prefix-scans ``_memtomem_meta`` for keys starting with
         ``ai_summary:`` so unrelated meta rows (embedding dimension etc.)
-        don't leak in. Records with corrupt JSON are silently dropped — the
-        Source-tab API treats them as "no preview".
+        don't leak in. A record with corrupt JSON is dropped (the
+        Source-tab API treats it as "no preview") but logged at DEBUG —
+        a shrinking result set was previously invisible. Neither the raw
+        value nor the key is logged: the key embeds a source path, which
+        can be secret-shaped (feedback_canonical_path_leak_resolved_root,
+        feedback_no_secret_in_validation_log), so only a short opaque
+        fingerprint of the key is emitted to correlate repeat failures.
         """
         db = self._get_read_db()
         rows = db.execute(
@@ -1732,6 +1750,8 @@ class SqliteBackend(
             try:
                 obj = json.loads(value)
             except (json.JSONDecodeError, TypeError):
+                fingerprint = hashlib.sha256(key.encode("utf-8", "replace")).hexdigest()[:12]
+                logger.debug("skipping AI-summary row with corrupt JSON (key %s)", fingerprint)
                 continue
             if isinstance(obj, dict):
                 result[path] = obj

--- a/packages/memtomem/src/memtomem/web/routes/wiki_mutations.py
+++ b/packages/memtomem/src/memtomem/web/routes/wiki_mutations.py
@@ -272,7 +272,11 @@ async def edit_wiki_override(
     Privacy posture (§D-E): ``content`` is scanned with the soft, scope-less
     ``privacy.scan`` and a non-blocking ``privacy_warning`` count is returned —
     the write is never refused (the handler is ``_REDACTION_EXEMPT``, not
-    ``_REDACTION_PROTECTED``: a single-curator host-global store).
+    ``_REDACTION_PROTECTED``: a single-curator host-global store). NOTE: the
+    exemption rests on the single-curator premise above — if the wiki ever
+    becomes multi-writer (shared host, remote editors), revisit whether
+    ``_REDACTION_EXEMPT`` still holds, since one curator's secret would then
+    be exposed to others (#1613).
     """
     _validate_name_or_error(asset_type, name)
     _require_vendor(asset_type, body.vendor)

--- a/packages/memtomem/tests/test_analytics.py
+++ b/packages/memtomem/tests/test_analytics.py
@@ -102,8 +102,9 @@ class TestKnowledgeGaps:
 
     @pytest.mark.asyncio
     async def test_db_error_logs_debug(self, storage, caplog):
-        # Drop the query_history table to force the query to fail — we want
-        # to verify the failure is logged (debug) rather than silently swallowed.
+        # Drop the query_history table to force the expected missing-table
+        # case — the failure is logged (debug) and degrades to [] rather
+        # than being silently swallowed.
         storage._get_db().execute("DROP TABLE IF EXISTS query_history")
 
         with caplog.at_level(logging.DEBUG, logger="memtomem.storage.mixins.analytics"):
@@ -111,9 +112,41 @@ class TestKnowledgeGaps:
 
         assert result == []
         assert any(
-            rec.levelno == logging.DEBUG and "get_knowledge_gaps query failed" in rec.message
+            rec.levelno == logging.DEBUG and "query_history table missing" in rec.message
             for rec in caplog.records
-        ), "Expected DEBUG log when get_knowledge_gaps query fails (not fully silent)"
+        ), "Expected DEBUG log when query_history is missing (not fully silent)"
+
+    @pytest.mark.asyncio
+    async def test_real_query_bug_reraises(self, storage, monkeypatch):
+        # A non-missing-table OperationalError (e.g. bad column / syntax)
+        # must NOT be swallowed to [] — it's a regression, so re-raise.
+        import sqlite3
+
+        class _BadDB:
+            def execute(self, *a, **k):
+                raise sqlite3.OperationalError("no such column: bogus")
+
+        monkeypatch.setattr(storage, "_get_db", lambda: _BadDB())
+        with pytest.raises(sqlite3.OperationalError, match="no such column"):
+            await storage.get_knowledge_gaps()
+
+
+class TestActivitySummary:
+    @pytest.mark.asyncio
+    async def test_missing_access_log_logs_debug_and_degrades(self, storage, caplog):
+        # Drop access_log to force the expected missing-table case. The
+        # summary must still return (from created/updated) and the failure
+        # must be logged at DEBUG rather than silently swallowed (#1613).
+        storage._get_db().execute("DROP TABLE IF EXISTS access_log")
+
+        with caplog.at_level(logging.DEBUG, logger="memtomem.storage.mixins.analytics"):
+            result = await storage.get_activity_summary()
+
+        assert isinstance(result, list)
+        assert any(
+            rec.levelno == logging.DEBUG and "access_log table missing" in rec.message
+            for rec in caplog.records
+        ), "Expected DEBUG log when access_log is missing (not fully silent)"
 
 
 class TestMostConnected:

--- a/packages/memtomem/tests/test_storage_extended.py
+++ b/packages/memtomem/tests/test_storage_extended.py
@@ -616,6 +616,65 @@ class TestStorageExtended:
         rec = await storage.get_ai_summary(Path("/tmp/never-saved.md"))
         assert rec is None
 
+    async def test_corrupt_ai_summary_row_dropped_and_logged_without_path(self, components, caplog):
+        """A corrupt-JSON AI-summary row is dropped from the result but
+        logged at DEBUG so the shrinking set isn't invisible (#1613). The
+        log must NOT contain the source path — keys can be secret-shaped
+        (feedback_canonical_path_leak_resolved_root); only a fingerprint
+        is emitted."""
+        import logging
+
+        storage = components.storage
+        good = Path("/tmp/good.md")
+        await storage.set_ai_summary(good, "valid prose", "sig", "en")
+
+        # Inject a corrupt row directly under a secret-shaped path.
+        secret_path = "/tmp/notes-sk-live-abc123XYZ.md"
+        db = storage._get_db()
+        db.execute(
+            "INSERT OR REPLACE INTO _memtomem_meta (key, value) VALUES (?, ?)",
+            (f"ai_summary:{secret_path}", "{not valid json"),
+        )
+        db.commit()
+
+        with caplog.at_level(logging.DEBUG, logger="memtomem.storage.sqlite_backend"):
+            summaries = await storage.get_all_ai_summaries()
+
+        # Corrupt row dropped, good row survives.
+        assert secret_path not in summaries
+        assert any("good.md" in k for k in summaries)
+        # Failure is observable...
+        corrupt_logs = [r for r in caplog.records if "corrupt JSON" in r.message]
+        assert corrupt_logs, "corrupt-JSON drop must be logged at DEBUG"
+        # ...but the path never leaks into any log record.
+        assert not any("sk-live-abc123XYZ" in r.getMessage() for r in caplog.records)
+
+    async def test_corrupt_single_ai_summary_logged_without_path(self, components, caplog):
+        """The single-row accessor ``get_ai_summary`` must not leak the
+        secret-shaped source path either — it logs a key fingerprint on
+        corrupt JSON, same as the bulk path (#1613)."""
+        import logging
+
+        from memtomem.storage.sqlite_backend import _ai_summary_key
+
+        storage = components.storage
+        secret_path = Path("/tmp/session-sk-live-QQQ999.md")
+        # Inject under the exact key the accessor computes (path
+        # normalization must match, or the lookup misses the row).
+        db = storage._get_db()
+        db.execute(
+            "INSERT OR REPLACE INTO _memtomem_meta (key, value) VALUES (?, ?)",
+            (_ai_summary_key(secret_path), "}corrupt{"),
+        )
+        db.commit()
+
+        with caplog.at_level(logging.DEBUG, logger="memtomem.storage.sqlite_backend"):
+            rec = await storage.get_ai_summary(secret_path)
+
+        assert rec is None
+        assert any("Corrupt ai_summary" in r.getMessage() for r in caplog.records)
+        assert not any("sk-live-QQQ999" in r.getMessage() for r in caplog.records)
+
     async def test_delete_ai_summary_clears_existing_row(self, components):
         """``delete_ai_summary`` is the targeted eviction primitive used
         by the summarizer's stale-cache cleanup paths (zero-chunk


### PR DESCRIPTION
## Summary

Sweep of the broad `except Exception` sites flagged in #1613. The per-site audit (full verdict table posted on the issue) found **most sites already correct** — rollback-and-reraise or already logging — so the actual change set is small.

## Changes

- **`sqlite_backend.get_all_ai_summaries` (corrupt-JSON drop)**: the one genuine silent swallow. A corrupt-JSON meta row was dropped with a bare `continue`, silently shrinking the result set. Now logs at DEBUG with the row **key only** (never the value — `feedback_no_secret_in_validation_log`); the "silently dropped" docstring is corrected.
- **`analytics.get_knowledge_gaps` / `get_activity_summary`**: narrowed the missing-table guards from `except Exception` → `except sqlite3.OperationalError`, so a real query bug surfaces instead of being swallowed to an empty result. DEBUG log kept.
- **`sqlite_backend.close()`**: added justification comments to the two teardown DEBUG swallows (WAL checkpoint / read-pool close) — DEBUG is deliberate (benign shutdown), not WARNING.
- **`wiki_mutations`**: added a caveat that `_REDACTION_EXEMPT` rests on the single-curator premise and must be revisited if the wiki ever becomes multi-writer.

## Verified-correct, left unchanged (see issue table)

- Rollback-and-reraise: `sqlite_backend.py:159/203/253/1104`, `sqlite_schema.py:824`, `mixins/sessions.py:33`.
- `indexing/engine.py:1441/1448` and `debounce.py:224` (`except BaseException`): both re-raise after cleanup — cancellation-safe, correct use of the broad net.

## Verification

- `uv run pytest packages/memtomem/tests/test_analytics.py packages/memtomem/tests/test_storage_extended.py packages/memtomem/tests/test_web_routes_wiki_mutations.py` — all pass (new caplog test asserts the access_log failure degrades to a partial summary with a DEBUG log).
- `ruff check` + `ruff format --check` clean.

Closes #1613

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
