### PR TITLE
cli: split mm init -y from --non-interactive with v0.5.0 deprecation warning (#1631)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `mem_context_memory_migrate` (or the `mem_do` action
   `context_memory_migrate`); the `mem_do` action alias `context_migrate`
   follows the same timeline.
+- **`mm init -y` as a wizard-skip alias** (deprecated in #1616, flag split +
+  warning in #1631) — `-y` and `--non-interactive` are now separate flags;
+  `-y` still implies `--non-interactive` but every use emits a stderr
+  deprecation warning. **Behavior-change target: v0.5.0**, when `-y` on
+  `mm init` becomes an accepted no-op (init has no confirmation prompt to
+  skip). Scripts should use `--non-interactive`, ideally with an explicit
+  `--preset`.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ The interactive picker starts with three presets — **Minimal** (BM25, no downl
 For automation / CI:
 
 ```bash
-mm init -y                            # minimal preset, same as before
-mm init --preset korean -y            # Korean-optimized bundle, no prompts
-mm init --advanced                    # force the full 10-step wizard
+mm init --non-interactive                   # minimal preset, no prompts
+mm init --preset korean --non-interactive   # Korean-optimized bundle, no prompts
+mm init --advanced                          # force the full 10-step wizard
 ```
 
 See [Embeddings](docs/guides/embeddings.md) for the full model/provider matrix.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -450,7 +450,7 @@ searchable.
 Non-interactive mode supports `--include-provider` (repeatable):
 
 ```bash
-mm init -y --include-provider claude-memory --include-provider codex
+mm init --non-interactive --include-provider claude-memory --include-provider codex
 ```
 
 Asking for a category with no detected dirs is a silent no-op, not an

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -185,25 +185,27 @@ Type `b` to go back or `q` to quit at any prompt.
 
 #### Non-interactive mode (CI / automation)
 
-Skip prompting with `-y`. `mm init -y` alone applies the **Minimal** preset (same defaults as before this feature landed); pass `--preset` for the others:
+Skip prompting with `--non-interactive`. `mm init --non-interactive` alone applies the **Minimal** preset (same defaults as before this feature landed); pass `--preset` for the others:
 
 ```bash
-mm init -y                                              # Minimal preset (BM25-only)
-mm init --preset english -y                             # English recommended
-mm init --preset korean -y                              # Korean-optimized
-mm init --advanced                                      # Force the full 10-step wizard
+mm init --non-interactive                                              # Minimal preset (BM25-only)
+mm init --preset english --non-interactive                             # English recommended
+mm init --preset korean --non-interactive                              # Korean-optimized
+mm init --advanced                                                     # Force the full 10-step wizard
 
 # Explicit flags override preset values:
-mm init -y --provider onnx --model all-MiniLM-L6-v2     # custom ONNX model
-mm init -y --provider ollama --model nomic-embed-text   # Ollama (requires `ollama serve`)
-mm init -y --provider openai --api-key sk-...           # OpenAI
-mm init -y --memory-dir ~/notes --mcp claude            # custom dir + Claude Code auto-setup
+mm init --non-interactive --provider onnx --model all-MiniLM-L6-v2     # custom ONNX model
+mm init --non-interactive --provider ollama --model nomic-embed-text   # Ollama (requires `ollama serve`)
+mm init --non-interactive --provider openai --api-key sk-...           # OpenAI
+mm init --non-interactive --memory-dir ~/notes --mcp claude            # custom dir + Claude Code auto-setup
 
 # Pull in AI tool memory folders (repeat per category):
-mm init -y --include-provider claude-memory --include-provider codex
+mm init --non-interactive --include-provider claude-memory --include-provider codex
 ```
 
-`--preset` and `--advanced` are mutually exclusive. Running without `-y` / `--preset` / `--advanced` from a non-TTY (e.g., piped stdin) exits with an error — pass one of those flags explicitly.
+`-y` is a deprecated alias for `--non-interactive` on `mm init` and will stop implying it in v0.5.0 (it becomes an accepted no-op — `init` has no confirmation prompt to skip).
+
+`--preset` and `--advanced` are mutually exclusive. From a non-TTY (e.g., piped stdin), always pass `--non-interactive` — `--preset` and `--advanced` on their own still run wizard prompts, so scripted runs without `--non-interactive` either exit with an error or cancel without writing a config.
 
 <details>
 <summary><b>Advanced: the full 10-step wizard</b></summary>

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -37,7 +37,7 @@ The picker offers three presets and an Advanced fallback:
 | Korean-optimized | ONNX `bge-m3` (~2.3 GB, 1024d) | Multilingual (`jina-reranker-v2`) | `kiwipiepy` |
 | Advanced | — | — | — (full 10-step wizard, all options) |
 
-Pick a preset interactively, or use `mm init -y` (minimal), `mm init --preset korean -y`, or `mm init --advanced` for scripted runs. See [Embeddings](https://github.com/memtomem/memtomem/blob/main/docs/guides/embeddings.md) for the full model matrix.
+Pick a preset interactively, or use `mm init --non-interactive` (minimal), `mm init --preset korean --non-interactive`, or `mm init --advanced` for scripted runs. See [Embeddings](https://github.com/memtomem/memtomem/blob/main/docs/guides/embeddings.md) for the full model matrix.
 
 > **Claude Code — indexing vs. discovery:** the memory folders `mm init` indexes are added to the search *index*. That is separate from the Web UI's opt-in Context Gateway scan of `~/.claude/projects/`, which discovers project *roots* for Skills, Custom Commands, and Subagents — see [Configuration → Context Gateway](https://github.com/memtomem/memtomem/blob/main/docs/guides/configuration.md#context-gateway) for the opt-in behavior and lossy-slug caveats.
 

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -392,16 +392,18 @@ def _have_module(name: str) -> bool:
 
 
 def _y_refuse_hint(flag: str, extra: str) -> str:
-    """Wizard → ``-y`` discoverability bridge (#403).
+    """Wizard → scripted-run discoverability bridge (#403).
 
-    Interactive wizard warns-and-saves when an extra is missing; ``mm init -y``
-    refuses with a non-zero exit (#396 / #402). A user who copies a wizard
-    choice into a scripted install gets an unexpected hard failure without
-    this hint. Surface the asymmetry at the wizard warning site.
+    Interactive wizard warns-and-saves when an extra is missing;
+    ``mm init --non-interactive`` refuses with a non-zero exit (#396 / #402).
+    A user who copies a wizard choice into a scripted install gets an
+    unexpected hard failure without this hint. Surface the asymmetry at the
+    wizard warning site. (Named after the legacy ``-y`` spelling; the hint
+    text teaches ``--non-interactive`` since the #1631 flag split.)
     """
     return (
-        f"  Note: `mm init -y {flag}` refuses without `memtomem[{extra}]`; "
-        f"install first for scripted setups."
+        f"  Note: `mm init --non-interactive {flag}` refuses without "
+        f"`memtomem[{extra}]`; install first for scripted setups."
     )
 
 
@@ -2952,15 +2954,22 @@ _MODEL_DIMS: dict[str, int] = {
 
 @click.command("init")
 @click.option(
-    "-y",
     "--non-interactive",
     is_flag=True,
     help=(
         "Skip the wizard. Without --preset this applies `--preset minimal` "
-        "(BM25-only, no embeddings) — unlike -y elsewhere in the CLI, it "
-        "selects configuration, not just prompt-skipping. A future release "
-        "will narrow -y to confirmation-skipping only; scripts should pass "
-        "an explicit --preset."
+        "(BM25-only, no embeddings); scripts should pass an explicit "
+        "--preset."
+    ),
+)
+@click.option(
+    "-y",
+    "legacy_yes",
+    is_flag=True,
+    help=(
+        "Deprecated alias for --non-interactive. From v0.5.0, -y on "
+        "`mm init` will be accepted but ignored (init has no confirmation "
+        "prompt to skip); use --non-interactive in scripts."
     ),
 )
 @click.option("--provider", type=click.Choice(["none", "onnx", "ollama", "openai"]), default=None)
@@ -3012,8 +3021,9 @@ _MODEL_DIMS: dict[str, int] = {
     help=(
         "Apply a preset bundle (minimal | english | korean) of embedding, "
         "reranker, tokenizer, and namespace defaults. Without this flag, the "
-        "interactive picker asks at startup; `mm init -y` alone behaves as "
-        "`--preset minimal -y`. Mutually exclusive with --advanced."
+        "interactive picker asks at startup; `mm init --non-interactive` alone "
+        "behaves as `--preset minimal --non-interactive`. Mutually exclusive "
+        "with --advanced."
     ),
 )
 @click.option(
@@ -3027,6 +3037,7 @@ _MODEL_DIMS: dict[str, int] = {
 )
 def init(
     non_interactive: bool,
+    legacy_yes: bool,
     provider: str | None,
     model: str | None,
     memory_dir: str | None,
@@ -3070,6 +3081,23 @@ def init(
         click.secho("  Detected: uvx (ephemeral) install", fg="blue")
         click.echo()
 
+    if legacy_yes:
+        # #1616/#1631 stage 2: `-y` is now a separate flag so the deprecation
+        # warning fires only for the legacy spelling — --non-interactive users
+        # are already on the stage-3 entry point. Warn on every parsed `-y`
+        # use, before any usage-error exit and preset or not: at v0.5.0 `-y`
+        # stops implying --non-interactive entirely, so `-y --preset english`
+        # scripts break too.
+        click.secho(
+            "  Deprecated: `-y` as a wizard-skip alias for --non-interactive "
+            "will be removed in v0.5.0; `mm init -y` will then run the wizard "
+            "(-y becomes a no-op — init has no confirmation prompt). "
+            "Use --non-interactive in scripts. (#1631)",
+            fg="yellow",
+            err=True,
+        )
+        non_interactive = True
+
     if preset and advanced:
         raise click.UsageError("--preset and --advanced are mutually exclusive")
 
@@ -3087,24 +3115,22 @@ def init(
     ]
 
     if non_interactive:
-        # `mm init -y` alone behaves as `--preset minimal -y`; minimal's defaults
-        # match the previous non-interactive block's (provider="none", no rerank,
-        # unicode61, auto_ns=False, top_k=10). Explicit flags then override the
-        # preset baseline, preserving the prior `-y --provider onnx --model X`
+        # `mm init --non-interactive` alone behaves as `--preset minimal
+        # --non-interactive`; minimal's defaults match the previous
+        # non-interactive block's (provider="none", no rerank, unicode61,
+        # auto_ns=False, top_k=10). Explicit flags then override the preset
+        # baseline, preserving the prior `-y --provider onnx --model X`
         # contract.
         if preset is None:
-            # #1616: everywhere else in the CLI `-y` means "skip the
-            # confirmation prompt"; here it silently selects a materially
-            # weaker setup than the wizard's default (english). Until the
-            # flag split lands, say so loudly — on stderr, so scripted
-            # stdout parsing is unaffected.
+            # #1616: skipping the wizard silently selects a materially
+            # weaker setup than the wizard's default (english). Say so
+            # loudly — on stderr, so scripted stdout parsing is unaffected.
             click.secho(
-                "  Note: -y without --preset applies the 'minimal' preset "
-                "(BM25 keyword search only, no embeddings); the interactive "
-                "wizard defaults to 'english'. Pass --preset "
+                "  Note: --non-interactive without --preset applies the "
+                "'minimal' preset (BM25 keyword search only, no embeddings); "
+                "the interactive wizard defaults to 'english'. Pass --preset "
                 "minimal|english|korean to choose explicitly, or run "
-                "`mm init` for the wizard. A future release will narrow -y "
-                "to confirmation-skipping only.",
+                "`mm init` for the wizard.",
                 fg="yellow",
                 err=True,
             )
@@ -3146,7 +3172,7 @@ def init(
         if required:
             hint = _extra_install_hint(required, state)
             raise click.ClickException(
-                f"Missing required extras for `mm init -y`: "
+                f"Missing required extras for `mm init --non-interactive`: "
                 f"{', '.join(required)}.\n"
                 f"  Install first: {hint}\n"
                 f"  Or drop the flag(s) that require them "
@@ -3178,7 +3204,10 @@ def init(
     else:
         # Default interactive path: show the preset picker, dispatch on choice.
         if not _isatty():
-            raise click.UsageError("Non-interactive terminal detected. Pass --preset <name> or -y.")
+            raise click.UsageError(
+                "Non-interactive terminal detected. Pass --non-interactive "
+                "(optionally with --preset <name>)."
+            )
         # Combine the picker with its follow-up steps in ONE run_steps call so
         # "b" at ``_step_memory_dir`` navigates back to the picker (#371). The
         # previous split ran picker alone in a separate call, which left

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -6418,7 +6418,7 @@ class TestYRefuseHintParity:
         from memtomem.cli import init_cmd
 
         hint = init_cmd._y_refuse_hint("--provider onnx", "onnx")
-        assert "mm init -y --provider onnx" in hint
+        assert "mm init --non-interactive --provider onnx" in hint
         assert "memtomem[onnx]" in hint
         assert "refuses" in hint
         assert "scripted" in hint
@@ -6564,12 +6564,13 @@ class TestBackNavThroughSilentStep:
 
 
 class TestNonInteractivePresetNotice:
-    """#1616: ``-y`` is the only CLI flag whose meaning goes beyond
-    "skip the confirmation prompt" — it silently selects ``--preset
-    minimal``, a materially weaker setup than the wizard's default
-    (english). Until the flag split lands, the implicit-preset run must
-    say so loudly on stderr, and an explicit ``--preset`` must silence
-    the notice."""
+    """#1616 / #1631 stage 2: ``--non-interactive`` selects ``--preset
+    minimal`` when no preset is given — a materially weaker setup than the
+    wizard's default (english) — so the implicit-preset run must say so
+    loudly on stderr, and an explicit ``--preset`` must silence that note.
+    ``-y`` is now a separate deprecated-alias flag: every ``-y`` use (preset
+    or not) must emit a deprecation warning naming v0.5.0, while the
+    ``--non-interactive`` spelling must never trigger it."""
 
     def _setup(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from memtomem.cli import init_cmd
@@ -6591,11 +6592,16 @@ class TestNonInteractivePresetNotice:
         result = CliRunner().invoke(cli, ["init", "-y", "--mcp", "skip"])
 
         assert result.exit_code == 0, result.output
+        # Deprecation warning for the -y spelling, naming the target version.
+        assert "Deprecated:" in result.stderr
+        assert "will be removed in v0.5.0" in result.stderr
+        assert "--non-interactive" in result.stderr
+        # Implicit-preset note still fires when no --preset is given.
         assert "'minimal' preset" in result.stderr
         assert "wizard defaults to 'english'" in result.stderr
-        assert "confirmation-skipping only" in result.stderr
-        # stderr only — scripted stdout consumers must not see the notice.
+        # stderr only — scripted stdout consumers must not see either notice.
         assert "'minimal' preset" not in result.stdout
+        assert "Deprecated:" not in result.stdout
         assert (tmp_path / ".memtomem" / "config.json").exists()
 
     def test_explicit_preset_silences_notice(
@@ -6611,7 +6617,111 @@ class TestNonInteractivePresetNotice:
 
         assert result.exit_code == 0, result.output
         assert "'minimal' preset" not in result.stderr
+        # The -y deprecation warning is NOT preset-gated: at v0.5.0 the flag
+        # stops implying --non-interactive entirely, so `-y --preset english`
+        # scripts break too and must be warned now.
+        assert "will be removed in v0.5.0" in result.stderr
         assert (tmp_path / ".memtomem" / "config.json").exists()
+
+    def test_non_interactive_spelling_no_deprecation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli
+
+        self._setup(tmp_path, monkeypatch)
+
+        result = CliRunner().invoke(cli, ["init", "--non-interactive", "--mcp", "skip"])
+
+        assert result.exit_code == 0, result.output
+        # The stage-3 spelling gets the implicit-preset note but never the
+        # deprecation warning.
+        assert "'minimal' preset" in result.stderr
+        assert "Deprecated:" not in result.stderr
+        assert (tmp_path / ".memtomem" / "config.json").exists()
+
+    def test_yes_equals_non_interactive_behavior(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Parity pin for the deprecation window: until v0.5.0, `-y` must
+        produce byte-identical config to `--non-interactive`."""
+        import json
+
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli
+
+        configs: list[dict] = []
+        for flag in ("-y", "--non-interactive"):
+            home = tmp_path / flag.lstrip("-")
+            home.mkdir()
+            self._setup(home, monkeypatch)
+            result = CliRunner().invoke(cli, ["init", flag, "--mcp", "skip"])
+            assert result.exit_code == 0, result.output
+            configs.append(json.loads((home / ".memtomem" / "config.json").read_text()))
+        assert configs[0] == configs[1]
+
+    def test_usage_error_still_emits_deprecation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The -y warning fires before validation exits, so even a rejected
+        `-y --preset X --advanced` invocation teaches the migration."""
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli
+
+        self._setup(tmp_path, monkeypatch)
+
+        result = CliRunner().invoke(cli, ["init", "-y", "--preset", "english", "--advanced"])
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.stderr
+        assert "will be removed in v0.5.0" in result.stderr
+
+    def test_missing_extras_error_teaches_non_interactive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#1631: failure paths on the new spelling must not teach the
+        deprecated `-y` alias."""
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli, init_cmd
+
+        set_home(monkeypatch, tmp_path)
+        monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "fastembed" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+
+        result = CliRunner().invoke(
+            cli, ["init", "--non-interactive", "--provider", "onnx", "--mcp", "skip"]
+        )
+
+        assert result.exit_code != 0, result.output
+        assert "Missing required extras for `mm init --non-interactive`" in result.output
+        assert "mm init -y" not in result.output
+
+    def test_non_tty_error_recommends_non_interactive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#1631: the non-TTY guard must point at --non-interactive, not the
+        deprecated `-y`, and not suggest --preset alone (which still prompts)."""
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli, init_cmd
+
+        self._setup(tmp_path, monkeypatch)
+        monkeypatch.setattr(init_cmd, "_isatty", lambda: False)
+
+        result = CliRunner().invoke(cli, ["init"])
+
+        assert result.exit_code != 0
+        assert "Non-interactive terminal detected" in result.stderr
+        assert "--non-interactive" in result.stderr
+        assert "or -y" not in result.stderr
 
     def test_help_documents_preset_side_effect(self) -> None:
         from click.testing import CliRunner
@@ -6621,12 +6731,14 @@ class TestNonInteractivePresetNotice:
         result = CliRunner().invoke(cli, ["init", "--help"])
 
         assert result.exit_code == 0
-        # The -y help must name the side-effect and the planned narrowing,
-        # not just "skip wizard". Normalize whitespace — click re-wraps
-        # help text, splitting words across lines.
+        # Normalize whitespace — click re-wraps help text, splitting words
+        # across lines.
         normalized = " ".join(result.output.split())
+        # --non-interactive help names the implicit-preset side effect.
         assert "`--preset minimal` (BM25-only, no embeddings)" in normalized
-        assert "A future release will narrow -y" in normalized
+        # -y is documented as a deprecated alias with the target version.
+        assert "Deprecated alias for --non-interactive" in normalized
+        assert "From v0.5.0" in normalized
 
 
 class TestStepHeaderPosition:


### PR DESCRIPTION
Stage 2 of the `-y` deprecation window recorded in #1616 and tracked in #1631 (stage 1 — the loud stderr notice — shipped in #1616).

## What changed

- **`-y` and `--non-interactive` are now separate flags** on `mm init`. `--non-interactive` keeps the wizard-skip semantics (including the implicit `--preset minimal` and its stderr note); `-y` (param `legacy_yes`) is a documented deprecated alias that still implies `--non-interactive`.
- **Every parsed `-y` use emits a stderr deprecation warning naming v0.5.0** — including `-y --preset X` (those scripts also break at stage 3) and usage-error exits (the warning is emitted before `--preset`/`--advanced` validation). The `--non-interactive` spelling never triggers it. Splitting the option is what makes spelling-precise warning possible: as a single click option the two spellings were indistinguishable.
- **Failure paths stop teaching the deprecated alias**: the missing-extras error now says `mm init --non-interactive`, the non-TTY guard says `Pass --non-interactive (optionally with --preset <name>)` instead of `Pass --preset <name> or -y` (`--preset` alone still prompts and cancels without writing config under piped stdin), and `_y_refuse_hint` teaches `--non-interactive`.
- **CHANGELOG**: new "Deprecations" entry with the v0.5.0 behavior-change target, following the timeline convention set in #1619.
- **Docs** (README, getting-started, configuration, PyPI README): examples switched to `--non-interactive`; getting-started documents the alias status and corrects the non-TTY paragraph (previously implied `--preset`/`--advanced` alone were scripted entry points).

## Tests

`TestNonInteractivePresetNotice` extended from 3 to 8 tests: deprecation warning presence/wording for `-y` (bare, with preset, on usage-error exit), absence for `--non-interactive`, `-y` ↔ `--non-interactive` config parity pin (stage-3 safety), help-text pins, and the two reworded error paths. Verified end-to-end with isolated-HOME smoke runs (`-y` vs `--non-interactive` configs byte-identical).

## Not in this PR

Stage 3 (the actual flip: `-y` stops implying `--non-interactive` and becomes an accepted no-op) is release-gated on a 0.4.x warning window — #1631 stays open.

Refs #1631

🤖 Generated with [Claude Code](https://claude.com/claude-code)
