### PR TITLE
feat(cli): --json write acks for mm reset / mm purge / mm add

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,6 +225,8 @@ Examples in the current CLI:
 - `--format` — `mm search` (has `context`, `smart`), `mm recall` (has
   `plain`), `mm config show` and `mm status` (keep the original option
   alongside `--json`).
+- `--json` write acks — `mm reset`, `mm purge`, `mm add` emit the
+  write-command `{"ok": ...}` shape below.
 
 **If the two-mode nature of a new command is uncertain** — i.e. it's
 plausible a `context` / `digest` / `diff` mode gets added later — choose

--- a/packages/memtomem/src/memtomem/cli/memory.py
+++ b/packages/memtomem/src/memtomem/cli/memory.py
@@ -32,11 +32,17 @@ def _resolve_memory_scope_dir(
         raise click.ClickException(str(exc)) from exc
 
 
-def _prompt_project_shared_confirm(target: Path) -> bool:
-    """Prompt before writing to the git-tracked project_shared tier."""
-    click.secho("This will write to the git-tracked project memory directory:", fg="yellow")
-    click.echo(f"  {target}")
-    return click.confirm("Continue?", default=False)
+def _prompt_project_shared_confirm(target: Path, *, err: bool = False) -> bool:
+    """Prompt before writing to the git-tracked project_shared tier.
+
+    ``err=True`` routes the prompt chrome to stderr so ``--json`` runs
+    keep stdout as a single machine-readable ack.
+    """
+    click.secho(
+        "This will write to the git-tracked project memory directory:", fg="yellow", err=err
+    )
+    click.echo(f"  {target}", err=err)
+    return click.confirm("Continue?", default=False, err=err)
 
 
 def _render_validity_window(valid_from_unix: int | None, valid_to_unix: int | None) -> str:
@@ -91,6 +97,13 @@ def _render_validity_window(valid_from_unix: int | None, valid_to_unix: int | No
     default=False,
     help="Skip confirmation prompts.",
 )
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit a machine-readable JSON ack instead of text output.",
+)
 def add(
     content: str,
     title: str | None,
@@ -100,6 +113,7 @@ def add(
     scope: TargetScope,
     confirm_project_shared: bool,
     yes: bool,
+    as_json: bool,
 ) -> None:
     """Add a memory entry and index it."""
     tag_list = [t.strip() for t in tags.split(",") if t.strip()] if tags else []
@@ -114,9 +128,16 @@ def add(
                 scope,
                 confirm_project_shared,
                 yes,
+                as_json=as_json,
             )
         )
-    except click.ClickException:
+    except click.ClickException as e:
+        if as_json:
+            # Write-command JSON error shape (CONTRIBUTING): failures the
+            # CLI classified ride the body with exit 0; unexpected
+            # exceptions below keep the nonzero Click exit.
+            click.echo(json.dumps({"ok": False, "reason": e.format_message()}))
+            return
         raise
     except Exception as e:
         raise click.ClickException(str(e)) from e
@@ -131,6 +152,8 @@ async def _add(
     scope: TargetScope = "user",
     confirm_project_shared: bool = False,
     yes: bool = False,
+    *,
+    as_json: bool = False,
 ) -> None:
     from memtomem import privacy
     from memtomem.cli._bootstrap import cli_components
@@ -214,7 +237,12 @@ async def _add(
                     "--yes alone is not sufficient: project_shared writes go to "
                     "the git-tracked memory tier and require explicit opt-in."
                 )
-            if not _prompt_project_shared_confirm(target):
+            if not _prompt_project_shared_confirm(target, err=as_json):
+                if as_json:
+                    # Declining the prompt is a handled outcome — surface
+                    # it as the write-command JSON error shape (exit 0)
+                    # instead of the text path's click.Abort.
+                    raise click.ClickException("cancelled at project_shared confirmation prompt")
                 raise click.Abort()
 
         from memtomem.context._atomic import (
@@ -262,7 +290,12 @@ async def _add(
                 "migrate in flight); retry."
             ) from exc
 
-        click.echo(f"Added to {target} ({stats.indexed_chunks} chunks indexed)")
+        if as_json:
+            click.echo(
+                json.dumps({"ok": True, "target": str(target), "chunks": stats.indexed_chunks})
+            )
+        else:
+            click.echo(f"Added to {target} ({stats.indexed_chunks} chunks indexed)")
 
 
 @click.command()

--- a/packages/memtomem/src/memtomem/cli/purge_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/purge_cmd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -55,7 +56,13 @@ def find_sources_matching_excluded(
     show_default=True,
     help="Number of sample paths to print in dry-run output.",
 )
-def purge(matching_excluded: bool, apply_: bool, sample_size: int) -> None:
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a machine-readable JSON ack instead of text output.",
+)
+def purge(matching_excluded: bool, apply_: bool, sample_size: int, as_json: bool) -> None:
     """Remove stored chunks matching a selector.
 
     Currently one selector is supported: ``--matching-excluded`` scans every
@@ -69,10 +76,10 @@ def purge(matching_excluded: bool, apply_: bool, sample_size: int) -> None:
     """
     if not matching_excluded:
         raise click.UsageError("no selector given. See: mm purge --help")
-    asyncio.run(_run_matching_excluded(apply_=apply_, sample_size=sample_size))
+    asyncio.run(_run_matching_excluded(apply_=apply_, sample_size=sample_size, as_json=as_json))
 
 
-async def _run_matching_excluded(*, apply_: bool, sample_size: int) -> None:
+async def _run_matching_excluded(*, apply_: bool, sample_size: int, as_json: bool = False) -> None:
     from memtomem.cli._bootstrap import cli_components
 
     async with cli_components() as comp:
@@ -84,7 +91,15 @@ async def _run_matching_excluded(*, apply_: bool, sample_size: int) -> None:
         )
 
         if not matched:
-            click.secho("No stored chunks match the current exclude set.", fg="green")
+            # Write-command JSON ack (CONTRIBUTING "JSON error shape"):
+            # a no-match run is a successful no-op, not an error.
+            if as_json:
+                payload: dict = {"ok": True, "apply": apply_, "files": 0, "chunks": 0}
+                if not apply_:
+                    payload["sample"] = []
+                click.echo(json.dumps(payload))
+            else:
+                click.secho("No stored chunks match the current exclude set.", fg="green")
             return
 
         # Count chunks per matched file for the summary.
@@ -92,9 +107,23 @@ async def _run_matching_excluded(*, apply_: bool, sample_size: int) -> None:
         total_chunks = sum(len(v) for v in chunks_by_source.values())
 
         if not apply_:
+            sample = [str(sf) for sf in sorted(matched)[:sample_size]]
+            if as_json:
+                click.echo(
+                    json.dumps(
+                        {
+                            "ok": True,
+                            "apply": False,
+                            "files": len(matched),
+                            "chunks": total_chunks,
+                            "sample": sample,
+                        }
+                    )
+                )
+                return
             click.echo(f"Would delete {total_chunks} chunks across {len(matched)} files. Sample:")
-            for sf in sorted(matched)[:sample_size]:
-                click.echo(f"  {sf}")
+            for path_text in sample:
+                click.echo(f"  {path_text}")
             if len(matched) > sample_size:
                 click.echo(f"  ... and {len(matched) - sample_size} more")
             click.echo("\nRun with --apply to execute.")
@@ -103,6 +132,13 @@ async def _run_matching_excluded(*, apply_: bool, sample_size: int) -> None:
         deleted_total = 0
         for sf in matched:
             deleted_total += await comp.storage.delete_by_source(sf)
+        if as_json:
+            click.echo(
+                json.dumps(
+                    {"ok": True, "apply": True, "files": len(matched), "chunks": deleted_total}
+                )
+            )
+            return
         click.secho(
             f"Deleted {deleted_total} chunks across {len(matched)} files.",
             fg="green",

--- a/packages/memtomem/src/memtomem/cli/reset_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/reset_cmd.py
@@ -22,6 +22,7 @@ Destructive by intent, so it carries the same operational gates as
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import sqlite3
 import sys
@@ -47,23 +48,36 @@ from memtomem.cli._liveness import check_server_liveness, check_web_liveness
     help="Bypass the running-server / write-lock safety gates (use only if you "
     "know the pid or lock is stale).",
 )
-def reset(yes: bool, backup: bool, force: bool) -> None:
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a machine-readable JSON ack instead of text output.",
+)
+def reset(yes: bool, backup: bool, force: bool, as_json: bool) -> None:
     """Delete ALL data (chunks, sessions, history, etc.) and reinitialize the DB.
 
     Embedding configuration is preserved — no need to re-configure after reset.
     A re-index is required to repopulate memory.
     """
-    asyncio.run(_run(yes, backup=backup, force=force))
+    asyncio.run(_run(yes, backup=backup, force=force, as_json=as_json))
 
 
-def _refuse(message: str, hint: str) -> None:
+def _refuse(message: str, hint: str, *, as_json: bool = False) -> None:
+    if as_json:
+        # Write-command JSON error shape (CONTRIBUTING): the refusal is a
+        # handled failure, so it rides the body with exit 0 — scripts read
+        # `ok`, not the exit code.
+        click.echo(json.dumps({"ok": False, "reason": f"{message} {hint}"}))
+        sys.exit(0)
     click.secho(message, fg="red")
     click.secho(f"  {hint}", fg="red")
     sys.exit(2)
 
 
-def _check_gates(db_path: Path) -> None:
-    """Refuse (exit 2) while any known writer is alive or holds the DB lock."""
+def _check_gates(db_path: Path, *, as_json: bool = False) -> None:
+    """Refuse (exit 2; exit 0 + ``ok: false`` under ``--json``) while any
+    known writer is alive or holds the DB lock."""
     server = check_server_liveness()
     if server.alive:
         who = f"pid {server.pid}" if server.pid is not None else "pid unknown, flock held"
@@ -71,6 +85,7 @@ def _check_gates(db_path: Path) -> None:
             f"MCP server still running ({who}). Refusing to reset — a live "
             "writer racing the wipe can lose data or corrupt the WAL.",
             "Stop the server first, or pass --force to override.",
+            as_json=as_json,
         )
     web = check_web_liveness()
     if web.alive:
@@ -80,6 +95,7 @@ def _check_gates(db_path: Path) -> None:
             f"mm web still running ({who}{port}). Refusing to reset — the web "
             "UI writes to this database.",
             "Stop it first (mm web is a foreground process), or pass --force to override.",
+            as_json=as_json,
         )
     db_lock = check_db_lock(db_path)
     if db_lock.locked:
@@ -87,6 +103,7 @@ def _check_gates(db_path: Path) -> None:
             f"Another process holds a write lock on {db_path}. Refusing to reset.",
             f"Find it with `lsof {db_path}` (or `ps aux | grep memtomem`), stop "
             "it, or pass --force to override.",
+            as_json=as_json,
         )
 
 
@@ -135,7 +152,9 @@ def _backup_db(db_path: Path) -> Path:
     return dest
 
 
-async def _run(yes: bool, *, backup: bool = False, force: bool = False) -> None:
+async def _run(
+    yes: bool, *, backup: bool = False, force: bool = False, as_json: bool = False
+) -> None:
     from memtomem.config import Mem2MemConfig, load_config_d, load_config_overrides
     from memtomem.storage.sqlite_backend import SqliteBackend
 
@@ -152,7 +171,7 @@ async def _run(yes: bool, *, backup: bool = False, force: bool = False) -> None:
     # migrations, i.e. write to a DB we have not yet verified is unowned.
     # --yes must never skip these (uninstall -y precedent).
     if not force:
-        _check_gates(db_path)
+        _check_gates(db_path, as_json=as_json)
 
     storage = SqliteBackend(
         cfg.storage,
@@ -166,34 +185,61 @@ async def _run(yes: bool, *, backup: bool = False, force: bool = False) -> None:
     total = stats.get("total_chunks", 0)
 
     if total == 0:
-        click.echo("Database is already empty — nothing to reset.")
+        if as_json:
+            click.echo(json.dumps({"ok": True, "deleted": {}, "backup": None}))
+        else:
+            click.echo("Database is already empty — nothing to reset.")
         await storage.close()
         return
 
     if not yes:
+        # err=as_json keeps stdout pure JSON under --json — the prompt is
+        # interactive chrome, and `mm reset --json | jq` must not choke on it.
         if not click.confirm(
             f"This will permanently delete ALL data ({total} chunks, sessions, "
             f"history, etc.) from the database. Continue?",
             default=False,
+            err=as_json,
         ):
-            click.echo("Cancelled.")
+            if as_json:
+                click.echo(json.dumps({"ok": False, "reason": "cancelled at confirmation prompt"}))
+            else:
+                click.echo("Cancelled.")
             await storage.close()
             return
 
+    backup_path: Path | None = None
     if backup:
         # After the confirm so a cancelled run leaves no backup litter;
         # abort without wiping if the snapshot fails.
         try:
-            dest = _backup_db(db_path)
+            backup_path = _backup_db(db_path)
         except (sqlite3.Error, OSError) as exc:
             await storage.close()
+            if as_json:
+                click.echo(
+                    json.dumps({"ok": False, "reason": f"backup failed ({exc}); nothing wiped"})
+                )
+                sys.exit(0)
             click.secho(f"Backup failed ({exc}); aborting without wiping.", fg="red")
             sys.exit(1)
-        click.echo(f"Backup written to {dest}")
+        if not as_json:
+            click.echo(f"Backup written to {backup_path}")
 
     deleted = await storage.reset_all()
     await storage.close()
 
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "ok": True,
+                    "deleted": {table: count for table, count in deleted.items() if count > 0},
+                    "backup": str(backup_path) if backup_path else None,
+                }
+            )
+        )
+        return
     click.secho("Database reset complete.", fg="green")
     for table, count in deleted.items():
         if count > 0:

--- a/packages/memtomem/tests/test_cli_add_json.py
+++ b/packages/memtomem/tests/test_cli_add_json.py
@@ -1,0 +1,143 @@
+"""Tests for the ``mm add --json`` write ack (#1615).
+
+The three write-shaped commands (``add``, ``reset``, ``purge``) gained
+``--json`` acks in the same change; reset/purge tests live next to their
+existing suites (``test_reset_cmd.py`` / ``test_purge_cli.py``). This
+file covers ``mm add``: the CONTRIBUTING write-command shape
+(``{"ok": true, ...}`` / ``{"ok": false, "reason": ...}`` with exit 0
+for CLI-classified failures) and the loud nonzero exit for unexpected
+errors.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem import privacy
+from memtomem.cli.memory import add as add_cmd
+
+_CLEAN = "team retro notes: rotate the on-call schedule monthly"
+_SECRET = "api_key=AKIA1234567890ABCDEF"
+
+
+@pytest.fixture(autouse=True)
+def _reset_privacy_counters():
+    privacy.reset_for_tests()
+    yield
+    privacy.reset_for_tests()
+
+
+def _components(tmp_path: Path, *, index_error: Exception | None = None) -> SimpleNamespace:
+    """Minimal Components double for the ``_add`` happy path: config with
+    a tmp memory dir, an index engine returning 2 chunks (or raising),
+    and a storage whose tag lookup is never reached (no tags passed)."""
+    index_file = (
+        AsyncMock(side_effect=index_error)
+        if index_error is not None
+        else AsyncMock(return_value=SimpleNamespace(indexed_chunks=2))
+    )
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            indexing=SimpleNamespace(
+                memory_dirs=[str(tmp_path / "memories")],
+                project_memory_dirs=[],
+            )
+        ),
+        index_engine=SimpleNamespace(index_file=index_file),
+        storage=SimpleNamespace(list_chunks_by_source=AsyncMock(return_value=[])),
+    )
+
+
+def _patch_components(monkeypatch: pytest.MonkeyPatch, comp: SimpleNamespace) -> None:
+    @asynccontextmanager
+    async def fake():
+        yield comp
+
+    monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", fake)
+    # ``_add`` lazy-imports this from its defining module; ``None`` means
+    # "not inside a project", which keeps the default user scope simple.
+    monkeypatch.setattr(
+        "memtomem.server.tools.search._resolve_project_context_root", lambda comp: None
+    )
+
+
+class TestAddJsonAck:
+    def test_success_json_ack(self, monkeypatch, tmp_path):
+        comp = _components(tmp_path)
+        _patch_components(monkeypatch, comp)
+
+        result = CliRunner().invoke(add_cmd, [_CLEAN, "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        assert data["chunks"] == 2
+        assert data["target"].endswith(".md")
+        assert Path(data["target"]).exists()
+
+    def test_text_path_unchanged(self, monkeypatch, tmp_path):
+        comp = _components(tmp_path)
+        _patch_components(monkeypatch, comp)
+
+        result = CliRunner().invoke(add_cmd, [_CLEAN])
+
+        assert result.exit_code == 0, result.output
+        assert "Added to" in result.output
+        assert "(2 chunks indexed)" in result.output
+
+    def test_privacy_block_json_exit_zero(self, monkeypatch):
+        # The guard fires before component bootstrap — a bootstrap call
+        # would mean the blocked write slipped past the chokepoint.
+        bootstrap = AsyncMock()
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", bootstrap)
+
+        result = CliRunner().invoke(add_cmd, [_SECRET, "--json"])
+
+        bootstrap.assert_not_called()
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["ok"] is False
+        assert "privacy pattern" in data["reason"]
+
+    def test_project_shared_decline_json_exit_zero(self, monkeypatch, tmp_path):
+        # Gate B prompt under --json: chrome rides stderr, and declining
+        # is a handled outcome ({"ok": false}, exit 0) instead of the
+        # text path's click.Abort.
+        proj = tmp_path / "proj"
+        base = proj / ".memtomem" / "memories"
+        comp = _components(tmp_path)
+        comp.config.indexing.project_memory_dirs = [str(base)]
+        _patch_components(monkeypatch, comp)
+        monkeypatch.setattr(
+            "memtomem.server.tools.search._resolve_project_context_root", lambda comp: proj
+        )
+
+        result = CliRunner().invoke(
+            add_cmd, [_CLEAN, "--scope", "project_shared", "--json"], input="n\n"
+        )
+
+        assert result.exit_code == 0, result.output
+        # stdout alone is the machine-readable ack; the prompt is stderr.
+        data = json.loads(result.stdout)
+        assert data == {"ok": False, "reason": "cancelled at project_shared confirmation prompt"}
+        assert "Continue?" in result.stderr
+        comp.index_engine.index_file.assert_not_called()
+
+    def test_unexpected_error_keeps_nonzero_exit(self, monkeypatch, tmp_path):
+        # Only CLI-classified failures (ClickException) ride the exit-0
+        # JSON body; a crashed index engine must stay loud (CONTRIBUTING:
+        # unhandled exceptions surface through Click).
+        comp = _components(tmp_path, index_error=RuntimeError("boom"))
+        _patch_components(monkeypatch, comp)
+
+        result = CliRunner().invoke(add_cmd, [_CLEAN, "--json"])
+
+        assert result.exit_code != 0
+        assert "boom" in result.output

--- a/packages/memtomem/tests/test_purge_cli.py
+++ b/packages/memtomem/tests/test_purge_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -149,4 +150,52 @@ class TestPurgeCLI:
 
         assert result.exit_code == 0, result.output
         assert "No stored chunks match" in result.output
+        comp.storage.delete_by_source.assert_not_called()
+
+
+class TestPurgeJson:
+    """``--json`` write acks (#1615) — CONTRIBUTING write-command shape."""
+
+    def test_dry_run_json_ack(self, monkeypatch):
+        comp = _mock_components([Path("/home/u/.gemini/oauth_creds.json")])
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = CliRunner().invoke(cli, ["purge", "--matching-excluded", "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data == {
+            "ok": True,
+            "apply": False,
+            "files": 1,
+            "chunks": 2,
+            # str(Path(...)) keeps the assertion portable across separators.
+            "sample": [str(Path("/home/u/.gemini/oauth_creds.json"))],
+        }
+        comp.storage.delete_by_source.assert_not_called()
+
+    def test_apply_json_ack(self, monkeypatch):
+        sources = [
+            Path("/home/u/.gemini/oauth_creds.json"),
+            Path("/home/u/.ssh/id_rsa.pub"),
+        ]
+        comp = _mock_components(sources)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = CliRunner().invoke(cli, ["purge", "--matching-excluded", "--apply", "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        # delete_by_source is mocked to return 2 per file.
+        assert data == {"ok": True, "apply": True, "files": 2, "chunks": 4}
+
+    def test_no_matches_json_is_ok_noop(self, monkeypatch):
+        comp = _mock_components([Path("/home/u/notes/day.md")])
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = CliRunner().invoke(cli, ["purge", "--matching-excluded", "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data == {"ok": True, "apply": False, "files": 0, "chunks": 0, "sample": []}
         comp.storage.delete_by_source.assert_not_called()

--- a/packages/memtomem/tests/test_reset_cmd.py
+++ b/packages/memtomem/tests/test_reset_cmd.py
@@ -14,6 +14,7 @@ gate ordering, not the wipe itself (``reset_all`` is covered in
 
 from __future__ import annotations
 
+import json
 import os
 import sqlite3
 import sys
@@ -149,6 +150,106 @@ class TestResetGates:
         assert result.exit_code == 0, result.output
         # Proceeded past the gates to the empty-DB early exit.
         assert "already empty" in result.output
+
+
+# ---------------------------------------------------------------- --json acks
+
+
+class TestResetJson:
+    """``--json`` write acks (#1615) — CONTRIBUTING write-command shape:
+    handled outcomes (success, gate refusal, cancellation, backup failure)
+    ride the body with exit 0; text-path behavior is untouched."""
+
+    def test_wipe_json_ack(self, home, monkeypatch):
+        _patch_liveness(monkeypatch)
+        runner = CliRunner()
+        db_path = _init_and_index(home, runner)
+
+        result = runner.invoke(cli, ["reset", "-y", "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        assert data["backup"] is None
+        assert data["deleted"].get("chunks", 0) >= 1
+        assert _count(db_path, "chunks") == 0
+
+    def test_already_empty_json_is_ok_noop(self, home, monkeypatch):
+        _patch_liveness(monkeypatch)
+        runner = CliRunner()
+        mem_dir = home / "memories"
+        mem_dir.mkdir(exist_ok=True)
+        r = runner.invoke(
+            cli,
+            ["init", "-y", "--provider", "none", "--memory-dir", str(mem_dir), "--mcp", "skip"],
+        )
+        assert r.exit_code == 0, r.output
+
+        result = runner.invoke(cli, ["reset", "-y", "--json"])
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {"ok": True, "deleted": {}, "backup": None}
+
+    def test_gate_refusal_json_exit_zero(self, home, monkeypatch):
+        _patch_liveness(
+            monkeypatch, server=ServerState(alive=True, pid=4242, pid_file=home / "pid")
+        )
+
+        result = CliRunner().invoke(cli, ["reset", "-y", "--json"])
+
+        # Text path exits 2; under --json the refusal is a handled failure
+        # carried in the body.
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["ok"] is False
+        assert "MCP server still running" in data["reason"]
+        assert "--force" in data["reason"]
+
+    def test_backup_json_ack_carries_path(self, home, monkeypatch):
+        _patch_liveness(monkeypatch)
+        runner = CliRunner()
+        _init_and_index(home, runner)
+
+        result = runner.invoke(cli, ["reset", "-y", "--backup", "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["ok"] is True
+        (bak,) = (home / ".memtomem").glob("memtomem.db.pre-reset-*.bak")
+        assert data["backup"] == str(bak)
+
+    def test_backup_failure_json_exit_zero_without_wiping(self, home, monkeypatch):
+        _patch_liveness(monkeypatch)
+        runner = CliRunner()
+        db_path = _init_and_index(home, runner)
+
+        def _boom(_db_path: Path) -> Path:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(reset_cmd, "_backup_db", _boom)
+        result = runner.invoke(cli, ["reset", "-y", "--backup", "--json"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["ok"] is False
+        assert "backup failed" in data["reason"]
+        assert _count(db_path, "chunks") >= 1, "DB was wiped despite backup failure"
+
+    def test_cancelled_confirm_json(self, home, monkeypatch):
+        _patch_liveness(monkeypatch)
+        runner = CliRunner()
+        db_path = _init_and_index(home, runner)
+
+        result = runner.invoke(cli, ["reset", "--json"], input="n\n")
+
+        assert result.exit_code == 0, result.output
+        # stdout must be a single JSON document — the prompt rides stderr
+        # under --json so `mm reset --json | jq` works on the cancel path.
+        # (result.output merges the streams; assert on stdout alone.)
+        data = json.loads(result.stdout)
+        assert data == {"ok": False, "reason": "cancelled at confirmation prompt"}
+        assert "Continue?" in result.stderr
+        assert _count(db_path, "chunks") >= 1
 
 
 # ---------------------------------------------------------------- backup


### PR DESCRIPTION
Closes #1615 (sub-items b, c, d — together with #1629, which delivered sub-item (a) `mm status --format/--json`).

## Problem

The write-shaped commands (`mm reset`, `mm purge`, `mm add`) had no machine-readable output — scripts had to scrape styled text. Read commands already follow the CONTRIBUTING "CLI output convention"; this closes the write side.

## Change

`--json` on all three commands emits the documented write-command shape: success `{"ok": true, ...}`, handled failure `{"ok": false, "reason": ...}`, both **exit 0**; unexpected exceptions keep the nonzero Click exit so a crash never reads as an ack.

- **`mm reset --json`** — success carries `{"deleted": {table: rows}, "backup": path|null}`; gate refusals (MCP server / `mm web` alive, DB write lock), prompt cancellation, and backup failure all become `{"ok": false, "reason": ...}` (text path keeps exit 2/1 respectively).
- **`mm purge --matching-excluded --json`** — dry-run: `{"apply": false, "files", "chunks", "sample"}`; apply: actual deleted counts; no-match: `ok: true` no-op.
- **`mm add --json`** — success `{"target", "chunks"}`; privacy-guard blocks and the project_shared Gate B decline ride the `ok: false` body.
- **Prompt chrome → stderr under `--json`** (Codex review): reset's confirm and add's Gate B prompt no longer contaminate stdout, so `--json | jq` works even when a prompt fires. Declining Gate B under `--json` is a handled `{"ok": false}` instead of `click.Abort`.
- Text-path output bytes, ordering, and exit codes are unchanged.
- **CONTRIBUTING.md** — write-ack commands added to the convention examples.

## Sub-item (c) — `mm recall --format`

Already implemented (`cli/memory.py` `--format [table|json|plain]`) and listed in the CONTRIBUTING examples; no code change needed. Sub-item (d)'s convention section also predates this cycle — only the examples list needed updating.

## Tests

- `test_cli_add_json.py` (new): success ack, text-path unchanged, privacy-block `ok:false` + exit 0, Gate B decline (stdout purity + stderr prompt pinned), unexpected-error nonzero exit.
- `test_reset_cmd.py::TestResetJson`: wipe ack, already-empty no-op, gate refusal exit 0, backup path in ack, backup-failure abort without wiping, cancel with stdout-purity pin.
- `test_purge_cli.py::TestPurgeJson`: dry-run/apply/no-match acks, delete-not-called pins.
- `uv run pytest -m "not ollama"`: 7929 passed. `ruff` + `mypy` clean on touched files.

Codex review: NEEDS-FIX → all three findings addressed (prompt stdout contamination ×2, echo-before-close ordering restored) → re-pinned in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
