### PR TITLE
feat(perf): opt-in embedder/reranker warmup to cut cold-start latency (#1621)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **Opt-in model warmup** (#1621) — `MEMTOMEM_WARMUP__ENABLED=true` makes the
+  MCP server pre-load the local embedder/reranker models in a background
+  task at startup, so the first query doesn't pay the model download/load
+  cost; `mm warmup` runs the same preload one-shot for CLI users. Default
+  off — the lazy handshake behaviour (#399) is unchanged unless explicitly
+  opted in. Remote providers (ollama, openai, cohere) are skipped.
 - **Schema-version downgrade fence** (#1614) — the database now records a
   monotonic `schema_version` in `_memtomem_meta`; opening a database written
   by a newer memtomem release fails fast with a typed `SchemaDowngradeError`

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -787,6 +787,21 @@ assert request.headers["X-Webhook-Signature"] == f"sha256={expected}"
 | `MEMTOMEM_CONSOLIDATION_SCHEDULE__MIN_GROUP_SIZE` | `3` | Minimum chunks per source to trigger consolidation |
 | `MEMTOMEM_CONSOLIDATION_SCHEDULE__MAX_GROUPS` | `10` | Maximum source groups to process per run |
 
+## Warmup
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MEMTOMEM_WARMUP__ENABLED` | `false` | Pre-load local embedder/reranker models at MCP server start |
+
+By default the embedding and reranker models load lazily on first use, so
+the first query after server start pays the model download/load cost. With
+warmup enabled the server front-loads that in a background task right after
+startup. Note this is the one opt-in exception to the lazy-handshake
+behaviour: an enabled warmup opens storage and loads models even for
+sessions that never issue a tool call. Remote providers (ollama, openai,
+cohere) are skipped — they have no local model to preload. CLI users can
+run the same preload once with `mm warmup` (no flag needed).
+
 ## Health Watchdog
 
 | Variable | Default | Description |

--- a/packages/memtomem/src/memtomem/cli/__init__.py
+++ b/packages/memtomem/src/memtomem/cli/__init__.py
@@ -63,6 +63,7 @@ def _register() -> None:
     from memtomem.cli.tags_cmd import tags
     from memtomem.cli.uninstall_cmd import uninstall
     from memtomem.cli.upgrade_cmd import upgrade
+    from memtomem.cli.warmup_cmd import warmup
     from memtomem.cli.watchdog_cmd import watchdog
     from memtomem.cli.web import web
     from memtomem.cli.wiki_cmd import wiki
@@ -93,6 +94,7 @@ def _register() -> None:
     cli.add_command(agent)
     cli.add_command(uninstall)
     cli.add_command(upgrade)
+    cli.add_command(warmup)
     cli.add_command(wiki)
 
 

--- a/packages/memtomem/src/memtomem/cli/warmup_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/warmup_cmd.py
@@ -1,0 +1,38 @@
+"""``mm warmup`` — pre-download and load the local models (#1621)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+from memtomem.cli._errors import raise_cli_error
+
+
+@click.command()
+def warmup() -> None:
+    """Pre-download and load the local embedding/reranker models.
+
+    The models otherwise download and load lazily on the first query.
+    Run this after `mm init` (or in a container build) to front-load
+    that cost. Remote providers (ollama, openai, cohere) are skipped —
+    they have no local model to preload. Long-running MCP servers can
+    opt into the same warmup at startup via MEMTOMEM_WARMUP__ENABLED.
+    """
+    try:
+        asyncio.run(_warmup())
+    except click.ClickException:
+        raise
+    except Exception as e:
+        raise_cli_error(e)
+
+
+async def _warmup() -> None:
+    from memtomem.cli._bootstrap import cli_components
+    from memtomem.server.warmup import warm_models
+
+    async with cli_components() as comp:
+        outcomes = await warm_models(comp)
+
+    for o in outcomes:
+        click.echo(f"{o.component}: {o.status} (provider={o.provider}, model={o.model})")

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -614,6 +614,21 @@ class ConsolidationScheduleConfig(ConfigModel):
     max_groups: int = 10
 
 
+class WarmupConfig(ConfigModel):
+    """Opt-in eager model loading at MCP server start (#1621).
+
+    Default off: handshake-only sessions stay fully lazy (#399 — no
+    storage open, no model import). When enabled, ``app_lifespan``
+    spawns a background task that runs the full component init and
+    pre-loads the local embedder/reranker models, so the first query
+    after server start doesn't pay the model download/load cost.
+    Remote providers (ollama, openai, cohere) are skipped — they have
+    no local model to preload. Startup-only; not runtime-mutable.
+    """
+
+    enabled: bool = False
+
+
 class PolicyConfig(ConfigModel):
     """Memory lifecycle policies."""
 
@@ -891,6 +906,7 @@ class Mem2MemConfig(BaseSettings):
     consolidation_schedule: ConsolidationScheduleConfig = Field(
         default_factory=ConsolidationScheduleConfig
     )
+    warmup: WarmupConfig = Field(default_factory=WarmupConfig)
     policy: PolicyConfig = Field(default_factory=PolicyConfig)
     context_window: ContextWindowConfig = Field(default_factory=ContextWindowConfig)
     health_watchdog: HealthWatchdogConfig = Field(default_factory=HealthWatchdogConfig)

--- a/packages/memtomem/src/memtomem/embedding/onnx.py
+++ b/packages/memtomem/src/memtomem/embedding/onnx.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from collections.abc import Callable
 from typing import Sequence
 
@@ -59,43 +60,55 @@ class OnnxEmbedder:
         # observe transient states without taking a lock.
         self._loading: bool = False
         self._load_error: str | None = None
+        # Serializes the first load: the MCP request path and the opt-in
+        # warmup task (#1621) can race into ``_get_model`` from different
+        # threads — without the lock both would construct (and download)
+        # the model.
+        self._load_lock = threading.Lock()
 
     def _get_model(self) -> object:
-        """Lazily initialise the fastembed model (downloads on first use)."""
+        """Lazily initialise the fastembed model (downloads on first use).
+
+        Double-checked lock so concurrent first-callers (request path vs
+        warmup) share a single construction.
+        """
         if self._model is not None:
             return self._model
-        try:
-            from fastembed import TextEmbedding  # type: ignore[import-untyped]
-        except ImportError as exc:
-            raise EmbeddingError(
-                "fastembed is required for the ONNX embedding provider. "
-                "Install it with: pip install memtomem[onnx]"
-            ) from exc
+        with self._load_lock:
+            if self._model is not None:
+                return self._model
+            try:
+                from fastembed import TextEmbedding  # type: ignore[import-untyped]
+            except ImportError as exc:
+                raise EmbeddingError(
+                    "fastembed is required for the ONNX embedding provider. "
+                    "Install it with: pip install memtomem[onnx]"
+                ) from exc
 
-        _register_custom_models_if_needed()
-        model_id = resolve_embedder_id(self._config.model)
-        # threads=0 → leave ORT default (all physical cores); threads>0 caps
-        # the intra-op pool so seeding doesn't saturate the machine.
-        threads = self._config.threads or None
-        cache_dir = resolve_fastembed_cache_dir()
-        logger.info(
-            "Loading ONNX embedding model %s (threads=%s, cache_dir=%s) …",
-            model_id,
-            threads if threads is not None else "ORT default",
-            cache_dir,
-        )
-        self._loading = True
-        self._load_error = None
-        try:
-            self._model = TextEmbedding(
-                model_name=model_id, threads=threads, cache_dir=str(cache_dir)
+            _register_custom_models_if_needed()
+            model_id = resolve_embedder_id(self._config.model)
+            # threads=0 → leave ORT default (all physical cores); threads>0 caps
+            # the intra-op pool so seeding doesn't saturate the machine.
+            threads = self._config.threads or None
+            cache_dir = resolve_fastembed_cache_dir()
+            logger.info(
+                "Loading ONNX embedding model %s (threads=%s, cache_dir=%s) …",
+                model_id,
+                threads if threads is not None else "ORT default",
+                cache_dir,
             )
-        except Exception as exc:
-            self._load_error = str(exc)
-            raise
-        finally:
-            self._loading = False
-        return self._model
+            self._loading = True
+            self._load_error = None
+            try:
+                self._model = TextEmbedding(
+                    model_name=model_id, threads=threads, cache_dir=str(cache_dir)
+                )
+            except Exception as exc:
+                self._load_error = str(exc)
+                raise
+            finally:
+                self._loading = False
+            return self._model
 
     @property
     def dimension(self) -> int:

--- a/packages/memtomem/src/memtomem/search/reranker/fastembed.py
+++ b/packages/memtomem/src/memtomem/search/reranker/fastembed.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from typing import TYPE_CHECKING
 
 from memtomem.embedding.fastembed_cache import resolve_fastembed_cache_dir
@@ -33,49 +34,62 @@ class FastEmbedReranker:
         # single contract without each provider having a bespoke surface.
         self._loading: bool = False
         self._load_error: str | None = None
+        # Serializes the first load — same contract as ``OnnxEmbedder``:
+        # the search path and the opt-in warmup task (#1621) can race into
+        # ``_get_model`` from different threads.
+        self._load_lock = threading.Lock()
 
     def _get_model(self) -> object:
-        """Lazily construct the ``TextCrossEncoder`` — downloads on first use."""
+        """Lazily construct the ``TextCrossEncoder`` — downloads on first use.
+
+        Double-checked lock so concurrent first-callers (search path vs
+        warmup) share a single construction.
+        """
         if self._model is not None:
             return self._model
-        try:
-            from fastembed.rerank.cross_encoder import (  # type: ignore[import-untyped]
-                TextCrossEncoder,
-            )
-        except ImportError as exc:
-            raise ImportError(
-                "fastembed is required for the fastembed reranker. "
-                "Install it with: pip install memtomem[onnx]"
-            ) from exc
+        with self._load_lock:
+            if self._model is not None:
+                return self._model
+            try:
+                from fastembed.rerank.cross_encoder import (  # type: ignore[import-untyped]
+                    TextCrossEncoder,
+                )
+            except ImportError as exc:
+                raise ImportError(
+                    "fastembed is required for the fastembed reranker. "
+                    "Install it with: pip install memtomem[onnx]"
+                ) from exc
 
-        cache_dir = resolve_fastembed_cache_dir()
-        logger.info(
-            "Loading fastembed reranker %s (cache_dir=%s) …",
-            self._config.model,
-            cache_dir,
-        )
-        self._loading = True
-        self._load_error = None
-        try:
-            self._model = TextCrossEncoder(model_name=self._config.model, cache_dir=str(cache_dir))
-        except ValueError as exc:
-            supported = [m.get("model", "") for m in TextCrossEncoder.list_supported_models()]
-            self._load_error = str(exc)
-            raise ValueError(
-                f"fastembed reranker model {self._config.model!r} is not supported. "
-                f"Built-in options: {', '.join(sorted(s for s in supported if s))}. "
-                "For Korean/Chinese/Japanese try "
-                "'jinaai/jina-reranker-v2-base-multilingual' (1.1 GB); for lightweight "
-                "English 'Xenova/ms-marco-MiniLM-L-6-v2' (80 MB). Custom ONNX exports "
-                "must be registered via TextCrossEncoder.add_custom_model() before the "
-                "reranker is invoked."
-            ) from exc
-        except Exception as exc:
-            self._load_error = str(exc)
-            raise
-        finally:
-            self._loading = False
-        return self._model
+            cache_dir = resolve_fastembed_cache_dir()
+            logger.info(
+                "Loading fastembed reranker %s (cache_dir=%s) …",
+                self._config.model,
+                cache_dir,
+            )
+            self._loading = True
+            self._load_error = None
+            try:
+                self._model = TextCrossEncoder(
+                    model_name=self._config.model, cache_dir=str(cache_dir)
+                )
+            except ValueError as exc:
+                supported = [m.get("model", "") for m in TextCrossEncoder.list_supported_models()]
+                self._load_error = str(exc)
+                raise ValueError(
+                    f"fastembed reranker model {self._config.model!r} is not supported. "
+                    f"Built-in options: {', '.join(sorted(s for s in supported if s))}. "
+                    "For Korean/Chinese/Japanese try "
+                    "'jinaai/jina-reranker-v2-base-multilingual' (1.1 GB); for lightweight "
+                    "English 'Xenova/ms-marco-MiniLM-L-6-v2' (80 MB). Custom ONNX exports "
+                    "must be registered via TextCrossEncoder.add_custom_model() before the "
+                    "reranker is invoked."
+                ) from exc
+            except Exception as exc:
+                self._load_error = str(exc)
+                raise
+            finally:
+                self._loading = False
+            return self._model
 
     def _rerank_sync(self, query: str, documents: list[str]) -> list[float]:
         """Run inference synchronously — called inside ``asyncio.to_thread``."""

--- a/packages/memtomem/src/memtomem/search/reranker/local.py
+++ b/packages/memtomem/src/memtomem/search/reranker/local.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -18,13 +19,19 @@ class LocalReranker:
     def __init__(self, config: RerankConfig):
         self._config = config
         self._model = None
+        # Serializes the first load — same contract as ``OnnxEmbedder``:
+        # the search path and the opt-in warmup task (#1621) can race into
+        # ``_get_model`` from different threads.
+        self._load_lock = threading.Lock()
 
     def _get_model(self):
         if self._model is None:
-            from sentence_transformers import CrossEncoder
+            with self._load_lock:
+                if self._model is None:
+                    from sentence_transformers import CrossEncoder
 
-            self._model = CrossEncoder(self._config.model)
-            logger.info("Loaded local reranker: %s", self._config.model)
+                    self._model = CrossEncoder(self._config.model)
+                    logger.info("Loaded local reranker: %s", self._config.model)
         return self._model
 
     async def rerank(

--- a/packages/memtomem/src/memtomem/server/context.py
+++ b/packages/memtomem/src/memtomem/server/context.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -125,6 +126,12 @@ class AppContext:
     _scheduler: object | None = field(default=None, init=False, repr=False)
     _policy_scheduler: object | None = field(default=None, init=False, repr=False)
     _health_watchdog: object | None = field(default=None, init=False, repr=False)
+    # Lifespan-owned model-warmup task (#1621, ``config.warmup.enabled``).
+    # Held here rather than in ``app_lifespan`` so the task keeps a strong
+    # reference (fire-and-forget tasks are otherwise GC-collectable) and
+    # so ``close()`` can cancel an in-flight warmup *before* components
+    # shut down under it. ``from_components`` contexts leave it ``None``.
+    _warmup_task: asyncio.Task | None = field(default=None, init=False, repr=False)
     # per-session, scoped to AppContext lifetime. Gate to emit a dim-mismatch
     # hint only once per MCP session so repeated mem_add / mem_search calls
     # do not spam the same notice. Writes go through ``_config_lock``.
@@ -443,6 +450,19 @@ class AppContext:
         calls are no-ops.
         """
         from memtomem.server.component_factory import close_components
+
+        # Cancel an in-flight warmup first so it can't race the component
+        # teardown below (loading a model into a closing embedder). The
+        # await also blocks until any in-flight loader *thread* settles —
+        # ``_warm_one`` waits for its executor future on cancellation,
+        # since a thread can't be interrupted. The task body swallows its
+        # own errors, so awaiting after cancel can only surface the
+        # CancelledError suppressed here.
+        if self._warmup_task is not None:
+            self._warmup_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._warmup_task
+            self._warmup_task = None
 
         await _stop_quietly(self._health_watchdog, "health_watchdog")
         await _stop_quietly(self._policy_scheduler, "policy_scheduler")

--- a/packages/memtomem/src/memtomem/server/lifespan.py
+++ b/packages/memtomem/src/memtomem/server/lifespan.py
@@ -97,6 +97,12 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
     and starts the file watcher + schedulers + health watchdog inside
     the context (which from then on owns their lifetime).
 
+    One opt-in exception (#1621): when ``config.warmup.enabled`` is set,
+    a background task runs the full init + local model preload right
+    away so the first query doesn't pay the cold-start cost. That flag
+    deliberately trades the handshake-only laziness for warm models —
+    the default-off path stays byte-for-byte lazy.
+
     Shutdown closes the webhook manager first — dropping outstanding
     network retries before the slower DB teardown, see PR #404 — then
     ``ctx.close()`` stops anything ``ensure_initialized`` started and
@@ -128,6 +134,10 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
         raise
 
     try:
+        if config.warmup.enabled:
+            from memtomem.server.warmup import spawn_warmup
+
+            ctx._warmup_task = spawn_warmup(ctx)
         yield ctx
     finally:
         await _stop_quietly(webhook_mgr, "webhook_manager")

--- a/packages/memtomem/src/memtomem/server/warmup.py
+++ b/packages/memtomem/src/memtomem/server/warmup.py
@@ -1,0 +1,126 @@
+"""Opt-in eager model warmup (#1621).
+
+The embedder and reranker load their models lazily on first use
+(``_get_model``), so the first query after server start pays the full
+model download/load cost. ``config.warmup.enabled`` (default off) lets
+operators front-load that: ``app_lifespan`` spawns :func:`spawn_warmup`
+as a background task right after allocating the ``AppContext``, and
+``mm warmup`` runs :func:`warm_models` one-shot for CLI users.
+
+Only local providers are warmed. The three local model classes
+(``OnnxEmbedder``, ``LocalReranker``, ``FastEmbedReranker``) expose a
+sync ``_get_model``; remote providers (ollama, openai, cohere) don't,
+so the ``getattr`` sniff below skips them by construction — warming a
+remote provider would mean real (possibly billed) API calls. The sniff
+reuses the private ``_get_model`` convention the model-readiness
+endpoint and the web hot-reload path already introspect (warmup is
+broader: readiness only inspects onnx/fastembed, warmup also warms the
+``local`` reranker).
+
+Lazy-import discipline: module level stays stdlib-only so importing
+this from the lifespan's flag gate adds nothing to the flag-off
+handshake path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from memtomem.server.component_factory import Components
+    from memtomem.server.context import AppContext
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class WarmupOutcome:
+    """One component's warmup result — for ``mm warmup`` output and logs."""
+
+    component: str  # "embedder" | "reranker"
+    provider: str
+    model: str
+    status: str  # "loaded" | "already-loaded" | "skipped"
+
+
+async def _warm_one(
+    component: str, provider: str, model: str, holder: object | None
+) -> WarmupOutcome:
+    if holder is None:
+        return WarmupOutcome(component, provider, model, "skipped")
+    load_model = getattr(holder, "_get_model", None)
+    if not callable(load_model):
+        # No lazy local model on this provider (remote / noop) — skip.
+        return WarmupOutcome(component, provider, model, "skipped")
+    if getattr(holder, "_model", None) is not None:
+        return WarmupOutcome(component, provider, model, "already-loaded")
+    loop = asyncio.get_running_loop()
+    future = loop.run_in_executor(None, load_model)
+    try:
+        await asyncio.shield(future)
+    except asyncio.CancelledError:
+        # A worker thread can't be interrupted — cancelling only the
+        # awaiting task would leave the load running while shutdown
+        # closes components under it. Wait for the in-flight load to
+        # settle (``close()`` awaits this task after cancelling), then
+        # propagate the cancellation.
+        with contextlib.suppress(BaseException):
+            await future
+        raise
+    return WarmupOutcome(component, provider, model, "loaded")
+
+
+async def warm_models(components: Components) -> list[WarmupOutcome]:
+    """Force the lazy local model loads (embedder, then pipeline reranker).
+
+    The reranker is read through ``search_pipeline`` rather than held
+    separately because web hot-reload swaps ``_reranker`` in place — a
+    snapshot taken at init time could warm an instance the pipeline no
+    longer uses.
+
+    Raises on load failure — callers decide policy: the lifespan task
+    logs-and-continues, ``mm warmup`` surfaces the error.
+    """
+    cfg = components.config
+    return [
+        await _warm_one(
+            "embedder", cfg.embedding.provider, cfg.embedding.model, components.embedder
+        ),
+        await _warm_one(
+            "reranker",
+            cfg.rerank.provider,
+            cfg.rerank.model,
+            getattr(components.search_pipeline, "_reranker", None),
+        ),
+    ]
+
+
+def spawn_warmup(ctx: AppContext) -> asyncio.Task[None]:
+    """Fire-and-forget lifespan warmup: full component init, then model loads.
+
+    Failures are logged loudly and never propagate — a warmup problem
+    must not take down the MCP server; models simply fall back to lazy
+    loading on first use. Cancellation propagates so ``AppContext.close``
+    can await the cancelled task during shutdown.
+    """
+
+    async def _run() -> None:
+        try:
+            components = await ctx.ensure_initialized()
+            outcomes = await warm_models(components)
+            logger.info(
+                "Model warmup finished: %s",
+                ", ".join(f"{o.component}={o.status}" for o in outcomes),
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "Model warmup failed — models will lazy-load on first use", exc_info=True
+            )
+
+    return asyncio.create_task(_run(), name="memtomem-warmup")

--- a/packages/memtomem/tests/test_lazy_init_acceptance.py
+++ b/packages/memtomem/tests/test_lazy_init_acceptance.py
@@ -54,6 +54,7 @@ def isolated_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str,
     monkeypatch.setenv("MEMTOMEM_POLICY__ENABLED", "false")
     monkeypatch.setenv("MEMTOMEM_HEALTH_WATCHDOG__ENABLED", "false")
     monkeypatch.setenv("MEMTOMEM_WEBHOOK__ENABLED", "false")
+    monkeypatch.setenv("MEMTOMEM_WARMUP__ENABLED", "false")
     return {"home": home, "db_path": db_path}
 
 

--- a/packages/memtomem/tests/test_warmup.py
+++ b/packages/memtomem/tests/test_warmup.py
@@ -1,0 +1,423 @@
+"""Tests for opt-in model warmup (#1621).
+
+Three layers:
+
+- ``warm_models`` unit contract — the ``_get_model`` sniff (local
+  providers warm, remote/noop providers skip, already-loaded reported),
+  the live-pipeline reranker read, and failure propagation.
+- Lifespan integration against the real ``app_lifespan`` — flag off
+  spawns nothing and preserves the #399 handshake invariant; flag on
+  runs the full init + model preload in the background; failures are
+  logged and never crash the server; shutdown cancels an in-flight
+  warmup.
+- ``mm warmup`` CLI — outcome lines on success, ``raise_cli_error``
+  hint on failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.server import lifespan as lifespan_mod
+from memtomem.server.warmup import warm_models
+
+from .helpers import set_home
+
+
+class _FakeLocalModel:
+    """Stand-in for OnnxEmbedder / FastEmbedReranker: sync ``_get_model``
+    that records whether it ran off the event-loop thread.
+    """
+
+    def __init__(self) -> None:
+        self._model: object | None = None
+        self.load_calls = 0
+        self.ran_on_main_thread: bool | None = None
+
+    def _get_model(self) -> object:
+        self.load_calls += 1
+        self.ran_on_main_thread = threading.current_thread() is threading.main_thread()
+        self._model = object()
+        return self._model
+
+
+def _fake_components(embedder: object | None, reranker: object | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        config=SimpleNamespace(
+            embedding=SimpleNamespace(provider="onnx", model="embed-model"),
+            rerank=SimpleNamespace(enabled=True, provider="fastembed", model="rerank-model"),
+        ),
+        embedder=embedder,
+        search_pipeline=SimpleNamespace(_reranker=reranker),
+    )
+
+
+class TestWarmModels:
+    @pytest.mark.asyncio
+    async def test_loads_local_embedder_and_reranker_off_the_loop_thread(self):
+        embedder = _FakeLocalModel()
+        reranker = _FakeLocalModel()
+
+        outcomes = await warm_models(_fake_components(embedder, reranker))
+
+        assert [(o.component, o.status) for o in outcomes] == [
+            ("embedder", "loaded"),
+            ("reranker", "loaded"),
+        ]
+        assert embedder.load_calls == 1
+        assert reranker.load_calls == 1
+        # ``asyncio.to_thread`` contract: the sync load must not block the loop.
+        assert embedder.ran_on_main_thread is False
+        assert reranker.ran_on_main_thread is False
+        # Provider/model strings come from config, for display.
+        assert outcomes[0].provider == "onnx"
+        assert outcomes[0].model == "embed-model"
+        assert outcomes[1].provider == "fastembed"
+        assert outcomes[1].model == "rerank-model"
+
+    @pytest.mark.asyncio
+    async def test_holders_without_get_model_are_skipped(self):
+        """Remote providers (OllamaEmbedder, OpenAIEmbedder, CohereReranker)
+        and NoopEmbedder expose no ``_get_model`` — warmup must skip them
+        rather than issue real (possibly billed) API calls.
+        """
+        outcomes = await warm_models(_fake_components(object(), object()))
+
+        assert [o.status for o in outcomes] == ["skipped", "skipped"]
+
+    @pytest.mark.asyncio
+    async def test_missing_reranker_is_skipped(self):
+        """``rerank.enabled=False`` leaves the pipeline with ``_reranker=None``."""
+        outcomes = await warm_models(_fake_components(_FakeLocalModel(), None))
+
+        assert outcomes[1].component == "reranker"
+        assert outcomes[1].status == "skipped"
+
+    @pytest.mark.asyncio
+    async def test_already_loaded_model_is_not_reloaded(self):
+        embedder = _FakeLocalModel()
+        embedder._model = object()
+
+        outcomes = await warm_models(_fake_components(embedder, None))
+
+        assert outcomes[0].status == "already-loaded"
+        assert embedder.load_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_reranker_read_from_live_pipeline_attribute(self):
+        """The reranker must be read through ``search_pipeline._reranker``
+        (hot-reload swaps it in place) — same contract as the readiness
+        endpoint.
+        """
+        reranker = _FakeLocalModel()
+        components = _fake_components(None, reranker)
+
+        outcomes = await warm_models(components)
+
+        assert outcomes[0].status == "skipped"  # embedder=None
+        assert outcomes[1].status == "loaded"
+        assert reranker.load_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_load_failure_propagates_to_caller(self):
+        """``warm_models`` raises — policy (log vs surface) is the caller's."""
+
+        class _Broken(_FakeLocalModel):
+            def _get_model(self) -> object:
+                raise RuntimeError("download failed")
+
+        with pytest.raises(RuntimeError, match="download failed"):
+            await warm_models(_fake_components(_Broken(), None))
+
+
+@pytest.fixture
+def isolated_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    """Same isolation shape as ``test_lazy_init_acceptance.isolated_state``:
+    tmp ``HOME`` (config.json read path), pinned DB path, no memory dirs,
+    fast NoopEmbedder, every optional subsystem off. Individual tests
+    flip ``MEMTOMEM_WARMUP__ENABLED`` / the embedding provider on top.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    db_path = tmp_path / "memtomem.db"
+    set_home(monkeypatch, home)
+    monkeypatch.setenv("MEMTOMEM_STORAGE__SQLITE_PATH", str(db_path))
+    monkeypatch.setenv("MEMTOMEM_INDEXING__MEMORY_DIRS", "[]")
+    monkeypatch.setenv("MEMTOMEM_EMBEDDING__PROVIDER", "none")
+    monkeypatch.setenv("MEMTOMEM_CONSOLIDATION_SCHEDULE__ENABLED", "false")
+    monkeypatch.setenv("MEMTOMEM_POLICY__ENABLED", "false")
+    monkeypatch.setenv("MEMTOMEM_HEALTH_WATCHDOG__ENABLED", "false")
+    monkeypatch.setenv("MEMTOMEM_WEBHOOK__ENABLED", "false")
+    return {"home": home, "db_path": db_path}
+
+
+class TestLifespanWarmup:
+    @pytest.mark.asyncio
+    async def test_flag_off_spawns_no_task_and_stays_lazy(self, isolated_state):
+        """Default (off) path: no warmup task, no components, no DB —
+        the #399 handshake invariant is untouched.
+        """
+        db_path = isolated_state["db_path"]
+
+        async with lifespan_mod.app_lifespan(MagicMock()) as ctx:
+            assert ctx._warmup_task is None
+            assert ctx._components is None
+
+        assert not db_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_flag_on_inits_and_loads_models_in_background(self, isolated_state, monkeypatch):
+        """Flag on: the lifespan spawns a task that runs the full init and
+        hits the model-load choke point (``OnnxEmbedder._get_model``,
+        monkeypatched here so no real download happens) before any tool
+        call.
+        """
+        from memtomem.embedding.onnx import OnnxEmbedder
+
+        monkeypatch.setenv("MEMTOMEM_WARMUP__ENABLED", "true")
+        monkeypatch.setenv("MEMTOMEM_EMBEDDING__PROVIDER", "onnx")
+
+        loads: list[str] = []
+
+        def fake_get_model(self: OnnxEmbedder) -> object:
+            loads.append(self._config.model)
+            self._model = object()
+            return self._model
+
+        monkeypatch.setattr(OnnxEmbedder, "_get_model", fake_get_model)
+
+        db_path = isolated_state["db_path"]
+
+        async with lifespan_mod.app_lifespan(MagicMock()) as ctx:
+            assert ctx._warmup_task is not None
+            await ctx._warmup_task
+
+            assert ctx._components is not None
+            assert db_path.exists(), "warmup must run the full init (DB open)"
+            assert len(loads) == 1, "embedder model load must happen exactly once"
+
+    @pytest.mark.asyncio
+    async def test_warmup_failure_logged_never_crashes_lifespan(
+        self, isolated_state, monkeypatch, caplog
+    ):
+        from memtomem.embedding.onnx import OnnxEmbedder
+
+        monkeypatch.setenv("MEMTOMEM_WARMUP__ENABLED", "true")
+        monkeypatch.setenv("MEMTOMEM_EMBEDDING__PROVIDER", "onnx")
+
+        def broken_get_model(self: OnnxEmbedder) -> object:
+            raise RuntimeError("model download failed")
+
+        monkeypatch.setattr(OnnxEmbedder, "_get_model", broken_get_model)
+
+        with caplog.at_level("WARNING", logger="memtomem.server.warmup"):
+            async with lifespan_mod.app_lifespan(MagicMock()) as ctx:
+                assert ctx._warmup_task is not None
+                await ctx._warmup_task  # must not raise — task swallows and logs
+
+        assert any(
+            "Model warmup failed" in rec.message and rec.levelname == "WARNING"
+            for rec in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_inflight_warmup(self, isolated_state, monkeypatch):
+        """Exiting the lifespan while warmup is still running must cancel
+        the task (``AppContext.close`` does it before component teardown)
+        rather than leak it or hang shutdown.
+        """
+        import memtomem.server.warmup as warmup_mod
+
+        monkeypatch.setenv("MEMTOMEM_WARMUP__ENABLED", "true")
+
+        started = asyncio.Event()
+
+        async def hanging_warm(components: object) -> list:
+            started.set()
+            await asyncio.Event().wait()  # block until cancelled
+            return []
+
+        monkeypatch.setattr(warmup_mod, "warm_models", hanging_warm)
+
+        async with lifespan_mod.app_lifespan(MagicMock()) as ctx:
+            task = ctx._warmup_task
+            assert task is not None
+            await asyncio.wait_for(started.wait(), timeout=5)
+
+        assert task.cancelled(), "in-flight warmup must be cancelled on shutdown"
+        assert ctx._warmup_task is None
+
+
+class TestShutdownThreadSettlement:
+    @pytest.mark.asyncio
+    async def test_close_waits_for_inflight_loader_thread(self, isolated_state, monkeypatch):
+        """Cancelling the warmup task can't interrupt a loader *thread* —
+        ``close()`` must wait for it to settle before tearing components
+        down (review finding on #1621: cancel-and-abandon would let the
+        load complete against closed components).
+        """
+        from memtomem.embedding.onnx import OnnxEmbedder
+
+        monkeypatch.setenv("MEMTOMEM_WARMUP__ENABLED", "true")
+        monkeypatch.setenv("MEMTOMEM_EMBEDDING__PROVIDER", "onnx")
+
+        entered = threading.Event()
+        gate = threading.Event()
+        settled: list[bool] = []
+
+        def blocking_get_model(self: OnnxEmbedder) -> object:
+            entered.set()
+            gate.wait(timeout=10)
+            settled.append(True)
+            self._model = object()
+            return self._model
+
+        monkeypatch.setattr(OnnxEmbedder, "_get_model", blocking_get_model)
+
+        async with lifespan_mod.app_lifespan(MagicMock()) as ctx:
+            task = ctx._warmup_task
+            assert task is not None
+            # Make sure the load thread is actually in flight before exit.
+            await asyncio.to_thread(entered.wait, 5)
+            # Release the gate shortly after shutdown starts cancelling.
+            threading.Timer(0.2, gate.set).start()
+
+        # Lifespan exit ran close(): by the time it returns, the loader
+        # thread must have settled — never abandoned mid-load.
+        assert settled == [True], "close() returned before the loader thread settled"
+        assert task.done()
+
+
+class TestLoaderConcurrency:
+    """The three local loaders serialize their first load (double-checked
+    ``_load_lock``) — warmup and the request path share one concurrency
+    contract instead of constructing (and downloading) the model twice
+    (review finding on #1621).
+    """
+
+    N_THREADS = 8
+
+    @staticmethod
+    def _hammer(get_model) -> None:
+        import concurrent.futures
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            for f in [pool.submit(get_model) for _ in range(TestLoaderConcurrency.N_THREADS)]:
+                f.result(timeout=10)
+
+    @staticmethod
+    def _slow_ctor(calls: list):
+        class _Ctor:
+            def __init__(self, *args, **kwargs) -> None:
+                calls.append((args, kwargs))
+                # Widen the race window so a missing lock surfaces reliably.
+                import time
+
+                time.sleep(0.05)
+
+        return _Ctor
+
+    def test_onnx_embedder_constructs_model_once(self, monkeypatch, tmp_path):
+        import sys
+
+        import memtomem.embedding.onnx as onnx_mod
+        from memtomem.config import EmbeddingConfig
+
+        calls: list = []
+        monkeypatch.setitem(
+            sys.modules, "fastembed", SimpleNamespace(TextEmbedding=self._slow_ctor(calls))
+        )
+        monkeypatch.setattr(onnx_mod, "_register_custom_models_if_needed", lambda: None)
+        monkeypatch.setattr(onnx_mod, "resolve_embedder_id", lambda m: m)
+        monkeypatch.setattr(onnx_mod, "resolve_fastembed_cache_dir", lambda: tmp_path)
+
+        embedder = onnx_mod.OnnxEmbedder(EmbeddingConfig(provider="onnx"))
+        self._hammer(embedder._get_model)
+
+        assert len(calls) == 1, f"model constructed {len(calls)}× under concurrency"
+        assert embedder._model is not None
+
+    def test_fastembed_reranker_constructs_model_once(self, monkeypatch, tmp_path):
+        import sys
+
+        import memtomem.search.reranker.fastembed as fe_mod
+        from memtomem.config import RerankConfig
+
+        calls: list = []
+        fake_mod = SimpleNamespace(TextCrossEncoder=self._slow_ctor(calls))
+        monkeypatch.setitem(sys.modules, "fastembed", SimpleNamespace(rerank=fake_mod))
+        monkeypatch.setitem(sys.modules, "fastembed.rerank", fake_mod)
+        monkeypatch.setitem(sys.modules, "fastembed.rerank.cross_encoder", fake_mod)
+        monkeypatch.setattr(fe_mod, "resolve_fastembed_cache_dir", lambda: tmp_path)
+
+        reranker = fe_mod.FastEmbedReranker(RerankConfig(enabled=True))
+        self._hammer(reranker._get_model)
+
+        assert len(calls) == 1, f"model constructed {len(calls)}× under concurrency"
+
+    def test_local_reranker_constructs_model_once(self, monkeypatch):
+        import sys
+
+        import memtomem.search.reranker.local as local_mod
+        from memtomem.config import RerankConfig
+
+        calls: list = []
+        monkeypatch.setitem(
+            sys.modules,
+            "sentence_transformers",
+            SimpleNamespace(CrossEncoder=self._slow_ctor(calls)),
+        )
+
+        reranker = local_mod.LocalReranker(RerankConfig(enabled=True, provider="local"))
+        self._hammer(reranker._get_model)
+
+        assert len(calls) == 1, f"model constructed {len(calls)}× under concurrency"
+
+
+class TestWarmupCli:
+    @staticmethod
+    def _patch_cli_components(monkeypatch, components):
+        import memtomem.cli._bootstrap as bootstrap
+
+        @asynccontextmanager
+        async def fake_components():
+            yield components
+
+        monkeypatch.setattr(bootstrap, "cli_components", fake_components)
+
+    def test_mm_warmup_reports_outcomes(self, monkeypatch):
+        from memtomem.cli import cli
+
+        embedder = _FakeLocalModel()
+        self._patch_cli_components(monkeypatch, _fake_components(embedder, None))
+
+        result = CliRunner().invoke(cli, ["warmup"])
+
+        assert result.exit_code == 0, result.output
+        assert "embedder: loaded (provider=onnx, model=embed-model)" in result.output
+        assert "reranker: skipped (provider=fastembed, model=rerank-model)" in result.output
+        assert embedder.load_calls == 1
+
+    def test_mm_warmup_surfaces_load_failure_with_hint(self, monkeypatch):
+        from memtomem.cli import cli
+        from memtomem.errors import EmbeddingError
+
+        class _Broken(_FakeLocalModel):
+            def _get_model(self) -> object:
+                raise EmbeddingError("fastembed is required")
+
+        self._patch_cli_components(monkeypatch, _fake_components(_Broken(), None))
+
+        result = CliRunner().invoke(cli, ["warmup"])
+
+        assert result.exit_code == 1
+        assert "fastembed is required" in result.output
+        assert "Hint:" in result.output, "EmbeddingError must carry the next-step hint"


### PR DESCRIPTION
## Summary

WS5 of the 2026-07 improvement cycle. Closes #1621.

Embedder/reranker models load lazily on first use, so the first query after server start pays the full model download/load cost. This adds a config-gated warmup, **default off**:

- **`MEMTOMEM_WARMUP__ENABLED=true`** — `app_lifespan` spawns a background task (`server/warmup.py:spawn_warmup`) that runs the full component init and pre-loads the local models right after startup. This is a deliberate, opt-in trade of the #399 handshake-only laziness for warm models; the default-off path stays byte-for-byte lazy (existing `test_lazy_init_acceptance` suite unchanged + a flag-off no-task pin).
- **`mm warmup`** — one-shot CLI preload for offline prep / container builds (no flag needed; running the command is the opt-in).
- **Local providers only** — `warm_models` sniffs the private `_get_model` convention (`OnnxEmbedder`, `LocalReranker`, `FastEmbedReranker`) that the readiness endpoint and web hot-reload already introspect; remote providers (ollama, openai, cohere) are skipped rather than issued real API calls. The reranker is read through `search_pipeline._reranker` so hot-reload swaps stay visible.
- **Lifecycle** — task handle on `AppContext._warmup_task`; `close()` cancels it first, and `_warm_one` waits for an in-flight loader **thread** to settle (threads can't be interrupted), so shutdown never races a model load into closing components. Warmup failure logs a WARNING and falls back to lazy loading — never crashes the server.
- **Loader concurrency contract** — all three local loaders now serialize their first load with a double-checked `threading.Lock`, so warmup and a concurrent first tool call share one construction instead of downloading the model twice. (Both lifecycle hazards were caught in review; each is pinned by a dedicated regression test.)

Docs: `configuration.md` gets a `## Warmup` section (env var + the lazy-handshake caveat + `mm warmup`); CHANGELOG entry under Unreleased/Added.

## Verification

- `uv run pytest -m "not ollama"` — 7979 passed (includes 16 new tests: `warm_models` unit contract, lifespan flag-off/flag-on/failure/cancel, thread-settlement on shutdown, 8-thread loader-concurrency pins for all three loaders, CLI success/failure).
- Mutation-validated pins: removing the lifespan flag gate, the `close()` cancel block, the settle-wait, or a loader lock each fails its test.
- E2E in an isolated `HOME`: `mm warmup` with the real fastembed reranker downloads and reports `reranker: loaded`; an MCP server with the flag on logs `Model warmup finished: …` at startup; with the flag off there is no warmup activity and no DB is created (lazy handshake preserved).
- `ruff check` + `ruff format --check` clean; `mypy` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
