### PR TITLE
fix(context): make single-asset install commit-true (#1643)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   skip). Scripts should use `--non-interactive`, ideally with an explicit
   `--preset`.
 
+### Changed
+
+- **`mm context install` (single asset) is commit-true** (#1643) — install now
+  extracts the asset's bytes from the wiki's git objects at HEAD (the same
+  mechanism as `install --all`'s pinned restore), so the recorded lockfile pin
+  always reproduces the installed bytes. If the asset's wiki working tree
+  differs from HEAD (modified/deleted tracked files, untracked files, or a
+  never-committed asset), install refuses with `UncommittedAssetError` (CLI)
+  / HTTP 409 `wiki_uncommitted` (web) and a runnable `mm wiki <type> commit`
+  hint; dirt elsewhere in the wiki does not block. Previously install copied
+  the dirty worktree bytes while pinning HEAD — silently recording a pin that
+  never contained them. As part of the same fix, committed symlinks are now
+  skipped (with a warning) during commit extraction — previously the pinned
+  `install --all` restore path materialized the symlink's *target path* as
+  file content. `mm context update` still copies the working tree; tracked
+  as a follow-up.
+
 ### Added
 
 - **Opt-in model warmup** (#1621) — `MEMTOMEM_WARMUP__ENABLED=true` makes the

--- a/docs/adr/0008-wiki-layer.md
+++ b/docs/adr/0008-wiki-layer.md
@@ -1,7 +1,7 @@
 # ADR-0008: Wiki layer for shared canonical artifacts
 
-**Status:** Accepted (PR-A/B/C/D/E merged — read-only browser, dev-tier override-seed, and dev-tier project install/update shipped; the in-browser canonical/override editor + isolated commit affordance also shipped, specified in ADR-0027 — see PR Breakdown)
-**Date:** 2026-04-30
+**Status:** Accepted (PR-A/B/C/D/E merged — read-only browser, dev-tier override-seed, and dev-tier project install/update shipped; the in-browser canonical/override editor + isolated commit affordance also shipped, specified in ADR-0027 — see PR Breakdown; amended 2026-07-04: single-asset install is commit-true, #1643)
+**Date:** 2026-04-30 (amended 2026-07-04)
 **Context:** Context gateway today is a per-project canonical → multi-runtime
 fan-out router (ADR-0001). Users with several projects must re-author the
 same skill/agent/command in each `<project>/.memtomem/`. This ADR introduces
@@ -242,9 +242,14 @@ without a valid manifest degrade to the pre-manifest behavior
 `digests` / `digests_installed_at` (added with the #1247 id 15
 content-digest work) record the SHA-256 of **the bytes the writing
 operation put into dest** — content identity of the install, not commit
-provenance (install/update copy from the wiki *working tree*; the digest
+provenance (update copies from the wiki *working tree*; the digest
 map inherits exactly the pre-existing `wiki_commit` provenance
-imprecision and adds none). The algorithm is fixed at SHA-256; an
+imprecision and adds none. **Amended 2026-07-04, #1643:** single-asset
+*install* is now commit-true — it extracts the asset's bytes from git
+objects at HEAD and refuses when the asset's worktree state differs
+from HEAD, so install-minted digests carry exact commit provenance;
+the imprecision remains only for update-minted and legacy entries,
+which `install --all`'s data-safety no-op continues to protect). The algorithm is fixed at SHA-256; an
 algorithm change is a NEW key name, not a value prefix. Hashes are
 computed from the in-memory bytes the copier wrote, never from a re-read
 of dest (a re-read would bless a concurrent edit — the TOCTOU this map

--- a/docs/guides/context-gateway.md
+++ b/docs/guides/context-gateway.md
@@ -109,6 +109,9 @@ wiki (~/.memtomem-wiki)  ──install──▶  project Store (<project>/.memto
 - **Install** — `mm context install <type> <name>` (or the **Install** button in
   the Web UI's Wiki section) snapshots one canonical asset from the wiki into the
   **current project's** `.memtomem/` Store, pinned to the wiki's HEAD commit.
+  Install is commit-true: it extracts the committed bytes at HEAD, and refuses
+  (with a `mm wiki <type> commit` hint) if the asset has uncommitted changes in
+  the wiki working tree — commit first, then install.
 - **Update** — `mm context update <type> <name>` refreshes an installed snapshot
   to the wiki's latest HEAD. Add `--dry-run` to print the would-update /
   unchanged / refuse preview without writing anything (also works with

--- a/docs/guides/reference/data-config-cli.md
+++ b/docs/guides/reference/data-config-cli.md
@@ -286,7 +286,7 @@ mm wiki list                           # list canonical assets (--type skills|ag
 mm wiki skill lint <name>              # CI gate — exits non-zero on errors
 mm wiki skill commit <name> --canonical   # ONE isolated commit of just the canonical path
 cd <your project>                      # wiki is global; install/status are project-scoped
-mm context install skill <name>        # snapshot the wiki asset into <project>/.memtomem/
+mm context install skill <name>        # snapshot the wiki asset (at HEAD; commit-true — refuses if the asset has uncommitted wiki changes)
 mm context update skill <name>         # re-snapshot an installed asset after the wiki changed (--all, --force, --yes)
 mm context status                      # installed wiki assets + drift (reads the CURRENT project)
 

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -44,6 +44,7 @@ from memtomem.context.install import (
     ProjectClassification,
     ProjectInstallClassification,
     StaleInstallError,
+    UncommittedAssetError,
     _apply_pinned_install,
     _apply_update,
     _classify_for_all_update,
@@ -1851,8 +1852,11 @@ def install_cmd(
     """Install a wiki asset into ``<project>/.memtomem/<type>/<name>/``.
 
     Without ``--all``: install a single ``<type> <name>`` from the wiki at
-    HEAD. The wiki at ``~/.memtomem-wiki/`` must be initialized first
-    (``mm wiki init``).
+    HEAD — commit-true (#1643): bytes are extracted from git objects at
+    HEAD, so an asset whose wiki working tree differs from HEAD (or was
+    never committed) refuses with a ``mm wiki <type> commit`` hint instead
+    of recording a pin that can't reproduce the installed bytes. The wiki
+    at ``~/.memtomem-wiki/`` must be initialized first (``mm wiki init``).
 
     With ``--all``: walk ``<project>/.memtomem/lock.json`` and re-install
     every entry **at the commit each entry pins** (NOT wiki HEAD). This
@@ -1880,6 +1884,7 @@ def install_cmd(
         WikiUnbornHeadError,
         AssetNotFoundError,
         AlreadyInstalledError,
+        UncommittedAssetError,
         InvalidNameError,
         LockfileError,
         PrivacyScanError,

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -1,9 +1,15 @@
 """Install a single wiki asset into ``<project>/.memtomem/<type>/<name>/``.
 
 Implements ADR-0008 PR-B (skills) and PR-C (agents, commands). The wiki at
-``~/.memtomem-wiki/`` is the source of truth; an "install" is a copytree
-snapshot pinned to the wiki's HEAD commit, recorded in
-:class:`memtomem.context.lockfile.Lockfile`.
+``~/.memtomem-wiki/`` is the source of truth; an "install" extracts the
+asset's bytes **from git objects at the wiki's HEAD commit** (#1643) and
+records that commit in :class:`memtomem.context.lockfile.Lockfile` — the pin
+therefore always reproduces the installed bytes. A wiki working tree that
+differs from HEAD for the asset (modified/deleted tracked files, untracked
+files, or a never-committed asset) refuses with
+:class:`UncommittedAssetError`; dirt elsewhere in the wiki does not block.
+(``mm context update`` still copies the working tree — follow-up tracked
+separately.)
 
 Public wrappers — :func:`install_skill`, :func:`install_agent`,
 :func:`install_command` — all delegate to :func:`_install_asset`. The wiki
@@ -65,6 +71,7 @@ __all__ = [
     "NotInstalledError",
     "ProjectInstallClassification",
     "StaleInstallError",
+    "UncommittedAssetError",
     "UpdateResult",
     "install_agent",
     "install_command",
@@ -91,6 +98,22 @@ class ProjectRootMissingError(FileNotFoundError):
 
 class AssetNotFoundError(RuntimeError):
     """Raised when the requested asset directory does not exist in the wiki."""
+
+
+class UncommittedAssetError(RuntimeError):
+    """Raised when install would snapshot wiki state the HEAD pin can't reproduce.
+
+    Single-asset install is commit-true (#1643): bytes are extracted from git
+    objects at HEAD and the lockfile pins that commit. When the asset's OWN
+    worktree state differs from HEAD — modified/deleted tracked files,
+    untracked files under the asset dir, or an asset that was never committed
+    at all — proceeding would either install bytes the user doesn't see in
+    the wiki (HEAD ≠ worktree) or record a pin that doesn't contain the asset.
+    The message carries a runnable ``mm wiki <type> commit`` hint plus a
+    raw-git fallback (the hinted command commits only the canonical file and
+    vendor overrides — it cannot commit e.g. a skill's ``scripts/`` or
+    deletions). Dirt outside the asset never raises this.
+    """
 
 
 class AlreadyInstalledError(RuntimeError):
@@ -125,8 +148,9 @@ class InstallResult:
 
     ``was_no_op=True`` is set only by ``install --all``'s
     :func:`_apply_pinned_install` when a ``--force`` row re-classifies CLEAN
-    AND its recorded digests differ from the pin's bytes (a clean install
-    taken off a dirty wiki working tree): the row is left untouched rather
+    AND its recorded digests differ from the pin's bytes (an entry written
+    by the pre-#1643 worktree-copying install, or by ``mm context update``,
+    off a dirty wiki working tree): the row is left untouched rather
     than silently re-extracted, so nothing is written or removed
     (``files_written=0``). It is reachable only under ``--force`` — without
     it the caller skips clean rows before calling this helper.
@@ -216,12 +240,16 @@ def install_skill(
     lock_timeout: float | None = None,
     surface: str = "cli_context_install",
 ) -> InstallResult:
-    """Snapshot ``<wiki>/skills/<name>/`` into ``<project>/.memtomem/skills/<name>/``.
+    """Snapshot ``skills/<name>/`` **at wiki HEAD** into ``<project>/.memtomem/skills/<name>/``.
 
-    Pins the wiki HEAD commit at the start of the operation so a concurrent
-    ``git pull`` in the wiki cannot make the recorded ``wiki_commit`` drift
-    from the bytes that were copied. Refuses if either the lockfile entry
-    or the destination directory already exists — see module docstring.
+    Commit-true (#1643): bytes are extracted from git objects at the HEAD
+    commit read at the start of the operation, so neither a concurrent
+    ``git pull`` nor a worktree edit in the wiki can make the recorded
+    ``wiki_commit`` drift from the bytes that were copied; an asset whose
+    worktree state differs from HEAD refuses with
+    :class:`UncommittedAssetError`. Also refuses if either the lockfile
+    entry or the destination directory already exists — see module
+    docstring.
 
     ``surface`` names the ingress in the Gate-A privacy audit log
     (#1246/#1248 real-ingress rule): the CLI keeps the default, the web
@@ -241,7 +269,7 @@ def install_agent(
     lock_timeout: float | None = None,
     surface: str = "cli_context_install",
 ) -> InstallResult:
-    """Snapshot ``<wiki>/agents/<name>/`` into ``<project>/.memtomem/agents/<name>/``."""
+    """Snapshot ``agents/<name>/`` at wiki HEAD into ``<project>/.memtomem/agents/<name>/``."""
     return _install_asset(
         project_root, "agents", name, wiki=wiki, lock_timeout=lock_timeout, surface=surface
     )
@@ -255,7 +283,7 @@ def install_command(
     lock_timeout: float | None = None,
     surface: str = "cli_context_install",
 ) -> InstallResult:
-    """Snapshot ``<wiki>/commands/<name>/`` into ``<project>/.memtomem/commands/<name>/``."""
+    """Snapshot ``commands/<name>/`` at wiki HEAD into ``<project>/.memtomem/commands/<name>/``."""
     return _install_asset(
         project_root, "commands", name, wiki=wiki, lock_timeout=lock_timeout, surface=surface
     )
@@ -476,8 +504,16 @@ def _gate_a_scan_pinned_asset(
     *,
     surface: str,
     project_root: Path,
+    remediation_hint: str | None = None,
 ) -> None:
-    """Gate A over the bytes a pinned re-extraction would write.
+    """Gate A over the bytes a pinned extraction would write.
+
+    ``remediation_hint`` overrides the default restore-flavored hint ("…
+    re-pin to a clean commit before restoring") — the commit-true single
+    install (#1643) scans HEAD here before a FIRST extraction, where
+    "restoring"/"re-pin" would misdirect; it passes an install-flavored
+    hint instead. ``{pin}``/``{rel}`` placeholders are not interpolated —
+    pass a fully-rendered string.
 
     The wiki working tree is irrelevant here — the extractor reads git
     objects at *pin*, so the scan does too (:meth:`WikiStore.
@@ -508,7 +544,8 @@ def _gate_a_scan_pinned_asset(
                 scope="project_shared",
                 kind=kind,
                 artifact_name=name,
-                remediation_hint=(
+                remediation_hint=remediation_hint
+                or (
                     f"The pinned wiki commit {pin[:12]} ships a secret in "
                     f"{asset_type}/{name}/{rel}; fix the asset in the wiki and "
                     f"re-pin to a clean commit before restoring."
@@ -525,14 +562,33 @@ def _install_asset(
     lock_timeout: float | None = None,
     surface: str = "cli_context_install",
 ) -> InstallResult:
-    """Internal: install a single asset of any type.
+    """Internal: install a single asset of any type — commit-true (#1643).
+
+    Bytes are extracted from git objects at HEAD
+    (:meth:`WikiStore.copy_asset_at_commit`, the same mechanism as
+    ``install --all``'s pinned restore), never from the wiki working tree,
+    so the recorded ``wiki_commit`` pin always reproduces the installed
+    bytes. Two gates precede extraction: the asset must exist at HEAD (an
+    asset present only in the worktree — never committed — refuses with
+    :class:`UncommittedAssetError` rather than pinning a commit that lacks
+    it), and the asset's own worktree state must match HEAD (any
+    modified/deleted/untracked path under the asset dir refuses the same
+    way; dirt elsewhere in the wiki is ignored). All refusals fire before
+    any dest mkdir / byte / lockfile write — zero residue. A crash DURING
+    extraction can leave a partially-mirrored dest with no lockfile entry,
+    the same residue class as the pre-#1643 copytree (the
+    dest-without-entry hint below covers it).
 
     Concurrency contract: same-asset races accept last-write-wins on the
-    lockfile entry. Both writers pin the same ``wiki_commit`` (HEAD is read
-    once per call before copy) and per-file ``atomic_write_bytes`` keeps
-    individual files consistent, so byte content under ``dest`` converges
-    even if the workers interleave. Distinct-asset writers serialize
-    cleanly on the lockfile sidecar lock and both entries survive.
+    lockfile entry. HEAD is read once per call and extraction reads that
+    commit's immutable objects, so racers that observe the SAME HEAD write
+    identical bytes regardless of interleaving — and a concurrent wiki
+    *edit* can no longer bleed into the copy (strictly stronger than the
+    worktree-copy era). Racers that observe DIFFERENT HEADs can still
+    interleave files from two commits with the last lockfile write winning
+    — the same class as before, reconciled by ``install --all``/update.
+    Distinct-asset writers serialize cleanly on the lockfile sidecar lock
+    and both entries survive.
 
     ``installed_at`` is captured at the lockfile-upsert boundary (after the
     copytree completes) so that a subsequent ``mm context update``'s
@@ -551,9 +607,11 @@ def _install_asset(
     wiki = wiki if wiki is not None else WikiStore.at_default()
     wiki.require_exists()
 
+    # Worktree presence is a boolean input to the HEAD-presence gate below,
+    # not a raise site — "in the worktree but not at HEAD" must classify as
+    # uncommitted, not absent (#1643).
     src = wiki.root / asset_type / validated
-    if not src.is_dir():
-        raise AssetNotFoundError(f"{asset_type}/{validated} not in wiki at {wiki.root}")
+    worktree_present = src.is_dir()
 
     wiki_commit = wiki.current_commit()
 
@@ -590,24 +648,82 @@ def _install_asset(
             f"{hint}"
         )
 
-    # Gate A (ADR-0011 §5, #1247): wiki bytes are user-tier — secrets are
-    # legal there — but dest is the git-tracked project_shared canonical.
-    # Scan before mkdir so refusal leaves zero residue (no empty type dir,
-    # no dest bytes, no lockfile entry).
-    _gate_a_scan_src_tree(
-        src,
-        surface=surface,
-        project_root=project_root,
-        asset_type=asset_type,
-        name=validated,
+    singular = asset_type.removesuffix("s")
+    commit_hint = (
+        f"commit it first: `mm wiki {singular} commit {validated} --canonical` "
+        f"(add `--vendor <vendor>` for override files; for scripts, deletions, "
+        f"or other paths that command can't commit, use git directly in the "
+        f"wiki at {wiki.root})"
     )
 
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    digest_map = copy_tree_atomic(src, dest, skip_suffixes=DIRTY_SKIP_SUFFIXES)
+    # HEAD-presence gate (#1643): the pin must CONTAIN the asset. An asset
+    # that exists only in the worktree would install bytes whose recorded
+    # provenance points at a commit that lacks them entirely — the worst
+    # shape of the unreproducible-pin bug (a `git clean` in the wiki then
+    # destroys the only source while the lockfile claims a valid pin).
+    try:
+        wiki.asset_files_at_commit(wiki_commit, asset_type, validated)
+    except AssetNotFoundError:
+        if worktree_present:
+            raise UncommittedAssetError(
+                f"{asset_type}/{validated}: exists in the wiki working tree but "
+                f"has never been committed, so the HEAD pin would not contain "
+                f"it; {commit_hint}"
+            ) from None
+        raise AssetNotFoundError(f"{asset_type}/{validated} not in wiki at {wiki.root}") from None
 
-    # files= derives from the copier's WRITTEN set, not a post-copy re-walk
-    # (#1247 id 15) — a concurrent addition landing during the copy can no
-    # longer be absorbed into the manifest as if wiki-shipped.
+    # Same-asset dirty gate (#1643): worktree state must equal HEAD for THIS
+    # asset — otherwise the user-visible wiki bytes and the installed bytes
+    # silently diverge. Repo-relative rows are stripped to asset-inner rels
+    # so is_copy_skipped_rel matches the same surface the extractor filters
+    # (a legacy untracked `*.bak` or a stray `.DS_Store` is not dirt: it
+    # would never be extracted). Dirt in OTHER assets never reaches this
+    # gate (asset_uncommitted_paths is pathspec-scoped).
+    asset_prefix = f"{asset_type}/{validated}/"
+    dirty_rels = sorted(
+        rel
+        for row in wiki.asset_uncommitted_paths(asset_type, validated)
+        if (rel := row[len(asset_prefix) :]) and not is_copy_skipped_rel(rel)
+    )
+    if dirty_rels:
+        shown = ", ".join(dirty_rels[:5])
+        more = "" if len(dirty_rels) <= 5 else f", +{len(dirty_rels) - 5} more"
+        raise UncommittedAssetError(
+            f"{asset_type}/{validated}: wiki working tree differs from HEAD for "
+            f"this asset ({len(dirty_rels)} file(s): {shown}{more}); install is "
+            f"commit-true and records HEAD's bytes only — {commit_hint}"
+        )
+
+    # Gate A (ADR-0011 §5, #1247): wiki bytes are user-tier — secrets are
+    # legal there — but dest is the git-tracked project_shared canonical.
+    # The scan reads git objects at the pin (#1643): exactly the immutable
+    # bytes the extractor below will write (scan set == write set, and no
+    # scan→write TOCTOU). Runs before any mkdir so refusal leaves zero
+    # residue (no empty type dir, no dest bytes, no lockfile entry).
+    _gate_a_scan_pinned_asset(
+        wiki,
+        wiki_commit,
+        asset_type,
+        validated,
+        surface=surface,
+        project_root=project_root,
+        remediation_hint=(
+            f"The wiki HEAD commit {wiki_commit[:12]} ships a secret in "
+            f"{asset_type}/{validated}; remove it from the asset, commit the "
+            f"fix in the wiki, and re-run install."
+        ),
+    )
+
+    # Commit-true extraction (#1643): bytes come from git objects at the
+    # pinned commit, never the worktree, so the lockfile's digests/
+    # files_commit claims below are literally true. copy_asset_at_commit
+    # does its own dest.parent.mkdir + tmpdir-adjacent materialization and
+    # applies the same skip predicate as the old copytree.
+    digest_map = wiki.copy_asset_at_commit(wiki_commit, asset_type, validated, dest)
+
+    # files= derives from the extractor's WRITTEN set (#1247 id 15) — and the
+    # source is now an immutable commit, so no concurrent wiki addition can
+    # be absorbed into the manifest as if wiki-shipped.
     installed_at = installed_at_from_dest(dest)
     lock.upsert_entry(
         asset_type,
@@ -1503,10 +1619,13 @@ def _apply_pinned_install(
             f"overwrite (every current file gets a .bak sibling)"
         )
 
-    # Data-safety no-op (ADR-0008 wiki_commit provenance imprecision): a single
-    # install/update copies the wiki WORKING TREE but pins HEAD, so a clean
-    # install taken off a *dirty* wiki holds bytes the recorded pin never
-    # described. Such a row re-classifies CLEAN here (dest == its recorded
+    # Data-safety no-op (ADR-0008 wiki_commit provenance imprecision): the
+    # legacy single-install path (pre-#1643) and the current update path copy
+    # the wiki WORKING TREE while pinning HEAD, so entries created by them off
+    # a *dirty* wiki hold bytes the recorded pin never described (the
+    # commit-true single install can no longer mint such entries, but
+    # existing lockfiles and update keep them alive). Such a row
+    # re-classifies CLEAN here (dest == its recorded
     # digests), and --force would then re-extract the pin over it — SILENTLY
     # swapping the installed bytes for the pin's, with no .bak (files_to_bak is
     # empty on a clean row). `install --all` reproduces the RECORDED install, so

--- a/packages/memtomem/src/memtomem/web/routes/context_mutations.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mutations.py
@@ -34,6 +34,7 @@ from memtomem.context.install import (
     NotInstalledError,
     ProjectRootMissingError,
     StaleInstallError,
+    UncommittedAssetError,
     UpdateResult,
     install_agent,
     install_command,
@@ -119,10 +120,14 @@ async def install_asset(
 ) -> dict:
     """Install a single wiki asset into the project (parity of ``mm context install``).
 
-    Snapshots ``<wiki>/<type>/<name>/`` into ``<project>/.memtomem/<type>/<name>/``
-    at the wiki HEAD and pins it in ``lock.json``. project_shared tier only — the
-    engine has no tier axis (see the pinned resolver). Non-destructive: an
-    already-installed asset refuses with 409 ``already_installed`` (use update).
+    Commit-true (#1643): extracts ``<type>/<name>/`` from the wiki's git
+    objects at HEAD and pins that commit in ``lock.json`` — never the
+    working tree, so the pin always reproduces the installed bytes. An
+    asset whose wiki working tree differs from HEAD (or was never
+    committed) refuses with 409 ``wiki_uncommitted``. project_shared tier
+    only — the engine has no tier axis (see the pinned resolver).
+    Non-destructive: an already-installed asset refuses with 409
+    ``already_installed`` (use update).
     """
     _validate_name_or_error(asset_type, name)
     installer = _INSTALLERS[asset_type]
@@ -161,6 +166,19 @@ async def install_asset(
             "conflict",
             f"{asset_type}/{name} is already installed in this project; use update to refresh",
             reason_code="already_installed",
+        ) from exc
+    except UncommittedAssetError as exc:
+        # Fixed message, NOT ``str(exc)`` — the engine message embeds the
+        # absolute wiki root (its raw-git remediation hint), which must not
+        # leak into the HTTP envelope (module contract; the
+        # ``_privacy_blocked`` precedent).
+        raise _error(
+            409,
+            "conflict",
+            f"{asset_type}/{name} has uncommitted changes in the wiki (install is "
+            f"commit-true and records HEAD's bytes only); commit them — e.g. "
+            f"`mm wiki <type> commit <name> --canonical` — and retry",
+            reason_code="wiki_uncommitted",
         ) from exc
     except PrivacyScanError as exc:
         raise _privacy_blocked() from exc

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1772,7 +1772,7 @@
   <script src="/context-gateway-detail.js?v=1"></script>
   <script src="/context-gateway-actions.js?v=1"></script>
   <script src="/context-portal.js?v=7"></script>
-  <script src="/wiki.js?v=9"></script>
+  <script src="/wiki.js?v=10"></script>
   <script src="/path-picker.js?v=4"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -538,6 +538,7 @@
   "settings.ctx.wiki_already_installed": "{type} \"{name}\" is already installed — use Update to refresh",
   "settings.ctx.wiki_not_installed": "{type} \"{name}\" is not installed — use Install first",
   "settings.ctx.wiki_install_privacy_blocked": "The privacy scan blocked this: a secret was detected in the wiki bytes of {type} \"{name}\". Remove it from the wiki, then retry.",
+  "settings.ctx.wiki_install_uncommitted": "{type} \"{name}\" has uncommitted wiki edits — install records committed content only. Commit them (Commit button or `mm wiki commit`), then retry.",
   "settings.ctx.wiki_install_failed": "Install/update failed: {error}",
   "settings.ctx.wiki_override_title": "Override source",
   "settings.ctx.wiki_override_edit": "Edit",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -538,6 +538,7 @@
   "settings.ctx.wiki_already_installed": "{type} \"{name}\" 은(는) 이미 설치됨 — 업데이트를 사용하세요",
   "settings.ctx.wiki_not_installed": "{type} \"{name}\" 은(는) 설치되지 않음 — 먼저 설치하세요",
   "settings.ctx.wiki_install_privacy_blocked": "프라이버시 스캔이 차단했습니다: {type} \"{name}\" 의 위키 콘텐츠에서 시크릿이 감지되었습니다. 위키에서 제거한 뒤 다시 시도하세요.",
+  "settings.ctx.wiki_install_uncommitted": "{type} \"{name}\" 에 커밋되지 않은 위키 수정이 있습니다 — 설치는 커밋된 콘텐츠만 기록합니다. 커밋(Commit 버튼 또는 `mm wiki commit`) 후 다시 시도하세요.",
   "settings.ctx.wiki_install_failed": "설치/업데이트 실패: {error}",
   "settings.ctx.wiki_override_title": "오버라이드 원본",
   "settings.ctx.wiki_override_edit": "편집",

--- a/packages/memtomem/src/memtomem/web/static/wiki.js
+++ b/packages/memtomem/src/memtomem/web/static/wiki.js
@@ -1079,6 +1079,15 @@ async function _installWikiAsset(type, name, scopeId, force, verb) {
       showToast(t('settings.ctx.wiki_not_installed', { type: _wikiTypeLabel(type), name }), 'error');
       return;
     }
+    if (reason === 'wiki_uncommitted') {
+      // Commit-true install (#1643): the asset's wiki working tree differs
+      // from HEAD, so the pin couldn't reproduce the installed bytes.
+      showToast(
+        t('settings.ctx.wiki_install_uncommitted', { type: _wikiTypeLabel(type), name }),
+        'error',
+      );
+      return;
+    }
     if (reason === 'privacy_blocked') {
       // Localized copy, not the envelope's detail.message — that prose is
       // English-only server text and, being always non-empty, would shadow

--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -685,8 +685,10 @@ class WikiStore:
 
         Wraps ``git status --porcelain`` — true on any combination of
         modified-tracked, staged, or untracked files. Used by ``mm
-        context update`` to warn the user that the install/update will
-        reflect HEAD only, not the dirty working tree.
+        context update`` to warn the user that the recorded pin reflects
+        HEAD only, not the dirty working tree. (Single-asset install
+        refuses instead, and only on the asset's own dirt — see
+        :meth:`asset_uncommitted_paths`, #1643.)
 
         Returns ``False`` if the wiki is clean. Raises ``WikiNotFoundError``
         if the wiki itself is missing (no ``.git`` directory) — caller
@@ -704,6 +706,69 @@ class WikiStore:
         self.require_exists()
         result = _git(["status", "--porcelain"], cwd=self.root)
         return bool(result.stdout.strip())
+
+    def asset_uncommitted_paths(self, asset_type: str, name: str) -> list[str]:
+        """List worktree paths under ``<asset_type>/<name>/`` that differ from HEAD.
+
+        ``git status --porcelain -z -uall -- <asset_type>/<name>/`` scoped by
+        pathspec, so dirt anywhere ELSE in the wiki is invisible — the
+        deliberate contrast with the repo-wide :meth:`is_dirty`. ``-z``
+        NUL-terminates verbatim pathnames (with git's default
+        ``core.quotePath=true``, line-oriented porcelain C-quotes non-ASCII
+        paths — same caveat as :meth:`asset_files_at_commit`); ``-uall``
+        expands an entirely-untracked asset dir into per-file rows instead of
+        one collapsed ``?? <dir>/`` row. A staged rename/copy row carries a
+        second NUL token (the original path) — both sides are checked against
+        the prefix, so a rename INTO or OUT OF the asset counts as dirt.
+
+        Returns repo-relative POSIX paths, decoded ``errors="replace"`` —
+        they feed refusal messages and skip-filtering only, never extraction.
+        The list is raw: ignored files never appear (the scaffold
+        ``.gitignore`` / :meth:`ensure_bak_excluded` hide ``*.bak``), but a
+        legacy clone where neither ran can still surface one — callers that
+        need the installed-surface view filter with
+        ``is_copy_skipped_rel`` (kept on the context side to avoid a
+        wiki→context import).
+
+        Calls :meth:`require_exists` first. On an unborn HEAD every file
+        reports as untracked/added — callers in the install flow read
+        :meth:`current_commit` before this, so they never get here unborn.
+        Shares :meth:`is_dirty`'s ``.gitattributes`` caveat: a normalizing
+        clean/eol filter can make committed files read permanently dirty,
+        which under the #1643 install gate means a permanent refusal until
+        the filter is dropped (memtomem ships no ``.gitattributes``).
+        """
+        self.require_exists()
+        prefix = f"{asset_type}/{name}/"
+        prefix_bytes = prefix.encode("utf-8")
+        result = _git_bytes(
+            ["status", "--porcelain", "-z", "-uall", "--", prefix],
+            cwd=self.root,
+        )
+        tokens = result.stdout.split(b"\0")
+        paths: list[str] = []
+        i = 0
+        while i < len(tokens):
+            entry = tokens[i]
+            i += 1
+            # Drop the empty tail after the final NUL and any malformed
+            # fragment shorter than "XY <path>".
+            if len(entry) < 4:
+                continue
+            status_xy = entry[:2]
+            path = entry[3:]
+            if path.startswith(prefix_bytes):
+                paths.append(path.decode("utf-8", errors="replace"))
+            # Porcelain v1 -z rename/copy rows are two tokens: "XY new\0orig".
+            # Consume the orig token here even when it's outside the asset —
+            # a naive splitter would misread it as the next row's XY field.
+            if status_xy[0:1] in (b"R", b"C"):
+                if i < len(tokens):
+                    orig = tokens[i]
+                    i += 1
+                    if orig.startswith(prefix_bytes):
+                        paths.append(orig.decode("utf-8", errors="replace"))
+        return paths
 
     def commit_paths(
         self,
@@ -961,17 +1026,27 @@ class WikiStore:
         return result.stdout
 
     def asset_files_at_commit(self, commit: str, asset_type: str, name: str) -> list[str]:
-        """List the asset's file relpaths (relative to the asset dir) at *commit*.
+        """List the asset's regular-file relpaths (relative to the asset dir) at *commit*.
 
-        ``git ls-tree -r -z --name-only`` (NUL-terminated bytes, so non-ASCII
-        pathnames survive ``core.quotePath``) against the commit's objects —
-        the wiki working tree is never consulted. Raises
+        ``git ls-tree -r -z`` (NUL-terminated bytes, so non-ASCII pathnames
+        survive ``core.quotePath``) against the commit's objects — the wiki
+        working tree is never consulted. Only blob modes ``100644``/``100755``
+        are returned: a symlink (``120000``) is skipped with a warning —
+        ``git show`` on one yields the *target string*, and materializing
+        that as file content would silently corrupt the extraction (the
+        worktree copier has always skipped symlinks the same way,
+        :func:`memtomem.context._atomic.copy_tree_atomic`; pre-#1643 the
+        pinned-restore path materialized target-as-content) — and a gitlink
+        (``160000``) is skipped likewise. Raises
         :class:`CommitNotFoundError` for an unreachable SHA and
         :class:`memtomem.context.install.AssetNotFoundError` when the asset
-        path has no files at that revision. Used by
-        :meth:`copy_asset_at_commit` for extraction and by
-        ``mm context install --all`` reconciliation, which needs the
-        expected file set without re-extracting (#1247).
+        path has NO entries at all at that revision — judged BEFORE the mode
+        filter, so a committed asset holding only skipped entries returns
+        ``[]`` (extractable as an empty tree) rather than reading as absent.
+        Used by :meth:`copy_asset_at_commit` for extraction, the pinned
+        Gate-A scan (scan set == write set), and ``mm context install --all``
+        reconciliation, which needs the expected file set without
+        re-extracting (#1247).
         """
         from memtomem.context.install import AssetNotFoundError
 
@@ -986,28 +1061,59 @@ class WikiStore:
         # in double quotes), which fails the prefix match below — a
         # Korean-named file silently vanished from extraction and the digest
         # map. NUL-terminated bytes round-trip every pathname exactly.
+        # Full (non ``--name-only``) output carries the mode column:
+        # ``<mode> <type> <sha>\t<path>`` per NUL-terminated entry.
         ls_result = _git_bytes(
-            ["ls-tree", "-r", "-z", "--name-only", commit, "--", src_prefix],
+            ["ls-tree", "-r", "-z", commit, "--", src_prefix],
             cwd=self.root,
         )
         prefix_bytes = src_prefix.encode("utf-8")
+        inner_relpaths: list[str] = []
+        seen_any_entry = False
         try:
-            inner_relpaths = [
-                entry[len(prefix_bytes) :].decode("utf-8")
-                for entry in ls_result.stdout.split(b"\0")
-                # The startswith filter guards against odd git path output;
-                # the truthiness check drops the empty tail after the final
-                # NUL (and a bare prefix row, which ls-tree -r shouldn't
-                # yield, but guard against odd git versions).
-                if entry.startswith(prefix_bytes) and entry[len(prefix_bytes) :]
-            ]
+            for entry in ls_result.stdout.split(b"\0"):
+                meta, sep, path = entry.partition(b"\t")
+                # The sep check drops the empty tail after the final NUL; the
+                # startswith filter guards against odd git path output, and
+                # the truthiness check drops a bare prefix row (which
+                # ls-tree -r shouldn't yield, but guard against odd
+                # versions).
+                if not sep or not path.startswith(prefix_bytes):
+                    continue
+                rel_bytes = path[len(prefix_bytes) :]
+                if not rel_bytes:
+                    continue
+                seen_any_entry = True
+                mode = meta.split(b" ", 1)[0]
+                if mode == b"120000":
+                    logger.warning(
+                        "asset_files_at_commit: skipping symlink %s/%s/%s at %s",
+                        asset_type,
+                        name,
+                        rel_bytes.decode("utf-8", errors="replace"),
+                        commit[:12],
+                    )
+                    continue
+                if mode not in (b"100644", b"100755"):
+                    # 160000 gitlinks (submodules) and any future exotic mode:
+                    # nothing extractable behind them.
+                    logger.warning(
+                        "asset_files_at_commit: skipping non-file mode %s for %s/%s/%s at %s",
+                        mode.decode("ascii", errors="replace"),
+                        asset_type,
+                        name,
+                        rel_bytes.decode("utf-8", errors="replace"),
+                        commit[:12],
+                    )
+                    continue
+                inner_relpaths.append(rel_bytes.decode("utf-8"))
         except UnicodeDecodeError as exc:
             # Path-free by design: the web routes render RuntimeError as a
             # clean envelope; the raw bytes stay in the chained exception.
             raise RuntimeError(
                 f"non-UTF-8 pathname under {asset_type}/{name} at commit {commit[:12]}"
             ) from exc
-        if not inner_relpaths:
+        if not seen_any_entry:
             raise AssetNotFoundError(
                 f"{asset_type}/{name} not present at commit {commit[:12]} in {self.root}"
             )

--- a/packages/memtomem/tests-js/wiki.test.mjs
+++ b/packages/memtomem/tests-js/wiki.test.mjs
@@ -417,6 +417,43 @@ describe('wiki.js install/update (E-3, dev tier)', () => {
     expect(errToast.msg).not.toContain(RAW_SERVER_MSG);
   });
 
+  it('a wiki_uncommitted install (#1643) shows the localized copy, not the raw envelope', async () => {
+    const dom = await bootDev();
+    const toasts = [];
+    dom.window.showToast = (msg, kind) => { toasts.push({ msg, kind }); };
+    const RAW_SERVER_MSG =
+      'skills/alpha has uncommitted changes in the wiki (install is commit-true '
+      + "and records HEAD's bytes only); commit them and retry";
+    const base = dom.window.fetch;
+    dom.window.fetch = async (input, init = {}) => {
+      const url = typeof input === 'string' ? input : input?.url;
+      const method = ((init && init.method) || 'GET').toUpperCase();
+      if (method === 'POST' && (url || '').split('?')[0] === '/api/context/skills/alpha/install') {
+        return {
+          ok: false, status: 409,
+          json: async () => ({
+            detail: {
+              error_kind: 'conflict',
+              reason_code: 'wiki_uncommitted',
+              message: RAW_SERVER_MSG,
+            },
+          }),
+          text: async () => '',
+        };
+      }
+      return base(input, init);
+    };
+    await dom.window.loadWiki();
+    await dom.window.loadWikiDetail('skills', 'alpha');
+    await dom.window._onWikiInstallOrUpdate('install');
+    const errToast = toasts.find((x) => x.kind === 'error');
+    expect(errToast).toBeTruthy();
+    expect(errToast.msg).toBe(dom.window.t('settings.ctx.wiki_install_uncommitted', {
+      type: dom.window._wikiTypeLabel('skills'), name: 'alpha',
+    }));
+    expect(errToast.msg).not.toContain(RAW_SERVER_MSG);
+  });
+
   it('rapid double-click on install fires exactly one POST (double-submit guard)', async () => {
     const dom = await bootDev();
     const posts = recordingCtxFetch(dom.window);

--- a/packages/memtomem/tests/test_context_install.py
+++ b/packages/memtomem/tests/test_context_install.py
@@ -25,6 +25,7 @@ from memtomem.context._names import InvalidNameError
 from memtomem.context.install import (
     AlreadyInstalledError,
     AssetNotFoundError,
+    UncommittedAssetError,
     install_agent,
     install_command,
     install_skill,
@@ -37,20 +38,29 @@ from memtomem.wiki.store import WikiNotFoundError, WikiStore
 # ── helpers ──────────────────────────────────────────────────────────────
 
 
-def _seed_skill(wiki_root_path: Path, name: str, files: dict[str, bytes]) -> None:
-    """Drop a skill into an initialized wiki and commit."""
+def _write_skill_files(wiki_root_path: Path, name: str, files: dict[str, bytes]) -> None:
+    """Drop skill files into the wiki working tree WITHOUT committing."""
     skill_dir = wiki_root_path / "skills" / name
-    skill_dir.mkdir(parents=True)
+    skill_dir.mkdir(parents=True, exist_ok=True)
     for relpath, data in files.items():
         target = skill_dir / relpath
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(data)
+
+
+def _git_commit_all(wiki_root_path: Path, message: str) -> None:
     subprocess.run(["git", "-C", str(wiki_root_path), "add", "."], check=True, capture_output=True)
     subprocess.run(
-        ["git", "-C", str(wiki_root_path), "commit", "-m", f"add {name}"],
+        ["git", "-C", str(wiki_root_path), "commit", "-m", message],
         check=True,
         capture_output=True,
     )
+
+
+def _seed_skill(wiki_root_path: Path, name: str, files: dict[str, bytes]) -> None:
+    """Drop a skill into an initialized wiki and commit."""
+    _write_skill_files(wiki_root_path, name, files)
+    _git_commit_all(wiki_root_path, f"add {name}")
 
 
 def _initialized_wiki(wiki_root_path: Path) -> WikiStore:
@@ -194,13 +204,15 @@ def test_install_skips_dsstore_and_pycache(wiki_root: Path, tmp_path: Path) -> N
 def test_install_skips_symlinks_in_source(
     wiki_root: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """copy_tree_atomic refuses to dereference symlinks — would silently
-    leak out-of-tree bytes (e.g., /etc/passwd) into the project otherwise."""
+    """A committed symlink is never dereferenced OR materialized: pre-#1643
+    the worktree copier skipped it (dereferencing would leak out-of-tree
+    bytes, e.g. /etc/passwd); the commit-true extractor must not regress
+    into writing the link's *target path* as file content either."""
     _initialized_wiki(wiki_root)
     skill_dir = wiki_root / "skills" / "foo"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text("real", encoding="utf-8")
-    # Dangling symlink — entry.is_symlink() fires regardless of target validity.
+    # Dangling symlink — mode 120000 in the commit regardless of target validity.
     (skill_dir / "danger.md").symlink_to("/nonexistent/target")
     subprocess.run(["git", "-C", str(wiki_root), "add", "."], check=True, capture_output=True)
     subprocess.run(
@@ -210,7 +222,7 @@ def test_install_skips_symlinks_in_source(
     )
     project = tmp_path
 
-    with caplog.at_level("WARNING", logger="memtomem.context._atomic"):
+    with caplog.at_level("WARNING", logger="memtomem.wiki.store"):
         install_skill(project, "foo")
 
     dest = project / ".memtomem" / "skills" / "foo"
@@ -661,3 +673,202 @@ def test_install_interrupted_before_lockfile_hint_breaks_circle(
     # hint pair really was a closed loop.
     with pytest.raises(NotInstalledError):
         update_skill(project, "foo")
+
+
+# ── commit-true install (#1643) ──────────────────────────────────────────
+#
+# Single-asset install extracts bytes from git objects at HEAD and refuses
+# when the asset's OWN worktree state differs from HEAD — the pin must
+# always reproduce the installed bytes. Dirt outside the asset never blocks.
+
+
+def _assert_zero_residue(project: Path, name: str) -> None:
+    """A refusal must leave no dest bytes, no type dir, and no lock entry."""
+    assert not (project / ".memtomem" / "skills" / name).exists()
+    lock_json = project / ".memtomem" / "lock.json"
+    if lock_json.exists():
+        assert Lockfile.at(project).read_entry("skills", name) is None
+
+
+def test_install_refuses_modified_tracked_file(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"v2 uncommitted\n")
+
+    with pytest.raises(UncommittedAssetError) as excinfo:
+        install_skill(tmp_path, "foo")
+
+    msg = str(excinfo.value)
+    assert "differs from HEAD" in msg
+    assert "SKILL.md" in msg
+    # Runnable commit hint + the raw-git fallback (the hinted command can
+    # only commit canonical/vendor paths — R3).
+    assert "`mm wiki skill commit foo --canonical`" in msg
+    assert "git directly" in msg
+    _assert_zero_residue(tmp_path, "foo")
+
+
+def test_install_refuses_untracked_file_inside_asset(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    (wiki_root / "skills" / "foo" / "notes.md").write_bytes(b"scratch\n")
+
+    with pytest.raises(UncommittedAssetError, match="notes.md"):
+        install_skill(tmp_path, "foo")
+    _assert_zero_residue(tmp_path, "foo")
+
+
+def test_install_refuses_worktree_deletion(wiki_root: Path, tmp_path: Path) -> None:
+    """Deleted-in-worktree files are dirt too: installing would resurrect
+    content the user just removed from the wiki they're looking at."""
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "foo", {"SKILL.md": b"v1\n", "scripts/run.sh": b"#!/bin/sh\n"})
+    (wiki_root / "skills" / "foo" / "scripts" / "run.sh").unlink()
+
+    with pytest.raises(UncommittedAssetError, match="run.sh"):
+        install_skill(tmp_path, "foo")
+    _assert_zero_residue(tmp_path, "foo")
+
+
+def test_install_refuses_entirely_untracked_asset(wiki_root: Path, tmp_path: Path) -> None:
+    """The #1643 repro: a never-committed asset must classify as
+    UNCOMMITTED (with the commit hint), not as absent — pre-fix this
+    installed the worktree bytes while pinning a HEAD that lacked them."""
+    _initialized_wiki(wiki_root)  # scaffold commit exists; asset is not in it
+    _write_skill_files(wiki_root, "foo", {"SKILL.md": b"never committed\n"})
+
+    with pytest.raises(UncommittedAssetError) as excinfo:
+        install_skill(tmp_path, "foo")
+
+    msg = str(excinfo.value)
+    assert "never been committed" in msg
+    assert "`mm wiki skill commit foo --canonical`" in msg
+    _assert_zero_residue(tmp_path, "foo")
+
+
+def test_install_dirt_in_other_asset_does_not_block(wiki_root: Path, tmp_path: Path) -> None:
+    """The gate is asset-scoped: a dirty sibling asset (or any other wiki
+    dirt) must not stop a clean asset from installing."""
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "foo", {"SKILL.md": b"clean\n"})
+    _seed_skill(wiki_root, "bar", {"SKILL.md": b"v1\n"})
+    (wiki_root / "skills" / "bar" / "SKILL.md").write_bytes(b"bar dirty\n")
+    _write_skill_files(wiki_root, "baz", {"SKILL.md": b"untracked sibling\n"})
+
+    result = install_skill(tmp_path, "foo")
+
+    assert result.files_written == 1
+    dest = tmp_path / ".memtomem" / "skills" / "foo"
+    assert (dest / "SKILL.md").read_bytes() == b"clean\n"
+
+
+def test_install_ignores_skip_filtered_dirt(wiki_root: Path, tmp_path: Path) -> None:
+    """Untracked files the extractor would never copy (.DS_Store, *.bak)
+    are not dirt. The wiki scaffold .gitignore is stripped so the rows
+    actually reach the is_copy_skipped_rel filter (legacy-clone shape)
+    instead of being hidden by git ignore rules."""
+    store = _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "foo", {"SKILL.md": b"clean\n"})
+    gitignore = store.root / ".gitignore"
+    if gitignore.exists():
+        gitignore.write_text("", encoding="utf-8")
+        _git_commit_all(wiki_root, "strip scaffold ignores")
+    exclude = store.root / ".git" / "info" / "exclude"
+    if exclude.exists():
+        exclude.write_text("", encoding="utf-8")
+    (wiki_root / "skills" / "foo" / ".DS_Store").write_bytes(b"\x00\x00")
+    (wiki_root / "skills" / "foo" / "SKILL.md.bak").write_bytes(b"old\n")
+    # Sanity: the rows are really visible to git status now.
+    assert store.asset_uncommitted_paths("skills", "foo")
+
+    result = install_skill(tmp_path, "foo")
+
+    assert result.files_written == 1
+    dest = tmp_path / ".memtomem" / "skills" / "foo"
+    assert not (dest / ".DS_Store").exists()
+    assert not (dest / "SKILL.md.bak").exists()
+
+
+def test_install_commit_true_digest_parity(wiki_root: Path, tmp_path: Path) -> None:
+    """The lockfile digests describe exactly the bytes at the pinned commit
+    — the literal #1643 contract (pin reproduces the installed bytes)."""
+    store = _initialized_wiki(wiki_root)
+    _seed_skill(
+        wiki_root,
+        "foo",
+        {"SKILL.md": b"# foo\n", "scripts/run.sh": b"#!/bin/sh\necho hi\n"},
+    )
+
+    result = install_skill(tmp_path, "foo")
+
+    entry = Lockfile.at(tmp_path).read_entry("skills", "foo")
+    assert entry is not None
+    pin = entry["wiki_commit"]
+    assert pin == result.wiki_commit
+    expected = {
+        rel: hashlib.sha256(store.read_asset_file_at_commit(pin, "skills", "foo", rel)).hexdigest()
+        for rel in store.asset_files_at_commit(pin, "skills", "foo")
+    }
+    assert entry["digests"] == expected
+    assert entry["files_commit"] == pin
+
+
+def test_install_gate_a_hint_is_install_flavored(wiki_root: Path, tmp_path: Path) -> None:
+    """The pinned Gate A scan runs before a FIRST extraction here — its
+    default restore-flavored hint ("re-pin … before restoring") would
+    misdirect; install passes its own remediation wording."""
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "leak", {"SKILL.md": b"# leak\n" + SECRET.encode() + b"\n"})
+
+    with pytest.raises(PrivacyBlockedError) as excinfo:
+        install_skill(tmp_path, "leak")
+
+    msg = excinfo.value.message
+    assert "re-run install" in msg
+    assert "restoring" not in msg
+    _assert_zero_residue(tmp_path, "leak")
+
+
+@pytest.mark.requires_symlinks
+def test_install_symlink_only_asset_is_empty_not_absent(wiki_root: Path, tmp_path: Path) -> None:
+    """A committed asset whose entries are ALL skipped (symlink-only) is an
+    empty extraction, not AssetNotFoundError — the empty-before-mode-filter
+    distinction (Codex gate Major-1)."""
+    _initialized_wiki(wiki_root)
+    skill_dir = wiki_root / "skills" / "linky"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "only.md").symlink_to("/nonexistent/target")
+    subprocess.run(["git", "-C", str(wiki_root), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root), "commit", "-m", "add symlink-only asset"],
+        check=True,
+        capture_output=True,
+    )
+
+    result = install_skill(tmp_path, "linky")
+
+    assert result.files_written == 0
+    dest = tmp_path / ".memtomem" / "skills" / "linky"
+    assert dest.is_dir()
+    assert not (dest / "only.md").exists()
+    entry = Lockfile.at(tmp_path).read_entry("skills", "linky")
+    assert entry is not None
+    assert entry["digests"] == {}
+
+
+def test_cli_install_uncommitted_message(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    """CLI boundary: UncommittedAssetError maps to exit 1 with the runnable
+    commit hint — never a traceback."""
+    _initialized_wiki(wiki_root)
+    _write_skill_files(wiki_root, "draft", {"SKILL.md": b"wip\n"})
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["install", "skill", "draft"])
+
+    assert result.exit_code == 1, result.output
+    assert "never been committed" in result.output
+    assert "mm wiki skill commit draft --canonical" in result.output
+    assert "Traceback" not in result.output

--- a/packages/memtomem/tests/test_context_install_all.py
+++ b/packages/memtomem/tests/test_context_install_all.py
@@ -32,6 +32,7 @@ from memtomem.context.install import (
     install_skill,
     install_agent,
     install_command,
+    update_skill,
 )
 from memtomem.context.lockfile import Lockfile
 from memtomem.wiki.store import WikiStore
@@ -274,25 +275,28 @@ def test_yes_force_emits_destructive_warning(wiki_root: Path, tmp_path: Path, mo
 def test_clean_install_off_dirty_wiki_survives_all_force(
     wiki_root: Path, tmp_path: Path, monkeypatch
 ) -> None:
-    """Regression: a clean row installed off a *dirty* wiki working tree must not
-    be silently swapped by ``install --all --force``.
+    """Regression: a clean row whose recorded bytes diverge from its pin must
+    not be silently swapped by ``install --all --force``.
 
-    A single install copies the wiki WORKING TREE but pins HEAD (ADR-0008's
-    accepted ``wiki_commit`` provenance imprecision), so a clean install taken
-    off a dirty wiki holds bytes the pin never described. ``--force`` used to
-    re-extract the pin over such a clean row with NO ``.bak`` — a silent
-    destructive swap. It must now leave the row untouched (the recorded digests
-    differ from the pin's bytes); ``--force`` re-extraction is reserved for
-    dirty/unprovable rows, which always get a ``.bak``.
+    ``mm context update`` copies the wiki WORKING TREE but pins HEAD (ADR-0008's
+    accepted ``wiki_commit`` provenance imprecision — since #1643 the single
+    install is commit-true and can no longer mint such entries, so the update
+    path builds the divergence here), so an update taken off a dirty wiki holds
+    bytes the pin never described. ``--force`` used to re-extract the pin over
+    such a clean row with NO ``.bak`` — a silent destructive swap. It must now
+    leave the row untouched (the recorded digests differ from the pin's bytes);
+    ``--force`` re-extraction is reserved for dirty/unprovable rows, which
+    always get a ``.bak``.
     """
     _initialized_wiki(wiki_root)
-    # Commit v1, then edit the wiki WORKING TREE without committing: HEAD still
-    # points at the v1 commit, but the working tree now holds v2 (wiki dirty).
-    pin = _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v1\n"})
-    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"working-tree-v2\n")
-    # The single install copies the working tree (v2) yet pins HEAD (v1): the
-    # recorded digests describe bytes the pin's commit does not contain.
+    _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v0\n"})
     install_skill(tmp_path, "foo")
+    # Advance HEAD to v1, then edit the WORKING TREE without committing: the
+    # update below copies the working tree (v2) yet pins HEAD (v1) — the
+    # recorded digests describe bytes the pin's commit does not contain.
+    pin = _advance_wiki(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v1\n"})
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"working-tree-v2\n")
+    update_skill(tmp_path, "foo")
     dest = tmp_path / ".memtomem" / "skills" / "foo" / "SKILL.md"
     assert dest.read_bytes() == b"working-tree-v2\n"
     lock_doc = json.loads((tmp_path / ".memtomem" / "lock.json").read_text())
@@ -321,22 +325,27 @@ def test_clean_empty_install_off_dirty_wiki_survives_all_force(
     """A VALID EMPTY recorded digest map (``digests={}``) must be honored, not
     treated as "no digests" (Codex gate).
 
-    If the wiki working tree has no copyable file at single-install time, the
-    install records ``digests={}`` (a valid empty map, not ``None``) while the
-    pin's commit still contains files. ``install --all --force`` must not fall
-    through and silently resurrect the pin's files over the recorded-empty dest
-    with no ``.bak``. The guard distinguishes ``{}`` (honor: divergence) from
-    ``None`` (pre-digest: legacy re-extract).
+    If the wiki working tree has no copyable file at update time, the update
+    records ``digests={}`` (a valid empty map, not ``None``) while the pin's
+    commit still contains files (post-#1643 the commit-true single install
+    can't produce this shape, so the worktree-copying update path builds it).
+    ``install --all --force`` must not fall through and silently resurrect the
+    pin's files over the recorded-empty dest with no ``.bak``. The guard
+    distinguishes ``{}`` (honor: divergence) from ``None`` (pre-digest: legacy
+    re-extract).
     """
     _initialized_wiki(wiki_root)
-    # The pinned commit contains SKILL.md...
-    _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"committed\n"})
+    _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v0\n"})
+    install_skill(tmp_path, "foo")
+    # The pinned commit (v1) contains SKILL.md...
+    _advance_wiki(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v1\n"})
     # ...but the dirty working tree has no copyable file (only a skip-filtered
-    # ``.bak``), so the single install copies zero files and records digests={}.
+    # ``.bak``), so the update copies zero files, reconciles the dest file
+    # away, and records digests={} while pinning v1.
     asset = wiki_root / "skills" / "foo"
     (asset / "SKILL.md").unlink()
     (asset / "SKILL.md.bak").write_bytes(b"skipped\n")
-    install_skill(tmp_path, "foo")
+    update_skill(tmp_path, "foo")
     dest = tmp_path / ".memtomem" / "skills" / "foo"
     lock_doc = json.loads((tmp_path / ".memtomem" / "lock.json").read_text())
     assert lock_doc["skills"]["foo"]["files"] == []
@@ -353,6 +362,38 @@ def test_clean_empty_install_off_dirty_wiki_survives_all_force(
     assert not (dest / "SKILL.md.bak").exists()
     assert "1 installed" not in result.output
     assert "skipped" in result.output
+
+
+@pytest.mark.requires_symlinks
+def test_install_all_symlink_only_asset_restores_empty(
+    wiki_root: Path, tmp_path: Path, monkeypatch
+) -> None:
+    """Codex gate Major-1 twin: a pin whose asset holds ONLY skipped entries
+    (symlink-only) restores as an empty tree — the asset exists at the pin,
+    so it must not classify as absent/orphan, and the symlink's target path
+    must not be materialized as file content."""
+    _initialized_wiki(wiki_root)
+    asset = wiki_root / "skills" / "linky"
+    asset.mkdir(parents=True)
+    (asset / "only.md").symlink_to("/nonexistent/target")
+    subprocess.run(["git", "-C", str(wiki_root), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root), "commit", "-m", "add symlink-only asset"],
+        check=True,
+        capture_output=True,
+    )
+    install_skill(tmp_path, "linky")
+    dest = tmp_path / ".memtomem" / "skills" / "linky"
+    shutil.rmtree(dest)
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["install", "--all", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "1 installed" in result.output
+    assert dest.is_dir()
+    assert not (dest / "only.md").exists()
 
 
 # ── orphan / error paths ────────────────────────────────────────────────
@@ -641,18 +682,22 @@ def test_legacy_row_with_stale_dest_only_file_noops_under_force(
 def test_legacy_clean_install_off_dirty_wiki_survives_all_force(
     wiki_root: Path, tmp_path: Path, monkeypatch
 ) -> None:
-    """The #1512 harmful case: a PRE-DIGEST legacy clean row installed off a
-    dirty wiki working tree must not be silently swapped by
+    """The #1512 harmful case: a PRE-DIGEST legacy clean row whose bytes
+    diverge from its pin must not be silently swapped by
     ``install --all --force``.
 
-    Same shape as ``test_clean_install_off_dirty_wiki_survives_all_force``,
-    but with the digest keys stripped: before #1512 the ``recorded_digests is
-    not None`` gate let exactly this row fall through to a silent, ``.bak``-less
-    re-extract. The clean-dest hash now stands in for the missing recorded map."""
+    Same shape as ``test_clean_install_off_dirty_wiki_survives_all_force``
+    (divergence minted via the worktree-copying update path — post-#1643 the
+    commit-true single install can't produce it), but with the digest keys
+    stripped: before #1512 the ``recorded_digests is not None`` gate let
+    exactly this row fall through to a silent, ``.bak``-less re-extract. The
+    clean-dest hash now stands in for the missing recorded map."""
     _initialized_wiki(wiki_root)
-    pin = _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v1\n"})
-    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"working-tree-v2\n")
+    _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v0\n"})
     install_skill(tmp_path, "foo")
+    pin = _advance_wiki(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v1\n"})
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"working-tree-v2\n")
+    update_skill(tmp_path, "foo")
     dest = tmp_path / ".memtomem" / "skills" / "foo" / "SKILL.md"
     assert dest.read_bytes() == b"working-tree-v2\n"
     lock_path = _strip_to_legacy_entry(tmp_path, "skills", "foo")

--- a/packages/memtomem/tests/test_web_routes_context_mutations.py
+++ b/packages/memtomem/tests/test_web_routes_context_mutations.py
@@ -165,6 +165,23 @@ async def test_install_already_installed_is_409(client, seeded_wiki, project_roo
 
 
 @pytest.mark.asyncio
+async def test_install_uncommitted_wiki_is_409(client, seeded_wiki, project_root: Path) -> None:
+    """Commit-true install (#1643): an asset whose wiki working tree differs
+    from HEAD refuses with 409 ``wiki_uncommitted`` and a fixed message —
+    the engine text embeds the absolute wiki root and must not leak."""
+    (seeded_wiki / "skills" / "alpha" / "SKILL.md").write_text(
+        _SKILL_BODY + "\nUncommitted edit.\n", encoding="utf-8"
+    )
+    resp = await client.post("/api/context/skills/alpha/install")
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["reason_code"] == "wiki_uncommitted"
+    assert str(seeded_wiki) not in resp.text
+    # Refusal left no residue in the project tree.
+    assert not (project_root / ".memtomem" / "skills" / "alpha").exists()
+    assert _lock_entry(project_root, "skills", "alpha") is None
+
+
+@pytest.mark.asyncio
 async def test_install_agent_and_command(client, seeded_wiki, project_root: Path) -> None:
     assert (await client.post("/api/context/agents/beta/install")).status_code == 200
     assert (await client.post("/api/context/commands/gamma/install")).status_code == 200

--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -303,6 +303,125 @@ class TestIsDirty:
             store.is_dirty()
 
 
+class TestAssetUncommittedPaths:
+    """Direct pins for the porcelain ``-z`` parser behind the #1643 install
+    gate — a subtly-wrong parser either misses same-asset dirt (silent
+    unreproducible pin) or false-blocks unrelated assets (Codex gate
+    Major-2), so the row shapes are exercised here, not only through the
+    CLI."""
+
+    def _store(self, wiki_root: Path, files: dict[str, bytes]) -> WikiStore:
+        store = WikiStore.at_default()
+        store.init()
+        _seed_skill(wiki_root, "foo", files)
+        return store
+
+    def test_clean_asset_is_empty(self, wiki_root: Path) -> None:
+        store = self._store(wiki_root, {"SKILL.md": b"v1\n"})
+        assert store.asset_uncommitted_paths("skills", "foo") == []
+
+    def test_modified_tracked_file(self, wiki_root: Path) -> None:
+        store = self._store(wiki_root, {"SKILL.md": b"v1\n"})
+        (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"v2\n")
+        assert store.asset_uncommitted_paths("skills", "foo") == ["skills/foo/SKILL.md"]
+
+    def test_untracked_file_inside_asset(self, wiki_root: Path) -> None:
+        store = self._store(wiki_root, {"SKILL.md": b"v1\n"})
+        (wiki_root / "skills" / "foo" / "notes.md").write_bytes(b"wip\n")
+        assert store.asset_uncommitted_paths("skills", "foo") == ["skills/foo/notes.md"]
+
+    def test_entirely_untracked_asset_lists_per_file(self, wiki_root: Path) -> None:
+        """``-uall`` expands the untracked dir into file rows — without it
+        git collapses to one ``?? skills/bar/`` row and the per-file skip
+        filter downstream has nothing to work with."""
+        store = self._store(wiki_root, {"SKILL.md": b"v1\n"})
+        bar = wiki_root / "skills" / "bar"
+        (bar / "scripts").mkdir(parents=True)
+        (bar / "SKILL.md").write_bytes(b"new\n")
+        (bar / "scripts" / "run.sh").write_bytes(b"#!/bin/sh\n")
+        assert store.asset_uncommitted_paths("skills", "bar") == [
+            "skills/bar/SKILL.md",
+            "skills/bar/scripts/run.sh",
+        ]
+
+    def test_deleted_worktree_file(self, wiki_root: Path) -> None:
+        store = self._store(wiki_root, {"SKILL.md": b"v1\n", "extra.md": b"x\n"})
+        (wiki_root / "skills" / "foo" / "extra.md").unlink()
+        assert store.asset_uncommitted_paths("skills", "foo") == ["skills/foo/extra.md"]
+
+    def test_dirt_outside_asset_is_invisible(self, wiki_root: Path) -> None:
+        """Pathspec scoping: sibling-asset and wiki-root dirt never leak in."""
+        store = self._store(wiki_root, {"SKILL.md": b"v1\n"})
+        _seed_skill(wiki_root, "bar", {"SKILL.md": b"v1\n"})
+        (wiki_root / "skills" / "bar" / "SKILL.md").write_bytes(b"dirty\n")
+        (wiki_root / "stray.txt").write_bytes(b"wip\n")
+        assert store.asset_uncommitted_paths("skills", "foo") == []
+
+    def test_staged_rename_within_asset_reports_both_sides(self, wiki_root: Path) -> None:
+        """A porcelain rename row is TWO NUL tokens (``XY new\\0orig``) — a
+        naive splitter would misread the orig token as the next row."""
+        store = self._store(wiki_root, {"SKILL.md": b"v1\n", "a.md": b"a\n"})
+        subprocess.run(
+            ["git", "-C", str(wiki_root), "mv", "skills/foo/a.md", "skills/foo/b.md"],
+            check=True,
+            capture_output=True,
+        )
+        # A second dirty file AFTER the rename row exercises the token-stream
+        # resync: misparse of the two-token row would swallow or garble it.
+        (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"v2\n")
+        paths = store.asset_uncommitted_paths("skills", "foo")
+        assert "skills/foo/SKILL.md" in paths
+        # Both rename sides are dirt (b.md appears, a.md disappears at install).
+        assert "skills/foo/b.md" in paths
+        assert "skills/foo/a.md" in paths
+
+    def test_staged_rename_out_of_asset_is_dirt(self, wiki_root: Path) -> None:
+        """Renaming a tracked file OUT of the asset must classify as dirt —
+        the asset at HEAD still has it, the worktree doesn't."""
+        store = self._store(wiki_root, {"SKILL.md": b"v1\n", "a.md": b"a\n"})
+        subprocess.run(
+            ["git", "-C", str(wiki_root), "mv", "skills/foo/a.md", "escaped.md"],
+            check=True,
+            capture_output=True,
+        )
+        paths = store.asset_uncommitted_paths("skills", "foo")
+        assert any(p.endswith("a.md") for p in paths), paths
+        # The out-of-asset side must NOT be reported.
+        assert not any("escaped" in p for p in paths), paths
+
+    def test_staged_rename_into_asset_is_dirt(self, wiki_root: Path) -> None:
+        store = self._store(wiki_root, {"SKILL.md": b"v1\n"})
+        (wiki_root / "incoming.md").write_bytes(b"in\n")
+        subprocess.run(
+            ["git", "-C", str(wiki_root), "add", "incoming.md"], check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "-C", str(wiki_root), "commit", "-m", "add incoming"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(wiki_root), "mv", "incoming.md", "skills/foo/incoming.md"],
+            check=True,
+            capture_output=True,
+        )
+        paths = store.asset_uncommitted_paths("skills", "foo")
+        assert "skills/foo/incoming.md" in paths, paths
+
+    def test_non_ascii_paths_round_trip(self, wiki_root: Path) -> None:
+        """``-z`` bytes framing: a Korean filename must come back verbatim,
+        not C-quoted (the ``core.quotePath`` default would octal-escape it
+        in line-oriented porcelain and break the prefix match)."""
+        store = self._store(wiki_root, {"SKILL.md": b"v1\n"})
+        (wiki_root / "skills" / "foo" / "한글노트.md").write_bytes("메모\n".encode())
+        assert store.asset_uncommitted_paths("skills", "foo") == ["skills/foo/한글노트.md"]
+
+    def test_raises_when_wiki_absent(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        with pytest.raises(WikiNotFoundError):
+            store.asset_uncommitted_paths("skills", "foo")
+
+
 # ── helpers for commit-bound tests ──────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Makes single-asset `mm context install` **commit-true**: bytes are extracted from the wiki's git objects at HEAD (the same mechanism `install --all`'s pinned restore already uses), so the lockfile pin always reproduces the installed bytes. Previously install copied the wiki **worktree** while pinning **HEAD** — installing a dirty or never-committed asset silently recorded a pin that didn't contain (or didn't match) the installed bytes, `status` looked healthy, `update` said "unchanged", and a `git clean` in the wiki could destroy the only source of the installed content.

Closes #1643

## Behavior changes

- **Commit-true extraction** — `_install_asset` now uses `WikiStore.copy_asset_at_commit(HEAD)`; the recorded `digests`/`files_commit` describe exactly the committed bytes.
- **Asset-scoped refusal** — new `WikiStore.asset_uncommitted_paths()` (`git status --porcelain -z -uall -- <type>/<name>/`); any same-asset dirt (modified/deleted tracked files, untracked files, or an entirely uncommitted asset) refuses with the new typed `UncommittedAssetError`, carrying a runnable `mm wiki <type> commit <name> --canonical` hint plus a raw-git fallback (that command can't commit scripts/deletions). Dirt elsewhere in the wiki does **not** block.
- **Gate A at the pin** — the privacy scan now reads git objects at HEAD (`_gate_a_scan_pinned_asset`, with an install-flavored remediation hint), so scan set == write set with no scan→write TOCTOU.
- **Symlink materialization bugfix (bundled)** — `WikiStore.asset_files_at_commit` is now mode-aware (`ls-tree -r -z` full output): committed symlinks (120000) and gitlinks (160000) are skipped with a warning. Previously the pinned `install --all` restore path wrote the symlink's *target path string* as file content. Asset-absent is judged **before** the mode filter, so a symlink-only asset extracts as an empty tree instead of raising `AssetNotFoundError`.
- **Surfaces** — CLI: `UncommittedAssetError` translated to exit 1; web: fixed-message 409 `wiki_uncommitted` (engine text embeds the wiki root and must not leak) + localized toast (en/ko) in the Wiki panel.
- **Out of scope** — `mm context update` still copies the worktree (and its `_WIKI_DIRTY_WARN` wording is inaccurate); tracked separately in #1652.

## Tests

- Engine: refuse on modified/untracked/deleted/never-committed; other-asset dirt passes; skip-filtered dirt (`.DS_Store`, legacy `.bak`) not treated as dirt; digest parity against `read_asset_file_at_commit`; install-flavored Gate A hint; symlink-only asset empty-not-absent (single + `--all`); zero-residue on every refusal.
- Parser: direct porcelain `-z` pins in `test_wiki_store.py` — staged rename within/into/out of the asset (two-token row resync), non-ASCII (Korean) paths, per-file `-uall` expansion, pathspec scoping.
- Surfaces: CLI exit-1 message; web 409 `wiki_uncommitted` (no wiki-path leak, zero residue); vitest toast localization.
- Reworked the three `install --all` off-dirty-wiki divergence fixtures to mint divergence via the (still worktree-copying) update path — the data-safety no-op they protect stays fully in force for legacy/update-minted entries.
- Full suite `-m "not ollama"` green; ruff clean; mypy clean on touched modules; live e2e in an isolated HOME reproduced the issue scenario and verified refuse → commit → install → status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
