### PR TITLE
cli(ctx): wording batch — context group help, status empty-state hints, force-unsafe flag docs, tier prose (#1647)

### DIFF
--- a/docs/guides/context-gateway.md
+++ b/docs/guides/context-gateway.md
@@ -287,6 +287,11 @@ them out:
   only — the Web UI has no Project (local) write surface (its write routes
   reject that tier before any privacy check).
 
+The override flag has two spellings, one per direction: `mm context sync
+--force-unsafe` (Store → runtimes) and `mm context init --force-unsafe-import`
+(existing runtime files being imported into the Store). Both follow the tier
+rules above — a `project_shared` destination always hard-refuses.
+
 See [`configuration.md#context-gateway`](configuration.md#context-gateway) for
 the related environment variables.
 

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -754,7 +754,16 @@ def _warn_label_ineligible_kinds(label: str | None, inc: set[str]) -> None:
 
 @click.group("context")
 def context() -> None:
-    """Manage unified agent context (CLAUDE.md, .cursorrules, GEMINI.md, etc.)."""
+    """Manage the canonical artifact Store and sync it to your AI tools.
+
+    The Store (``.memtomem/`` / ``~/.memtomem/``) holds your master copies
+    of skills, agents, commands, MCP servers and settings. ``sync`` fans
+    them out to detected runtimes (Claude Code, Codex, Kimi, Antigravity,
+    ...); ``init`` imports existing runtime copies into the Store;
+    ``install`` / ``update`` / ``version`` manage wiki assets. Also
+    includes the unified ``context.md`` generators (CLAUDE.md, GEMINI.md,
+    etc.).
+    """
 
 
 @context.command("detect")
@@ -2510,7 +2519,7 @@ def status_cmd(scope_flag: TargetScope, all_projects: bool) -> None:
     if untracked_count:
         extra_parts.append(f"{untracked_count} untracked")
     extra_suffix = f" (+ {', '.join(extra_parts)})" if extra_parts else ""
-    scope_suffix = f" — scope {scope_flag}"
+    scope_suffix = f" — tier {scope_flag}"
     if wiki_head is None:
         wiki_root = wiki.root
         # Absent vs present-but-unusable (#1247 id 9): exists() is a pure
@@ -2535,12 +2544,30 @@ def status_cmd(scope_flag: TargetScope, all_projects: bool) -> None:
     if not rows and lockfile_error is None:
         if scope_flag == "project_local":
             click.echo("\nNo project_local draft assets in this project.")
+            # init rejects an explicit project_* scope outside a project
+            # root — don't hint a command that immediately fails there.
+            if (root / ".git").exists() or (root / "pyproject.toml").exists():
+                click.echo("Run 'mm context init --scope=project_local' to seed drafts.")
+            else:
+                click.echo(
+                    "Run 'mm context init --scope=project_local' from inside a "
+                    "project (with .git or pyproject.toml) to seed drafts."
+                )
         elif scope_flag == "user":
-            click.echo("\nNo user-scope assets found under ~/.memtomem/.")
+            click.echo("\nNo user-tier assets found under ~/.memtomem/.")
+            click.echo(
+                "Run 'mm context init --include=agents,commands,skills --scope=user' "
+                "to import from runtimes."
+            )
         else:
             click.echo(
                 f"\nNo wiki assets installed and no untracked canonicals "
-                f"in this project for scope {scope_flag}."
+                f"in this project for tier {scope_flag}."
+            )
+            click.echo(
+                "Run 'mm context detect' to see importable runtime files, "
+                "'mm context init' to seed canonicals, or "
+                "'mm context install <type> <name>' to install from the wiki."
             )
         return
 

--- a/packages/memtomem/tests/test_context_status.py
+++ b/packages/memtomem/tests/test_context_status.py
@@ -388,7 +388,9 @@ def test_cli_status_empty_lockfile_exits_0(
     result = runner.invoke(context_group, ["status"])
     assert result.exit_code == 0
     assert "No wiki assets installed" in result.output
-    assert "scope project_shared" in result.output
+    assert "tier project_shared" in result.output
+    # Empty state must hint the next step (#1647 item 2).
+    assert "mm context init" in result.output
 
 
 def test_cli_status_renders_states(
@@ -646,7 +648,7 @@ def test_cli_status_renders_draft_no_fanout_annotation(
     assert "draft-only" in result.output
     assert "(draft, no fan-out)" in result.output
     assert "1 local-draft" in result.output
-    assert "scope project_local" in result.output
+    assert "tier project_local" in result.output
 
 
 def test_cli_status_default_hides_project_local_drafts(
@@ -877,7 +879,7 @@ def test_cli_status_user_scope_lists_user_artifacts(monkeypatch, tmp_path: Path)
 
     assert result.exit_code == 0
     assert "myagent" in result.output
-    assert "scope user" in result.output
+    assert "tier user" in result.output
 
 
 def test_cli_status_user_scope_empty_message(monkeypatch, tmp_path: Path) -> None:
@@ -891,7 +893,40 @@ def test_cli_status_user_scope_empty_message(monkeypatch, tmp_path: Path) -> Non
     )
 
     assert result.exit_code == 0
-    assert "No user-scope assets found" in result.output
+    assert "No user-tier assets found" in result.output
+    # Empty state must hint the next step (#1647 item 2). --include is
+    # load-bearing: bare `init --scope=user` seeds empty dirs, it does
+    # not import runtime copies.
+    assert "mm context init --include=agents,commands,skills --scope=user" in result.output
+
+
+def test_cli_status_project_local_empty_hint_gated_on_project_signal(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """The project_local empty-state hint must never recommend a command
+    that immediately fails: ``init --scope=project_local`` rejects cwds
+    without a project signal (.git / pyproject.toml), so outside one the
+    hint says to run it from inside a project instead (#1647 item 2)."""
+    home = tmp_path / "home"
+    set_home(monkeypatch, home)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+
+    result = CliRunner().invoke(
+        context_group, ["status", "--scope", "project_local"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    assert "No project_local draft assets" in result.output
+    assert "from inside a project" in result.output
+
+    (proj / ".git").mkdir()
+    result = CliRunner().invoke(
+        context_group, ["status", "--scope", "project_local"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    assert "Run 'mm context init --scope=project_local' to seed drafts." in result.output
+    assert "from inside a project" not in result.output
 
 
 # ── flat-layout reason (#1247 id 0) ──────────────────────────────────────


### PR DESCRIPTION
CLI wording/help polish batch from the 2026-07-04 post-campaign gateway audit. All four
items from the issue, all live-verified against the running CLI.

Closes #1647

## Changes

**1. `mm context --help` group description** — the one-liner described the legacy
context.md framing ("CLAUDE.md, .cursorrules, GEMINI.md") while the command list is
dominated by the artifact Store. Rewritten around the Store + sync model, using the
guide's canonical runtime list (Claude Code, Codex, Kimi, Antigravity, …) so the two
surfaces no longer drift.

**2. `mm context status` empty-state next-step hints** — all three tier variants ended
with no next step, unlike `generate`/`diff` which hint `mm context init`. Each variant
now hints a runnable command:

- `project_shared`: `detect` / `init` / `install <type> <name>` (wiki path)
- `user`: `init --include=agents,commands,skills --scope=user` — `--include` is
  load-bearing; a bare `init --scope=user` seeds empty dirs without importing
- `project_local`: `init --scope=project_local`, gated on the same project signal
  (`.git` / `pyproject.toml`) that `init --scope=project_*` requires, so the hint never
  recommends a command that immediately fails outside a project root

**3. Privacy-override flag docs** — the guide's Privacy section documented only
`--force-unsafe`; init's import valve is spelled `--force-unsafe-import`. Both spellings
are now documented with their direction (sync = Store → runtimes, init = import into
Store).

**4. tier/scope prose** — status output said "scope project_shared" where init/move/copy
prose calls the same values "tiers". Status prose standardized on "tier"; the `--scope`
flag name stays (ADR-0016 §7 / deferred #922).

## Testing

- `test_context_status.py` — updated pins + new test for the project-signal-gated
  project_local hint (60 passed)
- Full `-k context` suite: 2412 passed
- Live-verified in an isolated `HOME`: all three empty states render the hints, and the
  hinted `init --include=… --scope=user` command runs successfully
- `ruff check` + `ruff format --check` clean

Codex review: initial NEEDS-FIX (project_local hint could fail outside a project root;
user hint lacked `--include`) — both findings addressed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
