### PR TITLE
fix(context): canonicalize project roots before persisting (#1644)

### DIFF
--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -258,7 +258,11 @@ class KnownProjectsStore:
                 continue
             entries.append(
                 _KnownProjectEntry(
-                    root=Path(root),
+                    # Canonicalize on load so legacy relative rows (pre-#1644) stop
+                    # floating with the reader's cwd. In-memory only — the load path
+                    # must not write (#1567); mutators persist the healed roots on
+                    # their next locked load-then-write.
+                    root=Path(root).expanduser().resolve(),
                     added_at=str(item.get("added_at") or ""),
                     label=item.get("label") if isinstance(item.get("label"), str) else None,
                     # Legacy rows (pre-``enabled`` schema) and any non-bool value
@@ -296,8 +300,12 @@ class KnownProjectsStore:
 
         Raises :class:`KnownProjectsCorruptError` instead of re-baselining
         the list to ``[new_entry]`` when the file exists but is corrupt.
+
+        *root* is canonicalized (``expanduser().resolve()``) before dedup and
+        persist — a relative root would otherwise be stored verbatim and mean
+        a different directory per reader cwd (#1644).
         """
-        normalized = Path(root).expanduser()
+        normalized = Path(root).expanduser().resolve()
         with _file_lock(_lock_path_for(self._path)):
             entries = self.load(strict=True)
             for existing in entries:
@@ -352,7 +360,8 @@ class KnownProjectsStore:
         Updates *every* entry whose scope_id matches — mirroring
         ``remove_by_scope_id``'s all-matching semantics — so a manually corrupted
         file with duplicate rows can't leave a stale row behind a "success".
-        ``add`` dedups by resolved path, so duplicates never arise via the API.
+        ``add`` canonicalizes roots before persisting and dedups on the same
+        resolved form, so duplicates never arise via the API.
         """
         with _file_lock(_lock_path_for(self._path)):
             entries = self.load(strict=True)

--- a/packages/memtomem/tests/test_cli_context_projects.py
+++ b/packages/memtomem/tests/test_cli_context_projects.py
@@ -102,6 +102,34 @@ def test_add_is_idempotent_with_distinct_copy(cli_env: dict[str, Path]) -> None:
     assert len(KnownProjectsStore(cli_env["kp"]).load()) == 1
 
 
+def test_add_relative_path_registers_per_project(
+    cli_env: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1644 repro: ``projects add .`` from two different projects registers
+    both (no silent cross-project dedup) and echoes the resolved root."""
+    alpha = cli_env["cwd"] / "alpha"
+    beta = cli_env["cwd"] / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    runner = CliRunner()
+
+    monkeypatch.chdir(alpha)
+    first = runner.invoke(context, ["projects", "add", "."])
+    assert first.exit_code == 0, first.output
+    assert "Registered:" in first.output
+    assert str(alpha.resolve()) in first.output
+
+    monkeypatch.chdir(beta)
+    second = runner.invoke(context, ["projects", "add", "."])
+    assert second.exit_code == 0, second.output
+    assert "Registered:" in second.output
+    assert "Already registered:" not in second.output
+    assert str(beta.resolve()) in second.output
+
+    entries = KnownProjectsStore(cli_env["kp"]).load()
+    assert {e.root for e in entries} == {alpha.resolve(), beta.resolve()}
+
+
 def test_pause_resume_round_trip(cli_env: dict[str, Path]) -> None:
     KnownProjectsStore(cli_env["kp"]).add(cli_env["other"])
     scope_id = compute_scope_id(cli_env["other"])

--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -117,6 +117,85 @@ def test_store_add_with_status_reports_created(tmp_path: Path) -> None:
     assert len(store.load()) == 1
 
 
+def test_store_add_relative_root_persists_absolute(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A relative root is canonicalized before persist (#1644) — the on-disk
+    row must not depend on which process later reads the registry."""
+    alpha = tmp_path / "alpha"
+    alpha.mkdir()
+    kp = tmp_path / "kp.json"
+    store = KnownProjectsStore(kp)
+    monkeypatch.chdir(alpha)
+
+    entry = store.add(Path("."))
+
+    assert entry.root.is_absolute()
+    assert entry.root == alpha.resolve()
+    (row,) = json.loads(kp.read_text(encoding="utf-8"))["projects"]
+    assert Path(row["root"]).is_absolute()
+    assert compute_scope_id(entry.root) == compute_scope_id(alpha)
+
+
+def test_store_add_relative_root_from_two_cwds_registers_both(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1644 repro: ``add .`` from a second project must register it, not
+    silently dedup against the first project's floating relative entry."""
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    store = KnownProjectsStore(tmp_path / "kp.json")
+
+    monkeypatch.chdir(alpha)
+    _, created_alpha = store.add_with_status(Path("."))
+    monkeypatch.chdir(beta)
+    _, created_beta = store.add_with_status(Path("."))
+
+    assert created_alpha is True
+    assert created_beta is True
+    entries = store.load()
+    assert {e.root for e in entries} == {alpha.resolve(), beta.resolve()}
+    assert len({compute_scope_id(e.root) for e in entries}) == 2
+
+
+def test_store_load_heals_legacy_relative_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pre-#1644 relative row reads back absolute (resolved against the
+    reader's cwd — the interpretation every read surface already applied).
+    ``load`` itself must not rewrite the file (#1567: no writes on the load
+    path); the first mutation persists the healed root."""
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    kp = tmp_path / "kp.json"
+    kp.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "projects": [{"root": ".", "added_at": "2026-01-01T00:00:00Z", "label": None}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    store = KnownProjectsStore(kp)
+    monkeypatch.chdir(alpha)
+
+    (entry,) = store.load()
+    assert entry.root == alpha.resolve()
+    # Heal is in-memory only — the load path must not write.
+    assert json.loads(kp.read_text(encoding="utf-8"))["projects"][0]["root"] == "."
+
+    # First mutation rewrites the registry with the canonical root.
+    store.add(beta)
+    roots = [row["root"] for row in json.loads(kp.read_text(encoding="utf-8"))["projects"]]
+    assert all(Path(r).is_absolute() for r in roots)
+    assert Path(roots[0]) == alpha.resolve()
+
+
 def test_store_remove_by_scope_id(tmp_path: Path) -> None:
     project = tmp_path / "alpha"
     project.mkdir()

--- a/packages/memtomem/tests/test_web_routes_context_projects.py
+++ b/packages/memtomem/tests/test_web_routes_context_projects.py
@@ -692,6 +692,23 @@ async def test_post_idempotent(client, tmp_path: Path) -> None:
     assert len(listing.json()["scopes"]) == 2
 
 
+@pytest.mark.asyncio
+async def test_post_echoes_canonical_root(client, tmp_path: Path) -> None:
+    """The response ``root`` is the canonicalized path that was persisted
+    (#1644): an absolute-but-non-canonical input (``..`` component) must not
+    round-trip verbatim into the registry."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".claude").mkdir()
+    detour = tmp_path / "detour"
+    detour.mkdir()
+    non_canonical = detour / ".." / "proj"
+
+    resp = await client.post("/api/context/known-projects", json={"root": str(non_canonical)})
+    assert resp.status_code == 200
+    assert resp.json()["root"] == str(proj.resolve())
+
+
 # ── DELETE /context/known-projects/{scope_id} ───────────────────────────
 
 


### PR DESCRIPTION
## Summary

`mm context projects add <path>` persisted the root **as given** (only `expanduser()`), while dedup, scope-id, display, and `is_dir()` all resolve the stored root at **read time** against the current process cwd. A relative root like `"."`:

1. silently swallowed registrations from other projects — `add .` from proj-beta matched proj-alpha's stored `"."` because `"."` resolves to beta's cwd during that invocation, and
2. meant a different directory depending on which process read the registry (`mm web` launched from anywhere reinterpreted it).

## Changes

- **`add_with_status`** (`context/projects.py`): canonicalize with `Path(root).expanduser().resolve()` before dedup and persist. This is the single persistence site in `context/` (bug-shape sweep found no other place persisting a path with expanduser-only). Dedup already compared resolved forms, so absolute inputs are unchanged.
- **`load()`**: heal legacy relative rows in-memory — resolved against the reader's cwd, which is exactly the interpretation every read surface already applied per-call; this just makes it sticky. No write on the load path (#1567 house rule); the first mutation persists the healed roots through the existing locked load-then-write. Resolving all entries also canonicalizes symlinked absolute roots without changing their scope_id (`_normalize_for_scope_id` already resolved).
- **Echo surfaces**: CLI `Registered: <scope-id> (<root>)` and web POST `root` now show the resolved absolute path for free, since both echo `entry.root`.
- Docstring at `update_entry_by_scope_id` updated — "add dedups by resolved path" now also holds for persisted state.

## Tests

- Store: relative add persists an absolute row; `add .` from two different cwds registers **both** projects with distinct scope ids (issue repro); a hand-written legacy `{"root": "."}` row reads back absolute, `load()` does not rewrite the file, and the first mutation persists the healed root.
- CLI: `projects add .` from two directories → two `Registered:` lines with resolved roots, no silent `Already registered`.
- Web: POST response `root` echoes the canonical path for an absolute-but-non-canonical (`..`) input.

All five new tests fail on `main` and pass with the fix. Full suite: 8082 passed, 11 skipped (`-m "not ollama"`); ruff check + format clean. Live e2e repro with isolated HOME confirms two absolute entries in `known_projects.json`.

Closes #1644

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
