### PR TITLE
chore(cli/docs): polish batch — help text, mode glossary, MMR visibility, deprecation timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Deprecations
+
+- **`mem_context_migrate` MCP tool** (deprecated since #1147, timeline set in
+  #1619) — alias for `mem_context_memory_migrate`; forwards every argument
+  unchanged. **Removal target: v0.5.0.** Migrate callers to
+  `mem_context_memory_migrate` (or the `mem_do` action
+  `context_memory_migrate`); the `mem_do` action alias `context_migrate`
+  follows the same timeline.
+
 ### Added
 
 - **Schema-version downgrade fence** (#1614) — the database now records a

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -35,6 +35,16 @@
 | **Namespace** | A label to organize memories (e.g., "work", "personal", "project-x") |
 | **`mem_do`** | Meta-tool that routes to all non-core actions (with aliases). Use `mem_do(action="help")` to list all |
 
+### The three "modes"
+
+Three unrelated settings all use the word *mode* — they control different axes and don't interact:
+
+| Mode | Values | What it controls |
+|------|--------|------------------|
+| **View toggle** (Web UI header) | Simple / Advanced | Which *tabs and sections* the Web UI shows in your browser session. Purely cosmetic — flip the **Advanced** switch in the header. |
+| **Web surface** (`mm web --mode`, `MEMTOMEM_WEB__MODE`) | `prod` / `dev` | Which *pages and API endpoints* the web server exposes. `dev` adds maintainer pages (Sessions, Health Report, …) and structural namespace verbs. See [Operations → Web UI](reference/operations.md#web-ui). |
+| **Tool mode** (`MEMTOMEM_TOOL_MODE`) | `core` / `standard` / `full` | How many *MCP tools* the server registers for your editor. `core` (default) exposes 9 tools and routes the rest through `mem_do`. See [Configuration](configuration.md). |
+
 ---
 
 ## How memtomem Works

--- a/packages/memtomem/src/memtomem/cli/search.py
+++ b/packages/memtomem/src/memtomem/cli/search.py
@@ -49,6 +49,13 @@ from memtomem.server.tools.search import (
     "fmt",
     type=click.Choice(["table", "json", "plain", "context", "smart"]),
     default="table",
+    show_default=True,
+    help=(
+        "Output format: table (aligned columns), json (machine-readable), "
+        "plain (bare source+content lines), context (markdown 'Relevant "
+        "Memories' block ready to paste into a prompt), smart "
+        "(namespace-grouped, relevance-tiered truncation)."
+    ),
 )
 def search(
     query: str,

--- a/packages/memtomem/src/memtomem/cli/web.py
+++ b/packages/memtomem/src/memtomem/cli/web.py
@@ -536,7 +536,9 @@ def _web_stop() -> None:
 @click.group("web", invoke_without_command=True)
 @click.option("--host", default="127.0.0.1", help="Host to bind to")
 @click.option("--port", default=8080, type=int, help="Port to bind to")
-@click.option("--open", "open_browser", is_flag=True, help="Run with opening the browser")
+@click.option(
+    "--open", "open_browser", is_flag=True, help="Open the Web UI in your browser after startup."
+)
 @click.option(
     "--timeout", default=30, type=int, help="Timeout for web opening (seconds). Zero is no timeout."
 )

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -81,6 +81,24 @@ def _log_rescue_failure(site: str, msg: str, *args: object) -> None:
     logger.log(level, msg, *args, exc_info=True)
 
 
+# MMR-without-dense is a config mismatch that silently disables diversity
+# re-ranking (#1619) — log once per process, DEBUG afterwards, mirroring
+# the rescue-leg pattern above.
+_MMR_NO_DENSE_WARNED = False
+
+
+def _log_mmr_no_dense_once() -> None:
+    global _MMR_NO_DENSE_WARNED
+    level = logging.DEBUG if _MMR_NO_DENSE_WARNED else logging.INFO
+    _MMR_NO_DENSE_WARNED = True
+    logger.log(
+        level,
+        "MMR diversity re-ranking is enabled (mmr.enabled=True) but dense "
+        "retrieval is off (search.enable_dense=False) — MMR is skipped. "
+        "mem_status reports this as a `mmr_disabled_no_dense` warning.",
+    )
+
+
 def _bg_task_error_cb(task: asyncio.Task) -> None:
     """Log errors from fire-and-forget background tasks."""
     if task.cancelled():
@@ -942,6 +960,13 @@ class SearchPipeline:
             fused = apply_score_decay(fused, half_life_days=self._decay_config.half_life_days)
 
         # Stage 5: MMR diversity re-ranking
+        if self._mmr_config.enabled and not use_dense:
+            # #1619: without dense retrieval there are no vectors to
+            # diversify over, so an explicitly enabled MMR silently did
+            # nothing. Say so once per process (INFO — it's a config
+            # mismatch, not a runtime failure); mem_status carries the
+            # same fact as a persistent `mmr_disabled_no_dense` warning.
+            _log_mmr_no_dense_once()
         if self._mmr_config.enabled and fused and use_dense:
             from memtomem.search.mmr import apply_mmr
 

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -1289,7 +1289,8 @@ async def mem_context_migrate(
     full CLI ``mm context migrate`` (which also does artifact flat→dir and
     scope-tier moves, now exposed as ``mem_context_artifact_migrate``).
     Use ``mem_context_memory_migrate`` instead; this alias forwards every
-    argument unchanged and will be removed in a future major release.
+    argument unchanged and **will be removed in v0.5.0** (timeline recorded
+    in CHANGELOG "Deprecations", #1619 — deprecated since v0.3.x/#1147).
 
     The explicit signature is repeated (rather than ``**kwargs``) because
     the MCP schema is built by inspecting the function signature — a

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -158,6 +158,20 @@ async def collect_status_report(app: AppContext) -> dict:
                 "doc": "docs/guides/configuration.md#reset-flow",
             }
         )
+    # #1619: an explicitly enabled MMR silently does nothing without dense
+    # retrieval (no vectors to diversify over) — surface the mismatch where
+    # BM25-only operators will see it. MMR defaults to disabled, so this
+    # never fires out of the box.
+    if config.mmr.enabled and not config.search.enable_dense:
+        warnings.append(
+            {
+                "kind": "mmr_disabled_no_dense",
+                "detail": "mmr.enabled=True but search.enable_dense=False — diversity "
+                "re-ranking is skipped",
+                "fix": "set search.enable_dense=True (needs an embedding provider) "
+                "or set mmr.enabled=False",
+            }
+        )
 
     return {
         "config": {
@@ -337,7 +351,8 @@ async def mem_status(
     can pattern-match on the keys:
 
     ``kind``    open enum describing the warning. Current values:
-                ``embedding_dim_mismatch``. Future releases may add
+                ``embedding_dim_mismatch``, ``scheduler_watchdog_disabled``,
+                ``mmr_disabled_no_dense``. Future releases may add
                 ``stale_index``, ``orphan_vectors``, etc. — consumers
                 must tolerate unknown kinds rather than erroring.
     ``fix``     the canonical CLI command a user should run.

--- a/packages/memtomem/tests/test_cli_status.py
+++ b/packages/memtomem/tests/test_cli_status.py
@@ -550,6 +550,47 @@ class TestStatusJson:
         assert set(warning) == {"kind", "detail", "fix"}
         assert warning["kind"] == "scheduler_watchdog_disabled"
 
+    def test_mmr_without_dense_emits_warning(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # #1619: explicitly enabled MMR with dense retrieval off silently
+        # disables diversity re-ranking — mem_status must say so. Also
+        # covers text rendering: the generic warning renderer needs no
+        # changes for a new kind.
+        comp = _mock_components(
+            total_chunks=1,
+            total_sources=1,
+            config=Mem2MemConfig(mmr={"enabled": True}, search={"enable_dense": False}),
+        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["status", "--json"])
+        assert result.exit_code == 0, result.output
+        (warning,) = json.loads(result.output)["warnings"]
+        assert set(warning) == {"kind", "detail", "fix"}
+        assert warning["kind"] == "mmr_disabled_no_dense"
+        assert "search.enable_dense=False" in warning["detail"]
+        assert "mmr.enabled=False" in warning["fix"]
+
+        text = runner.invoke(cli, ["status"])
+        assert text.exit_code == 0, text.output
+        assert "- kind:       mmr_disabled_no_dense" in text.output
+
+    def test_mmr_enabled_with_dense_no_warning(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        comp = _mock_components(
+            total_chunks=1,
+            total_sources=1,
+            config=Mem2MemConfig(mmr={"enabled": True}),
+        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["status", "--json"])
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["warnings"] == []
+
     def test_json_unexpected_error_keeps_nonzero_exit(
         self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/packages/memtomem/tests/test_search_stages.py
+++ b/packages/memtomem/tests/test_search_stages.py
@@ -219,3 +219,28 @@ class TestApplyMMR:
         embs = {r1.chunk.id: [1.0, 0.0]}
         result = apply_mmr([r1, r2], embs, lambda_param=0.5)
         assert len(result) == 2
+
+
+class TestMmrNoDenseLog:
+    """#1619: MMR enabled without dense retrieval used to skip silently.
+    The pipeline now logs the mismatch once per process (INFO), then
+    demotes to DEBUG — same shape as the rescue-leg warn-once."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_flag(self, monkeypatch):
+        from memtomem.search import pipeline
+
+        monkeypatch.setattr(pipeline, "_MMR_NO_DENSE_WARNED", False)
+
+    def test_first_call_info_then_debug(self, caplog):
+        import logging
+
+        from memtomem.search.pipeline import _log_mmr_no_dense_once
+
+        with caplog.at_level(logging.DEBUG, logger="memtomem.search.pipeline"):
+            _log_mmr_no_dense_once()
+            _log_mmr_no_dense_once()
+
+        levels = [r.levelno for r in caplog.records if "MMR" in r.message]
+        assert levels == [logging.INFO, logging.DEBUG]
+        assert "mmr_disabled_no_dense" in caplog.records[0].message


### PR DESCRIPTION
Closes #1619.

Five small fixes batched per the issue:

- **`mm search --format` discoverability** — help text describing each format (the `context`/`smart` modes were invisible from `--help`) plus `show_default`.
- **`mm web --open` wording** — "Run with opening the browser" → "Open the Web UI in your browser after startup."
- **Mode glossary** (`docs/guides/reference.md`) — a "three modes" table disambiguating the overlapping vocabularies: **Simple/Advanced** (Web UI view toggle, cosmetic) vs **`--mode prod/dev`** / `MEMTOMEM_WEB__MODE` (server page/API surface) vs **`core/standard/full`** / `MEMTOMEM_TOOL_MODE` (MCP tool count). Links ride the existing doc link/anchor guards.
- **MMR silently disabled without dense retrieval** — the pipeline now logs the mismatch once per process (INFO then DEBUG, reusing the rescue-leg warn-once shape) and `collect_status_report` adds a persistent `mmr_disabled_no_dense` warning (`kind`/`detail`/`fix`; the #1629 generic warning renderer needed zero changes — the dict append is the whole integration). MMR defaults to disabled, so neither fires out of the box. `mem_status`'s open-enum docstring now lists all three current kinds.
- **`mem_context_migrate` removal timeline** — concrete target **v0.5.0**, recorded in a new CHANGELOG **Deprecations** section (the convention anchor the repo lacked) and in the tool docstring; the `mem_do` action alias `context_migrate` follows the same timeline.

## Tests

- `test_cli_status.py`: `mmr_disabled_no_dense` JSON keys + text rendering pin; enabled-with-dense no-warning pin.
- `test_search_stages.py`: warn-once level sequence (INFO → DEBUG).
- Full suite: 7957 passed; ruff + mypy clean; docs guards green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>