### PR TITLE
chore(cli): sweep remaining catch-all re-wraps through raise_cli_error

### DIFF
--- a/packages/memtomem/src/memtomem/cli/indexing.py
+++ b/packages/memtomem/src/memtomem/cli/indexing.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import click
 
+from memtomem.cli._errors import raise_cli_error
+
 
 @click.command()
 @click.argument("path", default=".", required=False)
@@ -114,7 +116,7 @@ def index(
     except click.ClickException:
         raise
     except Exception as e:
-        raise click.ClickException(str(e)) from e
+        raise_cli_error(e)
 
 
 async def _index(

--- a/packages/memtomem/src/memtomem/cli/ingest_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/ingest_cmd.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Protocol
 
 import click
 
+from memtomem.cli._errors import raise_cli_error
+
 from memtomem.config import index_excluded_filenames
 from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
 
@@ -123,7 +125,7 @@ def claude_memory(source_path: Path, dry_run: bool) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        raise click.ClickException(str(e)) from e
+        raise_cli_error(e)
 
 
 async def _run_claude_ingest(source_path: Path, dry_run: bool) -> None:
@@ -408,7 +410,7 @@ def gemini_memory(source_path: Path, dry_run: bool) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        raise click.ClickException(str(e)) from e
+        raise_cli_error(e)
 
 
 async def _run_gemini_ingest(source_path: Path, dry_run: bool) -> None:
@@ -516,7 +518,7 @@ def codex_memory(source_path: Path, dry_run: bool) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        raise click.ClickException(str(e)) from e
+        raise_cli_error(e)
 
 
 async def _run_codex_ingest(source_path: Path, dry_run: bool) -> None:

--- a/packages/memtomem/src/memtomem/cli/mem_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/mem_cmd.py
@@ -27,6 +27,8 @@ from typing import get_args
 
 import click
 
+from memtomem.cli._errors import raise_cli_error
+
 from memtomem import privacy
 from memtomem.cli.context_cmd import _find_project_root
 from memtomem.config import TargetScope
@@ -149,7 +151,7 @@ def rescan_cmd(
     except click.ClickException:
         raise
     except Exception as exc:
-        raise click.ClickException(str(exc)) from exc
+        raise_cli_error(exc)
 
     scanned, violations = result
     if as_json:

--- a/packages/memtomem/src/memtomem/cli/search.py
+++ b/packages/memtomem/src/memtomem/cli/search.py
@@ -11,6 +11,8 @@ import json
 
 import click
 
+from memtomem.cli._errors import raise_cli_error
+
 # ADR-0011 §6: re-export the project-context resolver from the MCP tool so
 # CLI and MCP surfaces share one resolution rule. Both ``app`` (server) and
 # ``comp`` (CLI) carry the same ``.config.indexing.project_memory_dirs``
@@ -64,7 +66,7 @@ def search(
     except click.ClickException:
         raise
     except Exception as e:
-        raise click.ClickException(str(e)) from e
+        raise_cli_error(e)
 
 
 async def _search(

--- a/packages/memtomem/src/memtomem/cli/tags_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/tags_cmd.py
@@ -92,7 +92,7 @@ async def _run_rename(old_tag: str, new_tag: str, *, apply_: bool, assume_yes: b
         try:
             preview = await tag_svc.rename_tag(comp.storage, old_tag, new_tag, dry_run=True)
         except ValueError as exc:
-            raise click.ClickException(str(exc))
+            raise click.ClickException(str(exc)) from exc
 
         old_s, new_s = old_tag.strip(), new_tag.strip()
         if preview.affected_chunks == 0:
@@ -150,7 +150,7 @@ async def _run_delete(name: str, *, apply_: bool, assume_yes: bool) -> None:
         try:
             preview = await tag_svc.delete_tag(comp.storage, name, dry_run=True)
         except ValueError as exc:
-            raise click.ClickException(str(exc))
+            raise click.ClickException(str(exc)) from exc
 
         name_s = name.strip()
         if preview.affected_chunks == 0:
@@ -209,7 +209,7 @@ async def _run_merge(
         try:
             preview = await tag_svc.merge_tags(comp.storage, list(sources), target, dry_run=True)
         except ValueError as exc:
-            raise click.ClickException(str(exc))
+            raise click.ClickException(str(exc)) from exc
 
         target_s = target.strip()
         src_display = ", ".join(f"'{s.strip()}'" for s in sources if s.strip())

--- a/packages/memtomem/src/memtomem/cli/watchdog_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/watchdog_cmd.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import click
 
+from memtomem.cli._errors import raise_cli_error
+
 
 @click.group()
 def watchdog() -> None:
@@ -23,7 +25,7 @@ def watchdog_status(as_json: bool) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        raise click.ClickException(str(e)) from e
+        raise_cli_error(e)
 
 
 @watchdog.command("run")
@@ -35,7 +37,7 @@ def watchdog_run(as_json: bool) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        raise click.ClickException(str(e)) from e
+        raise_cli_error(e)
 
 
 @watchdog.command("history")
@@ -48,7 +50,7 @@ def watchdog_history(check_name: str, hours: float) -> None:
     except click.ClickException:
         raise
     except Exception as e:
-        raise click.ClickException(str(e)) from e
+        raise_cli_error(e)
 
 
 # ── Async implementations ──────────────────────────────────────────

--- a/packages/memtomem/tests/test_cli_errors.py
+++ b/packages/memtomem/tests/test_cli_errors.py
@@ -8,8 +8,10 @@ catch-all sites used to emit.
 
 from __future__ import annotations
 
+import re
 import sqlite3
 from contextlib import asynccontextmanager
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -17,6 +19,7 @@ import click
 import pytest
 from click.testing import CliRunner
 
+import memtomem.cli
 from memtomem.cli import cli
 from memtomem.cli._errors import raise_cli_error
 from memtomem.errors import (
@@ -79,6 +82,33 @@ class TestHintMapping:
         with pytest.raises(click.ClickException) as info:
             raise_cli_error(exc)
         assert info.value.__cause__ is exc
+
+
+class TestNoBareCatchAllRegression:
+    """#1617 sweep pin: no ``except Exception`` in ``cli/`` may re-wrap
+    as a bare ``ClickException(str(e))`` — that's ``raise_cli_error``'s
+    job now. Typed conversions (``except WikiNotFoundError`` etc.) stay
+    allowed: their messages are already the actionable text."""
+
+    _PATTERN = re.compile(
+        r"except Exception as (\w+):\n"  # catch-all only
+        r"(?:[^\n]*\n){0,2}?"  # tolerate up to 2 bookkeeping lines (trace_ctx etc.)
+        r"\s*raise click\.ClickException\(str\(\1\)\)",
+    )
+
+    def test_no_catch_all_rewrap_in_cli(self) -> None:
+        cli_dir = Path(memtomem.cli.__file__).parent
+        offenders = []
+        for path in sorted(cli_dir.glob("*.py")):
+            if path.name == "_errors.py":  # docstring shows the old shape
+                continue
+            for match in self._PATTERN.finditer(path.read_text(encoding="utf-8")):
+                # Windows-safe: report by file name only.
+                offenders.append(f"{path.name}: {match.group(0).splitlines()[0]}")
+        assert not offenders, (
+            "bare `except Exception -> ClickException(str(e))` re-wraps found; "
+            f"route them through cli._errors.raise_cli_error instead: {offenders}"
+        )
 
 
 class TestWrappedCommandIntegration:


### PR DESCRIPTION
Closes #1617 (together with #1633, which added the helper and applied it at the issue's listed sites).

## Scope finding

The full-tree grep put the `ClickException(str(e))` surface at 61 sites, but classifying each shows the issue's anti-pattern — a **catch-all** `except Exception` swallowing infra errors with no guidance — covers only **9** of them: `watchdog_cmd` ×3, `ingest_cmd` ×3, `search`, `mem_cmd`, `indexing`. Those now route through `raise_cli_error`, so a locked DB / uninitialized DB / embedding / config failure in any wrapped command carries the same next-step hint.

The other ~47 are deliberate **typed** conversions (`WikiNotFoundError`, `InvalidNameError`, `versioning.VersionError`, `KnownProjectsCorruptError`, tag-service `ValueError`, …) whose messages already are the actionable text — rerouting them would add indirection with zero behavior change, so they stay as-is. `tags_cmd`'s three sites gain the missing `from exc` chaining in passing.

## Regression guard

`TestNoBareCatchAllRegression` scans `cli/*.py` for the `except Exception → ClickException(str(e))` shape (including the `trace_ctx` bookkeeping variant, bounded to ≤2 intervening lines) and fails with the offender list. The regex was mutation-validated against both historical shapes and confirmed to ignore typed conversions.

## Verification

- `grep -rn -B1 "raise click.ClickException(str(" cli/ | grep -c "except Exception"` → **0**
- Remaining site count bounded: context_cmd 22 + wiki_cmd 16 + tags_cmd 3 + session_cmd 2 + agent_cmd 2 + memory 1 — all typed.
- Full suite: 7955 passed; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>