### PR TITLE
docs: document mm web remote-access flags in the operations guide

### DIFF
--- a/docs/guides/reference/operations.md
+++ b/docs/guides/reference/operations.md
@@ -29,6 +29,36 @@ mm web --mode {prod,dev}       # explicit mode (mutually exclusive with --dev)
 
 Tab classification changes over time — run `mm web --dev` against your installed version to see the complete surface. The API endpoints backing dev-only pages return 404 in `prod` mode; scripts that hit `/api/sessions`, `/api/scratch`, `/api/namespaces/{ns}/rename`, `DELETE /api/namespaces/{ns}`, etc. need `dev` mode. `GET /api/namespaces` (list) and `PATCH /api/namespaces/{ns}` (cosmetic edit — color, description) are prod-tier and respond in both modes.
 
+### Remote access
+
+`mm web` binds the loopback interface (`127.0.0.1`) by default, and **refuses to start** when `--host` is anything else:
+
+```text
+Error: --host 0.0.0.0 exposes the Web UI off-loopback. Pass --allow-remote-ui
+to acknowledge, paired with --trusted-origin and --trusted-host so the
+CSRF/Origin/Host allow-list covers the remote shape.
+```
+
+The refusal is deliberate: the Web UI is an **unauthenticated** single-page app — memtomem ships no first-party login ([ADR-0029](../../adr/0029-mcp-network-transport-auth-stance.md)) — so anyone who can reach the port can read and modify your memory store. Exposing it off-loopback takes three flags:
+
+| Flag | Effect |
+|------|--------|
+| `--allow-remote-ui` | Acknowledge the off-loopback bind. Required whenever `--host` is non-loopback; startup refuses without it. |
+| `--trusted-origin HOST` | Add a hostname to the CSRF Origin/Referer allow-list (repeatable). Loopback (`127.0.0.1`, `::1`, `localhost`) is always trusted; anything else must be named explicitly. |
+| `--trusted-host HOST` | Add a hostname to the Host-header allow-list (repeatable). Defends DNS rebinding when running with `--allow-remote-ui`. |
+
+A trusted-LAN example — serving the UI to browsers that reach this machine as `workstation.local`:
+
+```bash
+mm web --host 0.0.0.0 --allow-remote-ui \
+  --trusted-origin workstation.local \
+  --trusted-host workstation.local
+```
+
+Requests whose `Origin`/`Referer` or `Host` headers are not on the allow-list are rejected by the three-layer request guard — see [SECURITY.md](../../../SECURITY.md#csrf--origin--host-guard-rfc-787) for the full model and the `MEMTOMEM_WEB__CSRF_ENFORCE` rollback valve.
+
+**Anything beyond a trusted LAN needs an authenticating reverse proxy** — TLS plus auth in front, with memtomem still bound to loopback behind it. The [authenticated reverse proxy recipe](../mcp-clients.md#authenticated-reverse-proxy-required-for-public-exposure) (nginx, TLS + Basic auth) applies to the Web UI the same way it does to MCP network transports.
+
 ---
 
 ## Troubleshooting

--- a/packages/memtomem/tests/test_docs_guards.py
+++ b/packages/memtomem/tests/test_docs_guards.py
@@ -82,6 +82,11 @@ def reference() -> str:
 
 
 @pytest.fixture(scope="module")
+def operations() -> str:
+    return _read(_GUIDES / "reference" / "operations.md")
+
+
+@pytest.fixture(scope="module")
 def canonical_footnote(reference: str) -> str:
     """The tool-mode footnote line, extracted from reference.md.
 
@@ -148,6 +153,42 @@ class TestToolModeFootnoteParity:
             "line verbatim so the CLI / Web UI alternate-access hint stays "
             "in sync across the two Config-table entry points."
         )
+
+
+class TestWebRemoteAccessDocs:
+    """#1618: the ``mm web`` remote-access flags are security-critical
+    (they gate off-loopback exposure and startup refuses without them),
+    so the operations guide must document them — and the doc must track
+    the live CLI, not a remembered spelling. ``TestDocumentedCliExists``
+    strips flags when validating ``mm ...`` snippets, so this guard
+    checks the flag surface explicitly."""
+
+    _REMOTE_FLAGS = ("--allow-remote-ui", "--trusted-origin", "--trusted-host")
+
+    def test_flags_exist_on_live_cli(self) -> None:
+        web = _CLI.commands["web"]
+        live = {p for param in web.params for p in param.opts}
+        for flag in self._REMOTE_FLAGS:
+            assert flag in live, (
+                f"{flag} disappeared from `mm web` — update the Remote access "
+                "section in docs/guides/reference/operations.md in the same PR."
+            )
+
+    def test_operations_documents_every_remote_flag(self, operations: str) -> None:
+        assert "### Remote access" in operations
+        for flag in self._REMOTE_FLAGS:
+            assert flag in operations, (
+                f"operations.md Remote access section lost {flag} — it must "
+                "name every off-loopback opt-in flag (#1618)."
+            )
+
+    def test_operations_names_the_refusal_and_proxy_guidance(self, operations: str) -> None:
+        # The two security-load-bearing statements: startup refuses
+        # off-loopback binds, and public exposure needs an authenticating
+        # reverse proxy (no first-party auth, ADR-0029).
+        assert "refuses to start" in operations
+        assert "reverse proxy" in operations
+        assert "0029-mcp-network-transport-auth-stance.md" in operations
 
 
 def _extract_hooks_snippet(claude_code_md: str) -> dict:


### PR DESCRIPTION
Closes #1618.

## Problem

`mm web --allow-remote-ui`, `--trusted-origin`, `--trusted-host` are security-critical — they gate off-loopback exposure and startup **refuses** without them — yet they were documented nowhere under `docs/guides/`, only in ADR-0029 and security reports. A user hitting the refusal had no guide to follow.

## Change

- **`docs/guides/reference/operations.md`** — new "Remote access" section under Web UI: the startup refusal and why (unauthenticated SPA, no first-party auth per [ADR-0029](../blob/main/docs/adr/0029-mcp-network-transport-auth-stance.md)), a flag table (verified against `cli/web.py` source), a trusted-LAN example, and the boundary rule: anything beyond a trusted LAN goes behind an authenticating reverse proxy — linking the existing nginx TLS + Basic-auth recipe in `mcp-clients.md` and the CSRF / Origin / Host guard model in `SECURITY.md`.
- **`tests/test_docs_guards.py`** — `TestWebRemoteAccessDocs`: bidirectional drift guard (`TestDocumentedCliExists` strips flags from `mm ...` snippets, so flags need their own check). Each remote flag must exist on the live `mm web` click command *and* appear in the guide; the refusal + reverse-proxy statements are pinned. New internal links are covered by the existing `TestInternalDocLinksResolve` anchor check.

## Verification

`uv run pytest packages/memtomem/tests/test_docs_guards.py` — 19 passed (including the new class and link/anchor resolution). Every flag name, help semantic, and the refusal message documented were read from `cli/web.py` before writing (docs-as-tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>