### PR TITLE
fix(web): make wiki-behind tooltip recommend a runnable update command (#1645)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -1830,8 +1830,9 @@ def version_enable_cmd(artifact_type: str, name: str, scope_flag: str | None) ->
     is_flag=True,
     help=(
         "Re-install every ASSET in THIS project's .memtomem/lock.json at its "
-        "pinned commit (fresh-machine restore). Note: `update --all` means a "
-        "different axis — ONE asset across every known PROJECT."
+        "pinned commit (fresh-machine restore). Note: `update <type> <name> "
+        "--all` means a different axis — that ONE asset across every known "
+        "PROJECT."
     ),
 )
 @click.option(
@@ -1865,7 +1866,8 @@ def install_cmd(
     is the "fresh-machine restore" verb: a teammate ``git clone``s the
     project, runs ``mm context install --all``, and reproduces the exact
     asset bytes the lockfile recorded. To advance to wiki HEAD instead,
-    use ``mm context update --all``.
+    run ``mm context update <type> <name>`` per asset (there is
+    deliberately no bulk per-project update verb).
     """
     if all_assets:
         if asset_type or name:
@@ -2455,7 +2457,7 @@ def status_cmd(scope_flag: TargetScope, all_projects: bool) -> None:
     Read-only. Walks ``<project>/.memtomem/lock.json`` and classifies
     each entry against the dest tree and the wiki. Always exits 0 for
     normal runs (cron-friendly chaining via ``mm context status && mm
-    context update --all``); only a corrupt / version-mismatched
+    context update <type> <name>``); only a corrupt / version-mismatched
     lockfile produces a non-zero exit.
 
     ``--all-projects`` (#1280) renders the cross-project aggregate

--- a/packages/memtomem/src/memtomem/context/status.py
+++ b/packages/memtomem/src/memtomem/context/status.py
@@ -4,7 +4,7 @@ Powers ``mm context status`` — a diagnostic verb that walks
 ``<project>/.memtomem/lock.json``, classifies each entry against the
 on-disk dest tree and the wiki, and returns a list of
 :class:`StatusRow` for the CLI to render. No writes anywhere; safe to
-run in cron pipes (``mm context status && mm context update --all``).
+run in cron pipes (``mm context status && mm context update <type> <name>``).
 
 State semantics for each lockfile entry:
 

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -439,7 +439,7 @@
   "settings.ctx.last_synced_label": "Store updated",
   "settings.ctx.last_synced_tooltip": "Reflects the most recent stored-file mtime, not a recorded sync event. Editing a stored file without Sync All also bumps this.",
   "settings.ctx.wiki_behind_badge": "Wiki updates available: {n}",
-  "settings.ctx.wiki_behind_tip": "The wiki has newer commits than {n} installed asset(s) in this project. Update them from the Wiki section, or run `mm context update --all`.",
+  "settings.ctx.wiki_behind_tip": "The wiki has newer commits than {n} installed asset(s) in this project. Run `mm context status` to list them, then `mm context update <type> <name>` for each — or, in dev mode, use each asset's Update button in the Wiki section.",
   "settings.ctx.runtime_undetected_tooltip": "Not detected in this project",
   "settings.ctx.refresh": "Refresh",
   "settings.ctx.sync_all": "Sync All",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -439,7 +439,7 @@
   "settings.ctx.last_synced_label": "저장소 갱신",
   "settings.ctx.last_synced_tooltip": "기록된 동기화 이벤트가 아니라 저장소에서 가장 최근에 바뀐 파일의 수정 시각 기준입니다. 전체 동기화 없이 저장된 파일을 편집해도 이 값이 갱신됩니다.",
   "settings.ctx.wiki_behind_badge": "위키 업데이트 가능: {n}",
-  "settings.ctx.wiki_behind_tip": "이 프로젝트에 설치된 자산 {n}개보다 위키에 더 새로운 커밋이 있습니다. 위키 섹션에서 업데이트하거나 `mm context update --all` 을 실행하세요.",
+  "settings.ctx.wiki_behind_tip": "이 프로젝트에 설치된 자산 {n}개보다 위키에 더 새로운 커밋이 있습니다. `mm context status` 로 대상을 확인한 뒤 자산별로 `mm context update <type> <name>` 을 실행하세요 — dev 모드에서는 위키 섹션의 Update 버튼도 사용할 수 있습니다.",
   "settings.ctx.runtime_undetected_tooltip": "이 프로젝트에서 감지되지 않음",
   "settings.ctx.refresh": "새로고침",
   "settings.ctx.sync_all": "전체 동기화",

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -126,6 +126,31 @@ class TestLocaleFiles:
                 f"tier-portable `mm wiki commit` remediation; got: {tip!r}"
             )
 
+    def test_wiki_behind_tip_remediation_is_runnable(
+        self, en: dict[str, str], ko: dict[str, str]
+    ) -> None:
+        """The wiki-behind badge tooltip must not recommend
+        ``mm context update --all`` — that invocation is a usage error
+        (``update`` requires ``ASSET_TYPE NAME``), and even with
+        arguments ``--all`` means "this ONE asset across every known
+        project", not "the N behind assets in THIS project" the badge
+        counts (#1645). Lead with the tier-portable per-asset CLI
+        remediation instead; the Wiki section's Update button is
+        dev-mode-only, same as the dirty-tip case above."""
+        for name, data in [("en", en), ("ko", ko)]:
+            tip = data["settings.ctx.wiki_behind_tip"]
+            assert "--all" not in tip, (
+                f"{name}.json settings.ctx.wiki_behind_tip must not steer "
+                f"users to any `--all` form — `mm context update --all` is a "
+                f"usage error, and even `update <type> <name> --all` is the "
+                f"cross-project axis, not this badge's per-project count; "
+                f"got: {tip!r}"
+            )
+            assert "mm context update" in tip, (
+                f"{name}.json settings.ctx.wiki_behind_tip must name the "
+                f"per-asset `mm context update` remediation; got: {tip!r}"
+            )
+
 
 _STATIC_JS_DIR = _LOCALES_DIR.parent
 


### PR DESCRIPTION
## Summary

The overview "Wiki updates available: N" badge tooltip (added in #1546) told users to run `mm context update --all` — a command that exits 2 with a usage error (`update` requires `ASSET_TYPE NAME`). Even spelled with arguments, `--all` is the one-asset-across-every-known-project axis (#1513 / #1605), not "update the N behind assets in THIS project" that the badge counts.

While fixing the copy, two adjacent defects of the same shape surfaced:

- The tooltip's other remediation ("Update them from the Wiki section") is **dev-mode-only**: the per-asset update POST route (`web/routes/context_mutations.py`) is in `_DEV_ONLY_ROUTERS`, so prod users were pointed at an affordance that does not exist — exactly the defect `settings.nav.ctx_wiki_dirty_tip` already fixed (see `test_wiki_dirty_tip_remediation_is_tier_portable`).
- User-visible `--help` text repeated the unrunnable spelling: the `mm context install` docstring ("To advance to wiki HEAD instead, use `mm context update --all`"), the `mm context status` docstring's cron-chaining example, and install's `--all` flag axis note — plus the `context/status.py` module docstring the status copy came from.

## Changes

- **locales `en.json` / `ko.json` — `settings.ctx.wiki_behind_tip`**: lead with the tier-portable per-asset CLI remediation (`mm context status` to list, then `mm context update <type> <name>` per asset) and qualify the Wiki section's Update button as dev-mode. `{n}` placeholder preserved; no JS change, so no cache-bust needed (locales are fetched no-store).
- **`cli/context_cmd.py`**: fix the three user-visible help strings above to name the runnable `mm context update <type> <name>` form; install's flag note now spells the cross-project axis as `update <type> <name> --all`.
- **`context/status.py`**: same fix in the module docstring's cron-pipe example.
- **`tests/test_i18n.py`**: new guard `test_wiki_behind_tip_remediation_is_runnable` — rejects **any** `--all` form in this tooltip (per review, a runnable `update <type> <name> --all` would still be the wrong axis for this badge) and requires the per-asset `mm context update` remediation. Mirrors the dirty-tip guard. Verified RED against the old copy before the fix.

Out of scope, deliberately: internal dev-facing comments that use `update --all` as shorthand for the flag combination, and adding a real bulk per-project update verb (a separate #1513-adjacent policy call, as the issue notes).

## Testing

- `uv run pytest packages/memtomem/tests/test_i18n.py` — 92 passed (new guard RED before the copy fix, GREEN after).
- `uv run pytest` over `test_docs_guards.py`, `test_context_status.py`, `test_context_update.py`, `test_context_install.py`, `test_context_install_all.py` — 321 passed.
- `uv run ruff check` + `ruff format --check` — clean.
- Live `--help` verification: `mm context install --help` and `mm context status --help` no longer contain `update --all`; the recommended `mm context update <type> <name>` form matches the actual Click signature.

Closes #1645

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
