### PR TITLE
feat(cli): mm status --format/--json via dict-first status report

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,11 +220,11 @@ command:
 
 Examples in the current CLI:
 
-- `--json` — `mm watchdog status`, `mm watchdog run`, `mm config show`
-  (alias of `--format json`).
+- `--json` — `mm watchdog status`, `mm watchdog run`, `mm config show`,
+  `mm status` (aliases of `--format json`).
 - `--format` — `mm search` (has `context`, `smart`), `mm recall` (has
-  `plain`), `mm config show` (keeps the original option alongside
-  `--json`).
+  `plain`), `mm config show` and `mm status` (keep the original option
+  alongside `--json`).
 
 **If the two-mode nature of a new command is uncertain** — i.e. it's
 plausible a `context` / `digest` / `diff` mode gets added later — choose

--- a/packages/memtomem/src/memtomem/cli/status_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/status_cmd.py
@@ -3,19 +3,20 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
-import re
+from typing import TYPE_CHECKING, Any
 
 import click
 
-
-_DENSE_RE = re.compile(r"^(Dense vectors: )(\d+)/(\d+)( \([^)]+\).*)?$")
-_KEY_RE = re.compile(r"^([A-Za-z][A-Za-z .-]*:)(\s+.*)$")
-_IMMUTABLE_KEY_RE = re.compile(r"^([a-z.]+:)(\s+.*)$")
+if TYPE_CHECKING:
+    from memtomem.server.tools.status_config import StatusLine
 
 
 @click.command("status")
-def status() -> None:
+@click.option("--format", "fmt", type=click.Choice(["table", "json"]), default="table")
+@click.option("--json", "as_json", is_flag=True, help="Shortcut for --format json.")
+def status(fmt: str, *, as_json: bool = False) -> None:
     """Show indexing statistics and current configuration summary.
 
     Mirrors the MCP ``mem_status`` tool — same output, callable from a
@@ -23,101 +24,87 @@ def status() -> None:
     check that the binary works, the config is readable, and the DB is
     reachable, without having to run a search.
     """
+    # --json is an alias for --format json (CONTRIBUTING "CLI output
+    # convention"); if both are passed, --json wins since it's the more
+    # specific intent.
+    if as_json:
+        fmt = "json"
+
     try:
-        asyncio.run(_status())
-    except click.ClickException:
+        asyncio.run(_status(fmt))
+    except click.ClickException as e:
+        if fmt == "json":
+            # Read-command error shape: {"error": ...} with exit code 0
+            # (CONTRIBUTING "JSON error shape") so `... --json | jq`
+            # pipelines see the failure in-band instead of a broken pipe.
+            # Only ClickException qualifies — it marks failures the CLI
+            # classified as expected; anything else falls through below
+            # and keeps the nonzero exit, per the same convention.
+            click.echo(json.dumps({"error": e.format_message()}))
+            return
         raise
     except Exception as e:
         raise click.ClickException(str(e)) from e
 
 
-async def _status() -> None:
+async def _status(fmt: str) -> None:
     from memtomem.cli._bootstrap import cli_components
     from memtomem.server.context import AppContext
-    from memtomem.server.tools.status_config import format_status_report
+    from memtomem.server.tools.status_config import (
+        collect_status_report,
+        iter_status_lines,
+        render_status_report,
+    )
 
     async with cli_components() as comp:
         ctx = AppContext.from_components(comp)
-        output = await format_status_report(ctx)
+        data = await collect_status_report(ctx)
 
-    click.echo(_style_status_report(output))
+    if fmt == "json":
+        click.echo(json.dumps(data, indent=2, ensure_ascii=False, default=str))
+    elif "NO_COLOR" in os.environ:
+        click.echo(render_status_report(data))
+    else:
+        click.echo(_style_status_lines(iter_status_lines(data)))
 
 
-def _style_status_report(output: str) -> str:
+_TONE_STYLES: dict[str, dict[str, Any]] = {
+    "title": {"fg": "cyan", "bold": True},
+    "plain": {"bold": True},
+    "warn": {"fg": "yellow", "bold": True},
+}
+
+_DENSE_STATE_COLORS = {"full": "green", "partial": "yellow", "none": "red", "empty": "yellow"}
+
+
+def _style_status_lines(lines: list[StatusLine]) -> str:
     """Add terminal-only scanability hints without changing report text."""
-
-    if "NO_COLOR" in os.environ:
-        return output
-
-    lines = output.splitlines()
     styled: list[str] = []
-    immutable_section = False
 
     for line in lines:
-        if line == "memtomem Status":
-            styled.append(click.style(line, fg="cyan", bold=True))
-        elif line == "==============":
-            styled.append(click.style(line, fg="cyan", bold=True))
-        elif line == "Index stats":
-            immutable_section = False
-            styled.append(click.style(line, bold=True))
-        elif line == "-----------":
-            styled.append(click.style(line, bold=True))
-        elif line == "Immutable fields (set once at init)":
-            immutable_section = True
-            styled.append(click.style(line, fg="yellow", bold=True))
-        elif line == "------------------------------------":
-            styled.append(click.style(line, fg="yellow", bold=True))
-        elif line == "Warnings":
-            immutable_section = False
-            styled.append(click.style(line, fg="yellow", bold=True))
-        elif line == "--------":
-            styled.append(click.style(line, fg="yellow", bold=True))
-        elif line.startswith("Dense vectors: "):
-            styled.append(_style_dense_vectors(line))
-        elif line.startswith("  ->"):
-            styled.append(_style_guidance_line(line))
-        elif immutable_section:
-            styled.append(_style_key_value(line, _IMMUTABLE_KEY_RE))
-        else:
-            styled.append(_style_key_value(line, _KEY_RE))
+        if line.role == "title":
+            styled.append(click.style(line.text, fg="cyan", bold=True))
+        elif line.role in ("rule", "section"):
+            styled.append(click.style(line.text, **_TONE_STYLES[line.meta["tone"]]))
+        elif line.role == "dense":
+            styled.append(
+                click.style(line.key, bold=True)
+                + click.style(
+                    line.value + line.suffix,
+                    fg=_DENSE_STATE_COLORS[line.meta["state"]],
+                    bold=True,
+                )
+            )
+        elif line.role == "guidance":
+            styled.append(_style_guidance_line(line.text))
+        elif line.role in ("kv", "immutable_kv"):
+            value_fg = line.meta.get("value_fg")
+            value = click.style(line.value, fg=value_fg) if value_fg else line.value
+            styled.append(click.style(line.key, bold=True) + value + line.suffix)
+        else:  # "warning_kv" | "blank" — plain on purpose
+            styled.append(line.text)
 
     return "\n".join(styled)
-
-
-def _style_key_value(line: str, pattern: re.Pattern[str]) -> str:
-    match = pattern.match(line)
-    if not match:
-        return line
-
-    key, value = match.groups()
-    if key == "DB path:":
-        return click.style(key, bold=True) + click.style(value, fg="cyan")
-    return click.style(key, bold=True) + value
-
-
-def _style_dense_vectors(line: str) -> str:
-    match = _DENSE_RE.match(line)
-    if not match:
-        return click.style(line, bold=True)
-
-    label, with_dense_text, total_text, suffix = match.groups()
-    suffix = suffix or ""
-    with_dense = int(with_dense_text)
-    total = int(total_text)
-
-    if total == 0:
-        color = "yellow"
-    elif with_dense == total:
-        color = "green"
-    elif with_dense == 0:
-        color = "red"
-    else:
-        color = "yellow"
-
-    return click.style(label, bold=True) + click.style(
-        f"{with_dense_text}/{total_text}{suffix}", fg=color, bold=True
-    )
 
 
 def _style_guidance_line(line: str) -> str:

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -62,6 +63,252 @@ async def mem_stats(
     return out
 
 
+async def collect_status_report(app: AppContext) -> dict:
+    """Gather the status report as a structured dict.
+
+    Single source of truth for both surfaces: ``mm status --format json``
+    emits this dict verbatim, and ``render_status_report`` turns it into
+    the human-readable text ``mem_status`` / ``mm status`` print. Keys are
+    part of the CLI's machine-readable contract — treat renames as
+    breaking. ``warnings`` entries keep the stable ``kind``/``fix``
+    (plus optional ``doc``/``detail``) schema documented on
+    ``mem_status``.
+    """
+    stats = await app.storage.get_stats()
+    config = app.config
+
+    stored = getattr(app.storage, "stored_embedding_info", None)
+    if stored:
+        embedding = {
+            "provider": stored["provider"],
+            "model": stored["model"],
+            "dimension": stored["dimension"],
+            "source": "stored",
+        }
+    else:
+        embedding = {
+            "provider": config.embedding.provider,
+            "model": config.embedding.model,
+            "dimension": config.embedding.dimension,
+            "source": "configured",
+        }
+
+    # Orphan check — count source files no longer on disk
+    orphaned = 0
+    try:
+        source_files = await app.storage.get_all_source_files()
+        orphaned = sum(1 for sf in source_files if not sf.exists())
+    except Exception:
+        logger.debug("Orphan detection failed", exc_info=True)
+
+    # Dense-vector coverage. The ``none`` state surfaces the BM25-only
+    # run case loudly: an embedder that crashed mid-init or fell back to
+    # NoopEmbedder will still index chunks into ``chunks`` +
+    # ``chunks_fts`` but skip ``chunks_vec`` entirely, so semantic search
+    # returns nothing while keyword search keeps working. The check is
+    # gated on ``hasattr`` so older storage doubles that haven't grown
+    # the method don't break the report; ``None`` means "unknown", not
+    # "no coverage".
+    dense_coverage = None
+    if hasattr(app.storage, "get_dense_coverage"):
+        try:
+            cov = await app.storage.get_dense_coverage()
+            total = int(cov["total"])
+            with_dense = int(cov["with_dense"])
+            if total > 0:
+                if with_dense == total:
+                    state = "full"
+                elif with_dense == 0:
+                    state = "none"
+                else:
+                    state = "partial"
+                dense_coverage = {
+                    "with_dense": with_dense,
+                    "total": total,
+                    "percent": round((with_dense / total) * 100, 1),
+                    "state": state,
+                }
+            else:
+                dense_coverage = {
+                    "with_dense": with_dense,
+                    "total": total,
+                    "percent": None,
+                    "state": "empty",
+                }
+        except Exception:
+            logger.debug("dense coverage query failed", exc_info=True)
+
+    warnings: list[dict] = []
+    if config.scheduler.enabled and not config.health_watchdog.enabled:
+        warnings.append(
+            {
+                "kind": "scheduler_watchdog_disabled",
+                "detail": "scheduler.enabled=True but health_watchdog.enabled=False",
+                "fix": "set health_watchdog.enabled=True (scheduler rides its tick)",
+            }
+        )
+    mismatch = getattr(app.storage, "embedding_mismatch", None)
+    if mismatch is not None:
+        warnings.append(
+            {
+                "kind": "embedding_dim_mismatch",
+                "stored": dict(mismatch["stored"]),
+                "configured": dict(mismatch["configured"]),
+                "fix": "uv run mm embedding-reset --mode apply-current",
+                "doc": "docs/guides/configuration.md#reset-flow",
+            }
+        )
+
+    return {
+        "config": {
+            "storage_backend": config.storage.backend,
+            "db_path": str(Path(config.storage.sqlite_path).expanduser()),
+            "embedding": embedding,
+            "top_k": config.search.default_top_k,
+            "rrf_k": config.search.rrf_k,
+        },
+        "index": {
+            "total_chunks": stats["total_chunks"],
+            "total_sources": stats["total_sources"],
+            "orphaned_sources": orphaned,
+            "dense_coverage": dense_coverage,
+        },
+        # Immutable fields — these cannot be changed via mem_config at
+        # runtime. Keys are the dotted names ``mm config set`` takes, so
+        # operators are not surprised when a set on one of these paths
+        # fails silently.
+        "immutable": {
+            "embedding.provider": config.embedding.provider,
+            "embedding.model": config.embedding.model or None,
+            "embedding.dimension": config.embedding.dimension,
+            "search.tokenizer": config.search.tokenizer,
+            "storage.backend": config.storage.backend,
+        },
+        "warnings": warnings,
+    }
+
+
+# Dense-coverage hints, keyed by ``dense_coverage["state"]``.
+_DENSE_HINTS = {
+    "none": "  (BM25-only — dense retrieval will return nothing)",
+    "partial": "  (partial dense coverage — some chunks BM25-only)",
+}
+
+_IMMUTABLE_GUIDANCE = (
+    "  -> To change: re-run `mm init` for provider/tokenizer/backend, "
+    "or `mm embedding-reset` to switch embedder (re-index required)."
+)
+
+
+@dataclass(frozen=True)
+class StatusLine:
+    """One rendered report line, split so stylers never re-parse text.
+
+    ``key`` carries its column padding (and the ``"- "``/``"  "`` warning
+    prefix) so ``key + value + suffix`` reproduces the plain line exactly;
+    ``role``/``meta`` tell the CLI styler what the line is without the
+    regex re-parsing this replaced (#1615).
+    """
+
+    role: str  # "title" | "rule" | "section" | "kv" | "immutable_kv"
+    # | "dense" | "guidance" | "warning_kv" | "blank"
+    key: str = ""
+    value: str = ""
+    suffix: str = ""
+    meta: dict = field(default_factory=dict)
+
+    @property
+    def text(self) -> str:
+        return self.key + self.value + self.suffix
+
+
+def iter_status_lines(data: dict) -> list[StatusLine]:
+    """Lay out a ``collect_status_report`` dict as report lines."""
+    cfg = data["config"]
+    emb = cfg["embedding"]
+    index = data["index"]
+
+    lines = [
+        StatusLine("title", value="memtomem Status"),
+        StatusLine("rule", value="==============", meta={"tone": "title"}),
+        StatusLine("kv", key="Storage:".ljust(11), value=str(cfg["storage_backend"])),
+        StatusLine("kv", key="DB path:".ljust(11), value=cfg["db_path"], meta={"value_fg": "cyan"}),
+        StatusLine("kv", key="Embedding:".ljust(11), value=f"{emb['provider']} / {emb['model']}"),
+        StatusLine("kv", key="Dimension:".ljust(11), value=str(emb["dimension"])),
+        StatusLine("kv", key="Top-K:".ljust(11), value=str(cfg["top_k"])),
+        StatusLine("kv", key="RRF k:".ljust(11), value=str(cfg["rrf_k"])),
+        StatusLine("blank"),
+        StatusLine("section", value="Index stats", meta={"tone": "plain"}),
+        StatusLine("rule", value="-----------", meta={"tone": "plain"}),
+        StatusLine("kv", key="Total chunks:".ljust(15), value=str(index["total_chunks"])),
+        StatusLine(
+            "kv",
+            key="Source files:".ljust(15),
+            value=str(index["total_sources"]),
+            suffix=(
+                f" ({index['orphaned_sources']} orphaned — run mem_cleanup_orphans)"
+                if index["orphaned_sources"]
+                else ""
+            ),
+        ),
+    ]
+
+    coverage = index["dense_coverage"]
+    if coverage is not None:
+        percent = coverage["percent"]
+        lines.append(
+            StatusLine(
+                "dense",
+                key="Dense vectors:".ljust(15),
+                value=f"{coverage['with_dense']}/{coverage['total']}",
+                suffix=(
+                    f" ({percent}%){_DENSE_HINTS.get(coverage['state'], '')}"
+                    if percent is not None
+                    else ""
+                ),
+                meta={"state": coverage["state"]},
+            )
+        )
+
+    lines += [
+        StatusLine("blank"),
+        StatusLine("section", value="Immutable fields (set once at init)", meta={"tone": "warn"}),
+        StatusLine("rule", value="------------------------------------", meta={"tone": "warn"}),
+    ]
+    for key, value in data["immutable"].items():
+        lines.append(
+            StatusLine(
+                "immutable_kv",
+                key=f"{key}:".ljust(21),
+                value="(unset)" if value is None else str(value),
+            )
+        )
+    lines.append(StatusLine("guidance", value=_IMMUTABLE_GUIDANCE))
+
+    if data["warnings"]:
+        lines += [
+            StatusLine("blank"),
+            StatusLine("section", value="Warnings", meta={"tone": "warn"}),
+            StatusLine("rule", value="--------", meta={"tone": "warn"}),
+        ]
+        for warning in data["warnings"]:
+            for i, (key, value) in enumerate(warning.items()):
+                if isinstance(value, dict):
+                    # stored/configured embedding sub-blocks
+                    text = f"{value['provider']}/{value['model']} ({value['dimension']}d)"
+                else:
+                    text = str(value)
+                prefix = "- " if i == 0 else "  "
+                lines.append(StatusLine("warning_kv", key=prefix + f"{key}:".ljust(12), value=text))
+
+    return lines
+
+
+def render_status_report(data: dict) -> str:
+    """Render a ``collect_status_report`` dict as plain report text."""
+    return "\n".join(line.text for line in iter_status_lines(data))
+
+
 async def format_status_report(app: AppContext) -> str:
     """Render the status report shared by ``mem_status`` and ``mm status``.
 
@@ -69,108 +316,7 @@ async def format_status_report(app: AppContext) -> str:
     same formatting without going through MCP — both surface the same
     text so users learn one output and can recognize it in either place.
     """
-    stats = await app.storage.get_stats()
-    config = app.config
-
-    stored = getattr(app.storage, "stored_embedding_info", None)
-    if stored:
-        emb_line = f"{stored['provider']} / {stored['model']}"
-        dim_line = str(stored["dimension"])
-    else:
-        emb_line = f"{config.embedding.provider} / {config.embedding.model}"
-        dim_line = str(config.embedding.dimension)
-
-    lines = [
-        "memtomem Status",
-        "==============",
-        f"Storage:   {config.storage.backend}",
-        f"DB path:   {Path(config.storage.sqlite_path).expanduser()}",
-        f"Embedding: {emb_line}",
-        f"Dimension: {dim_line}",
-        f"Top-K:     {config.search.default_top_k}",
-        f"RRF k:     {config.search.rrf_k}",
-        "",
-        "Index stats",
-        "-----------",
-        f"Total chunks:  {stats['total_chunks']}",
-        f"Source files:  {stats['total_sources']}",
-    ]
-
-    # Orphan check — count source files no longer on disk
-    try:
-        source_files = await app.storage.get_all_source_files()
-        orphaned = sum(1 for sf in source_files if not sf.exists())
-        if orphaned:
-            lines[-1] = (
-                f"Source files:  {stats['total_sources']} ({orphaned} orphaned — run mem_cleanup_orphans)"
-            )
-    except Exception:
-        logger.debug("Orphan detection failed", exc_info=True)
-
-    # Dense-vector coverage line. The hint at the end surfaces the
-    # BM25-only run case loudly: an embedder that crashed mid-init or
-    # fell back to NoopEmbedder will still index chunks into ``chunks``
-    # + ``chunks_fts`` but skip ``chunks_vec`` entirely, so semantic
-    # search returns nothing while keyword search keeps working. The
-    # check is gated on ``hasattr`` so older storage doubles that
-    # haven't grown the method don't break the report.
-    if hasattr(app.storage, "get_dense_coverage"):
-        try:
-            cov = await app.storage.get_dense_coverage()
-            total = int(cov["total"])
-            with_dense = int(cov["with_dense"])
-            if total > 0:
-                pct = round((with_dense / total) * 100, 1)
-                hint = ""
-                if with_dense == 0:
-                    hint = "  (BM25-only — dense retrieval will return nothing)"
-                elif with_dense < total:
-                    hint = "  (partial dense coverage — some chunks BM25-only)"
-                lines.append(f"Dense vectors: {with_dense}/{total} ({pct}%){hint}")
-            else:
-                lines.append("Dense vectors: 0/0")
-        except Exception:
-            logger.debug("dense coverage query failed", exc_info=True)
-
-    # Immutable fields — these cannot be changed via mem_config at runtime.
-    # Surfacing them here so operators are not surprised when a `mm config set`
-    # on one of these paths fails silently.
-    lines.append("")
-    lines.append("Immutable fields (set once at init)")
-    lines.append("------------------------------------")
-    lines.append(f"embedding.provider:  {config.embedding.provider}")
-    lines.append(f"embedding.model:     {config.embedding.model or '(unset)'}")
-    lines.append(f"embedding.dimension: {config.embedding.dimension}")
-    lines.append(f"search.tokenizer:    {config.search.tokenizer}")
-    lines.append(f"storage.backend:     {config.storage.backend}")
-    lines.append(
-        "  -> To change: re-run `mm init` for provider/tokenizer/backend, "
-        "or `mm embedding-reset` to switch embedder (re-index required)."
-    )
-
-    mismatch = getattr(app.storage, "embedding_mismatch", None)
-    scheduler_misconfig = config.scheduler.enabled and not config.health_watchdog.enabled
-    if mismatch is not None or scheduler_misconfig:
-        lines.append("")
-        lines.append("Warnings")
-        lines.append("--------")
-    if scheduler_misconfig:
-        lines.append("- kind:       scheduler_watchdog_disabled")
-        lines.append("  detail:     scheduler.enabled=True but health_watchdog.enabled=False")
-        lines.append("  fix:        set health_watchdog.enabled=True (scheduler rides its tick)")
-    if mismatch is not None:
-        stored_info = mismatch["stored"]
-        cfg = mismatch["configured"]
-        lines.append("- kind:       embedding_dim_mismatch")
-        lines.append(
-            f"  stored:     {stored_info['provider']}/{stored_info['model']} "
-            f"({stored_info['dimension']}d)"
-        )
-        lines.append(f"  configured: {cfg['provider']}/{cfg['model']} ({cfg['dimension']}d)")
-        lines.append("  fix:        uv run mm embedding-reset --mode apply-current")
-        lines.append("  doc:        docs/guides/configuration.md#reset-flow")
-
-    return "\n".join(lines)
+    return render_status_report(await collect_status_report(app))
 
 
 @mcp.tool()
@@ -195,8 +341,10 @@ async def mem_status(
                 ``stale_index``, ``orphan_vectors``, etc. — consumers
                 must tolerate unknown kinds rather than erroring.
     ``fix``     the canonical CLI command a user should run.
-    ``doc``     a relative-path link into ``docs/guides/`` with the full
-                remediation flow (see ``configuration.md#reset-flow``).
+    ``doc``     optional — a relative-path link into ``docs/guides/``
+                with the full remediation flow (see
+                ``configuration.md#reset-flow``). Not every warning kind
+                carries one (``scheduler_watchdog_disabled`` does not).
 
     Embedding-mismatch entries also include ``stored`` and ``configured``
     sub-blocks echoing the DB vs runtime provider/model/dimension so the

--- a/packages/memtomem/tests/test_cli_status.py
+++ b/packages/memtomem/tests/test_cli_status.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -12,8 +13,14 @@ import click
 from click.testing import CliRunner
 
 from memtomem.cli import cli
-from memtomem.cli.status_cmd import _style_status_report
+from memtomem.cli.status_cmd import _style_status_lines
 from memtomem.config import Mem2MemConfig
+from memtomem.server.tools.status_config import (
+    StatusLine,
+    collect_status_report,
+    iter_status_lines,
+    render_status_report,
+)
 
 
 def _mock_components(
@@ -24,6 +31,7 @@ def _mock_components(
     stored_embedding_info: dict | None = None,
     embedding_mismatch: dict | None = None,
     dense_coverage: dict | None = None,
+    config: Mem2MemConfig | None = None,
 ) -> SimpleNamespace:
     """Build a minimal ``Components``-shaped mock for ``mm status`` tests.
 
@@ -51,7 +59,7 @@ def _mock_components(
     if dense_coverage is not None:
         storage.get_dense_coverage = AsyncMock(return_value=dense_coverage)
     return SimpleNamespace(
-        config=Mem2MemConfig(),
+        config=config or Mem2MemConfig(),
         storage=storage,
         embedder=SimpleNamespace(),
     )
@@ -187,69 +195,87 @@ class TestStatusOutput:
         assert "Dense vectors:" not in result.output
 
     def test_colored_output_preserves_plain_text(self) -> None:
-        plain = "\n".join(
-            [
-                "memtomem Status",
-                "==============",
-                "Storage:   sqlite",
-                r"DB path:   C:\Users\TonyStark\.memtomem\memtomem.db",
-                "Embedding: onnx / bge-m3",
-                "Dimension: 1024",
-                "Top-K:     10",
-                "RRF k:     60",
-                "",
-                "Index stats",
-                "-----------",
-                "Total chunks:  53",
-                "Source files:  25",
-                "Dense vectors: 53/53 (100.0%)",
-                "",
-                "Immutable fields (set once at init)",
-                "------------------------------------",
-                "embedding.provider:  onnx",
-                "embedding.model:     bge-m3",
-                "embedding.dimension: 1024",
-                "search.tokenizer:    kiwipiepy",
-                "storage.backend:     sqlite",
-                "  -> To change: re-run `mm init` for provider/tokenizer/backend, "
-                "or `mm embedding-reset` to switch embedder (re-index required).",
-            ]
+        # Styling and plain rendering consume the same StatusLine parts,
+        # so unstyle(styled) must reproduce render_status_report exactly.
+        import asyncio
+
+        from memtomem.server.context import AppContext
+
+        comp = _mock_components(
+            total_chunks=53,
+            total_sources=25,
+            stored_embedding_info={"provider": "onnx", "model": "bge-m3", "dimension": 1024},
+            dense_coverage={"total": 53, "with_dense": 53},
         )
+        data = asyncio.run(collect_status_report(AppContext.from_components(comp)))
 
-        styled = _style_status_report(plain)
+        styled = _style_status_lines(iter_status_lines(data))
 
-        assert click.unstyle(styled) == plain
+        assert click.unstyle(styled) == render_status_report(data)
         assert "\x1b[" in styled
         assert "\x1b[36m" in styled  # cyan title/path/commands
         assert "\x1b[32m" in styled  # full dense coverage
         assert "\x1b[33m" in styled  # immutable guidance
 
     @pytest.mark.parametrize(
-        ("line", "ansi_color"),
+        ("with_dense", "total", "percent", "state", "hint", "ansi_color"),
         [
-            ("Dense vectors: 42/42 (100.0%)", "\x1b[32m"),
+            (42, 42, 100.0, "full", "", "\x1b[32m"),
             (
-                "Dense vectors: 21/42 (50.0%)  (partial dense coverage — some chunks BM25-only)",
+                21,
+                42,
+                50.0,
+                "partial",
+                "  (partial dense coverage — some chunks BM25-only)",
                 "\x1b[33m",
             ),
             (
-                "Dense vectors: 0/42 (0.0%)  (BM25-only — dense retrieval will return nothing)",
+                0,
+                42,
+                0.0,
+                "none",
+                "  (BM25-only — dense retrieval will return nothing)",
                 "\x1b[31m",
             ),
-            ("Dense vectors: 0/0", "\x1b[33m"),
+            (0, 0, None, "empty", "", "\x1b[33m"),
         ],
     )
-    def test_dense_coverage_color_thresholds(self, line: str, ansi_color: str) -> None:
-        styled = _style_status_report(line)
+    def test_dense_coverage_color_thresholds(
+        self,
+        with_dense: int,
+        total: int,
+        percent: float | None,
+        state: str,
+        hint: str,
+        ansi_color: str,
+    ) -> None:
+        line = StatusLine(
+            "dense",
+            key="Dense vectors: ",
+            value=f"{with_dense}/{total}",
+            suffix=f" ({percent}%){hint}" if percent is not None else "",
+            meta={"state": state},
+        )
 
-        assert click.unstyle(styled) == line
+        styled = _style_status_lines([line])
+
+        assert click.unstyle(styled) == line.text
         assert ansi_color in styled
 
-    def test_no_color_disables_status_styling(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        plain = "memtomem Status\n==============\nDense vectors: 42/42 (100.0%)"
+    def test_no_color_disables_status_styling(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        comp = _mock_components(total_chunks=1, total_sources=1)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
         monkeypatch.setenv("NO_COLOR", "1")
 
-        assert _style_status_report(plain) == plain
+        # color=True forces click to keep ANSI codes in the captured
+        # output, so their absence proves NO_COLOR won, not the non-tty
+        # stripping CliRunner does by default.
+        result = runner.invoke(cli, ["status"], color=True)
+
+        assert result.exit_code == 0, result.output
+        assert "\x1b[" not in result.output
 
     def test_embedding_mismatch_warning_block_emitted(
         self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
@@ -337,3 +363,206 @@ class TestStatusUnconfigured:
         assert result.exit_code != 0
         assert "not configured" in result.output
         assert "mm init" in result.output
+
+
+class TestStatusTextPin:
+    """Byte-level pin of the rendered report for a maxed-out fixture.
+
+    The #1615 refactor split ``format_status_report`` into
+    ``collect_status_report`` + ``render_status_report``; this literal
+    pin (captured from the pre-refactor output) proves the split changed
+    no bytes — and from now on it is the canonical text-shape regression
+    net for the report. Update it deliberately, never to make a diff
+    pass.
+    """
+
+    def test_full_report_matches_captured_literal(self, tmp_path: Path) -> None:
+        import asyncio
+
+        from memtomem.server.context import AppContext
+        from memtomem.server.tools.status_config import format_status_report
+
+        present = tmp_path / "present.md"
+        present.write_text("hi")
+        comp = _mock_components(
+            total_chunks=53,
+            total_sources=25,
+            source_files=[Path("/nonexistent/a.md"), Path("/nonexistent/b.md"), present],
+            stored_embedding_info={"provider": "onnx", "model": "bge-m3", "dimension": 1024},
+            embedding_mismatch={
+                "stored": {"provider": "ollama", "model": "bge-m3", "dimension": 1024},
+                "configured": {"provider": "ollama", "model": "nomic", "dimension": 768},
+            },
+            dense_coverage={"total": 53, "with_dense": 21},
+            config=Mem2MemConfig(
+                storage={"sqlite_path": "/opt/mm/memtomem.db"},
+                scheduler={"enabled": True},
+            ),
+        )
+
+        text = asyncio.run(format_status_report(AppContext.from_components(comp)))
+
+        # str(Path(...)) so the DB-path line survives Windows separators.
+        expected = f"""\
+memtomem Status
+==============
+Storage:   sqlite
+DB path:   {Path("/opt/mm/memtomem.db").expanduser()}
+Embedding: onnx / bge-m3
+Dimension: 1024
+Top-K:     10
+RRF k:     60
+
+Index stats
+-----------
+Total chunks:  53
+Source files:  25 (2 orphaned — run mem_cleanup_orphans)
+Dense vectors: 21/53 (39.6%)  (partial dense coverage — some chunks BM25-only)
+
+Immutable fields (set once at init)
+------------------------------------
+embedding.provider:  none
+embedding.model:     (unset)
+embedding.dimension: 0
+search.tokenizer:    unicode61
+storage.backend:     sqlite
+  -> To change: re-run `mm init` for provider/tokenizer/backend, or `mm embedding-reset` to switch embedder (re-index required).
+
+Warnings
+--------
+- kind:       scheduler_watchdog_disabled
+  detail:     scheduler.enabled=True but health_watchdog.enabled=False
+  fix:        set health_watchdog.enabled=True (scheduler rides its tick)
+- kind:       embedding_dim_mismatch
+  stored:     ollama/bge-m3 (1024d)
+  configured: ollama/nomic (768d)
+  fix:        uv run mm embedding-reset --mode apply-current
+  doc:        docs/guides/configuration.md#reset-flow"""
+        assert text == expected
+
+
+class TestStatusJson:
+    """``mm status --format json`` / ``--json`` — CONTRIBUTING read-command
+    contract: stable payload keys, ``{"error": ...}`` + exit 0 on handled
+    failure, and byte-parity between the alias and the long form."""
+
+    def test_json_payload_has_stable_keys(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        comp = _mock_components(
+            total_chunks=42,
+            total_sources=7,
+            embedding_mismatch={
+                "stored": {"provider": "ollama", "model": "bge-m3", "dimension": 1024},
+                "configured": {"provider": "ollama", "model": "nomic", "dimension": 768},
+            },
+            dense_coverage={"total": 42, "with_dense": 21},
+        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["status", "--json"])
+        assert result.exit_code == 0, result.output
+
+        data = json.loads(result.output)
+        assert set(data) == {"config", "index", "immutable", "warnings"}
+        assert data["index"]["total_chunks"] == 42
+        assert data["index"]["dense_coverage"] == {
+            "with_dense": 21,
+            "total": 42,
+            "percent": 50.0,
+            "state": "partial",
+        }
+        # Warnings keep the stable key schema advertised by mem_status,
+        # with stored/configured as structured sub-objects.
+        (warning,) = data["warnings"]
+        assert warning["kind"] == "embedding_dim_mismatch"
+        assert warning["stored"] == {"provider": "ollama", "model": "bge-m3", "dimension": 1024}
+        assert warning["configured"] == {"provider": "ollama", "model": "nomic", "dimension": 768}
+        assert warning["fix"] == "uv run mm embedding-reset --mode apply-current"
+        assert warning["doc"] == "docs/guides/configuration.md#reset-flow"
+
+    def test_json_flag_matches_format_json(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        comp = _mock_components(total_chunks=3, total_sources=2)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        via_flag = runner.invoke(cli, ["status", "--json"])
+        via_format = runner.invoke(cli, ["status", "--format", "json"])
+
+        assert via_flag.exit_code == 0, via_flag.output
+        assert via_flag.output == via_format.output
+
+    def test_json_output_is_never_styled(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        comp = _mock_components(total_chunks=1, total_sources=1)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["status", "--json"], color=True)
+
+        assert result.exit_code == 0, result.output
+        assert "\x1b[" not in result.output
+
+    def test_json_dense_coverage_null_when_method_missing(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        comp = _mock_components(total_chunks=1, total_sources=1)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["status", "--json"])
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["index"]["dense_coverage"] is None
+
+    def test_json_error_shape_when_unconfigured(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(
+            "memtomem.cli._bootstrap._CONFIG_PATH", tmp_path / "no-such-config.json"
+        )
+
+        result = runner.invoke(cli, ["status", "--json"])
+
+        # Handled failure rides the JSON body, not the exit code, so
+        # `mm status --json | jq` pipelines keep working.
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert set(data) == {"error"}
+        assert "not configured" in data["error"]
+
+    def test_scheduler_warning_keys_have_no_doc(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ``doc`` is optional per the mem_status docstring — this warning
+        # kind ships without one, and JSON consumers must not assume it.
+        comp = _mock_components(
+            total_chunks=1,
+            total_sources=1,
+            config=Mem2MemConfig(scheduler={"enabled": True}),
+        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["status", "--json"])
+
+        assert result.exit_code == 0, result.output
+        (warning,) = json.loads(result.output)["warnings"]
+        assert set(warning) == {"kind", "detail", "fix"}
+        assert warning["kind"] == "scheduler_watchdog_disabled"
+
+    def test_json_unexpected_error_keeps_nonzero_exit(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Only CLI-classified failures (ClickException) become the exit-0
+        # {"error": ...} shape; programmer errors must stay loud so
+        # scripts/CI don't read a crash as a successful status report
+        # (CONTRIBUTING: "Unhandled exceptions ... should still surface
+        # through Click").
+        comp = _mock_components(total_chunks=1, total_sources=1)
+        comp.storage.get_stats = AsyncMock(side_effect=RuntimeError("boom"))
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["status", "--json"])
+
+        assert result.exit_code != 0
+        assert "boom" in result.output


### PR DESCRIPTION
Part of #1615 (sub-item a — `mm status --json` and the `format_status_report` dict-first refactor).

## Problem

`mm status` mirrors the MCP `mem_status` tool but offered no structured output, so scripting a post-install sanity check required an MCP client. The root cause was `format_status_report` assembling display text directly — the CLI then re-parsed that rendered string with three regexes (`_DENSE_RE`, `_KEY_RE`, `_IMMUTABLE_KEY_RE`) just to re-apply color.

## Change

- **`server/tools/status_config.py`** — split into:
  - `collect_status_report(app) -> dict` — all I/O + degradation guards; the dict is the `--format json` payload verbatim. Top-level keys: `config`, `index`, `immutable`, `warnings`.
  - `iter_status_lines(data)` / `render_status_report(data)` — pure renderer over a `StatusLine(role, key, value, suffix, meta)` line model; warnings render generically from entry keys, so new warning kinds (e.g. the #1619 `mmr_disabled_no_dense` follow-up) need zero renderer changes.
  - `format_status_report` kept as a one-line compat wrapper — **MCP `mem_status` output is byte-identical**, pinned by a captured-literal test.
- **`cli/status_cmd.py`** — `--format [table|json]` + `--json` alias (mirrors `mm config show`); the styler consumes `StatusLine` roles, killing the three regexes. `NO_COLOR` and visual output unchanged.
- **JSON error shape** (CONTRIBUTING read-command contract): CLI-classified failures (`ClickException`) emit `{"error": ...}` with exit 0 so `--json | jq` pipelines see them in-band; unexpected exceptions keep the nonzero Click exit so crashes never masquerade as a report.
- **Warnings schema**: entries keep the documented stable keys; `doc` is now explicitly optional in the `mem_status` docstring (`scheduler_watchdog_disabled` ships without one), with the key-set pinned in tests.
- **CONTRIBUTING.md** — `mm status` added to the output-convention examples.

## Tests

- New byte-parity pin: pre-refactor output captured as a literal for a maxed-out fixture (stored embedding info, orphans, partial dense coverage, both warning kinds) — now the canonical text-shape regression net.
- New `TestStatusJson`: stable payload keys, structured `stored`/`configured` sub-objects, `--json` ≡ `--format json` byte parity, error shape + exit 0 when unconfigured, nonzero exit on unexpected errors, no ANSI under `--json`, `dense_coverage: null` when storage lacks the probe.
- Style tests rewritten against the line model; `TestStatusMcpParity` and `test_watchdog_dispatch` pass unchanged.
- `uv run pytest -m "not ollama"`: 7921 passed. Smoke-tested `mm status --json | jq`-style parse and the text path against a real DB.

Codex review: NEEDS-FIX → both majors addressed (exception classification for exit-0 JSON errors; `doc` optionality made explicit) → re-pinned in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
