### PR TITLE
fix(cli): keep --json stdout byte-clean across platforms via stderr confirm helper (#1640)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/_prompts.py
+++ b/packages/memtomem/src/memtomem/cli/_prompts.py
@@ -1,0 +1,38 @@
+"""Prompt helpers that keep ``--json`` stdout byte-clean on every platform."""
+
+from __future__ import annotations
+
+import sys
+
+import click
+
+
+def confirm(text: str, *, default: bool = False, err: bool = False) -> bool:
+    """``click.confirm`` with a stdout-safe stderr path.
+
+    With ``err=False`` this defers to ``click.confirm`` unchanged. With
+    ``err=True`` the prompt is written to stderr and the reply is read
+    straight from ``sys.stdin``, bypassing click's prompt machinery: click
+    8.4's ``_readline_prompt`` redirects the prompt function's stdout to
+    stderr on POSIX but not on Windows, where the prompt tail (and, under
+    ``CliRunner``, the echoed reply) leaks into stdout and corrupts the
+    single-JSON-document contract of ``--json`` runs (#1640).
+    """
+    if not err:
+        return click.confirm(text, default=default)
+    suffix = " [Y/n]: " if default else " [y/N]: "
+    while True:
+        click.echo(f"{text}{suffix}", nl=False, err=True)
+        line = sys.stdin.readline()
+        if not line:
+            # EOF — mirror click.confirm: nothing to answer with, abort.
+            click.echo(err=True)
+            raise click.Abort()
+        value = line.strip().lower()
+        if value in ("y", "yes"):
+            return True
+        if value in ("n", "no"):
+            return False
+        if not value:
+            return default
+        click.echo("Error: invalid input", err=True)

--- a/packages/memtomem/src/memtomem/cli/memory.py
+++ b/packages/memtomem/src/memtomem/cli/memory.py
@@ -11,6 +11,7 @@ from typing import get_args
 import click
 
 from memtomem.cli._errors import raise_cli_error
+from memtomem.cli._prompts import confirm as _confirm
 from memtomem.config import TargetScope
 from memtomem.memory_scope import (
     MemoryScopeError,
@@ -37,13 +38,14 @@ def _prompt_project_shared_confirm(target: Path, *, err: bool = False) -> bool:
     """Prompt before writing to the git-tracked project_shared tier.
 
     ``err=True`` routes the prompt chrome to stderr so ``--json`` runs
-    keep stdout as a single machine-readable ack.
+    keep stdout as a single machine-readable ack (via ``_prompts.confirm``,
+    which bypasses click's Windows stdout leak — #1640).
     """
     click.secho(
         "This will write to the git-tracked project memory directory:", fg="yellow", err=err
     )
     click.echo(f"  {target}", err=err)
-    return click.confirm("Continue?", default=False, err=err)
+    return _confirm("Continue?", default=False, err=err)
 
 
 def _render_validity_window(valid_from_unix: int | None, valid_to_unix: int | None) -> str:

--- a/packages/memtomem/src/memtomem/cli/reset_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/reset_cmd.py
@@ -33,6 +33,7 @@ import click
 
 from memtomem.cli._db_lock import check_db_lock, sqlite_file_uri
 from memtomem.cli._liveness import check_server_liveness, check_web_liveness
+from memtomem.cli._prompts import confirm as _confirm
 
 
 @click.command("reset")
@@ -195,7 +196,8 @@ async def _run(
     if not yes:
         # err=as_json keeps stdout pure JSON under --json — the prompt is
         # interactive chrome, and `mm reset --json | jq` must not choke on it.
-        if not click.confirm(
+        # _prompts.confirm bypasses click's Windows stdout leak (#1640).
+        if not _confirm(
             f"This will permanently delete ALL data ({total} chunks, sessions, "
             f"history, etc.) from the database. Continue?",
             default=False,

--- a/packages/memtomem/src/memtomem/cli/upgrade_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/upgrade_cmd.py
@@ -41,6 +41,7 @@ from memtomem.cli._liveness import (
     check_web_liveness,
     probe_pid_file,
 )
+from memtomem.cli._prompts import confirm as _confirm
 
 # Bare PEP 440 release identifier — no operators, no whitespace. We pin
 # with ``memtomem==<version>``, so accepting a specifier like ``>=0.1.30``
@@ -355,7 +356,9 @@ def upgrade(
                 sys.exit(1)
             click.secho(msg, fg="red")
             raise click.Abort()
-        if not click.confirm("\nProceed with upgrade?", default=True):
+        # err=json_out keeps stdout a single JSON document in interactive
+        # `mm upgrade --json` runs (via _prompts.confirm — #1640).
+        if not _confirm("\nProceed with upgrade?", default=True, err=json_out):
             # Voluntary cancel → exit 0; keep JSON schema consistent.
             if json_out:
                 click.echo(_json.dumps({"ok": True, "cancelled": True}))

--- a/packages/memtomem/tests/test_cli_add_json.py
+++ b/packages/memtomem/tests/test_cli_add_json.py
@@ -130,6 +130,30 @@ class TestAddJsonAck:
         assert "Continue?" in result.stderr
         comp.index_engine.index_file.assert_not_called()
 
+    def test_project_shared_decline_json_win_prompt_branch(self, monkeypatch, tmp_path):
+        """#1640: forced WIN prompt branch must not pollute the JSON ack —
+        this flow failed on windows-latest until Gate B moved to
+        ``_prompts.confirm``."""
+        import click.termui
+
+        proj = tmp_path / "proj"
+        base = proj / ".memtomem" / "memories"
+        comp = _components(tmp_path)
+        comp.config.indexing.project_memory_dirs = [str(base)]
+        _patch_components(monkeypatch, comp)
+        monkeypatch.setattr(
+            "memtomem.server.tools.search._resolve_project_context_root", lambda comp: proj
+        )
+        monkeypatch.setattr(click.termui, "WIN", True)
+
+        result = CliRunner().invoke(
+            add_cmd, [_CLEAN, "--scope", "project_shared", "--json"], input="n\n"
+        )
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.stdout)
+        assert data == {"ok": False, "reason": "cancelled at project_shared confirmation prompt"}
+
     def test_unexpected_error_keeps_nonzero_exit(self, monkeypatch, tmp_path):
         # Only CLI-classified failures (ClickException) ride the exit-0
         # JSON body; a crashed index engine must stay loud (CONTRIBUTING:

--- a/packages/memtomem/tests/test_cli_prompts.py
+++ b/packages/memtomem/tests/test_cli_prompts.py
@@ -1,0 +1,95 @@
+"""Tests for ``cli/_prompts.confirm`` (#1640).
+
+click 8.4's ``_readline_prompt`` redirects the prompt function's stdout to
+stderr on POSIX when ``err=True`` but not on Windows, where the prompt tail
+(and, under ``CliRunner``, the echoed reply) leaks into stdout.
+``confirm(err=True)`` bypasses click's prompt machinery so ``--json`` stdout
+stays a single JSON document on every platform. The end-to-end pins for the
+two production call sites live next to their suites
+(``test_reset_cmd.py`` / ``test_cli_add_json.py``).
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli._prompts import confirm
+
+
+@click.command()
+@click.option("--default", "default_", is_flag=True)
+def _cmd(default_: bool) -> None:
+    click.echo(f"answer={confirm('Continue?', default=default_, err=True)}")
+
+
+class TestConfirmErrTrue:
+    @pytest.mark.parametrize(
+        ("reply", "expected"),
+        [
+            ("n\n", "False"),
+            ("no\n", "False"),
+            ("y\n", "True"),
+            ("YES\n", "True"),
+            ("\n", "False"),
+        ],
+    )
+    def test_reply_parsing_and_stdout_purity(self, reply: str, expected: str) -> None:
+        result = CliRunner().invoke(_cmd, [], input=reply)
+
+        assert result.exit_code == 0, result.output
+        # Exact-equality pin: nothing but the command's own stdout output —
+        # no prompt tail, no reply echo.
+        assert result.stdout == f"answer={expected}\n"
+        assert "Continue? [y/N]: " in result.stderr
+
+    def test_empty_reply_returns_default_true(self) -> None:
+        result = CliRunner().invoke(_cmd, ["--default"], input="\n")
+
+        assert result.exit_code == 0, result.output
+        assert result.stdout == "answer=True\n"
+        assert "[Y/n]" in result.stderr
+
+    def test_invalid_reply_reprompts_on_stderr(self) -> None:
+        result = CliRunner().invoke(_cmd, [], input="maybe\ny\n")
+
+        assert result.exit_code == 0, result.output
+        assert result.stdout == "answer=True\n"
+        assert "Error: invalid input" in result.stderr
+        assert result.stderr.count("Continue?") == 2
+
+    def test_eof_aborts(self) -> None:
+        result = CliRunner().invoke(_cmd, [], input="")
+
+        assert result.exit_code == 1
+        assert "answer=" not in result.stdout
+
+    def test_stdout_stays_clean_under_simulated_windows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The #1640 trigger — forcing click's WIN prompt branch must not
+        # matter because the helper never enters click's prompt machinery.
+        import click.termui
+
+        monkeypatch.setattr(click.termui, "WIN", True)
+
+        result = CliRunner().invoke(_cmd, [], input="n\n")
+
+        assert result.exit_code == 0, result.output
+        assert result.stdout == "answer=False\n"
+
+
+class TestConfirmErrFalse:
+    def test_defers_to_click_confirm(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """err=False keeps click's interactive UX (readline editing etc.)."""
+        calls: dict[str, tuple] = {}
+
+        def fake_confirm(text: str, default: bool = False) -> bool:
+            calls["args"] = (text, default)
+            return True
+
+        monkeypatch.setattr(click, "confirm", fake_confirm)
+
+        assert confirm("Go?", default=True, err=False) is True
+        assert calls["args"] == ("Go?", True)

--- a/packages/memtomem/tests/test_reset_cmd.py
+++ b/packages/memtomem/tests/test_reset_cmd.py
@@ -251,6 +251,24 @@ class TestResetJson:
         assert "Continue?" in result.stderr
         assert _count(db_path, "chunks") >= 1
 
+    def test_cancelled_confirm_json_win_prompt_branch(self, home, monkeypatch):
+        """#1640: click's WIN prompt branch leaked the CliRunner reply echo
+        into stdout (`' n\\n' + JSON`), failing this flow on windows-latest.
+        ``_prompts.confirm`` bypasses that branch, so stdout must stay a
+        single JSON document even with the branch forced."""
+        import click.termui
+
+        _patch_liveness(monkeypatch)
+        runner = CliRunner()
+        _init_and_index(home, runner)
+        monkeypatch.setattr(click.termui, "WIN", True)
+
+        result = runner.invoke(cli, ["reset", "--json"], input="n\n")
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.stdout)
+        assert data == {"ok": False, "reason": "cancelled at confirmation prompt"}
+
 
 # ---------------------------------------------------------------- backup
 

--- a/packages/memtomem/tests/test_upgrade_cmd.py
+++ b/packages/memtomem/tests/test_upgrade_cmd.py
@@ -480,11 +480,29 @@ def test_cancel_exits_zero_and_json_consistent(monkeypatch, fake_uv, force_tty):
     calls, _configure = fake_uv
     _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))
 
-    # Decline confirmation by feeding "n" to click.confirm.
+    # Decline confirmation by feeding "n" to the prompt.
     result = CliRunner().invoke(cli, ["upgrade", "--json"], input="n\n")
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output.strip().splitlines()[-1])
+    # #1640: stdout must be a single JSON document — the prompt rides
+    # stderr under --json, so `mm upgrade --json | jq` works on cancel.
+    payload = json.loads(result.stdout)
     assert payload == {"ok": True, "cancelled": True}
+    assert "Proceed with upgrade?" in result.stderr
+    assert calls == []
+
+
+def test_cancel_json_win_prompt_branch(monkeypatch, fake_uv, force_tty):
+    """#1640: forcing click's WIN prompt branch must not pollute the JSON
+    ack — _prompts.confirm never enters click's prompt machinery."""
+    import click.termui
+
+    calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))
+    monkeypatch.setattr(click.termui, "WIN", True)
+
+    result = CliRunner().invoke(cli, ["upgrade", "--json"], input="n\n")
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {"ok": True, "cancelled": True}
     assert calls == []
 
 


### PR DESCRIPTION
Fixes the Windows-only stdout pollution behind the two `windows-latest` CI failures introduced by #1630 (root cause and bisect in #1640): click 8.4's `_readline_prompt` redirects the prompt function's stdout to stderr on POSIX when `err=True`, but the `WIN` branch calls the prompt function unredirected — under `CliRunner` that leaks the prompt tail and the echoed reply (`" n\n"`) into stdout, breaking the `--json` single-JSON-document contract from #1615.

## What changed

- **New `cli/_prompts.py` — `confirm(text, *, default, err)`**: with `err=False` it defers to `click.confirm` unchanged (interactive UX untouched); with `err=True` it writes the full prompt (`[y/N]`/`[Y/n]` + `: ` suffix, matching click's format) to stderr and reads the reply from `sys.stdin` directly, bypassing click's prompt machinery entirely. Semantics mirror `click.confirm`: y/yes/n/no case-insensitive, empty → default, invalid → re-prompt with `Error: invalid input`, EOF → `Abort`.
- **Three call sites migrated** (the third found in review — thanks Codex):
  - `reset_cmd.py` — `mm reset --json` confirmation (`err=as_json`)
  - `memory.py` — `mm add --json` project_shared Gate B (`err=err`)
  - `upgrade_cmd.py` — `mm upgrade --json` interactive confirmation, which previously passed no `err=` at all, so its prompt polluted stdout **on every platform**, not just Windows; the existing test masked it by parsing only the last output line.

## Tests

- `test_cli_prompts.py` (new): reply parsing with exact stdout-equality pins, default handling, invalid-input re-prompt, EOF abort, forced-`WIN`-branch purity, and `err=False` deferral to `click.confirm`.
- WIN-branch regression pins added next to each production flow (`test_reset_cmd.py`, `test_cli_add_json.py`, `test_upgrade_cmd.py`): `monkeypatch click.termui.WIN = True` → `json.loads(result.stdout)` must succeed. **Mutation-validated**: reverting any call site to `click.confirm` turns the corresponding pins red with the exact CI failure signature.
- `test_upgrade_cmd.py::test_cancel_exits_zero_and_json_consistent` tightened from last-line parsing to whole-stdout parsing + prompt-on-stderr assertion.

The two previously-failing `windows-latest` tests are unchanged — they are the platform-real contract pins and should go green on Windows with this fix.

Possible follow-up (noted in #1640): file the `err=True` asymmetry upstream against click.

Closes #1640

🤖 Generated with [Claude Code](https://claude.com/claude-code)
