### PR TITLE
fix(context): make update commit-true (#1652)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,25 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   never contained them. As part of the same fix, committed symlinks are now
   skipped (with a warning) during commit extraction — previously the pinned
   `install --all` restore path materialized the symlink's *target path* as
-  file content. `mm context update` still copies the working tree; tracked
-  as a follow-up.
+  file content.
+- **`mm context update` is commit-true** (#1652) — update (single asset and
+  `--all`) now extracts from the wiki's git objects at HEAD like install
+  (#1643), closing the same unreproducible-pin defect on the last verb that
+  had it: previously update copied the dirty worktree bytes while pinning
+  HEAD. A write refuses with `UncommittedAssetError` (CLI, also on `--all`
+  and `--dry-run`, which exit non-zero) / HTTP 409 `wiki_uncommitted` (web)
+  when the asset's wiki working tree differs from HEAD; `--force` does NOT
+  bypass this (it only overrides project-side edits), and dirt elsewhere in
+  the wiki does not block. A no-op update (pin already at HEAD) still
+  succeeds and prints an asset-scoped note when the asset has uncommitted
+  wiki edits. The repo-wide `_WIKI_DIRTY_WARN` stderr warning is removed —
+  its wording ("using HEAD which doesn't include them") described the
+  opposite of what update actually did. Behavior change: a pin already at
+  HEAD with the asset directory deleted from the wiki worktree now reports
+  `unchanged` (exit 0) instead of "not in wiki" — the no-op short-circuit
+  runs before the presence gate because nothing would be written. With both
+  verbs commit-true, `install --all --force`'s data-safety no-op now
+  protects legacy-lockfile rows only; no verb can mint pin≠bytes entries.
 
 ### Added
 

--- a/docs/adr/0008-wiki-layer.md
+++ b/docs/adr/0008-wiki-layer.md
@@ -1,6 +1,6 @@
 # ADR-0008: Wiki layer for shared canonical artifacts
 
-**Status:** Accepted (PR-A/B/C/D/E merged — read-only browser, dev-tier override-seed, and dev-tier project install/update shipped; the in-browser canonical/override editor + isolated commit affordance also shipped, specified in ADR-0027 — see PR Breakdown; amended 2026-07-04: single-asset install is commit-true, #1643)
+**Status:** Accepted (PR-A/B/C/D/E merged — read-only browser, dev-tier override-seed, and dev-tier project install/update shipped; the in-browser canonical/override editor + isolated commit affordance also shipped, specified in ADR-0027 — see PR Breakdown; amended 2026-07-04: single-asset install and update are commit-true, #1643/#1652)
 **Date:** 2026-04-30 (amended 2026-07-04)
 **Context:** Context gateway today is a per-project canonical → multi-runtime
 fan-out router (ADR-0001). Users with several projects must re-author the
@@ -242,14 +242,15 @@ without a valid manifest degrade to the pre-manifest behavior
 `digests` / `digests_installed_at` (added with the #1247 id 15
 content-digest work) record the SHA-256 of **the bytes the writing
 operation put into dest** — content identity of the install, not commit
-provenance (update copies from the wiki *working tree*; the digest
-map inherits exactly the pre-existing `wiki_commit` provenance
-imprecision and adds none. **Amended 2026-07-04, #1643:** single-asset
-*install* is now commit-true — it extracts the asset's bytes from git
-objects at HEAD and refuses when the asset's worktree state differs
-from HEAD, so install-minted digests carry exact commit provenance;
-the imprecision remains only for update-minted and legacy entries,
-which `install --all`'s data-safety no-op continues to protect). The algorithm is fixed at SHA-256; an
+provenance (historically: the pre-commit-true verbs copied from the wiki
+*working tree*; the digest map inherited exactly the pre-existing
+`wiki_commit` provenance imprecision and added none. **Amended
+2026-07-04, #1643/#1652:** single-asset *install* and *update* are now
+commit-true — both extract the asset's bytes from git objects at HEAD
+and refuse when the asset's worktree state differs from HEAD, so
+newly-minted digests carry exact commit provenance; the imprecision
+remains only for legacy entries in existing lockfiles, which
+`install --all`'s data-safety no-op continues to protect). The algorithm is fixed at SHA-256; an
 algorithm change is a NEW key name, not a value prefix. Hashes are
 computed from the in-memory bytes the copier wrote, never from a re-read
 of dest (a re-read would bless a concurrent edit — the TOCTOU this map

--- a/docs/adr/0027-in-browser-wiki-editor.md
+++ b/docs/adr/0027-in-browser-wiki-editor.md
@@ -106,9 +106,11 @@ This is the fact the "→commit" half of the deferred question exists for:
 
 So an edit that is **saved but not committed** is visible in the editor
 and in `diff`/`lint`, but **does not propagate to any project** until it
-is committed. The CLI already surfaces this (`_WIKI_DIRTY_WARN`: "warning:
-wiki has uncommitted changes; using HEAD which doesn't include them",
-`context_cmd.py:1830`). The editor must make the same gap legible — and a
+is committed. The CLI surfaces this gap asset-scoped (#1643/#1652
+commit-true gates: install/update refuse to write a dirty asset with a
+`mm wiki <type> commit` hint, and a no-op update prints an
+uncommitted-edits note; the earlier repo-wide `_WIKI_DIRTY_WARN` was
+removed by #1652). The editor must make the same gap legible — and a
 Commit affordance is what lets the user close it without a terminal.
 
 ### What already exists to build on
@@ -198,8 +200,8 @@ prior bytes intact:
 
 This preserves the shipped E-2 + ADR-0008:286 "never auto-commit"
 contract bit-for-bit. The dirty→not-yet-fanned-out gap (§Background) is
-surfaced by the dirty badge and a one-line hint reusing the
-`_WIKI_DIRTY_WARN` wording.
+surfaced by the dirty badge and a one-line hint mirroring the CLI's
+asset-scoped uncommitted-edits note (#1652).
 
 ### 3. Commit semantics — explicit, opt-in, dev-tier (the deferred core question)
 

--- a/docs/guides/context-gateway.md
+++ b/docs/guides/context-gateway.md
@@ -113,7 +113,10 @@ wiki (~/.memtomem-wiki)  ──install──▶  project Store (<project>/.memto
   (with a `mm wiki <type> commit` hint) if the asset has uncommitted changes in
   the wiki working tree — commit first, then install.
 - **Update** — `mm context update <type> <name>` refreshes an installed snapshot
-  to the wiki's latest HEAD. Add `--dry-run` to print the would-update /
+  to the wiki's latest HEAD. Update is commit-true like install: it extracts
+  the committed bytes at HEAD, and refuses (with a `mm wiki <type> commit`
+  hint; `--force` does not bypass) if the asset has uncommitted changes in
+  the wiki working tree. Add `--dry-run` to print the would-update /
   unchanged / refuse preview without writing anything (also works with
   `--all`, where it prints the batch table and skips the confirm prompt).
 

--- a/docs/guides/reference/data-config-cli.md
+++ b/docs/guides/reference/data-config-cli.md
@@ -287,7 +287,7 @@ mm wiki skill lint <name>              # CI gate — exits non-zero on errors
 mm wiki skill commit <name> --canonical   # ONE isolated commit of just the canonical path
 cd <your project>                      # wiki is global; install/status are project-scoped
 mm context install skill <name>        # snapshot the wiki asset (at HEAD; commit-true — refuses if the asset has uncommitted wiki changes)
-mm context update skill <name>         # re-snapshot an installed asset after the wiki changed (--all, --force, --yes)
+mm context update skill <name>         # re-snapshot at HEAD (commit-true — refuses if the asset has uncommitted wiki changes; --all, --force, --yes)
 mm context status                      # installed wiki assets + drift (reads the CURRENT project)
 
 # Add-on — seed a vendor override (only when a runtime needs a divergent render):

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -47,8 +47,10 @@ from memtomem.context.install import (
     UncommittedAssetError,
     _apply_pinned_install,
     _apply_update,
+    _asset_dirty_rels,
     _classify_for_all_update,
     _classify_for_install_all,
+    _commit_hint,
     install_agent,
     install_command,
     install_skill,
@@ -1907,7 +1909,43 @@ def install_cmd(
     click.echo(f"  {result.files_written} file(s) copied")
 
 
-_WIKI_DIRTY_WARN = "warning: wiki has uncommitted changes; using HEAD which doesn't include them"
+def _maybe_hint_dirty_noop(wiki: WikiStore, asset_type_plural: str, name: str) -> None:
+    """Asset-scoped stderr note on a no-op update whose wiki asset is dirty (#1652).
+
+    The commit-true gates only protect writes, so a pin-already-at-HEAD
+    update succeeds without them — but a user who just edited the wiki and
+    ran ``update`` would otherwise see a bare "unchanged" and wonder why
+    the edit didn't land. One pathspec-scoped ``git status`` per no-op;
+    dirt outside the asset stays silent (install parity).
+    """
+    if _asset_dirty_rels(wiki, asset_type_plural, name):
+        singular = asset_type_plural.removesuffix("s")
+        click.secho(
+            f"note: {asset_type_plural}/{name} has uncommitted wiki edits; commit "
+            f"them (`mm wiki {singular} commit {name} --canonical`) and re-run "
+            f"update to make them installable",
+            fg="yellow",
+            err=True,
+        )
+
+
+def _dirty_asset_refusal_text(
+    wiki: WikiStore, asset_type_plural: str, name: str, dirty: list[str]
+) -> str:
+    """Refusal copy for the wiki-side dirty gate on the batch/dry-run paths (#1652).
+
+    Mirrors the engine's single-asset ``UncommittedAssetError`` message so
+    both surfaces read identically; ``--force`` is deliberately not offered
+    as a bypass (it only overrides project-side edits, never wiki dirt).
+    """
+    shown = ", ".join(dirty[:5])
+    more = "" if len(dirty) <= 5 else f", +{len(dirty) - 5} more"
+    return (
+        f"{asset_type_plural}/{name}: wiki working tree differs from HEAD for "
+        f"this asset ({len(dirty)} file(s): {shown}{more}); update is "
+        f"commit-true and records HEAD's bytes only (--force only overrides "
+        f"project-side edits) — {_commit_hint(wiki, asset_type_plural, name)}"
+    )
 
 
 @context.command("update")
@@ -1939,7 +1977,8 @@ _WIKI_DIRTY_WARN = "warning: wiki has uncommitted changes; using HEAD which does
     help=(
         "Classify and print the preview only — nothing is written and no "
         "prompt is shown. Exits 0 whenever the preview was computable, "
-        "including rows the real run would refuse."
+        "including project-side rows the real run would refuse; wiki-side "
+        "uncommitted-asset refusals exit non-zero like the real run."
     ),
 )
 def update_cmd(
@@ -1952,37 +1991,48 @@ def update_cmd(
 ) -> None:
     """Refresh an installed wiki asset from the wiki HEAD.
 
+    Commit-true (#1652): bytes are extracted from git objects at HEAD, so
+    a write refuses with a ``mm wiki <type> commit`` hint when the
+    asset's wiki working tree differs from HEAD (``--force`` does NOT
+    bypass this — it only overrides project-side edits). Dirt elsewhere
+    in the wiki never blocks. A no-op (pin already at HEAD) still
+    succeeds and prints an asset-scoped note when the asset has
+    uncommitted wiki edits.
+
     Without ``--all``: refresh in the current project only. No-op when
     the wiki commit pinned in ``.memtomem/lock.json`` already matches
     the wiki HEAD — the lockfile is not touched and ``unchanged`` is
     reported. Refuses to write when local edits are detected, unless
     ``--force`` is passed (each dirty file is preserved as ``<file>.bak``
-    before overwriting with wiki bytes).
+    before overwriting with the pinned bytes).
 
     With ``--all``: classify the asset across every known project, print
     a 4-state preview (update / unchanged / refuse / error), prompt for
-    confirmation, then refresh each project that needs it. ``--yes``
+    confirmation, then refresh each project that needs it. The wiki-side
+    dirty gate fires once per batch, before the prompt, whenever any
+    ``update`` or ``refuse`` row exists (regardless of ``--force`` —
+    single-asset parity; an all-unchanged batch only hints). ``--yes``
     skips the prompt for automation. ``--yes --force`` is the
     automation invariant — destructive batch with WARNING on stderr,
     no prompt.
 
     With ``--dry-run``: print the same 4-state preview and stop — no
-    writes, no prompt. Works with and without ``--all``; a not-installed
-    asset still exits non-zero with the install hint (a dry run of an
-    impossible update fails the way the real run would).
+    writes, no prompt. Works with and without ``--all``. Project-side
+    ``refuse`` rows preview with exit 0; failures the real run could not
+    be forced past — a not-installed asset, or the wiki-side uncommitted
+    gate — exit non-zero the way the real run would.
     """
     root = _find_project_root()
 
-    # Pin wiki + dirty warn — applies to both single-asset and --all paths.
-    # Warn timing: at update entry, BEFORE classification, BEFORE prompt.
+    # Pin wiki once — applies to both single-asset and --all paths. The old
+    # repo-wide dirty WARN that lived here is gone (#1652): wiki-side dirt
+    # is now an asset-scoped hard gate on the write paths (and a no-op
+    # hint), not a repo-wide advisory with inverted wording.
     try:
         wiki = WikiStore.at_default()
         wiki.require_exists()
     except WikiNotFoundError as exc:
         raise click.ClickException(str(exc)) from exc
-
-    if wiki.is_dirty():
-        click.secho(_WIKI_DIRTY_WARN, fg="yellow", err=True)
 
     if all_projects:
         _run_update_all(asset_type, name, root, wiki=wiki, yes=yes, force=force, dry_run=dry_run)
@@ -1999,6 +2049,7 @@ def update_cmd(
         AssetNotFoundError,
         NotInstalledError,
         StaleInstallError,
+        UncommittedAssetError,
         InvalidNameError,
         LockfileError,
         PrivacyScanError,
@@ -2017,6 +2068,7 @@ def update_cmd(
             f"{result.asset_type}/{result.name} unchanged (wiki {result.new_wiki_commit[:12]})",
             fg="cyan",
         )
+        _maybe_hint_dirty_noop(wiki, result.asset_type, result.name)
         return
 
     click.secho(
@@ -2052,10 +2104,15 @@ def _run_update_dry_run_single(
     preview carries the exact gate parity the ``--all`` table already has
     (dirty / flat-layout / unprovable-record, #1247 id 13 family): what
     this prints as ``refuse`` is what the real run would raise as
-    ``StaleInstallError`` — no duplicated gate logic to drift.
+    ``StaleInstallError`` — no duplicated gate logic to drift. The
+    wiki-side uncommitted gate (#1652) exits non-zero instead (the
+    not-installed precedent below: a dry run of an update the real run
+    could not be forced past fails the way the real run would).
     """
     asset_type_plural = f"{asset_type}s"
-    with _translate_to_click(InvalidNameError, AssetNotFoundError, WikiUnbornHeadError):
+    with _translate_to_click(
+        InvalidNameError, AssetNotFoundError, UncommittedAssetError, WikiUnbornHeadError
+    ):
         new_commit, classifications = _classify_for_all_update(
             asset_type_plural,
             name,
@@ -2077,12 +2134,24 @@ def _run_update_dry_run_single(
     _print_classification_table(classifications, asset_type_plural, name, new_commit)
 
     row = classifications[0]
+
+    # Wiki-side dirty gate (#1652): fires only when the real run would
+    # write (parity with the single wet path, where the no-op returns
+    # before the gate). Non-force-able, so it exits non-zero like the
+    # real run — unlike project-side refuse rows, which stay exit 0.
+    if row.state != "unchanged" and (dirty := _asset_dirty_rels(wiki, asset_type_plural, name)):
+        raise click.ClickException(
+            f"the real run would refuse — "
+            f"{_dirty_asset_refusal_text(wiki, asset_type_plural, name, dirty)}"
+        )
+
     if row.state == "update":
         old = (row.lock_entry or {}).get("wiki_commit", "")
         old_abbr = old[:12] if isinstance(old, str) and old else "(unpinned)"
         click.echo(f"\nDry run — nothing written; would update {old_abbr} → {new_commit[:12]}.")
     elif row.state == "unchanged":
         click.echo("\nDry run — nothing written; already up to date.")
+        _maybe_hint_dirty_noop(wiki, asset_type_plural, name)
     elif row.state == "refuse":
         click.echo(
             "\nDry run — nothing written; the real run would refuse "
@@ -2154,8 +2223,11 @@ def _run_update_all(
     # loop runs — the message names the rejected input verbatim.
     # WikiUnbornHeadError: ``current_commit`` fires once at classification
     # entry — a commit-less wiki (clone of an empty remote) has no HEAD to
-    # update to.
-    with _translate_to_click(InvalidNameError, AssetNotFoundError, WikiUnbornHeadError):
+    # update to. UncommittedAssetError: the classifier's HEAD-presence gate
+    # (#1652) — a worktree-only asset can never be batch-updated.
+    with _translate_to_click(
+        InvalidNameError, AssetNotFoundError, UncommittedAssetError, WikiUnbornHeadError
+    ):
         new_commit, classifications = _classify_for_all_update(
             asset_type_plural,
             name,
@@ -2178,7 +2250,34 @@ def _run_update_all(
 
     if not needs_update and not needs_force and not has_errors:
         click.echo("\nAll projects are up to date.")
+        _maybe_hint_dirty_noop(wiki, asset_type_plural, name)
         return
+
+    # Wiki-side dirty gate (#1652): asset-global, so it fires ONCE per
+    # batch — after classification, before the prompt and before any
+    # write. It triggers on `update` plus `refuse` rows REGARDLESS of
+    # --force (only an all-unchanged or error-only batch skips it):
+    # deliberate single-asset parity — the engine's wiki gates precede
+    # the dest-dirty gate there too, so a refuse-only batch without
+    # --force surfaces the wiki dirt (the batch-global, non-force-able
+    # blocker whose remedy moves HEAD and invalidates this preview)
+    # rather than the per-project "pass --force" hint. Not re-checked
+    # per row during execution: the extraction reads immutable objects
+    # at new_commit, so written bytes stay pin-reproducible even if
+    # wiki dirt appears while the user sits on the prompt.
+    if (needs_update or needs_force) and (
+        dirty := _asset_dirty_rels(wiki, asset_type_plural, name)
+    ):
+        refusal = _dirty_asset_refusal_text(wiki, asset_type_plural, name, dirty)
+        if dry_run:
+            click.echo(f"\nDry run — nothing written; the real run would refuse — {refusal}.")
+        else:
+            click.secho(
+                f"\nRefusing to write any project — {refusal}.",
+                fg="red",
+                err=True,
+            )
+        raise click.exceptions.Exit(1)
 
     if dry_run:
         # Preview verb: report what the wet run would do and stop — exit 0
@@ -2231,14 +2330,13 @@ def _run_update_all(
         # preview-only; an edit made during the confirm prompt must still
         # refuse / get its .bak).
         assert c.lock_entry is not None
-        src = wiki.root / asset_type_plural / name
         dest = c.project_root / ".memtomem" / asset_type_plural / name
         try:
             upd = _apply_update(
                 c.project_root,
                 asset_type_plural,
                 name,
-                src=src,
+                wiki=wiki,
                 dest=dest,
                 wiki_commit=new_commit,
                 lock_entry=c.lock_entry,
@@ -2246,6 +2344,13 @@ def _run_update_all(
                 surface="cli_context_update_all",
             )
         except StaleInstallError as exc:
+            click.secho(f"  ✗ {c.project_root}: {exc}", fg="red")
+            failures += 1
+        except CommitNotFoundError as exc:
+            # copy_asset_at_commit's reachability precheck: new_commit was
+            # pinned at classify time, so this needs a wiki reset + gc
+            # mid-batch — vanishingly rare, but a red row beats crashing
+            # out of the loop with earlier projects written.
             click.secho(f"  ✗ {c.project_root}: {exc}", fg="red")
             failures += 1
         except PrivacyScanError as exc:

--- a/packages/memtomem/src/memtomem/context/_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_atomic.py
@@ -461,9 +461,10 @@ def iter_installed_files(root: Path) -> Iterator[Path]:
 
     Enumeration is FAIL-CLOSED by design: an unreadable directory or entry
     raises ``OSError`` rather than silently shrinking the result. The
-    privacy-gate source scan (``install._gate_a_scan_src_tree``) walks this
-    to decide what to copy, so a silently-dropped file would be copied
-    UNSCANNED — the same fail-open hole the skills-import scanner avoids with
+    ``--force`` update/restore paths walk this to enumerate the dest files
+    to preserve as ``.bak`` before overwriting, so a silently-dropped file
+    would be clobbered with NO ``.bak`` — the same fail-open hole the
+    skills-import scanner avoids with
     its own fail-closed walker. Callers that must instead survive an
     unreadable subtree (the read-only ``is_asset_dirty`` status walk) wrap the
     iteration in their own ``try``/``except OSError`` and degrade to "dirty"

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -1,15 +1,15 @@
 """Install a single wiki asset into ``<project>/.memtomem/<type>/<name>/``.
 
 Implements ADR-0008 PR-B (skills) and PR-C (agents, commands). The wiki at
-``~/.memtomem-wiki/`` is the source of truth; an "install" extracts the
-asset's bytes **from git objects at the wiki's HEAD commit** (#1643) and
-records that commit in :class:`memtomem.context.lockfile.Lockfile` — the pin
-therefore always reproduces the installed bytes. A wiki working tree that
-differs from HEAD for the asset (modified/deleted tracked files, untracked
-files, or a never-committed asset) refuses with
-:class:`UncommittedAssetError`; dirt elsewhere in the wiki does not block.
-(``mm context update`` still copies the working tree — follow-up tracked
-separately.)
+``~/.memtomem-wiki/`` is the source of truth; install (#1643) and update
+(#1652) both extract the asset's bytes **from git objects at the wiki's
+HEAD commit** and record that commit in
+:class:`memtomem.context.lockfile.Lockfile` — the pin therefore always
+reproduces the written bytes. A wiki working tree that differs from HEAD
+for the asset (modified/deleted tracked files, untracked files, or a
+never-committed asset) refuses with :class:`UncommittedAssetError`; dirt
+elsewhere in the wiki does not block. (Update's no-op path — pin already
+at HEAD — succeeds without the gates: nothing is written.)
 
 Public wrappers — :func:`install_skill`, :func:`install_agent`,
 :func:`install_command` — all delegate to :func:`_install_asset`. The wiki
@@ -38,8 +38,6 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 from memtomem.context._atomic import (
-    DIRTY_SKIP_SUFFIXES,
-    copy_tree_atomic,
     installed_at_from_dest,
     is_copy_skipped_rel,
     iter_installed_files,
@@ -101,18 +99,20 @@ class AssetNotFoundError(RuntimeError):
 
 
 class UncommittedAssetError(RuntimeError):
-    """Raised when install would snapshot wiki state the HEAD pin can't reproduce.
+    """Raised when install/update would record a HEAD pin that can't reproduce the write.
 
-    Single-asset install is commit-true (#1643): bytes are extracted from git
-    objects at HEAD and the lockfile pins that commit. When the asset's OWN
-    worktree state differs from HEAD — modified/deleted tracked files,
-    untracked files under the asset dir, or an asset that was never committed
-    at all — proceeding would either install bytes the user doesn't see in
-    the wiki (HEAD ≠ worktree) or record a pin that doesn't contain the asset.
-    The message carries a runnable ``mm wiki <type> commit`` hint plus a
-    raw-git fallback (the hinted command commits only the canonical file and
-    vendor overrides — it cannot commit e.g. a skill's ``scripts/`` or
-    deletions). Dirt outside the asset never raises this.
+    Single-asset install (#1643) and update (#1652) are commit-true: bytes
+    are extracted from git objects at HEAD and the lockfile pins that
+    commit. When the asset's OWN worktree state differs from HEAD —
+    modified/deleted tracked files, untracked files under the asset dir, or
+    an asset that was never committed at all — proceeding would either
+    write bytes the user doesn't see in the wiki (HEAD ≠ worktree) or
+    record a pin that doesn't contain the asset. The message carries a
+    runnable ``mm wiki <type> commit`` hint plus a raw-git fallback (the
+    hinted command commits only the canonical file and vendor overrides —
+    it cannot commit e.g. a skill's ``scripts/`` or deletions). Dirt
+    outside the asset never raises this, and update's ``force`` never
+    bypasses it (that flag overrides project-side edits, not wiki dirt).
     """
 
 
@@ -149,8 +149,9 @@ class InstallResult:
     ``was_no_op=True`` is set only by ``install --all``'s
     :func:`_apply_pinned_install` when a ``--force`` row re-classifies CLEAN
     AND its recorded digests differ from the pin's bytes (an entry written
-    by the pre-#1643 worktree-copying install, or by ``mm context update``,
-    off a dirty wiki working tree): the row is left untouched rather
+    off a dirty wiki working tree by the pre-#1643 install or the
+    pre-#1652 update — both verbs are commit-true now, so only legacy
+    lockfiles still carry such rows): the row is left untouched rather
     than silently re-extracted, so nothing is written or removed
     (``files_written=0``). It is reachable only under ``--force`` — without
     it the caller skips clean rows before calling this helper.
@@ -175,8 +176,9 @@ class UpdateResult:
       ``installed_at`` is the value previously recorded (echoed for
       display) and ``files_written``/``bak_files_written`` are empty.
     - ``was_no_op=False`` means a real refresh happened: the dest tree
-      was mirrored to the wiki bytes — files written/overwritten AND
-      dest files absent upstream reconciled away (``files_removed``,
+      was mirrored to the pinned HEAD commit's bytes (#1652) — files
+      written/overwritten AND dest files absent from the pin reconciled
+      away (``files_removed``,
       #1247) — ``installed_at`` was re-captured after the copy, and any
       dirty files were preserved at the listed ``.bak`` paths (only
       populated when ``--force`` was used against a dirty asset).
@@ -422,45 +424,6 @@ def _reconcile_removed_files(
     return tuple(removed)
 
 
-def _gate_a_scan_src_tree(
-    src: Path,
-    *,
-    surface: str,
-    project_root: Path,
-    asset_type: str,
-    name: str,
-) -> None:
-    """Gate A over the copier's effective file set of a wiki working-tree asset.
-
-    Iterates :func:`iter_installed_files` rather than handing the directory
-    to :func:`scan_artifact_tree` directly — the walker shares
-    ``copy_tree_atomic``'s skip rules, so a wiki-shipped ``*.bak`` that the
-    copier would never install cannot false-block the install (#1247;
-    scan set == copy set). Raises
-    :class:`memtomem.context.privacy_scan.PrivacyBlockedError` on the first
-    hit; callers run this BEFORE any dest mutation so refusal leaves zero
-    residue.
-    """
-    kind = asset_type.removesuffix("s")
-    for path in iter_installed_files(src):
-        result = scan_artifact_tree(
-            path, surface=surface, scope="project_shared", project_root=project_root
-        )
-        if result.blocked:
-            blocked = result.blocked[0]
-            raise_or_collect(
-                blocked,
-                scope="project_shared",
-                kind=kind,
-                artifact_name=name,
-                remediation_hint=(
-                    f"Remove the secret from the wiki copy at {blocked.path} "
-                    f"and re-run — wiki bytes must be clean before they can land "
-                    f"in the git-tracked project tree."
-                ),
-            )
-
-
 def _gate_a_scan_dirty_files(
     dirty_files: tuple[Path, ...] | list[Path] | frozenset[Path],
     *,
@@ -510,10 +473,10 @@ def _gate_a_scan_pinned_asset(
 
     ``remediation_hint`` overrides the default restore-flavored hint ("…
     re-pin to a clean commit before restoring") — the commit-true single
-    install (#1643) scans HEAD here before a FIRST extraction, where
-    "restoring"/"re-pin" would misdirect; it passes an install-flavored
-    hint instead. ``{pin}``/``{rel}`` placeholders are not interpolated —
-    pass a fully-rendered string.
+    install (#1643) and update (#1652) scan HEAD here before extraction,
+    where "restoring"/"re-pin" would misdirect; each passes a
+    verb-flavored hint instead. ``{pin}``/``{rel}`` placeholders are not
+    interpolated — pass a fully-rendered string.
 
     The wiki working tree is irrelevant here — the extractor reads git
     objects at *pin*, so the scan does too (:meth:`WikiStore.
@@ -551,6 +514,40 @@ def _gate_a_scan_pinned_asset(
                     f"re-pin to a clean commit before restoring."
                 ),
             )
+
+
+def _commit_hint(wiki: WikiStore, asset_type: str, name: str) -> str:
+    """Runnable remediation hint for :class:`UncommittedAssetError` messages.
+
+    Shared by the install (#1643) and update (#1652) commit-true gates so
+    both verbs point at the identical `mm wiki <type> commit` command (plus
+    the raw-git fallback for paths that command can't commit).
+    """
+    singular = asset_type.removesuffix("s")
+    return (
+        f"commit it first: `mm wiki {singular} commit {name} --canonical` "
+        f"(add `--vendor <vendor>` for override files; for scripts, deletions, "
+        f"or other paths that command can't commit, use git directly in the "
+        f"wiki at {wiki.root})"
+    )
+
+
+def _asset_dirty_rels(wiki: WikiStore, asset_type: str, name: str) -> list[str]:
+    """Asset-inner rels whose worktree state differs from HEAD — gate input.
+
+    Strips :meth:`WikiStore.asset_uncommitted_paths` repo-relative rows to
+    asset-inner rels so ``is_copy_skipped_rel`` matches the same surface the
+    extractor filters (a legacy untracked ``*.bak`` or a stray ``.DS_Store``
+    is not dirt: it would never be extracted). Dirt in OTHER assets never
+    appears here (the underlying ``git status`` call is pathspec-scoped).
+    Non-empty ⇒ the commit-true install/update gates (#1643/#1652) refuse.
+    """
+    asset_prefix = f"{asset_type}/{name}/"
+    return sorted(
+        rel
+        for row in wiki.asset_uncommitted_paths(asset_type, name)
+        if (rel := row[len(asset_prefix) :]) and not is_copy_skipped_rel(rel)
+    )
 
 
 def _install_asset(
@@ -648,13 +645,7 @@ def _install_asset(
             f"{hint}"
         )
 
-    singular = asset_type.removesuffix("s")
-    commit_hint = (
-        f"commit it first: `mm wiki {singular} commit {validated} --canonical` "
-        f"(add `--vendor <vendor>` for override files; for scripts, deletions, "
-        f"or other paths that command can't commit, use git directly in the "
-        f"wiki at {wiki.root})"
-    )
+    commit_hint = _commit_hint(wiki, asset_type, validated)
 
     # HEAD-presence gate (#1643): the pin must CONTAIN the asset. An asset
     # that exists only in the worktree would install bytes whose recorded
@@ -674,17 +665,9 @@ def _install_asset(
 
     # Same-asset dirty gate (#1643): worktree state must equal HEAD for THIS
     # asset — otherwise the user-visible wiki bytes and the installed bytes
-    # silently diverge. Repo-relative rows are stripped to asset-inner rels
-    # so is_copy_skipped_rel matches the same surface the extractor filters
-    # (a legacy untracked `*.bak` or a stray `.DS_Store` is not dirt: it
-    # would never be extracted). Dirt in OTHER assets never reaches this
-    # gate (asset_uncommitted_paths is pathspec-scoped).
-    asset_prefix = f"{asset_type}/{validated}/"
-    dirty_rels = sorted(
-        rel
-        for row in wiki.asset_uncommitted_paths(asset_type, validated)
-        if (rel := row[len(asset_prefix) :]) and not is_copy_skipped_rel(rel)
-    )
+    # silently diverge. Skip-filter and scoping semantics live in
+    # _asset_dirty_rels (shared with the update gate, #1652).
+    dirty_rels = _asset_dirty_rels(wiki, asset_type, validated)
     if dirty_rels:
         shown = ", ".join(dirty_rels[:5])
         more = "" if len(dirty_rels) <= 5 else f", +{len(dirty_rels) - 5} more"
@@ -755,11 +738,15 @@ def update_skill(
     lock_timeout: float | None = None,
     surface: str = "cli_context_update",
 ) -> UpdateResult:
-    """Refresh ``<wiki>/skills/<name>/`` snapshot at ``<project>/.memtomem/skills/<name>/``.
+    """Refresh ``skills/<name>/`` **at wiki HEAD** into ``<project>/.memtomem/skills/<name>/``.
 
-    No-op when wiki HEAD already matches the lockfile pin. Refuses when
-    local edits would be clobbered, unless ``force=True`` (which preserves
-    each dirty file as ``<file>.bak`` before overwriting).
+    Commit-true (#1652): bytes are extracted from git objects at HEAD, so
+    an asset whose wiki working tree differs from HEAD refuses with
+    :class:`UncommittedAssetError` (never force-able). No-op when wiki
+    HEAD already matches the lockfile pin — returned BEFORE the wiki-side
+    gates (nothing would be written). Refuses when local dest edits would
+    be clobbered, unless ``force=True`` (which preserves each dirty file
+    as ``<file>.bak`` before overwriting).
 
     ``surface`` names the ingress in the Gate-A privacy audit log
     (#1246/#1248 real-ingress rule): the CLI keeps the default, the web
@@ -786,7 +773,7 @@ def update_agent(
     lock_timeout: float | None = None,
     surface: str = "cli_context_update",
 ) -> UpdateResult:
-    """Refresh ``<wiki>/agents/<name>/`` snapshot at ``<project>/.memtomem/agents/<name>/``."""
+    """Refresh ``agents/<name>/`` at wiki HEAD into ``<project>/.memtomem/agents/<name>/``."""
     return _update_asset(
         project_root,
         "agents",
@@ -807,7 +794,7 @@ def update_command(
     lock_timeout: float | None = None,
     surface: str = "cli_context_update",
 ) -> UpdateResult:
-    """Refresh ``<wiki>/commands/<name>/`` snapshot at ``<project>/.memtomem/commands/<name>/``."""
+    """Refresh ``commands/<name>/`` at wiki HEAD into ``<project>/.memtomem/commands/<name>/``."""
     return _update_asset(
         project_root,
         "commands",
@@ -829,26 +816,40 @@ def _update_asset(
     lock_timeout: float | None = None,
     surface: str = "cli_context_update",
 ) -> UpdateResult:
-    """Internal: refresh a single installed asset of any type.
+    """Internal: refresh a single installed asset of any type — commit-true (#1652).
 
     Pipeline:
 
     1. Validate ``name`` and project root.
-    2. Locate the wiki + the source asset directory (``AssetNotFoundError``
-       if the wiki has dropped the asset entirely).
-    3. Read the existing lockfile entry — ``NotInstalledError`` if absent.
-    4. Pin wiki HEAD as ``new_commit`` once (concurrent ``git pull`` in the
+    2. Read the existing lockfile entry — ``NotInstalledError`` if absent.
+    3. Pin wiki HEAD as ``new_commit`` once (concurrent ``git pull`` in the
        wiki cannot make the recorded commit drift mid-update).
-    5. **True no-op short-circuit**: when ``new_commit`` matches the lockfile
+    4. **True no-op short-circuit**: when ``new_commit`` matches the lockfile
        pin, return early *without touching the lockfile*. ``installed_at``
-       is echoed from the existing entry; ``was_no_op=True``.
-    6. Delegate to :func:`_apply_update`, which classifies the dest tree
+       is echoed from the existing entry; ``was_no_op=True``. The no-op
+       runs BEFORE the wiki-side gates below: the gates protect a write,
+       and a matching pin writes nothing — uncommitted wiki edits must not
+       fail a refresh that would be a no-op anyway (the CLI surfaces an
+       asset-scoped hint instead).
+    5. **HEAD-presence gate** (#1652, mirrors #1643 install): the asset
+       must exist at ``new_commit``. Present only in the worktree —
+       committed history has dropped it — refuses with
+       :class:`UncommittedAssetError` (the pin the update would record
+       wouldn't contain the asset); absent everywhere raises
+       :class:`AssetNotFoundError`.
+    6. **Same-asset dirty gate** (#1652): any worktree divergence from HEAD
+       under the asset dir (via :func:`_asset_dirty_rels`) refuses with
+       :class:`UncommittedAssetError`. NOT force-able — ``force`` only
+       overrides project-side (dest) edits; the remedy for wiki-side dirt
+       is committing it. Dirt elsewhere in the wiki never blocks.
+    7. Delegate to :func:`_apply_update`, which classifies the dest tree
        via :func:`is_asset_dirty` immediately before its gates (#1247
-       id 13) and then refuses or writes.
+       id 13) and then refuses or writes — extracting at ``new_commit``.
 
-    The split lets ``mm context update --all`` (commit 4) reuse step 6
+    The split lets ``mm context update --all`` (commit 4) reuse step 7
     after rendering a preview classification across all known projects
-    up front.
+    up front (its wiki-side gates run once per batch in the CLI, not per
+    project — the wiki state is asset-global).
     """
     validated = validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
     project_root = Path(project_root).expanduser()
@@ -869,10 +870,6 @@ def _update_asset(
             f"{asset_type}/{validated}: no lockfile entry; "
             f"run `mm context install {asset_type_singular} {validated}` first"
         )
-
-    src = wiki.root / asset_type / validated
-    if not src.is_dir():
-        raise AssetNotFoundError(f"{asset_type}/{validated} not in wiki at {wiki.root}")
 
     new_commit = wiki.current_commit()
     dest = project_root / ".memtomem" / asset_type / validated
@@ -900,11 +897,43 @@ def _update_asset(
             files_written=0,
         )
 
+    commit_hint = _commit_hint(wiki, asset_type, validated)
+
+    # HEAD-presence gate (#1652, mirrors #1643 install): the pin the update
+    # would record must CONTAIN the asset. Worktree presence is a boolean
+    # input, not a raise site — "in the worktree but not at HEAD" must
+    # classify as uncommitted, not absent.
+    try:
+        wiki.asset_files_at_commit(new_commit, asset_type, validated)
+    except AssetNotFoundError:
+        if (wiki.root / asset_type / validated).is_dir():
+            raise UncommittedAssetError(
+                f"{asset_type}/{validated}: exists in the wiki working tree but "
+                f"is not present at HEAD, so the pin the update would record "
+                f"would not contain it; {commit_hint}"
+            ) from None
+        raise AssetNotFoundError(f"{asset_type}/{validated} not in wiki at {wiki.root}") from None
+
+    # Same-asset dirty gate (#1652): worktree state must equal HEAD for THIS
+    # asset — otherwise the user-visible wiki bytes and the refreshed bytes
+    # silently diverge. Deliberately ignores ``force``: that flag overrides
+    # project-side (dest) edits, never wiki-side dirt (the remedy is
+    # committing). Skip-filter/scoping semantics live in _asset_dirty_rels.
+    dirty_rels = _asset_dirty_rels(wiki, asset_type, validated)
+    if dirty_rels:
+        shown = ", ".join(dirty_rels[:5])
+        more = "" if len(dirty_rels) <= 5 else f", +{len(dirty_rels) - 5} more"
+        raise UncommittedAssetError(
+            f"{asset_type}/{validated}: wiki working tree differs from HEAD for "
+            f"this asset ({len(dirty_rels)} file(s): {shown}{more}); update is "
+            f"commit-true and records HEAD's bytes only — {commit_hint}"
+        )
+
     return _apply_update(
         project_root,
         asset_type,
         validated,
-        src=src,
+        wiki=wiki,
         dest=dest,
         wiki_commit=new_commit,
         lock_entry=lock_entry,
@@ -919,7 +948,7 @@ def _apply_update(
     asset_type: str,
     name: str,
     *,
-    src: Path,
+    wiki: WikiStore,
     dest: Path,
     wiki_commit: str,
     lock_entry: dict[str, Any],
@@ -927,7 +956,12 @@ def _apply_update(
     surface: str = "cli_context_update",
     lock_timeout: float | None = None,
 ) -> UpdateResult:
-    """Execute an update against apply-time dirty evidence.
+    """Execute an update against apply-time dirty evidence — commit-true (#1652).
+
+    Bytes are extracted from git objects at ``wiki_commit``
+    (:meth:`WikiStore.copy_asset_at_commit`), never from the wiki working
+    tree, so the lockfile's ``wiki_commit``/``digests`` claims below are
+    literally true — pin==bytes holds by construction.
 
     Pre-conditions enforced by callers (``_update_asset`` for the single-
     asset path, ``mm context update --all`` orchestration for the batch
@@ -936,6 +970,15 @@ def _apply_update(
     - ``lock_entry`` is non-None (``NotInstalledError`` is raised earlier).
     - The no-op case (``lock_entry["wiki_commit"] == wiki_commit``) was
       already short-circuited; this helper unconditionally writes.
+    - The wiki-side commit-true gates (HEAD presence, same-asset dirt —
+      #1652) already ran in the caller; this helper only enforces
+      dest-side gates. On the ``--all`` path those gates fire once per
+      batch (before the confirm prompt), so wiki dirt appearing DURING the
+      prompt is not re-checked here — deliberate: the extraction below
+      reads immutable objects at ``wiki_commit``, so the written bytes
+      stay pin-reproducible regardless; only the decide-time divergence
+      check is prompt-stale, the same acceptance class as install's
+      sub-second gate→extract window.
 
     The dest tree is classified HERE, immediately before the gates. A
     report computed earlier — in particular before ``--all``'s unbounded
@@ -949,16 +992,16 @@ def _apply_update(
 
     Refuses with :class:`StaleInstallError` when ``dirty_report.reason ==
     "dirty"`` and ``force=False``. With ``force=True`` and a dirty tree,
-    each dirty file is preserved alongside the wiki bytes as
+    each dirty file is preserved alongside the extracted bytes as
     ``<file>.bak`` before the copy. An existing dest whose entry has an
     unusable ``installed_at`` (``reason == "never_installed"``) refuses
     the same way — nothing is provably clean — and ``--force`` preserves
     EVERY current dest file as ``.bak`` (#1247). ``shutil.copy2`` is used
     so the user's edit-mtime survives onto the ``.bak``
     (atomic_write_bytes would lose it). After the copy, dest files absent
-    from the wiki
-    source are reconciled away (:func:`_reconcile_removed_files`,
-    #1247) so the refreshed tree mirrors the wiki instead of growing
+    from the pinned commit's extracted set are reconciled away
+    (:func:`_reconcile_removed_files`,
+    #1247) so the refreshed tree mirrors the pin instead of growing
     additively. ``installed_at`` is captured *after* copy + reconcile,
     mirroring the C2a (#630) install invariant so a follow-up dirty
     check can't false-positive on this update's own writes.
@@ -1038,12 +1081,21 @@ def _apply_update(
     # Gate A (ADR-0011 §5, #1247): both scans precede the .bak loop — the
     # first dest mutation with no rollback — so a privacy refusal leaves
     # no .bak, no copied bytes, and (upserts trail copies) no lockfile drift.
-    _gate_a_scan_src_tree(
-        src,
+    # The scan reads git objects at the pin (#1652): exactly the immutable
+    # bytes the extractor below will write (scan set == write set, no
+    # scan→write TOCTOU).
+    _gate_a_scan_pinned_asset(
+        wiki,
+        wiki_commit,
+        asset_type,
+        name,
         surface=surface,
         project_root=project_root,
-        asset_type=asset_type,
-        name=name,
+        remediation_hint=(
+            f"The wiki commit {wiki_commit[:12]} ships a secret in "
+            f"{asset_type}/{name}; remove it from the asset, commit the "
+            f"fix in the wiki, and re-run update."
+        ),
     )
     files_to_bak: tuple[Path, ...] = ()
     if force and dirty_report.reason == "dirty":
@@ -1063,24 +1115,26 @@ def _apply_update(
     for f in files_to_bak:
         bak = f.with_suffix(f.suffix + ".bak")
         # shutil.copy2 preserves user edit's mtime — atomic_write_bytes
-        # would lose it. Race window between copy2 and copy_tree_atomic
-        # is sub-ms; acceptable for v1. Overwrite-if-exists policy
-        # (prior .bak from earlier --force gets replaced).
+        # would lose it. Race window between copy2 and the pinned
+        # extraction is sub-ms; acceptable for v1. Overwrite-if-exists
+        # policy (prior .bak from earlier --force gets replaced).
         shutil.copy2(f, bak)
         bak_paths.append(bak)
 
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    digest_map = copy_tree_atomic(src, dest, skip_suffixes=DIRTY_SKIP_SUFFIXES)
+    # Commit-true extraction (#1652): bytes come from git objects at the
+    # pinned commit, never the worktree, so the lockfile's digests/
+    # files_commit claims below are literally true. copy_asset_at_commit
+    # does its own dest.parent.mkdir + tmpdir-adjacent materialization and
+    # applies the same skip predicate as the old copytree.
+    digest_map = wiki.copy_asset_at_commit(wiki_commit, asset_type, name, dest)
 
-    # Mirror semantics (#1247): drop dest files the wiki no longer ships.
-    # Membership is the copier's RETURNED written set, not a re-walk of
-    # ``src`` (#1247 id 15 impl gate): the wiki working tree is mutable,
-    # so a post-copy walk reads a DIFFERENT snapshot than the one copied —
-    # a file dropped from the worktree in that window would erase a file
-    # this update just wrote (when its bytes are unchanged between
-    # versions they still match the OLD digests → "provably untouched")
-    # while ``files=``/``digests=`` below record it — a phantom entry.
-    # The map shares the copier's skip rules by construction, covering
+    # Mirror semantics (#1247): drop dest files the pin no longer ships.
+    # Membership is the extractor's RETURNED written set, not a re-walk of
+    # the wiki (#1247 id 15 impl gate; the source is now an immutable
+    # commit — #1652 — so the walk-a-different-snapshot hazard the
+    # worktree copy had is closed by construction, and the returned map
+    # remains the single provenance surface).
+    # The map shares the extractor's skip rules by construction, covering
     # B5's symlink concern (a wiki file replaced by a symlink is absent
     # from the map, so the old regular file in dest reconciles away). The
     # guard epoch is the PRE-update install timestamp (the same basis
@@ -1141,8 +1195,8 @@ def _classify_for_all_update(
     the same snapshot the user confirmed.
 
     Used by ``mm context update --all``. The wiki state is read **once**
-    up front: ``wiki.current_commit()`` and the source-asset existence
-    check both happen before the per-project loop, so every project is
+    up front: ``wiki.current_commit()`` and the HEAD-presence gate
+    (#1652) both happen before the per-project loop, so every project is
     classified against the same snapshot. This guarantees the preview
     table the user confirms against matches what the execute phase will
     actually see.
@@ -1167,10 +1221,11 @@ def _classify_for_all_update(
     preview. A corrupt lockfile is the exception — it produces an
     explicit ``"error"`` row so the user can see and triage.
 
-    The wiki source asset is read once up front. If it's missing,
-    callers get :class:`AssetNotFoundError` here, *before* any project
-    loop runs — preventing a confusing per-project "asset not found"
-    storm.
+    The asset's presence at HEAD is checked once up front. If it's
+    missing everywhere, callers get :class:`AssetNotFoundError` (or
+    :class:`UncommittedAssetError` when it exists only in the worktree)
+    here, *before* any project loop runs — preventing a confusing
+    per-project error storm.
 
     ``name`` is validated at the boundary (defense in depth) — even
     though the CLI ``update_cmd`` is the expected upstream caller, this
@@ -1182,9 +1237,25 @@ def _classify_for_all_update(
     """
     name = validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
     new_commit = wiki.current_commit()
-    src = wiki.root / asset_type / name
-    if not src.is_dir():
-        raise AssetNotFoundError(f"{asset_type}/{name} not in wiki at {wiki.root}")
+
+    # HEAD-presence gate (#1652, mirrors the single-asset update): the pin
+    # every subsequent _apply_update would record must CONTAIN the asset.
+    # Fires once, before the project loop (same storm-prevention rationale
+    # as the old worktree existence check it replaces). Worktree-only
+    # presence classifies as uncommitted, not absent. The same-asset dirty
+    # gate is deliberately NOT here: its trigger — "at least one row would
+    # write" — is a function of the classification output, so the CLI
+    # applies it post-classify (unchanged-only batches just hint).
+    try:
+        wiki.asset_files_at_commit(new_commit, asset_type, name)
+    except AssetNotFoundError:
+        if (wiki.root / asset_type / name).is_dir():
+            raise UncommittedAssetError(
+                f"{asset_type}/{name}: exists in the wiki working tree but is "
+                f"not present at HEAD, so the pin the update would record "
+                f"would not contain it; {_commit_hint(wiki, asset_type, name)}"
+            ) from None
+        raise AssetNotFoundError(f"{asset_type}/{name} not in wiki at {wiki.root}") from None
 
     out: list[ProjectClassification] = []
     for project_root in projects:
@@ -1620,11 +1691,11 @@ def _apply_pinned_install(
         )
 
     # Data-safety no-op (ADR-0008 wiki_commit provenance imprecision): the
-    # legacy single-install path (pre-#1643) and the current update path copy
+    # legacy single-install (pre-#1643) and update (pre-#1652) paths copied
     # the wiki WORKING TREE while pinning HEAD, so entries created by them off
-    # a *dirty* wiki hold bytes the recorded pin never described (the
-    # commit-true single install can no longer mint such entries, but
-    # existing lockfiles and update keep them alive). Such a row
+    # a *dirty* wiki hold bytes the recorded pin never described (both verbs
+    # are commit-true now and can no longer mint such entries — only
+    # existing lockfiles keep them alive). Such a row
     # re-classifies CLEAN here (dest == its recorded
     # digests), and --force would then re-extract the pin over it — SILENTLY
     # swapping the installed bytes for the pin's, with no .bak (files_to_bak is

--- a/packages/memtomem/src/memtomem/web/routes/context_mutations.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mutations.py
@@ -222,10 +222,16 @@ async def update_asset(
 ) -> dict:
     """Refresh an installed wiki asset to wiki HEAD (parity of ``mm context update``).
 
-    No-op when the lockfile pin already matches HEAD (``was_no_op=True``).
-    Refuses with 409 ``stale_install`` when local edits would be clobbered; the
-    client re-POSTs ``{"force": true}`` to overwrite (each dirty file kept as a
-    ``.bak`` sibling). An asset with no lockfile entry → 404 ``not_installed``.
+    Commit-true (#1652): extracts the asset from the wiki's git objects at
+    HEAD and pins that commit — never the working tree, so the pin always
+    reproduces the refreshed bytes. An asset whose wiki working tree
+    differs from HEAD refuses with 409 ``wiki_uncommitted`` (``force``
+    does NOT bypass — it only overrides project-side edits). No-op when
+    the lockfile pin already matches HEAD (``was_no_op=True``) — returned
+    before the wiki-side gates. Refuses with 409 ``stale_install`` when
+    local edits would be clobbered; the client re-POSTs
+    ``{"force": true}`` to overwrite (each dirty file kept as a ``.bak``
+    sibling). An asset with no lockfile entry → 404 ``not_installed``.
     """
     _validate_name_or_error(asset_type, name)
     force = body.force if body is not None else False
@@ -271,6 +277,19 @@ async def update_asset(
             f"{asset_type}/{name} has local edits; re-run with force to overwrite "
             "(each edited file is kept as a .bak sibling)",
             reason_code="stale_install",
+        ) from exc
+    except UncommittedAssetError as exc:
+        # Fixed message, NOT ``str(exc)`` — the engine message embeds the
+        # absolute wiki root (its raw-git remediation hint), which must not
+        # leak into the HTTP envelope (module contract; the
+        # ``_privacy_blocked`` precedent). Same shape as install's arm.
+        raise _error(
+            409,
+            "conflict",
+            f"{asset_type}/{name} has uncommitted changes in the wiki (update is "
+            f"commit-true and records HEAD's bytes only); commit them — e.g. "
+            f"`mm wiki <type> commit <name> --canonical` — and retry",
+            reason_code="wiki_uncommitted",
         ) from exc
     except PrivacyScanError as exc:
         raise _privacy_blocked() from exc

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1772,7 +1772,7 @@
   <script src="/context-gateway-detail.js?v=1"></script>
   <script src="/context-gateway-actions.js?v=1"></script>
   <script src="/context-portal.js?v=7"></script>
-  <script src="/wiki.js?v=10"></script>
+  <script src="/wiki.js?v=11"></script>
   <script src="/path-picker.js?v=4"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -538,7 +538,7 @@
   "settings.ctx.wiki_already_installed": "{type} \"{name}\" is already installed — use Update to refresh",
   "settings.ctx.wiki_not_installed": "{type} \"{name}\" is not installed — use Install first",
   "settings.ctx.wiki_install_privacy_blocked": "The privacy scan blocked this: a secret was detected in the wiki bytes of {type} \"{name}\". Remove it from the wiki, then retry.",
-  "settings.ctx.wiki_install_uncommitted": "{type} \"{name}\" has uncommitted wiki edits — install records committed content only. Commit them (Commit button or `mm wiki commit`), then retry.",
+  "settings.ctx.wiki_install_uncommitted": "{type} \"{name}\" has uncommitted wiki edits — install and update record committed content only. Commit them (Commit button or `mm wiki commit`), then retry.",
   "settings.ctx.wiki_install_failed": "Install/update failed: {error}",
   "settings.ctx.wiki_override_title": "Override source",
   "settings.ctx.wiki_override_edit": "Edit",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -538,7 +538,7 @@
   "settings.ctx.wiki_already_installed": "{type} \"{name}\" 은(는) 이미 설치됨 — 업데이트를 사용하세요",
   "settings.ctx.wiki_not_installed": "{type} \"{name}\" 은(는) 설치되지 않음 — 먼저 설치하세요",
   "settings.ctx.wiki_install_privacy_blocked": "프라이버시 스캔이 차단했습니다: {type} \"{name}\" 의 위키 콘텐츠에서 시크릿이 감지되었습니다. 위키에서 제거한 뒤 다시 시도하세요.",
-  "settings.ctx.wiki_install_uncommitted": "{type} \"{name}\" 에 커밋되지 않은 위키 수정이 있습니다 — 설치는 커밋된 콘텐츠만 기록합니다. 커밋(Commit 버튼 또는 `mm wiki commit`) 후 다시 시도하세요.",
+  "settings.ctx.wiki_install_uncommitted": "{type} \"{name}\" 에 커밋되지 않은 위키 수정이 있습니다 — 설치와 업데이트는 커밋된 콘텐츠만 기록합니다. 커밋(Commit 버튼 또는 `mm wiki commit`) 후 다시 시도하세요.",
   "settings.ctx.wiki_install_failed": "설치/업데이트 실패: {error}",
   "settings.ctx.wiki_override_title": "오버라이드 원본",
   "settings.ctx.wiki_override_edit": "편집",

--- a/packages/memtomem/src/memtomem/web/static/wiki.js
+++ b/packages/memtomem/src/memtomem/web/static/wiki.js
@@ -1080,8 +1080,8 @@ async function _installWikiAsset(type, name, scopeId, force, verb) {
       return;
     }
     if (reason === 'wiki_uncommitted') {
-      // Commit-true install (#1643): the asset's wiki working tree differs
-      // from HEAD, so the pin couldn't reproduce the installed bytes.
+      // Commit-true install/update (#1643/#1652): the asset's wiki working
+      // tree differs from HEAD, so the pin couldn't reproduce the bytes.
       showToast(
         t('settings.ctx.wiki_install_uncommitted', { type: _wikiTypeLabel(type), name }),
         'error',

--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -684,11 +684,11 @@ class WikiStore:
         """``True`` when the wiki working tree has uncommitted modifications.
 
         Wraps ``git status --porcelain`` — true on any combination of
-        modified-tracked, staged, or untracked files. Used by ``mm
-        context update`` to warn the user that the recorded pin reflects
-        HEAD only, not the dirty working tree. (Single-asset install
-        refuses instead, and only on the asset's own dirt — see
-        :meth:`asset_uncommitted_paths`, #1643.)
+        modified-tracked, staged, or untracked files. Used by the web
+        wiki-status surfaces and the commit flow's ``wiki_dirty`` echo.
+        (The install/update verbs never consult this repo-wide view:
+        their commit-true gates refuse on the asset's OWN dirt only —
+        see :meth:`asset_uncommitted_paths`, #1643/#1652.)
 
         Returns ``False`` if the wiki is clean. Raises ``WikiNotFoundError``
         if the wiki itself is missing (no ``.git`` directory) — caller
@@ -735,8 +735,9 @@ class WikiStore:
         :meth:`current_commit` before this, so they never get here unborn.
         Shares :meth:`is_dirty`'s ``.gitattributes`` caveat: a normalizing
         clean/eol filter can make committed files read permanently dirty,
-        which under the #1643 install gate means a permanent refusal until
-        the filter is dropped (memtomem ships no ``.gitattributes``).
+        which under the #1643/#1652 install/update gates means a permanent
+        refusal until the filter is dropped (memtomem ships no
+        ``.gitattributes``).
         """
         self.require_exists()
         prefix = f"{asset_type}/{name}/"
@@ -968,8 +969,11 @@ class WikiStore:
            filesystem, so subsequent ``copy_tree_atomic`` rename steps
            don't span devices).
         5. ``copy_tree_atomic(tmpdir, dest)`` mirrors the structure into
-           *dest* using the same per-file atomic semantics as
-           :func:`memtomem.context.install._install_asset`.
+           *dest* using the same per-file atomic semantics as the
+           commit-true install/update verbs
+           (:func:`memtomem.context.install._install_asset` /
+           ``_apply_update``, #1643/#1652), which both extract through
+           this method.
 
         The wiki working tree is **never touched** — every read uses the
         commit's git objects directly, so a concurrent ``git checkout``

--- a/packages/memtomem/tests/test_context_install_all.py
+++ b/packages/memtomem/tests/test_context_install_all.py
@@ -32,7 +32,6 @@ from memtomem.context.install import (
     install_skill,
     install_agent,
     install_command,
-    update_skill,
 )
 from memtomem.context.lockfile import Lockfile
 from memtomem.wiki.store import WikiStore
@@ -94,6 +93,38 @@ def _bump_mtime(path: Path, *, seconds_in_future: float = 1.0) -> None:
 
     future = datetime.now(timezone.utc).timestamp() + seconds_in_future
     os.utime(path, (future, future))
+
+
+def _rewrite_entry_as_legacy_update(project_root: Path, name: str, *, pin: str) -> None:
+    """Rewrite ``skills/<name>``'s lock entry the way a pre-#1652 update minted it.
+
+    The worktree-copying update recorded ``wiki_commit=<pin>`` while its
+    ``files``/``digests`` described whatever bytes sat in the wiki WORKING
+    TREE — bytes the pin never contained. Both verbs are commit-true now
+    (#1643/#1652), so tests exercising ``install --all``'s data-safety
+    no-op mint that legacy shape directly: digests are hashed from the
+    CURRENT dest bytes and ``installed_at`` is captured after the dest
+    write so the ``digests_installed_at`` pairing holds (a broken pairing
+    would degrade the row to the pre-digest path and mask the guard).
+    """
+    import hashlib
+
+    from memtomem.context._atomic import installed_at_from_dest, iter_installed_files
+
+    dest = project_root / ".memtomem" / "skills" / name
+    digests = {
+        f.relative_to(dest).as_posix(): hashlib.sha256(f.read_bytes()).hexdigest()
+        for f in iter_installed_files(dest)
+    }
+    Lockfile.at(project_root).upsert_entry(
+        "skills",
+        name,
+        wiki_commit=pin,
+        installed_at=installed_at_from_dest(dest),
+        files=sorted(digests),
+        files_commit=pin,
+        digests=digests,
+    )
 
 
 def _make_orphan(wiki_root_path: Path, name: str) -> None:
@@ -278,27 +309,26 @@ def test_clean_install_off_dirty_wiki_survives_all_force(
     """Regression: a clean row whose recorded bytes diverge from its pin must
     not be silently swapped by ``install --all --force``.
 
-    ``mm context update`` copies the wiki WORKING TREE but pins HEAD (ADR-0008's
-    accepted ``wiki_commit`` provenance imprecision — since #1643 the single
-    install is commit-true and can no longer mint such entries, so the update
-    path builds the divergence here), so an update taken off a dirty wiki holds
-    bytes the pin never described. ``--force`` used to re-extract the pin over
-    such a clean row with NO ``.bak`` — a silent destructive swap. It must now
-    leave the row untouched (the recorded digests differ from the pin's bytes);
-    ``--force`` re-extraction is reserved for dirty/unprovable rows, which
-    always get a ``.bak``.
+    Pre-#1652, ``mm context update`` copied the wiki WORKING TREE but pinned
+    HEAD (ADR-0008's accepted ``wiki_commit`` provenance imprecision), so an
+    update taken off a dirty wiki held bytes the pin never described. Both
+    verbs are commit-true now, so the divergence is minted directly
+    (``_rewrite_entry_as_legacy_update``) — the rows this guard protects
+    survive only in legacy lockfiles. ``--force`` used to re-extract the pin
+    over such a clean row with NO ``.bak`` — a silent destructive swap. It
+    must leave the row untouched (the recorded digests differ from the pin's
+    bytes); ``--force`` re-extraction is reserved for dirty/unprovable rows,
+    which always get a ``.bak``.
     """
     _initialized_wiki(wiki_root)
     _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v0\n"})
     install_skill(tmp_path, "foo")
-    # Advance HEAD to v1, then edit the WORKING TREE without committing: the
-    # update below copies the working tree (v2) yet pins HEAD (v1) — the
-    # recorded digests describe bytes the pin's commit does not contain.
+    # Advance HEAD to v1, then mint the legacy shape: dest bytes (v2) the
+    # pin's commit (v1) does not contain, recorded as a clean install.
     pin = _advance_wiki(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v1\n"})
-    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"working-tree-v2\n")
-    update_skill(tmp_path, "foo")
     dest = tmp_path / ".memtomem" / "skills" / "foo" / "SKILL.md"
-    assert dest.read_bytes() == b"working-tree-v2\n"
+    dest.write_bytes(b"working-tree-v2\n")
+    _rewrite_entry_as_legacy_update(tmp_path, "foo", pin=pin)
     lock_doc = json.loads((tmp_path / ".memtomem" / "lock.json").read_text())
     assert lock_doc["skills"]["foo"]["wiki_commit"] == pin
 
@@ -325,28 +355,24 @@ def test_clean_empty_install_off_dirty_wiki_survives_all_force(
     """A VALID EMPTY recorded digest map (``digests={}``) must be honored, not
     treated as "no digests" (Codex gate).
 
-    If the wiki working tree has no copyable file at update time, the update
-    records ``digests={}`` (a valid empty map, not ``None``) while the pin's
-    commit still contains files (post-#1643 the commit-true single install
-    can't produce this shape, so the worktree-copying update path builds it).
-    ``install --all --force`` must not fall through and silently resurrect the
-    pin's files over the recorded-empty dest with no ``.bak``. The guard
-    distinguishes ``{}`` (honor: divergence) from ``None`` (pre-digest: legacy
-    re-extract).
+    Pre-#1652, an update off a wiki working tree with no copyable file
+    recorded ``digests={}`` (a valid empty map, not ``None``) while the
+    pin's commit still contained files. The commit-true verbs can't produce
+    this shape anymore, so it is minted directly — it survives only in
+    legacy lockfiles. ``install --all --force`` must not fall through and
+    silently resurrect the pin's files over the recorded-empty dest with no
+    ``.bak``. The guard distinguishes ``{}`` (honor: divergence) from
+    ``None`` (pre-digest: legacy re-extract).
     """
     _initialized_wiki(wiki_root)
     _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v0\n"})
     install_skill(tmp_path, "foo")
     # The pinned commit (v1) contains SKILL.md...
-    _advance_wiki(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v1\n"})
-    # ...but the dirty working tree has no copyable file (only a skip-filtered
-    # ``.bak``), so the update copies zero files, reconciles the dest file
-    # away, and records digests={} while pinning v1.
-    asset = wiki_root / "skills" / "foo"
-    (asset / "SKILL.md").unlink()
-    (asset / "SKILL.md.bak").write_bytes(b"skipped\n")
-    update_skill(tmp_path, "foo")
+    pin = _advance_wiki(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v1\n"})
+    # ...but the legacy entry records an EMPTY install at that pin.
     dest = tmp_path / ".memtomem" / "skills" / "foo"
+    (dest / "SKILL.md").unlink()
+    _rewrite_entry_as_legacy_update(tmp_path, "foo", pin=pin)
     lock_doc = json.loads((tmp_path / ".memtomem" / "lock.json").read_text())
     assert lock_doc["skills"]["foo"]["files"] == []
     assert lock_doc["skills"]["foo"]["digests"] == {}
@@ -687,19 +713,19 @@ def test_legacy_clean_install_off_dirty_wiki_survives_all_force(
     ``install --all --force``.
 
     Same shape as ``test_clean_install_off_dirty_wiki_survives_all_force``
-    (divergence minted via the worktree-copying update path — post-#1643 the
-    commit-true single install can't produce it), but with the digest keys
-    stripped: before #1512 the ``recorded_digests is not None`` gate let
-    exactly this row fall through to a silent, ``.bak``-less re-extract. The
-    clean-dest hash now stands in for the missing recorded map."""
+    (divergence minted directly via ``_rewrite_entry_as_legacy_update`` —
+    the commit-true verbs, #1643/#1652, can't produce it), but with the
+    digest keys stripped: before #1512 the ``recorded_digests is not None``
+    gate let exactly this row fall through to a silent, ``.bak``-less
+    re-extract. The clean-dest hash now stands in for the missing recorded
+    map."""
     _initialized_wiki(wiki_root)
     _seed_wiki_asset(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v0\n"})
     install_skill(tmp_path, "foo")
     pin = _advance_wiki(wiki_root, "skills", "foo", {"SKILL.md": b"committed-v1\n"})
-    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"working-tree-v2\n")
-    update_skill(tmp_path, "foo")
     dest = tmp_path / ".memtomem" / "skills" / "foo" / "SKILL.md"
-    assert dest.read_bytes() == b"working-tree-v2\n"
+    dest.write_bytes(b"working-tree-v2\n")
+    _rewrite_entry_as_legacy_update(tmp_path, "foo", pin=pin)
     lock_path = _strip_to_legacy_entry(tmp_path, "skills", "foo")
 
     monkeypatch.chdir(tmp_path)

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -27,8 +27,10 @@ from memtomem.cli.context_cmd import context as context_group
 from memtomem.context._names import InvalidNameError
 from memtomem.context.install import (
     AlreadyInstalledError,
+    AssetNotFoundError,
     NotInstalledError,
     StaleInstallError,
+    UncommittedAssetError,
     _classify_for_all_update,
     install_skill,
     update_agent,
@@ -1140,40 +1142,50 @@ def test_cli_update_all_force_baks_file_dirtied_during_confirm_prompt(
     assert second.read_bytes() == b"e2\n"
 
 
-# ── CLI: wiki dirty warn timing (single-asset & --all) ──────────────────
+# ── CLI: dirt OUTSIDE the asset never blocks or warns (#1652) ────────────
+# (Replaces the pre-#1652 repo-wide `_WIKI_DIRTY_WARN` timing tests: the
+# warn is gone — wiki dirt is now an asset-scoped hard gate on writes and
+# an asset-scoped hint on no-ops; dirt elsewhere is silent, install parity.)
 
 
-def test_cli_update_wiki_dirty_warn_single_asset(
+def test_cli_update_dirt_outside_asset_proceeds_silently(
     wiki_root: Path,
     project_cwd: Path,
 ) -> None:
-    """Single-asset path: wiki dirty → warn on stderr at update entry."""
+    """Single-asset path: dirt outside the asset → update writes, no warning."""
     _initialized_wiki(wiki_root)
     _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    _seed_wiki_skill(wiki_root, "other", {"SKILL.md": b"other-v1\n"})
     install_skill(project_cwd, "foo")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
 
-    # Make the wiki dirty.
+    # Dirt everywhere EXCEPT skills/foo: repo root + a sibling asset.
     (wiki_root / "untracked_marker.txt").write_text("wip", encoding="utf-8")
+    (wiki_root / "skills" / "other" / "SKILL.md").write_bytes(b"other-dirty\n")
 
     runner = CliRunner()
     result = runner.invoke(context_group, ["update", "skill", "foo"])
 
     assert result.exit_code == 0, result.output
-    assert "wiki has uncommitted changes" in result.output
+    assert "Updated skills/foo" in result.output
+    assert "uncommitted" not in result.output
+    dest = project_cwd / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    assert dest.read_bytes() == b"v2\n"
 
 
-def test_cli_update_wiki_dirty_warn_all(
+def test_cli_update_all_dirt_outside_asset_proceeds(
     wiki_root: Path,
     project_cwd: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """--all path: wiki dirty → warn on stderr BEFORE classification."""
+    """--all path: dirt outside the asset → batch writes, exit 0, no warning."""
     _initialized_wiki(wiki_root)
     _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
     proj = tmp_path / "p"
     proj.mkdir()
     install_skill(proj, "foo")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
 
     (wiki_root / "untracked_marker.txt").write_text("wip", encoding="utf-8")
 
@@ -1185,23 +1197,8 @@ def test_cli_update_wiki_dirty_warn_all(
     result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--yes"])
 
     assert result.exit_code == 0, result.output
-    assert "wiki has uncommitted changes" in result.output
-
-
-def test_cli_update_no_wiki_dirty_warn_when_clean(
-    wiki_root: Path,
-    project_cwd: Path,
-) -> None:
-    """Negative pin: clean wiki → no dirty warn line."""
-    _initialized_wiki(wiki_root)
-    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
-    install_skill(project_cwd, "foo")
-
-    runner = CliRunner()
-    result = runner.invoke(context_group, ["update", "skill", "foo"])
-
-    assert result.exit_code == 0, result.output
-    assert "wiki has uncommitted changes" not in result.output
+    assert "uncommitted" not in result.output
+    assert (proj / ".memtomem" / "skills" / "foo" / "SKILL.md").read_bytes() == b"v2\n"
 
 
 # ── B1: upstream-deletion reconcile + deletion-dirty (#1247) ─────────────
@@ -1500,8 +1497,10 @@ class TestUpdatePrivacyGate:
         privacy.reset_for_tests()
 
     def test_update_blocks_on_poisoned_wiki_src(self, wiki_root: Path, tmp_path: Path) -> None:
-        """Design test 2: secret lands in the wiki → update hard-refuses
-        BEFORE any dest write — zero residue (old bytes, old pin, no .bak)."""
+        """Design test 2: secret lands in the wiki HEAD (committed — #1652's
+        pinned Gate A scans git objects, not the worktree) → update
+        hard-refuses BEFORE any dest write — zero residue (old bytes, old
+        pin, no .bak)."""
         _initialized_wiki(wiki_root)
         old_commit = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
         project = tmp_path
@@ -1982,3 +1981,459 @@ def test_cli_update_all_dry_run_all_up_to_date(
 
     assert result.exit_code == 0, result.output
     assert "All projects are up to date." in result.output
+
+
+# ── commit-true update (#1652) ───────────────────────────────────────────
+#
+# Update extracts bytes from git objects at HEAD (mirror of the #1643
+# install contract) and refuses when the asset's OWN worktree state differs
+# from HEAD — never force-able (--force is the dest-side axis). The no-op
+# path (pin already at HEAD) runs BEFORE the gates: nothing would be
+# written, so uncommitted wiki edits only produce an asset-scoped hint.
+
+
+def _install_and_advance(wiki_root: Path, project: Path) -> tuple[str, str]:
+    """Seed+install skills/foo at v1, then advance the wiki to v2 (clean).
+
+    Returns ``(old_pin, new_pin)`` — the standard would-write posture for
+    the gate tests (pin != HEAD, so update is not a no-op).
+    """
+    _initialized_wiki(wiki_root)
+    old_pin = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project, "foo")
+    new_pin = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    return old_pin, new_pin
+
+
+def _assert_update_zero_residue(project: Path, *, old_pin: str) -> None:
+    """A wiki-side refusal must leave dest bytes, pin, and .bak state untouched."""
+    dest = project / ".memtomem" / "skills" / "foo"
+    assert (dest / "SKILL.md").read_bytes() == b"v1\n"
+    assert _lock_entry(project, "skills", "foo")["wiki_commit"] == old_pin
+    assert list(dest.rglob("*.bak")) == []
+
+
+def test_update_refuses_modified_tracked_file(wiki_root: Path, tmp_path: Path) -> None:
+    old_pin, _ = _install_and_advance(wiki_root, tmp_path)
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"v3 uncommitted\n")
+
+    with pytest.raises(UncommittedAssetError) as excinfo:
+        update_skill(tmp_path, "foo")
+
+    msg = str(excinfo.value)
+    assert "differs from HEAD" in msg
+    assert "SKILL.md" in msg
+    assert "`mm wiki skill commit foo --canonical`" in msg
+    assert "git directly" in msg
+    _assert_update_zero_residue(tmp_path, old_pin=old_pin)
+
+
+def test_update_refuses_untracked_file_inside_asset(wiki_root: Path, tmp_path: Path) -> None:
+    old_pin, _ = _install_and_advance(wiki_root, tmp_path)
+    (wiki_root / "skills" / "foo" / "notes.md").write_bytes(b"scratch\n")
+
+    with pytest.raises(UncommittedAssetError, match="notes.md"):
+        update_skill(tmp_path, "foo")
+    _assert_update_zero_residue(tmp_path, old_pin=old_pin)
+
+
+def test_update_refuses_worktree_deletion(wiki_root: Path, tmp_path: Path) -> None:
+    old_pin, _ = _install_and_advance(wiki_root, tmp_path)
+    (wiki_root / "skills" / "foo" / "SKILL.md").unlink()
+
+    with pytest.raises(UncommittedAssetError, match="SKILL.md"):
+        update_skill(tmp_path, "foo")
+    _assert_update_zero_residue(tmp_path, old_pin=old_pin)
+
+
+def test_update_force_does_not_bypass_uncommitted_gate(wiki_root: Path, tmp_path: Path) -> None:
+    """--force is the dest-side axis; wiki-side dirt refuses regardless."""
+    old_pin, _ = _install_and_advance(wiki_root, tmp_path)
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"v3 uncommitted\n")
+
+    with pytest.raises(UncommittedAssetError):
+        update_skill(tmp_path, "foo", force=True)
+    _assert_update_zero_residue(tmp_path, old_pin=old_pin)
+
+
+def test_update_refuses_asset_absent_at_head_but_in_worktree(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """HEAD drops the asset but the worktree keeps it → uncommitted, not
+    absent: the pin the update would record would not contain the asset."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(tmp_path, "foo")
+    subprocess.run(
+        ["git", "-C", str(wiki_root), "rm", "-r", "--cached", "skills/foo"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(wiki_root), "commit", "-m", "drop foo from history"],
+        check=True,
+        capture_output=True,
+    )
+    assert (wiki_root / "skills" / "foo" / "SKILL.md").exists()
+
+    with pytest.raises(UncommittedAssetError, match="not present at HEAD"):
+        update_skill(tmp_path, "foo")
+
+
+def test_update_absent_everywhere_still_asset_not_found(wiki_root: Path, tmp_path: Path) -> None:
+    """Worktree AND HEAD both lack the asset → the plain AssetNotFoundError
+    message survives the gate rewrite (pin != HEAD so the no-op does not
+    swallow it)."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(tmp_path, "foo")
+    subprocess.run(
+        ["git", "-C", str(wiki_root), "rm", "-r", "skills/foo"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(wiki_root), "commit", "-m", "drop foo entirely"],
+        check=True,
+        capture_output=True,
+    )
+
+    with pytest.raises(AssetNotFoundError, match="not in wiki"):
+        update_skill(tmp_path, "foo")
+
+
+def test_update_dirt_in_other_asset_does_not_block(wiki_root: Path, tmp_path: Path) -> None:
+    """Engine-level twin of the CLI negatives: the gate is pathspec-scoped."""
+    _, new_pin = _install_and_advance(wiki_root, tmp_path)
+    _seed_wiki_skill(wiki_root, "other", {"SKILL.md": b"other-v1\n"})
+    (wiki_root / "skills" / "other" / "SKILL.md").write_bytes(b"other-dirty\n")
+    (wiki_root / "stray.txt").write_bytes(b"wip\n")
+
+    result = update_skill(tmp_path, "foo")
+
+    assert result.was_no_op is False
+    dest = tmp_path / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    assert dest.read_bytes() == b"v2\n"
+
+
+def test_update_ignores_skip_filtered_dirt(wiki_root: Path, tmp_path: Path) -> None:
+    """Untracked files the extractor would never copy (.DS_Store, *.bak)
+    are not dirt. The wiki scaffold .gitignore is stripped so the rows
+    actually reach the is_copy_skipped_rel filter (legacy-clone shape)."""
+    store = _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(tmp_path, "foo")
+    gitignore = store.root / ".gitignore"
+    if gitignore.exists():
+        gitignore.write_text("", encoding="utf-8")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    exclude = store.root / ".git" / "info" / "exclude"
+    if exclude.exists():
+        exclude.write_text("", encoding="utf-8")
+    (wiki_root / "skills" / "foo" / ".DS_Store").write_bytes(b"\x00\x00")
+    (wiki_root / "skills" / "foo" / "SKILL.md.bak").write_bytes(b"old\n")
+    assert store.asset_uncommitted_paths("skills", "foo")
+
+    result = update_skill(tmp_path, "foo")
+
+    assert result.was_no_op is False
+    dest = tmp_path / ".memtomem" / "skills" / "foo"
+    assert (dest / "SKILL.md").read_bytes() == b"v2\n"
+    assert not (dest / ".DS_Store").exists()
+    assert not (dest / "SKILL.md.bak").exists()
+
+
+def test_update_commit_true_bytes(wiki_root: Path, tmp_path: Path) -> None:
+    """The refreshed bytes and lockfile digests describe exactly the bytes
+    at the pinned commit — the literal #1652 contract."""
+    import hashlib
+
+    store = _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(tmp_path, "foo")
+    new_pin = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    result = update_skill(tmp_path, "foo")
+
+    assert result.new_wiki_commit == new_pin
+    dest = tmp_path / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    pin_bytes = store.read_asset_file_at_commit(new_pin, "skills", "foo", "SKILL.md")
+    assert dest.read_bytes() == pin_bytes
+    entry = _lock_entry(tmp_path, "skills", "foo")
+    assert entry["digests"]["SKILL.md"] == hashlib.sha256(pin_bytes).hexdigest()
+    assert entry["files_commit"] == new_pin
+
+
+def test_update_no_op_before_gate(wiki_root: Path, tmp_path: Path) -> None:
+    """Pin already at HEAD + dirty asset → unchanged succeeds (the gate only
+    protects writes) and the lockfile bytes stay byte-identical."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(tmp_path, "foo")
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"v2 uncommitted\n")
+    lock_path = tmp_path / ".memtomem" / "lock.json"
+    pre_lock_bytes = lock_path.read_bytes()
+
+    result = update_skill(tmp_path, "foo")
+
+    assert result.was_no_op is True
+    assert lock_path.read_bytes() == pre_lock_bytes
+
+
+def test_update_gate_a_hint_is_update_flavored(wiki_root: Path, tmp_path: Path) -> None:
+    """The pinned Gate A scan on the update path carries update wording, not
+    the default restore-flavored hint ("re-pin … before restoring")."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "leak", {"SKILL.md": b"v1\n"})
+    install_skill(tmp_path, "leak")
+    _modify_wiki_skill(wiki_root, "leak", {"SKILL.md": b"# leak\n" + SECRET.encode() + b"\n"})
+
+    with pytest.raises(PrivacyBlockedError) as excinfo:
+        update_skill(tmp_path, "leak")
+
+    msg = excinfo.value.message
+    assert "re-run update" in msg
+    assert "restoring" not in msg
+
+
+def test_cli_update_uncommitted_message(wiki_root: Path, project_cwd: Path) -> None:
+    """CLI surface: exit 1 with the file list + runnable commit hint, no
+    traceback."""
+    old_pin, _ = _install_and_advance(wiki_root, project_cwd)
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"v3 uncommitted\n")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo"])
+
+    assert result.exit_code == 1, result.output
+    assert "differs from HEAD" in result.output
+    assert "`mm wiki skill commit foo --canonical`" in result.output
+    assert "Traceback" not in result.output
+    _assert_update_zero_residue(project_cwd, old_pin=old_pin)
+
+
+def test_cli_update_noop_dirty_asset_hints(wiki_root: Path, project_cwd: Path) -> None:
+    """Pin at HEAD + dirty asset → exit 0 "unchanged" plus the asset-scoped
+    stderr note (the answer to "why didn't my wiki edit land?")."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project_cwd, "foo")
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"v2 uncommitted\n")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo"])
+
+    assert result.exit_code == 0, result.output
+    assert "unchanged" in result.output
+    assert "uncommitted wiki edits" in result.output
+    assert "`mm wiki skill commit foo --canonical`" in result.output
+
+
+def test_cli_update_noop_clean_asset_no_hint(wiki_root: Path, project_cwd: Path) -> None:
+    """Negative pin: a clean no-op prints no note (and dirt OUTSIDE the
+    asset doesn't produce one either)."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project_cwd, "foo")
+    (wiki_root / "stray.txt").write_bytes(b"wip\n")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo"])
+
+    assert result.exit_code == 0, result.output
+    assert "uncommitted wiki edits" not in result.output
+
+
+def test_cli_update_all_refuses_dirty_asset_batch(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--all with a dirty asset and at least one would-write row refuses the
+    whole batch before the prompt — exit 1, zero writes."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    proj_behind = tmp_path / "behind"
+    proj_behind.mkdir()
+    install_skill(proj_behind, "foo")
+    new_pin = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    proj_current = tmp_path / "current"
+    proj_current.mkdir()
+    install_skill(proj_current, "foo")
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"v3 uncommitted\n")
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj_behind, proj_current])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--yes", "--force"])
+
+    assert result.exit_code == 1, result.output
+    assert "differs from HEAD" in result.output
+    assert "Refusing to write any project" in result.output
+    behind_dest = proj_behind / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    assert behind_dest.read_bytes() == b"v1\n"
+    assert (
+        json.loads((proj_behind / ".memtomem" / "lock.json").read_text())["skills"]["foo"][
+            "wiki_commit"
+        ]
+        != new_pin
+    )
+
+
+def test_cli_update_all_dirty_asset_all_unchanged_is_up_to_date(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--all with a dirty asset but every pin at HEAD: nothing would write,
+    so exit 0 "up to date" plus the asset-scoped note (no refusal)."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    proj = tmp_path / "p"
+    proj.mkdir()
+    install_skill(proj, "foo")
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"v2 uncommitted\n")
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "All projects are up to date." in result.output
+    assert "uncommitted wiki edits" in result.output
+
+
+def test_cli_update_dry_run_dirty_asset_exits_nonzero(wiki_root: Path, project_cwd: Path) -> None:
+    """Single --dry-run: the wiki-side gate is not force-able, so the dry
+    run fails the way the real run would (the not-installed precedent) —
+    unlike dest-side refuse rows, which preview with exit 0."""
+    old_pin, _ = _install_and_advance(wiki_root, project_cwd)
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"v3 uncommitted\n")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--dry-run"])
+
+    assert result.exit_code == 1, result.output
+    assert "the real run would refuse" in result.output
+    assert "differs from HEAD" in result.output
+    _assert_update_zero_residue(project_cwd, old_pin=old_pin)
+
+
+def test_cli_update_all_dry_run_dirty_asset_exits_nonzero(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--all --dry-run mirrors the wet batch's wiki-side refusal: exit 1
+    when a would-write row meets a dirty asset."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    proj = tmp_path / "p"
+    proj.mkdir()
+    install_skill(proj, "foo")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"v3 uncommitted\n")
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--dry-run"])
+
+    assert result.exit_code == 1, result.output
+    assert "the real run would refuse" in result.output
+    assert (proj / ".memtomem" / "skills" / "foo" / "SKILL.md").read_bytes() == b"v1\n"
+
+
+def test_update_wiki_gate_precedes_dest_dirty_gate(wiki_root: Path, tmp_path: Path) -> None:
+    """Single-asset gate precedence: when BOTH the wiki asset and the dest
+    tree are dirty, the wiki-side UncommittedAssetError fires (the engine's
+    wiki gates run before _apply_update's dest classification) — the parity
+    anchor for --all's refuse-row gating below."""
+    _install_and_advance(wiki_root, tmp_path)
+    dest = tmp_path / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    dest.write_bytes(b"local edit\n")
+    _bump_mtime(dest)
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"v3 uncommitted\n")
+
+    with pytest.raises(UncommittedAssetError):
+        update_skill(tmp_path, "foo")
+    # Not force-able either — still the wiki error, not a .bak write.
+    with pytest.raises(UncommittedAssetError):
+        update_skill(tmp_path, "foo", force=True)
+    assert dest.read_bytes() == b"local edit\n"
+    assert not dest.with_suffix(dest.suffix + ".bak").exists()
+
+
+def _seed_refuse_only_dirty_batch(
+    wiki_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Path:
+    """One project with LOCAL dest edits (refuse row), wiki advanced past its
+    pin, and the wiki asset left dirty — the refuse-only × dirty-wiki grid
+    cell (no update rows)."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    proj = tmp_path / "p"
+    proj.mkdir()
+    install_skill(proj, "foo")
+    edited = proj / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    edited.write_bytes(b"local edit\n")
+    _bump_mtime(edited)
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"v3 uncommitted\n")
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj])
+    _patch_known_projects_path(monkeypatch, known)
+    return proj
+
+
+def test_cli_update_all_refuse_only_dirty_asset_prefers_wiki_refusal(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refuse-only batch WITHOUT --force still surfaces the wiki-side
+    refusal, not the per-project "pass --force" hint — single-asset parity
+    (the engine fires the wiki gate before the dest-dirty gate there too),
+    and committing the wiki dirt moves HEAD, invalidating this preview."""
+    proj = _seed_refuse_only_dirty_batch(wiki_root, tmp_path, monkeypatch)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--yes"])
+
+    assert result.exit_code == 1, result.output
+    assert "differs from HEAD" in result.output
+    assert "pass --force" not in result.output
+    edited = proj / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    assert edited.read_bytes() == b"local edit\n"
+    assert not edited.with_suffix(edited.suffix + ".bak").exists()
+
+
+def test_cli_update_all_dry_run_refuse_only_dirty_asset_exits_nonzero(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--all --dry-run on the refuse-only × dirty-wiki cell mirrors the wet
+    run above: exit 1 with the wiki-side message (a dest-side refuse row
+    alone still previews with exit 0 — pinned elsewhere)."""
+    _seed_refuse_only_dirty_batch(wiki_root, tmp_path, monkeypatch)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--dry-run"])
+
+    assert result.exit_code == 1, result.output
+    assert "the real run would refuse" in result.output
+    assert "differs from HEAD" in result.output

--- a/packages/memtomem/tests/test_dirty_digest.py
+++ b/packages/memtomem/tests/test_dirty_digest.py
@@ -352,29 +352,32 @@ def test_reconcile_digest_provenance_beats_divergent_manifest(
 def test_reconcile_membership_is_written_set_not_post_copy_src_walk(
     wiki_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Codex impl-gate Major: ``_apply_update`` derived reconcile membership
-    by re-walking the wiki working tree AFTER the copy returned. A src
-    mutation landing in that window (file dropped from the worktree) made
-    reconcile erase a file this very update just wrote — its unchanged
-    bytes still matched the OLD digests ("provably untouched") — while
-    ``files``/``digests`` recorded it: a phantom lock entry that the next
-    dirty check reports as a local deletion. Membership must come from the
-    copier's returned written set."""
-    import memtomem.context.install as install_module
-
+    """Codex impl-gate Major: ``_apply_update`` used to derive reconcile
+    membership by re-walking the wiki working tree AFTER the copy returned —
+    a src mutation in that window made reconcile erase a file this very
+    update just wrote while ``files``/``digests`` recorded it (a phantom
+    lock entry). The commit-true update (#1652) closes the mutable-src
+    window by construction, but the contract this test pins survives:
+    membership must come from the extractor's RETURNED written set, never a
+    re-read of the (mutable) wiki — so a worktree mutation landing in the
+    extract→reconcile window must still be invisible."""
     _initialized_wiki(wiki_root)
     _seed_wiki_skill(wiki_root, "web", {"SKILL.md": b"v1\n", "keep.md": b"same\n"})
     install_skill(tmp_path, "web")
     _modify_wiki_skill(wiki_root, "web", {"SKILL.md": b"v2\n"})  # keep.md unchanged
 
-    real_copy = install_module.copy_tree_atomic
+    real_extract = WikiStore.copy_asset_at_commit
 
-    def copy_then_mutate_src(src: Path, dst: Path, **kwargs: object) -> dict[str, str]:
-        result = real_copy(src, dst, **kwargs)  # type: ignore[arg-type]
-        (src / "keep.md").unlink()  # worktree mutation in the copy→reconcile window
+    def extract_then_mutate_worktree(
+        self: WikiStore, commit: str, asset_type: str, name: str, dest: Path
+    ) -> dict[str, str]:
+        result = real_extract(self, commit, asset_type, name, dest)
+        # Worktree mutation in the extract→reconcile window (after the
+        # wiki-side dirty gate already passed).
+        (self.root / asset_type / name / "keep.md").unlink()
         return result
 
-    monkeypatch.setattr(install_module, "copy_tree_atomic", copy_then_mutate_src)
+    monkeypatch.setattr(WikiStore, "copy_asset_at_commit", extract_then_mutate_worktree)
     result = update_skill(tmp_path, "web")
 
     kept = tmp_path / ".memtomem" / "skills" / "web" / "keep.md"

--- a/packages/memtomem/tests/test_web_routes_context_mutations.py
+++ b/packages/memtomem/tests/test_web_routes_context_mutations.py
@@ -340,6 +340,30 @@ async def test_update_dirty_with_force_writes_bak(
 
 
 @pytest.mark.asyncio
+async def test_update_uncommitted_wiki_is_409(
+    client, seeded_wiki: Path, project_root: Path
+) -> None:
+    """Commit-true update (#1652): an asset whose wiki working tree differs
+    from HEAD refuses with 409 ``wiki_uncommitted`` and a fixed message —
+    the engine text embeds the absolute wiki root and must not leak."""
+    assert (await client.post("/api/context/skills/alpha/install")).status_code == 200
+    old_pin = _lock_entry(project_root, "skills", "alpha")["wiki_commit"]
+    _advance_wiki(seeded_wiki)
+    (seeded_wiki / "skills" / "alpha" / "SKILL.md").write_text(
+        _SKILL_BODY + "\nUncommitted edit.\n", encoding="utf-8"
+    )
+    resp = await client.post("/api/context/skills/alpha/update")
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["reason_code"] == "wiki_uncommitted"
+    assert str(seeded_wiki) not in resp.text
+    # Zero residue: old bytes, old pin, no .bak.
+    landed = project_root / ".memtomem" / "skills" / "alpha" / "SKILL.md"
+    assert landed.read_text(encoding="utf-8") == _SKILL_BODY
+    assert _lock_entry(project_root, "skills", "alpha")["wiki_commit"] == old_pin
+    assert list(landed.parent.rglob("*.bak")) == []
+
+
+@pytest.mark.asyncio
 async def test_update_never_installed_is_404(client, seeded_wiki) -> None:
     resp = await client.post("/api/context/skills/alpha/update")
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Makes `mm context update` (single asset and `--all`) **commit-true**: bytes are extracted from the wiki's git objects at HEAD (the same `WikiStore.copy_asset_at_commit` machinery install uses since #1643), so the lockfile pin always reproduces the refreshed bytes. Previously update copied the wiki **worktree** while pinning **HEAD** — updating off a dirty wiki silently recorded a pin that never described the written bytes — and the accompanying `_WIKI_DIRTY_WARN` claimed the opposite failure mode ("using HEAD which doesn't include them"). With both verbs commit-true, no verb can mint pin≠bytes entries anymore.

Closes #1652

## Behavior changes

- **Commit-true extraction** — `_apply_update` takes `wiki: WikiStore` instead of `src: Path` and extracts at the pinned commit; `_reconcile_removed_files` membership stays the extractor's returned written set (now backed by immutable objects, closing the #1247 id 15 mutable-src window by construction).
- **Asset-scoped refusal** — a write refuses with the existing typed `UncommittedAssetError` when the asset's OWN worktree state differs from HEAD (shared gates factored into `_asset_dirty_rels` / `_commit_hint`, reused by install). **`--force` does not bypass** — it only overrides project-side (dest) edits. Dirt elsewhere in the wiki never blocks or warns.
- **No-op stays gate-free** — pin already at HEAD returns `unchanged` (exit 0) before the gates (nothing is written) and prints an asset-scoped stderr note when the asset has uncommitted wiki edits, answering "why didn't my edit land?".
- **`_WIKI_DIRTY_WARN` removed** — the repo-wide warning is replaced by the asset-scoped gate + note above.
- **`--all`** — the wiki-side gate fires once per batch, post-classification, before the prompt, whenever an `update`/`refuse` row exists **regardless of `--force`** (single-asset parity: the engine's wiki gates precede the dest-dirty gate there too; the wiki dirt is the batch-global, non-force-able blocker). The classifier's up-front existence check became a HEAD-presence gate; per-row `CommitNotFoundError` now degrades to a red row instead of crashing the loop.
- **Dry-run** — wiki-side uncommitted refusals exit non-zero the way the real run would (the not-installed precedent); project-side `refuse` rows still preview with exit 0.
- **Gate A at the pin** — `_gate_a_scan_src_tree` (worktree scan) deleted; update uses `_gate_a_scan_pinned_asset` with an update-flavored remediation hint (scan set == write set, no scan→write TOCTOU).
- **Web** — `POST /api/context/{type}/{name}/update` returns fixed-message 409 `wiki_uncommitted` (no wiki-root leak; same shape as install's arm). The wiki panel toast reuses the existing verb-agnostic handler; the shared locale string is reworded verb-neutral (en/ko).
- **Edge case** — pin==HEAD with the asset dir deleted from the wiki worktree now reports `unchanged` (exit 0) instead of `AssetNotFoundError` — the no-op short-circuit runs before the presence gate (called out in CHANGELOG).

## Tests

- New "commit-true update (#1652)" section mirroring install's suite: refuse on modified/untracked/deleted/absent-at-HEAD-but-in-worktree; force-does-not-bypass; other-asset dirt passes; skip-filtered dirt not dirt; commit-true byte + digest parity vs `read_asset_file_at_commit`; no-op-before-gate (lockfile byte-identical); zero residue on refusal; update-flavored Gate A hint; CLI exit-1 message; no-op hint (positive + clean negative); `--all` batch refusal, refuse-only×dirty-wiki cell (wet + dry-run), all-unchanged hint; dry-run non-zero exits (single + `--all`); engine wiki-gate-precedes-dest-gate precedence pin.
- The three `_WIKI_DIRTY_WARN` timing tests are repurposed as dirt-outside-asset negatives (update writes, no warning).
- The three `install --all --force` divergence fixtures minted pin≠bytes rows via the worktree-copying update; they now mint the legacy shape directly (`_rewrite_entry_as_legacy_update`) — the data-safety no-op they pin stays fully in force for legacy lockfiles.
- `test_reconcile_membership_is_written_set_not_post_copy_src_walk` re-pinned at the new seam (`WikiStore.copy_asset_at_commit`): a worktree mutation in the extract→reconcile window stays invisible.
- Web: `test_update_uncommitted_wiki_is_409` (409 + reason code + no path leak + zero residue). vitest wiki suite green (45).
- Full suite `-m "not ollama"` green; ruff clean (src+tests); mypy clean on touched modules; live e2e in an isolated HOME walked refuse → hinted `mm wiki skill commit` → update == HEAD bytes → clean no-op silent → dirty no-op note, plus a curl 409 against `mm web` dev mode.

## Review

Codex review: NEEDS-FIX with one Major — it read the batch gate's trigger ("would write") as excluding `refuse` rows when `--force` is absent. Kept the implemented semantics deliberately for single-asset parity (the engine fires wiki gates before the dest-dirty gate) and because committing the wiki dirt moves HEAD, invalidating the preview either way; the contract comment now spells this out and the refuse-only×dirty-wiki cell is pinned by tests (wet + dry-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
