### PR TITLE
ci: make the Windows test cell gating; add a hang-guard timeout (#634 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    # Windows ships informational pending the test-portability triage tracked
-    # in #634 (umbrella) — ubuntu + macOS are the gating cells today. Flip
-    # this to `false` (or remove) once the Windows triage sub-issues close.
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    # All three OS cells gate. Windows was informational during the #634
+    # portability triage; it went (and stayed) green once that closed, and
+    # the informational window let a real Windows regression hide behind a
+    # green run-level badge for a day (#1640) — the failure mode this flip
+    # removes. The timeout guards the historical Windows hang mode: a hung
+    # cell must fail fast, not block the required check for six hours.
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
Follow-up to #634 (CLOSED) and the #1640 incident: the `continue-on-error: windows` informational window let a real Windows-only regression (#1630 → fixed in #1641) sit invisible behind a green run-level badge across four main pushes. With the cell green again (branch run + post-merge main run), flip it to gating:

- remove `continue-on-error` for the Windows cell (all three OS cells now fail the run when red);
- add `timeout-minutes: 35` to the `test` job — the Windows cell has a historical hang mode, and once the cell is a required check a hang must fail fast rather than hold merges for the 6-hour default (current cell wall-clock is ~17 min, so 35 gives 2× headroom);
- update the stale comment.

After merge + one green main run, `test (windows-latest)` gets added to the branch-protection required contexts (same list that already carries ubuntu/macos) — that step is API-side, not in this diff.

Refs #634, #1640

🤖 Generated with [Claude Code](https://claude.com/claude-code)