### PR TITLE
fix(server): prune tool modes via public API + pin the exact per-mode surface

### DIFF
--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -187,10 +187,34 @@ _STANDARD_PACKS = frozenset(
     }
 )
 
+
+def _registered_tool_names() -> frozenset[str]:
+    """Enumerate registered tool names via FastMCP's public-ish surface.
+
+    FastMCP exposes ``remove_tool`` publicly but has no *synchronous*
+    public tool listing (``FastMCP.list_tools`` is async and yields wire
+    objects), so we call the tool manager's synchronous ``list_tools``.
+    Both that method and ``FastMCP.remove_tool`` (used below) are the
+    coupling points to FastMCP internals — pinned by
+    ``tests/test_tool_mode_pruning.py``. Guard the shape explicitly and
+    raise if it changes: a silent failure here would ship every tool in
+    ``core`` mode instead of pruning to 9 (#1609).
+    """
+    manager = getattr(mcp, "_tool_manager", None)
+    lister = getattr(manager, "list_tools", None)
+    if manager is None or not callable(lister):
+        raise RuntimeError(
+            "FastMCP tool-manager API changed: cannot enumerate registered tools "
+            "for MEMTOMEM_TOOL_MODE pruning. Pin the mcp dependency or update the "
+            "tool-mode pruning in memtomem/server/__init__.py."
+        )
+    return frozenset(t.name for t in lister())
+
+
 # Snapshot of every tool registered by the imports above, taken BEFORE
 # pruning — the only place the full surface is still observable once a
 # non-full mode has pruned ``mcp``. Used by the per-mode pin tests.
-_ALL_REGISTERED_TOOLS = frozenset(t.name for t in mcp._tool_manager.list_tools())
+_ALL_REGISTERED_TOOLS = _registered_tool_names()
 
 if _TOOL_MODE != "full":
     if _TOOL_MODE == "standard":
@@ -201,9 +225,18 @@ if _TOOL_MODE != "full":
         }
     else:
         _allowed = _CORE_TOOLS
+    # ``FastMCP.remove_tool`` is the public removal API (mcp>=1.27.2);
+    # raise rather than silently no-op if a future release drops it, so
+    # pruning can't fail open to full mode.
+    if not callable(getattr(mcp, "remove_tool", None)):
+        raise RuntimeError(
+            "FastMCP.remove_tool is unavailable: cannot prune tools for "
+            "MEMTOMEM_TOOL_MODE. Pin the mcp dependency or update "
+            "memtomem/server/__init__.py."
+        )
     for name in _ALL_REGISTERED_TOOLS:
         if name not in _allowed:
-            mcp._tool_manager.remove_tool(name)
+            mcp.remove_tool(name)
 
 
 def _install_sigterm_handler(*pid_files: Path) -> None:

--- a/packages/memtomem/tests/test_tool_mode_pruning.py
+++ b/packages/memtomem/tests/test_tool_mode_pruning.py
@@ -1,0 +1,212 @@
+"""Per-mode tool-surface pins for ``MEMTOMEM_TOOL_MODE`` (#1609).
+
+Pruning in ``server/__init__.py`` couples to two FastMCP surfaces:
+``ToolManager.list_tools`` (to enumerate) and ``FastMCP.remove_tool``
+(to prune). A version bump that renames or restructures either would
+break pruning **silently** — the server would start in effective
+``full`` mode with no error. These tests are the canary:
+
+* An in-process check asserts the guarded enumeration helper and the
+  public ``remove_tool`` API are both present and shaped as expected.
+* Subprocess checks drive the ``tools/list`` RPC under each
+  ``MEMTOMEM_TOOL_MODE`` and assert the EXACT exposed tool set, computed
+  independently from ``_CORE_TOOLS`` + the ``_STANDARD_PACKS`` registry
+  slice (mirrors ``test_server_instructions.py``'s harness).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import select
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from memtomem.server import (
+    _ALL_REGISTERED_TOOLS,
+    _CORE_TOOLS,
+    _STANDARD_PACKS,
+    mcp,
+)
+from memtomem.server.tool_registry import ACTIONS
+
+
+def _expected_tools(mode: str) -> set[str]:
+    """Independently compute the tool set a mode should expose — the
+    same derivation the pruning uses, so a drift in either fails here."""
+    if mode == "full":
+        return set(_ALL_REGISTERED_TOOLS)
+    if mode == "standard":
+        pack_tools = {
+            f"mem_{name}" for name, info in ACTIONS.items() if info.category in _STANDARD_PACKS
+        }
+        return set(_CORE_TOOLS) | (pack_tools & set(_ALL_REGISTERED_TOOLS))
+    return set(_CORE_TOOLS)
+
+
+def test_coupled_fastmcp_apis_present() -> None:
+    """The two FastMCP coupling points pruning relies on must exist and
+    be shaped as expected. If this fails after an ``mcp`` bump, the
+    pruning logic in ``server/__init__.py`` needs updating — do not just
+    relax this test."""
+    manager = getattr(mcp, "_tool_manager", None)
+    assert manager is not None, "FastMCP no longer exposes _tool_manager"
+    assert callable(getattr(manager, "list_tools", None)), (
+        "ToolManager.list_tools is gone — tool enumeration for pruning will break"
+    )
+    assert callable(getattr(mcp, "remove_tool", None)), (
+        "FastMCP.remove_tool is gone — tool pruning will break"
+    )
+    # list_tools must yield objects carrying a ``.name`` we can key on.
+    names = [t.name for t in manager.list_tools()]
+    assert "mem_do" in names
+
+
+def test_core_is_nine_tools() -> None:
+    assert len(_CORE_TOOLS) == 9
+
+
+def _tools_list_under_mode(mode: str, tmp_path: Path) -> set[str]:
+    """Spawn the server with ``MEMTOMEM_TOOL_MODE=mode`` and return the
+    tool names it advertises via the ``tools/list`` RPC.
+
+    Isolates HOME/XDG under ``tmp_path`` (mirrors
+    ``test_server_instructions.py``) so the probe never touches real
+    developer state.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+    os.chmod(xdg, 0o700)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["XDG_RUNTIME_DIR"] = str(xdg)
+    env["MEMTOMEM_TOOL_MODE"] = mode
+
+    init = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "prune-probe", "version": "0.1"},
+        },
+    }
+    initialized = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+    list_req = {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "memtomem.server"],
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        assert proc.stdin is not None and proc.stdout is not None
+        for msg in (init, initialized, list_req):
+            proc.stdin.write((json.dumps(msg) + "\n").encode())
+        proc.stdin.flush()
+
+        deadline = time.monotonic() + 20
+        tools: set[str] | None = None
+        stdout_fd = proc.stdout.fileno()
+        buf = b""
+        while tools is None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            # select + nonblocking os.read (never buffered readline): a
+            # readable fd only guarantees *some* bytes, so readline could
+            # still block on a partial line without a newline. Accumulate
+            # raw bytes and split complete frames ourselves so no read
+            # path can outlive the deadline (POSIX-only test).
+            ready, _, _ = select.select([stdout_fd], [], [], remaining)
+            if not ready:
+                if proc.poll() is not None:
+                    stderr = proc.stderr.read().decode(errors="replace") if proc.stderr else ""
+                    pytest.fail(f"server exited early (rc={proc.returncode}). stderr:\n{stderr}")
+                continue
+            chunk = os.read(stdout_fd, 65536)
+            if not chunk:  # EOF
+                if proc.poll() is not None:
+                    stderr = proc.stderr.read().decode(errors="replace") if proc.stderr else ""
+                    pytest.fail(f"server exited early (rc={proc.returncode}). stderr:\n{stderr}")
+                continue
+            buf += chunk
+            while b"\n" in buf:
+                raw, buf = buf.split(b"\n", 1)
+                try:
+                    resp = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if resp.get("id") == 2 and "result" in resp:
+                    tools = {t["name"] for t in resp["result"]["tools"]}
+                    break
+        if tools is None:
+            # Deadline hit with the server still alive and silent — kill
+            # first, THEN drain stderr. Reading an open stderr pipe on a
+            # live process would itself block forever, defeating the very
+            # timeout this path exists to enforce (Codex review).
+            proc.kill()
+            try:
+                _, stderr_b = proc.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                stderr_b = b""
+            pytest.fail(
+                f"no tools/list response within 20s. stderr:\n{stderr_b.decode(errors='replace')}"
+            )
+        return tools
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+        for stream in (proc.stdin, proc.stdout, proc.stderr):
+            if stream is not None:
+                try:
+                    stream.close()
+                except Exception:
+                    pass
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="server is POSIX-only")
+@pytest.mark.parametrize("mode", ["core", "standard", "full"])
+def test_tools_list_matches_expected_set(mode: str, tmp_path: Path) -> None:
+    """End-to-end: the tool set advertised in each mode is EXACTLY the
+    independently-derived expected set. Catches both a pruning
+    regression (wrong tools removed) and a silent FastMCP-API break
+    (nothing removed → full surface in core mode)."""
+    advertised = _tools_list_under_mode(mode, tmp_path)
+    expected = _expected_tools(mode)
+    assert advertised == expected, (
+        f"{mode} mode advertised {sorted(advertised - expected)} extra / "
+        f"{sorted(expected - advertised)} missing vs expected"
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="server is POSIX-only")
+def test_core_mode_prunes_multi_agent_tools(tmp_path: Path) -> None:
+    """Regression guard for the #1608/#1609 class: the multi-agent and
+    session tools the instructions route through ``mem_do`` must NOT be
+    individually exposed in the default core mode."""
+    advertised = _tools_list_under_mode("core", tmp_path)
+    for pruned in (
+        "mem_agent_register",
+        "mem_agent_search",
+        "mem_agent_share",
+        "mem_session_start",
+        "mem_batch_add",
+    ):
+        assert pruned not in advertised, f"{pruned} must be pruned in core mode"
+    assert "mem_do" in advertised


### PR DESCRIPTION
## Problem

Tool-mode pruning reached into FastMCP private internals — iterating `mcp._tool_manager._tools` and calling `mcp._tool_manager.remove_tool` (`server/__init__.py`). A future `mcp` release renaming or restructuring `_tool_manager` would break core/standard pruning **silently**: the server would start in effective `full` mode, exposing every tool, with no error.

## Change

- Removal now uses the **public** `FastMCP.remove_tool` (available mcp>=1.27.2, the pinned floor).
- Enumeration routes through a guarded `_registered_tool_names()` helper that **raises** if `_tool_manager.list_tools` or `remove_tool` change shape — pruning can no longer fail open to full mode.
- The two coupling points are documented as such and pinned by the new test.

## Test — `tests/test_tool_mode_pruning.py`

- In-process: asserts both coupling points (`_tool_manager.list_tools`, `remove_tool`) exist and are shaped as expected — the upstream-change canary.
- Subprocess `tools/list` probes under each `MEMTOMEM_TOOL_MODE` assert the **exact** advertised tool set, computed independently from `_CORE_TOOLS` + the `_STANDARD_PACKS` registry slice (intersected with the pre-prune snapshot so register-only actions like `ingest` don't create phantom expectations). A pruning regression (wrong tools removed) and a silent FastMCP-API break (nothing removed) both fail here.
- A focused guard asserts the multi-agent/session tools the instructions route through `mem_do` are pruned in the default core mode (the #1608/#1609 class).

## Verification

- `uv run pytest packages/memtomem/tests/test_tool_mode_pruning.py` — 6 passed.
- `test_server_instructions.py` + `test_docs_guards.py` + `test_meta_tool.py` — 120 passed.
- `ruff check` + `ruff format --check` clean.

Built on `origin/main` after #1608 (mode-aware instructions) merged, since both touch `server/__init__.py`.

Closes #1609

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
