### PR TITLE
feat(cli): shared error helper with next-step hints for catch-all sites

### DIFF
--- a/packages/memtomem/src/memtomem/cli/_errors.py
+++ b/packages/memtomem/src/memtomem/cli/_errors.py
@@ -1,0 +1,92 @@
+"""Shared CLI error presentation (#1617).
+
+Several commands end in ``except Exception as e: raise
+click.ClickException(str(e)) from e`` — no traceback (good) but also no
+next-step guidance (bad): a locked DB or an unreadable config surfaces
+as a terse upstream message. ``raise_cli_error`` keeps the catch-all
+shape but appends an actionable hint when the failure class is one the
+CLI knows how to remediate, modeled on the tailored messages in
+``reset``/``uninstall``/``upgrade`` and the server-side
+``error_handler._KNOWN_EXCEPTIONS`` split.
+
+Usage — replace the bare re-wrap tail:
+
+    except click.ClickException:
+        raise
+    except Exception as e:
+        raise_cli_error(e)
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import NoReturn
+
+import click
+
+
+def raise_cli_error(e: Exception) -> NoReturn:
+    """Re-raise ``e`` as a ``ClickException``, appending a next-step hint
+    for recognized failure classes.
+
+    ``ClickException`` passes through unchanged so already-tailored
+    messages keep their wording and exit semantics; everything else
+    falls back to the plain ``str(e)`` the call sites used before.
+    """
+    if isinstance(e, click.ClickException):
+        raise e
+    message = str(e) or type(e).__name__
+    hint = _hint_for(e)
+    if hint:
+        raise click.ClickException(f"{message}\n  Hint: {hint}") from e
+    raise click.ClickException(message) from e
+
+
+def _hint_for(e: Exception) -> str | None:
+    """Map a failure class to a one-line remediation hint (``None`` = no
+    mapping). Subclass checks come before their bases (e.g. the embedding
+    mismatch before ``StorageError``)."""
+    # Lazy import: this module is on the error path of every wrapped
+    # command, and cli/ modules keep import time lean.
+    from memtomem.errors import (
+        ConfigError,
+        EmbeddingDimensionMismatchError,
+        EmbeddingError,
+        SchemaDowngradeError,
+        StorageError,
+    )
+
+    if isinstance(e, sqlite3.OperationalError):
+        text = str(e).lower()
+        if "database is locked" in text:
+            return (
+                "another process is writing to the database (MCP server, mm web, "
+                "or the watchdog) — stop it and retry. On POSIX, "
+                "`ps aux | grep memtomem` finds live writers."
+            )
+        if "no such table" in text:
+            return "the database looks uninitialized — run `mm init`, then `mm index <path>`."
+        return None
+    if isinstance(e, EmbeddingDimensionMismatchError):
+        return (
+            "stored and configured embedding settings disagree — `mm status` shows "
+            "the mismatch; `mm embedding-reset --mode apply-current` repairs it."
+        )
+    if isinstance(e, SchemaDowngradeError):
+        return (
+            "the database was written by a newer memtomem — upgrade this binary "
+            "(`mm upgrade`) instead of downgrading the data."
+        )
+    if isinstance(e, EmbeddingError):
+        return (
+            "the embedding backend failed — check provider/model with `mm status` "
+            "and see docs/guides/embeddings.md for setup."
+        )
+    if isinstance(e, ConfigError):
+        return (
+            "configuration failed to load — inspect it with `mm config show`, check "
+            "~/.memtomem/config.json permissions, or re-run `mm init`."
+        )
+    if isinstance(e, StorageError):
+        return "storage backend error — run `mm status` to check the DB path and health."
+    return None

--- a/packages/memtomem/src/memtomem/cli/memory.py
+++ b/packages/memtomem/src/memtomem/cli/memory.py
@@ -10,6 +10,7 @@ from typing import get_args
 
 import click
 
+from memtomem.cli._errors import raise_cli_error
 from memtomem.config import TargetScope
 from memtomem.memory_scope import (
     MemoryScopeError,
@@ -140,7 +141,7 @@ def add(
             return
         raise
     except Exception as e:
-        raise click.ClickException(str(e)) from e
+        raise_cli_error(e)
 
 
 async def _add(
@@ -331,7 +332,7 @@ def recall(
     except click.ClickException:
         raise
     except Exception as e:
-        raise click.ClickException(str(e)) from e
+        raise_cli_error(e)
 
 
 async def _recall(

--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import click
 
+from memtomem.cli._errors import raise_cli_error
 from memtomem.constants import (
     AGENT_NAMESPACE_PREFIX,
     InvalidNameError,
@@ -211,9 +212,7 @@ def start(
             )
         except Exception as e:
             trace_ctx["exit_code"] = 1
-            if isinstance(e, click.ClickException):
-                raise
-            raise click.ClickException(str(e)) from e
+            raise_cli_error(e)
 
 
 async def _start(
@@ -356,9 +355,7 @@ def end(summary: str | None, auto_summary: bool) -> None:
             )
         except Exception as e:
             trace_ctx["exit_code"] = 1
-            if isinstance(e, click.ClickException):
-                raise
-            raise click.ClickException(str(e)) from e
+            raise_cli_error(e)
 
 
 async def _end(session_id: str, summary: str | None, auto_summary: bool) -> tuple[str | None, int]:
@@ -419,7 +416,7 @@ def list_sessions(
             trace_ctx["payload"]["count"] = count
         except Exception as e:
             trace_ctx["exit_code"] = 1
-            raise click.ClickException(str(e)) from e
+            raise_cli_error(e)
 
 
 async def _list_sessions(
@@ -492,7 +489,7 @@ def events(session_id: str, *, as_json: bool = False) -> None:
             trace_ctx["payload"]["count"] = count
         except Exception as e:
             trace_ctx["exit_code"] = 1
-            raise click.ClickException(str(e)) from e
+            raise_cli_error(e)
 
 
 async def _events(session_id: str, *, as_json: bool = False) -> int:

--- a/packages/memtomem/src/memtomem/cli/status_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/status_cmd.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from memtomem.cli._errors import raise_cli_error
+
 if TYPE_CHECKING:
     from memtomem.server.tools.status_config import StatusLine
 
@@ -44,7 +46,7 @@ def status(fmt: str, *, as_json: bool = False) -> None:
             return
         raise
     except Exception as e:
-        raise click.ClickException(str(e)) from e
+        raise_cli_error(e)
 
 
 async def _status(fmt: str) -> None:

--- a/packages/memtomem/tests/test_cli_errors.py
+++ b/packages/memtomem/tests/test_cli_errors.py
@@ -1,0 +1,103 @@
+"""Tests for the shared CLI error helper (#1617).
+
+Two layers: the class→hint mapping in ``cli/_errors.py``, and an
+integration pin through a wrapped command (``mm status``) proving the
+hint actually reaches the user instead of the bare ``str(e)`` the
+catch-all sites used to emit.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+from memtomem.cli._errors import raise_cli_error
+from memtomem.errors import (
+    ConfigError,
+    EmbeddingDimensionMismatchError,
+    EmbeddingError,
+    SchemaDowngradeError,
+    StorageError,
+)
+
+
+def _message_of(exc: Exception) -> str:
+    with pytest.raises(click.ClickException) as info:
+        raise_cli_error(exc)
+    return info.value.format_message()
+
+
+class TestHintMapping:
+    @pytest.mark.parametrize(
+        ("exc", "fragment"),
+        [
+            (sqlite3.OperationalError("database is locked"), "another process is writing"),
+            (sqlite3.OperationalError("no such table: chunks"), "run `mm init`"),
+            (EmbeddingDimensionMismatchError("dim 0 vs 1024"), "mm embedding-reset"),
+            (SchemaDowngradeError("schema 2 > 1"), "`mm upgrade`"),
+            (EmbeddingError("model not found"), "docs/guides/embeddings.md"),
+            (ConfigError("bad json"), "mm config show"),
+            (StorageError("disk I/O error"), "run `mm status`"),
+        ],
+    )
+    def test_known_classes_get_hints(self, exc: Exception, fragment: str) -> None:
+        message = _message_of(exc)
+        assert str(exc) in message, "original message must be preserved"
+        assert "Hint:" in message
+        assert fragment in message
+
+    def test_unknown_exception_falls_back_to_plain_message(self) -> None:
+        message = _message_of(RuntimeError("boom"))
+        assert message == "boom"
+
+    def test_unknown_operational_error_gets_no_hint(self) -> None:
+        # Only the recognized sqlite messages map; others stay bare so we
+        # never attach a misleading remediation.
+        message = _message_of(sqlite3.OperationalError("disk I/O error"))
+        assert message == "disk I/O error"
+        assert "Hint:" not in message
+
+    def test_empty_message_falls_back_to_class_name(self) -> None:
+        message = _message_of(RuntimeError())
+        assert message == "RuntimeError"
+
+    def test_click_exception_passes_through_unwrapped(self) -> None:
+        original = click.ClickException("already tailored")
+        with pytest.raises(click.ClickException) as info:
+            raise_cli_error(original)
+        assert info.value is original
+
+    def test_chains_original_exception(self) -> None:
+        exc = StorageError("disk I/O error")
+        with pytest.raises(click.ClickException) as info:
+            raise_cli_error(exc)
+        assert info.value.__cause__ is exc
+
+
+class TestWrappedCommandIntegration:
+    """A locked DB surfacing through ``mm status`` carries the hint."""
+
+    def test_status_locked_db_shows_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        storage = SimpleNamespace(
+            get_stats=AsyncMock(side_effect=sqlite3.OperationalError("database is locked")),
+        )
+        comp = SimpleNamespace(config=None, storage=storage, embedder=SimpleNamespace())
+
+        @asynccontextmanager
+        async def fake():
+            yield comp
+
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", fake)
+
+        result = CliRunner().invoke(cli, ["status"])
+
+        assert result.exit_code != 0
+        assert "database is locked" in result.output
+        assert "Hint: another process is writing" in result.output


### PR DESCRIPTION
Part of #1617 (helper + the issue's listed sites; the remaining ~50 `ClickException(str(e))` sites across `cli/` follow in a mechanical sweep PR that closes the issue).

## Problem

Several commands wrap unexpected exceptions as `raise click.ClickException(str(e)) from e` — no traceback (good), but no next-step guidance (bad). A locked DB or unreadable config surfaces as a terse upstream message, unlike the tailored failures in `reset`/`uninstall`/`upgrade`.

## Change

- **`cli/_errors.py` (new)** — `raise_cli_error(e)` keeps the catch-all shape but appends a one-line `Hint:` for recognized failure classes:
  - `sqlite3.OperationalError` "database is locked" → stop the live writer (POSIX `ps aux` pointer); "no such table" → `mm init` + `mm index`
  - `EmbeddingDimensionMismatchError` → `mm status` + `mm embedding-reset --mode apply-current`
  - `SchemaDowngradeError` → upgrade the binary, don't downgrade the data
  - `EmbeddingError` → `mm status` + `docs/guides/embeddings.md`
  - `ConfigError` → `mm config show` / permissions / re-`init`
  - `StorageError` (base, checked after its subclasses) → `mm status`
  - `ClickException` passes through unchanged (tailored messages and the `--json` error-shape contract are preserved); unknown exceptions fall back to the bare `str(e)` — no misleading advice is ever attached.
- **Applied at the issue's sites**: `status_cmd.py`, `memory.py` (add/recall wrappers), `session_cmd.py` ×4 (the `trace_ctx["exit_code"] = 1` marking is preserved; two sites' manual `isinstance` pass-through guards fold into the helper). The typed `InvalidNameError`/`MemoryScopeError` conversions stay as-is — their messages are already the actionable text. (The issue's session_cmd 669/681/701 line refs turned out to be the `session wrap` soft-fail path, not `ClickException` sites.)

## Tests

`test_cli_errors.py`: class→hint mapping (7 classes parametrized), unknown-exception plain fallback, unknown `OperationalError` no-hint pin, empty-message class-name fallback, ClickException identity pass-through, `__cause__` chaining, and an integration pin (`mm status` on a locked DB shows the hint). Full suite: 7951 passed; ruff + mypy clean.

Codex review: SHIP (one nit — `ps aux` hint made platform-qualified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
