### PR TITLE
fix(storage): schema-version guard — refuse newer DB opened by older binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **Schema-version downgrade fence** (#1614) — the database now records a
+  monotonic `schema_version` in `_memtomem_meta`; opening a database written
+  by a newer memtomem release fails fast with a typed `SchemaDowngradeError`
+  naming both versions and the upgrade command, instead of running
+  unknown-structure code paths. Same, older, and pre-versioning databases
+  open unchanged — additive idempotent migrations remain the forward
+  mechanism; this adds only the downgrade guard.
+
 ## [0.3.3] — 2026-07-04
 
 ### Added

--- a/packages/memtomem/src/memtomem/errors.py
+++ b/packages/memtomem/src/memtomem/errors.py
@@ -22,6 +22,17 @@ class EmbeddingDimensionMismatchError(StorageError):
     """
 
 
+class SchemaDowngradeError(StorageError):
+    """Raised when the DB's stored schema version is newer than this binary's.
+
+    A newer memtomem release ran migrations this binary does not know about.
+    Migrations are additive/idempotent, so same-or-older versions always
+    pass — this fence only blocks the downgrade direction, where an old
+    binary could misread structures it has never seen. Fail-fast at open
+    with an upgrade remediation instead of undefined behavior later.
+    """
+
+
 class EmbeddingError(Mem2MemError):
     """Embedding provider error."""
 

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -57,7 +57,7 @@ from memtomem.storage.mixins import (
     SessionMixin,
     ShareLinkMixin,
 )
-from memtomem.storage.sqlite_schema import create_tables
+from memtomem.storage.sqlite_schema import check_schema_downgrade, create_tables
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +157,10 @@ class SqliteBackend(
             self._db.enable_load_extension(True)
             sqlite_vec.load(self._db)
             self._db.enable_load_extension(False)
+            # Downgrade fence before any write — the journal-mode PRAGMAs
+            # below mutate the DB file, and a refused open (newer DB, older
+            # binary) must leave it byte-identical for the newer release.
+            check_schema_downgrade(self._db)
         except Exception:
             self._db.close()
             self._db = None

--- a/packages/memtomem/src/memtomem/storage/sqlite_schema.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_schema.py
@@ -8,7 +8,7 @@ import re
 import sqlite3
 from datetime import datetime, timezone
 
-from memtomem.errors import EmbeddingDimensionMismatchError
+from memtomem.errors import EmbeddingDimensionMismatchError, SchemaDowngradeError
 from memtomem.storage.sqlite_meta import MetaManager
 
 logger = logging.getLogger(__name__)
@@ -33,6 +33,55 @@ _TAGS_UNICODE_REPAIR_KEY = "tags_unicode_repair_v1"
 # Matches a single ``\uXXXX`` BMP escape sequence as literal text (a backslash,
 # a ``u``, then four hex digits) — what a mis-decoded tag still carries.
 _UNICODE_ESCAPE_RE = re.compile(r"\\u[0-9a-fA-F]{4}")
+
+# Monotonic schema generation for the downgrade fence (#1614). Bump by 1
+# whenever create_tables gains a migration an older binary must not run
+# under. Same-or-older stored versions always pass (migrations stay
+# additive + idempotent); only stored > SCHEMA_VERSION is fatal.
+SCHEMA_VERSION = 1
+
+_SCHEMA_VERSION_KEY = "schema_version"
+
+
+def check_schema_downgrade(db: sqlite3.Connection) -> None:
+    """Raise :class:`SchemaDowngradeError` if the DB records a newer schema version.
+
+    Read-only — safe to call before any mutating setup (journal-mode PRAGMAs,
+    table creation), so a refused open leaves the DB file untouched. A missing
+    meta table or missing key means a fresh or pre-versioning DB and passes.
+    A non-integer value cannot be a legitimate newer version (all binaries
+    write integers) — it is evidence of corruption or hand-editing, so warn
+    loudly and pass; the stamp at the end of ``create_tables`` overwrites it
+    with the truth.
+    """
+    try:
+        row = db.execute(
+            "SELECT value FROM _memtomem_meta WHERE key = ?", (_SCHEMA_VERSION_KEY,)
+        ).fetchone()
+    except sqlite3.OperationalError as e:
+        if "no such table" in str(e).lower():
+            return
+        raise
+    if row is None:
+        return
+    try:
+        stored_ver = int(row[0])
+    except ValueError:
+        logger.warning(
+            "Non-integer schema_version %r in _memtomem_meta — treating as "
+            "pre-versioning and restamping to %d.",
+            row[0],
+            SCHEMA_VERSION,
+        )
+        return
+    if stored_ver > SCHEMA_VERSION:
+        raise SchemaDowngradeError(
+            f"This database has schema version {stored_ver}, but this "
+            f"memtomem binary only supports up to {SCHEMA_VERSION}. "
+            f"The database was created or migrated by a newer memtomem "
+            f"release. Upgrade memtomem to open it: "
+            f"'uv tool upgrade memtomem' or 'pip install -U memtomem'."
+        )
 
 
 def create_tables(
@@ -65,6 +114,12 @@ def create_tables(
             value TEXT NOT NULL
         )
     """)
+
+    # ---- schema-version downgrade fence (#1614) ----
+    # Must run before any migration touches user data. SqliteBackend also
+    # runs this check earlier, before its journal-mode PRAGMAs, so a refused
+    # open never writes; this second call covers direct callers.
+    check_schema_downgrade(db)
 
     db.execute("""
         CREATE TABLE IF NOT EXISTS chunks (
@@ -557,6 +612,24 @@ def create_tables(
         )
     """)
     db.execute("CREATE INDEX IF NOT EXISTS idx_schedules_enabled ON schedules(enabled)")
+
+    # ---- stamp schema version (monotonic, after migrations) ----
+    # After, not before: a failed migration must not leave the DB claiming a
+    # version it doesn't have. Atomic upsert — racing processes can never
+    # lower a canonical newer value; an equal value writes 0 rows. The second
+    # WHERE clause restamps any non-canonical-integer text (e.g. '2abc',
+    # '1.9') that the fence treated as corruption — SQLite CAST alone would
+    # read its numeric prefix and leave it in place, disagreeing with the
+    # fence's int() rule.
+    db.execute(
+        """
+        INSERT INTO _memtomem_meta(key, value) VALUES(?, ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        WHERE CAST(_memtomem_meta.value AS INTEGER) < CAST(excluded.value AS INTEGER)
+           OR _memtomem_meta.value != CAST(CAST(_memtomem_meta.value AS INTEGER) AS TEXT)
+        """,
+        (_SCHEMA_VERSION_KEY, str(SCHEMA_VERSION)),
+    )
 
     db.commit()
 

--- a/packages/memtomem/tests/test_schema_version_guard.py
+++ b/packages/memtomem/tests/test_schema_version_guard.py
@@ -1,0 +1,227 @@
+"""Tests for the ``create_tables`` schema-version downgrade fence (#1614).
+
+An older binary opening a DB written by a newer release must be detected
+and refused with :class:`SchemaDowngradeError` before any migration touches
+user data. Same/older/pre-versioning DBs open unchanged — the fence only
+blocks the downgrade direction; additive idempotent migrations remain the
+forward mechanism.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+
+import pytest
+import sqlite_vec
+
+from memtomem.config import StorageConfig
+from memtomem.errors import SchemaDowngradeError, StorageError
+from memtomem.storage.sqlite_backend import SqliteBackend
+from memtomem.storage.sqlite_meta import MetaManager
+from memtomem.storage.sqlite_schema import SCHEMA_VERSION, create_tables
+
+
+def _connect_with_vec() -> sqlite3.Connection:
+    db = sqlite3.connect(":memory:")
+    db.enable_load_extension(True)
+    sqlite_vec.load(db)
+    db.enable_load_extension(False)
+    return db
+
+
+def _seed_schema_version(db: sqlite3.Connection, value: str) -> None:
+    """Pre-create ``_memtomem_meta`` with a ``schema_version`` row, as a
+    prior ``create_tables`` run of some other release would."""
+    db.execute(
+        "CREATE TABLE IF NOT EXISTS _memtomem_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+    )
+    db.execute(
+        "INSERT OR REPLACE INTO _memtomem_meta(key, value) VALUES ('schema_version', ?)",
+        (value,),
+    )
+    db.commit()
+
+
+def _stored_version(db: sqlite3.Connection) -> str | None:
+    row = db.execute("SELECT value FROM _memtomem_meta WHERE key = 'schema_version'").fetchone()
+    return row[0] if row else None
+
+
+def _create_tables(db: sqlite3.Connection) -> None:
+    """Run ``create_tables`` with dim=8 / provider ``none`` so the #298
+    dim-mismatch gate stays out of the way."""
+    create_tables(db, MetaManager(lambda: db), 8, "none", "")
+
+
+class TestDowngradeFence:
+    def test_fresh_db_stamps_current_version(self) -> None:
+        db = _connect_with_vec()
+        try:
+            _create_tables(db)
+            assert _stored_version(db) == str(SCHEMA_VERSION)
+        finally:
+            db.close()
+
+    def test_pre_versioning_db_passes_and_gets_stamped(self) -> None:
+        """Every existing install: meta table exists (legacy embedding keys)
+        but has no ``schema_version`` row — must open and get stamped."""
+        db = _connect_with_vec()
+        try:
+            db.execute(
+                "CREATE TABLE IF NOT EXISTS _memtomem_meta "
+                "(key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+            )
+            db.executemany(
+                "INSERT OR REPLACE INTO _memtomem_meta(key, value) VALUES (?, ?)",
+                [
+                    ("embedding_dimension", "8"),
+                    ("embedding_provider", "none"),
+                    ("embedding_model", ""),
+                ],
+            )
+            db.commit()
+            _create_tables(db)
+            assert _stored_version(db) == str(SCHEMA_VERSION)
+        finally:
+            db.close()
+
+    def test_newer_version_raises_typed_error(self) -> None:
+        db = _connect_with_vec()
+        try:
+            _seed_schema_version(db, str(SCHEMA_VERSION + 1))
+            with pytest.raises(SchemaDowngradeError) as excinfo:
+                _create_tables(db)
+            assert isinstance(excinfo.value, StorageError)
+            msg = str(excinfo.value)
+            assert str(SCHEMA_VERSION + 1) in msg
+            assert str(SCHEMA_VERSION) in msg
+            assert "uv tool upgrade memtomem" in msg
+            assert "pip install -U memtomem" in msg
+        finally:
+            db.close()
+
+    def test_newer_version_raises_before_any_migration(self) -> None:
+        """The fence must fire before any user-data DDL runs."""
+        db = _connect_with_vec()
+        try:
+            _seed_schema_version(db, str(SCHEMA_VERSION + 1))
+            with pytest.raises(SchemaDowngradeError):
+                _create_tables(db)
+            row = db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='chunks'"
+            ).fetchone()
+            assert row is None
+        finally:
+            db.close()
+
+    def test_newer_version_not_lowered_by_failed_open(self) -> None:
+        """The failure path must never write — the stored (newer) version
+        survives the refused open."""
+        db = _connect_with_vec()
+        try:
+            _seed_schema_version(db, str(SCHEMA_VERSION + 1))
+            with pytest.raises(SchemaDowngradeError):
+                _create_tables(db)
+            assert _stored_version(db) == str(SCHEMA_VERSION + 1)
+        finally:
+            db.close()
+
+    def test_equal_version_passes(self) -> None:
+        db = _connect_with_vec()
+        try:
+            _seed_schema_version(db, str(SCHEMA_VERSION))
+            _create_tables(db)
+            assert _stored_version(db) == str(SCHEMA_VERSION)
+        finally:
+            db.close()
+
+    def test_older_version_passes_and_bumps(self) -> None:
+        db = _connect_with_vec()
+        try:
+            _seed_schema_version(db, "0")
+            _create_tables(db)
+            assert _stored_version(db) == str(SCHEMA_VERSION)
+        finally:
+            db.close()
+
+    @pytest.mark.parametrize("garbage", ["banana", "2abc", "1.9", "+3x", "999banana"])
+    def test_garbage_value_warns_migrates_and_restamps(
+        self, garbage: str, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A non-integer value cannot be a legitimate newer version — warn
+        loudly, treat as pre-versioning (migrations run), and restamp with
+        the truth. Includes numeric-prefixed garbage, where SQLite ``CAST``
+        alone would read the prefix and leave the row unrepaired."""
+        db = _connect_with_vec()
+        try:
+            _seed_schema_version(db, garbage)
+            with caplog.at_level(logging.WARNING, logger="memtomem.storage.sqlite_schema"):
+                _create_tables(db)
+            assert any("schema_version" in r.message for r in caplog.records)
+            row = db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='chunks'"
+            ).fetchone()
+            assert row is not None
+            assert _stored_version(db) == str(SCHEMA_VERSION)
+        finally:
+            db.close()
+
+    def test_noncanonical_integer_normalized(self) -> None:
+        """A non-canonical but parseable integer (e.g. ``'01'``) passes the
+        fence and gets rewritten to the canonical current version."""
+        db = _connect_with_vec()
+        try:
+            _seed_schema_version(db, "01")
+            _create_tables(db)
+            assert _stored_version(db) == str(SCHEMA_VERSION)
+        finally:
+            db.close()
+
+    def test_create_tables_idempotent_after_stamp(self) -> None:
+        db = _connect_with_vec()
+        try:
+            _create_tables(db)
+            _create_tables(db)
+            assert _stored_version(db) == str(SCHEMA_VERSION)
+        finally:
+            db.close()
+
+
+class TestBackendInitialize:
+    async def test_backend_initialize_raises_and_leaves_db_untouched(self, tmp_path: Path) -> None:
+        """End-to-end: ``SqliteBackend.initialize()`` refuses a newer DB with
+        the typed error *before any write* — the fence runs ahead of the
+        journal-mode PRAGMAs, so the refused open must not flip the journal
+        mode or create WAL sidecar files."""
+        cfg = StorageConfig()
+        cfg.sqlite_path = tmp_path / "m.db"
+        storage = SqliteBackend(cfg, dimension=8)
+        await storage.initialize()
+        await storage.close()
+
+        db = sqlite3.connect(cfg.sqlite_path)
+        try:
+            db.execute("PRAGMA journal_mode=DELETE")
+            db.execute(
+                "UPDATE _memtomem_meta SET value = ? WHERE key = 'schema_version'",
+                (str(SCHEMA_VERSION + 1),),
+            )
+            db.commit()
+        finally:
+            db.close()
+
+        reopened = SqliteBackend(cfg, dimension=8)
+        with pytest.raises(SchemaDowngradeError):
+            await reopened.initialize()
+
+        assert not Path(str(cfg.sqlite_path) + "-wal").exists()
+        db = sqlite3.connect(cfg.sqlite_path)
+        try:
+            assert db.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+            assert db.execute(
+                "SELECT value FROM _memtomem_meta WHERE key = 'schema_version'"
+            ).fetchone()[0] == str(SCHEMA_VERSION + 1)
+        finally:
+            db.close()


### PR DESCRIPTION
## Problem

There is no schema-version / downgrade fence: an older binary opening a DB written by a newer release is not detected or refused — safety relies entirely on migrations staying additive. A future forward-incompatible migration would have no loud guard; `storage/mixins/schedules.py` already anticipates this footgun with its phantom-row "downgrade / bad migration" warning.

## Approach

Reuses the existing `_memtomem_meta` keyed store — no `PRAGMA user_version` machinery.

- **`SCHEMA_VERSION = 1`** constant in `sqlite_schema.py`, with the bump discipline documented next to it. A missing key means a pre-versioning DB (every existing install) — it passes and gets stamped.
- **Read-only `check_schema_downgrade(db)`** raises the new typed **`SchemaDowngradeError`** (a `StorageError`) when the stored version exceeds the binary's, naming both versions plus the remediation (`uv tool upgrade memtomem` / `pip install -U memtomem`). `SqliteBackend.initialize()` runs it **before** the journal-mode PRAGMAs and read-pool setup, so a refused open leaves the DB file untouched for the newer release; `create_tables` keeps a second check for direct callers.
- **Stamp after migrations**, just before the final commit — a failed migration must not leave the DB claiming a version it doesn't have (idempotent migrations make the retry safe). The stamp is one atomic upsert: racing processes can never lower a canonical newer value, an equal value writes 0 rows, and non-canonical text (e.g. `2abc` — corruption SQLite `CAST` alone would silently keep) is restamped to match the fence's `int()` rule, with a loud warning.
- CLI surfaces need no change — the existing `except Exception → ClickException(str(e))` wrappers render the message cleanly (verified manually: `mm status` on a version-99 DB prints the typed message, no traceback). No degraded-mode branch in `component_factory` — a downgrade is unrecoverable by design.

Additive idempotent migrations remain the forward mechanism; this adds only the downgrade fence.

## Testing

- New `tests/test_schema_version_guard.py` (15 tests): fresh-DB stamp, pre-versioning pass+stamp, newer→typed error (before any user-data DDL, value never lowered on the failure path), equal/older pass, parametrized garbage values (`banana`, `2abc`, `1.9`, `+3x`, `999banana`) warn+migrate+restamp, non-canonical `'01'` normalization, and an end-to-end `SqliteBackend.initialize()` test asserting the refused open leaves journal mode, sidecars, and the stored version untouched.
- Old-DB migration fixtures stay green (`test_sqlite_schema.py`, `test_chunk_links_schema.py`).
- Full suite: 7915 passed, 11 skipped (`-m "not ollama"`). `ruff check` + `format --check` clean; mypy at the pre-existing 13-error baseline (none in touched files).
- Codex review: initial NEEDS-FIX (pre-fence PRAGMA write; `CAST` vs `int()` disagreement on numeric-prefixed garbage) → both fixed → re-review **SHIP**.

Closes #1614

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
