### PR TITLE
fix(cli): loud notice when mm init -y silently applies --preset minimal

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -2952,7 +2952,16 @@ _MODEL_DIMS: dict[str, int] = {
 
 @click.command("init")
 @click.option(
-    "-y", "--non-interactive", is_flag=True, help="Skip wizard, use defaults or provided options"
+    "-y",
+    "--non-interactive",
+    is_flag=True,
+    help=(
+        "Skip the wizard. Without --preset this applies `--preset minimal` "
+        "(BM25-only, no embeddings) — unlike -y elsewhere in the CLI, it "
+        "selects configuration, not just prompt-skipping. A future release "
+        "will narrow -y to confirmation-skipping only; scripts should pass "
+        "an explicit --preset."
+    ),
 )
 @click.option("--provider", type=click.Choice(["none", "onnx", "ollama", "openai"]), default=None)
 @click.option("--model", default=None, help="Embedding model name")
@@ -3083,6 +3092,22 @@ def init(
         # unicode61, auto_ns=False, top_k=10). Explicit flags then override the
         # preset baseline, preserving the prior `-y --provider onnx --model X`
         # contract.
+        if preset is None:
+            # #1616: everywhere else in the CLI `-y` means "skip the
+            # confirmation prompt"; here it silently selects a materially
+            # weaker setup than the wizard's default (english). Until the
+            # flag split lands, say so loudly — on stderr, so scripted
+            # stdout parsing is unaffected.
+            click.secho(
+                "  Note: -y without --preset applies the 'minimal' preset "
+                "(BM25 keyword search only, no embeddings); the interactive "
+                "wizard defaults to 'english'. Pass --preset "
+                "minimal|english|korean to choose explicitly, or run "
+                "`mm init` for the wizard. A future release will narrow -y "
+                "to confirmation-skipping only.",
+                fg="yellow",
+                err=True,
+            )
         effective_preset = preset or "minimal"
         _apply_preset(state, effective_preset)
         _override_from_flags(

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -6563,6 +6563,72 @@ class TestBackNavThroughSilentStep:
         )
 
 
+class TestNonInteractivePresetNotice:
+    """#1616: ``-y`` is the only CLI flag whose meaning goes beyond
+    "skip the confirmation prompt" — it silently selects ``--preset
+    minimal``, a materially weaker setup than the wizard's default
+    (english). Until the flag split lands, the implicit-preset run must
+    say so loudly on stderr, and an explicit ``--preset`` must silence
+    the notice."""
+
+    def _setup(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from memtomem.cli import init_cmd
+
+        set_home(monkeypatch, tmp_path)
+        monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
+        monkeypatch.setattr("importlib.util.find_spec", lambda name: object())
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+
+    def test_bare_yes_emits_notice_on_stderr(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli
+
+        self._setup(tmp_path, monkeypatch)
+
+        result = CliRunner().invoke(cli, ["init", "-y", "--mcp", "skip"])
+
+        assert result.exit_code == 0, result.output
+        assert "'minimal' preset" in result.stderr
+        assert "wizard defaults to 'english'" in result.stderr
+        assert "confirmation-skipping only" in result.stderr
+        # stderr only — scripted stdout consumers must not see the notice.
+        assert "'minimal' preset" not in result.stdout
+        assert (tmp_path / ".memtomem" / "config.json").exists()
+
+    def test_explicit_preset_silences_notice(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli
+
+        self._setup(tmp_path, monkeypatch)
+
+        result = CliRunner().invoke(cli, ["init", "-y", "--preset", "english", "--mcp", "skip"])
+
+        assert result.exit_code == 0, result.output
+        assert "'minimal' preset" not in result.stderr
+        assert (tmp_path / ".memtomem" / "config.json").exists()
+
+    def test_help_documents_preset_side_effect(self) -> None:
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli
+
+        result = CliRunner().invoke(cli, ["init", "--help"])
+
+        assert result.exit_code == 0
+        # The -y help must name the side-effect and the planned narrowing,
+        # not just "skip wizard". Normalize whitespace — click re-wraps
+        # help text, splitting words across lines.
+        normalized = " ".join(result.output.split())
+        assert "`--preset minimal` (BM25-only, no embeddings)" in normalized
+        assert "A future release will narrow -y" in normalized
+
+
 class TestStepHeaderPosition:
     """(#420) ``step_header`` reads its step number from
     ``state["_wizard_position"]`` (seeded by ``run_steps``) rather than from a


### PR DESCRIPTION
Closes #1616. Follow-up flag split tracked in #1631.

## Problem

Every other destructive command binds `-y`/`--yes` to "skip the confirmation prompt" (`reset`, `uninstall`, `upgrade`, `gc`, `tags`). `mm init -y` is the lone exception: it binds to `--non-interactive` and, without `--preset`, **silently applies `--preset minimal`** (BM25-only, no embeddings) — while the interactive wizard's default cursor is the `english` preset. A user who has internalized the `-y` convention gets a materially weaker setup with no signal.

## Change (non-breaking first step per the issue)

- `mm init -y` without `--preset` now prints a yellow notice **on stderr** (scripted stdout parsing unaffected): which preset is applied, that the wizard defaults to `english`, how to choose explicitly, and that a future release will narrow `-y` to confirmation-skipping only.
- The `-y` `--help` text states the preset side-effect and the planned narrowing instead of just "Skip wizard".
- An explicit `--preset` silences the notice; behavior is otherwise unchanged.

## Flag-split decision (recorded per the issue)

`-y` will be narrowed to confirmation-skip semantics with a deprecation window — plan and timeline recorded in follow-up #1631.

## Notes

- The issue's en/ko strings note doesn't apply: CLI strings are English-only; the 1597-key i18n parity is a web-UI surface.

## Tests

`TestNonInteractivePresetNotice`: bare `-y` emits the notice on stderr (and not stdout), explicit `--preset` silences it, `--help` pins the side-effect wording (whitespace-normalized against click re-wrapping). Full suite: 7926 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
