### PR TITLE
feat(wiki): pave the first-authoring path — new verb, conditional commit default, wrong-case lint

### DIFF
--- a/docs/adr/0008-wiki-layer.md
+++ b/docs/adr/0008-wiki-layer.md
@@ -1,7 +1,7 @@
 # ADR-0008: Wiki layer for shared canonical artifacts
 
-**Status:** Accepted (PR-A/B/C/D/E merged — read-only browser, dev-tier override-seed, and dev-tier project install/update shipped; the in-browser canonical/override editor + isolated commit affordance also shipped, specified in ADR-0027 — see PR Breakdown; amended 2026-07-04: single-asset install and update are commit-true, #1643/#1652)
-**Date:** 2026-04-30 (amended 2026-07-04)
+**Status:** Accepted (PR-A/B/C/D/E merged — read-only browser, dev-tier override-seed, and dev-tier project install/update shipped; the in-browser canonical/override editor + isolated commit affordance also shipped, specified in ADR-0027 — see PR Breakdown; amended 2026-07-04: single-asset install and update are commit-true, #1643/#1652; amended 2026-07-05: `new` scaffold verb + bare-commit canonical default, #1648)
+**Date:** 2026-04-30 (amended 2026-07-05)
 **Context:** Context gateway today is a per-project canonical → multi-runtime
 fan-out router (ADR-0001). Users with several projects must re-author the
 same skill/agent/command in each `<project>/.memtomem/`. This ADR introduces
@@ -121,8 +121,8 @@ be reconsidered in v2 if a real workflow demands it.
 
 ## Subcommands
 
-`mm wiki` is nested per asset type so `{override, diff, lint, commit}` form
-a single mental group of "manipulate this artifact":
+`mm wiki` is nested per asset type so `{new, override, diff, lint, commit}`
+form a single mental group of "manipulate this artifact":
 
 ```
 mm wiki init [--from <git-url>]
@@ -131,9 +131,9 @@ mm wiki remote [<url>]
 mm wiki push
 mm wiki pull
 
-mm wiki skill   {override, diff, lint, commit} <name> [--vendor <vendor>]
-mm wiki agent   {override, diff, lint, commit} <name> [--vendor <vendor>]
-mm wiki command {override, diff, lint, commit} <name> [--vendor <vendor>]
+mm wiki skill   {new, override, diff, lint, commit} <name> [--vendor <vendor>]
+mm wiki agent   {new, override, diff, lint, commit} <name> [--vendor <vendor>]
+mm wiki command {new, override, diff, lint, commit} <name> [--vendor <vendor>]
 
 mm context install <type> <name>
 mm context install --all                # lockfile-driven re-setup
@@ -141,6 +141,17 @@ mm context update  <type> <name> [--all]
 mm context status
 mm context migrate [<type> [<name>]] [--apply] [--force] [--yes]
 ```
+
+`new` (2026-07-05, #1648) scaffolds the canonical file
+(`skills/<name>/SKILL.md`, `agents/<name>/agent.md`,
+`commands/<name>/command.md` — the filenames are case-sensitive) from a
+minimal parse-clean template, refusing to overwrite an existing asset. It is
+the creation counterpart of the ADR-0027 editor, which deliberately only
+edits. `commit` with neither `--canonical` nor `--vendor` defaults to the
+canonical when — and only when — the asset has no registered vendor override
+on disk (with overrides present it still requires explicit selection, so a
+bare commit can never silently omit an edited override); scripts should keep
+passing `--canonical` explicitly.
 
 `mm context sync --include=skills` (existing, ADR-0001 §3) is unchanged.
 The `mm wiki` group is single-asset; `mm context sync` remains the

--- a/docs/guides/context-gateway.md
+++ b/docs/guides/context-gateway.md
@@ -135,6 +135,18 @@ install never changes your machine-wide settings or User-tier copies. Once
 installed, the snapshot is an ordinary Store artifact: you Sync it out to your
 runtimes like any other.
 
+**Authoring a new asset** — `mm wiki <type> new <name>` scaffolds the
+canonical file, e.g. `mm wiki skill new my-skill` writes
+`~/.memtomem-wiki/skills/my-skill/SKILL.md` with a minimal starter template
+(`--editor` opens it in `$EDITOR`). The canonical filenames are exactly
+`SKILL.md`, `agent.md`, and `command.md` — **case-sensitive**: git records the
+stored case, so an `AGENT.md` authored on macOS is invisible to clones on
+case-sensitive filesystems (`mm wiki <type> lint` warns about this). Edit the
+file, then record it with `mm wiki <type> commit <name>` — while the asset has
+no vendor overrides, the commit defaults to the canonical, so no flags are
+needed; in scripts, keep the explicit `mm wiki <type> commit <name>
+--canonical` form.
+
 In the Web UI the wiki panel is **read-only** (browse + Install); authoring
 canonical or vendor-override files is done with the `mm wiki …` CLI (or the
 in-browser editor in dev mode). See [the CLI reference](reference/data-config-cli.md#cli-reference)

--- a/docs/guides/reference/data-config-cli.md
+++ b/docs/guides/reference/data-config-cli.md
@@ -282,9 +282,10 @@ mm wiki init                           # create ~/.memtomem-wiki (writes a READM
 mm wiki list                           # list canonical assets (--type skills|agents|commands)
 
 # Minimal first asset (canonical-only) — empty wiki to installed project copy:
-#   create ~/.memtomem-wiki/skills/<name>/SKILL.md   (see the wiki README for the layout)
+mm wiki skill new <name>               # scaffold skills/<name>/SKILL.md (exact, case-sensitive filename; --editor opens $EDITOR)
 mm wiki skill lint <name>              # CI gate — exits non-zero on errors
 mm wiki skill commit <name> --canonical   # ONE isolated commit of just the canonical path
+                                       # (bare `commit <name>` defaults to --canonical while no vendor overrides exist)
 cd <your project>                      # wiki is global; install/status are project-scoped
 mm context install skill <name>        # snapshot the wiki asset (at HEAD; commit-true — refuses if the asset has uncommitted wiki changes)
 mm context update skill <name>         # re-snapshot at HEAD (commit-true — refuses if the asset has uncommitted wiki changes; --all, --force, --yes)

--- a/packages/memtomem/src/memtomem/cli/wiki_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/wiki_cmd.py
@@ -33,8 +33,10 @@ from memtomem.wiki.inspect import (
     lint_asset,
 )
 from memtomem.wiki.override import (
+    AssetExistsError,
     OverrideExistsError,
     canonical_asset_file,
+    create_canonical,
     seed_override,
 )
 from memtomem.wiki.store import WikiHeadMovedError, _redact_url_userinfo
@@ -121,6 +123,44 @@ def _run_seed_override(
 
     if editor:
         click.edit(filename=str(result.path), require_save=False)
+
+
+def _run_new(
+    asset_type: Literal["skills", "agents", "commands"],
+    name: str,
+    *,
+    editor: bool,
+) -> None:
+    """Shared body for ``mm wiki {skill,agent,command} new``.
+
+    Scaffolds the asset's canonical file from the minimal starter template
+    (:func:`memtomem.wiki.override.create_canonical`), then mirrors the
+    ``override`` verb's trust-UX: green summary + absolute path on stdout,
+    next-step hints steering to the flag-free ``commit``, classified
+    ClickException for known errors, optional ``$EDITOR``.
+    """
+    store = WikiStore.at_default()
+    try:
+        path = create_canonical(store, asset_type, name)
+    except (WikiNotFoundError, AssetExistsError, InvalidNameError) as exc:
+        # Disjoint siblings (WikiNotFoundError / AssetExistsError -> RuntimeError;
+        # InvalidNameError -> ValueError), ordering irrelevant. AssetExistsError's
+        # message is path-free by contract, so surfacing it verbatim leaks nothing.
+        raise click.ClickException(str(exc)) from exc
+
+    # ``create_canonical`` invariant: target lives under ``store.root``.
+    rel = path.relative_to(store.root)
+    click.secho(f"Created {rel.as_posix()}", fg="green")
+    click.echo(str(path))
+    singular = asset_type[:-1]  # "skills" -> "skill": the per-type CLI verb is singular
+    click.echo(f"# next: edit the file, then: mm wiki {singular} commit {name}")
+    click.echo(
+        f"# then: cd <project> && mm context install {singular} {name}"
+        "   # or update an installed copy"
+    )
+
+    if editor:
+        click.edit(filename=str(path), require_save=False)
 
 
 def _echo_diff_line(line: str) -> None:
@@ -245,7 +285,9 @@ def _run_commit(
     :func:`memtomem.wiki.commit.commit_targets` engine — never a bare
     ``git add . && git commit`` that would sweep unrelated staged changes. The
     paths are server-resolved from the typed ``--canonical`` / ``--vendor`` flags
-    (a raw path is never accepted), and every engine error maps to a classified
+    (a raw path is never accepted); a bare invocation defaults to the canonical
+    when — and only when — no registered vendor override exists on disk, so the
+    first-authoring flow needs no flags. Every engine error maps to a classified
     :class:`click.ClickException` so no traceback — and no absolute wiki path —
     leaks. Unlike the web route there is no client Save token, so the commit
     takes the bytes currently on disk and lands on the freshest HEAD (the
@@ -264,9 +306,32 @@ def _run_commit(
         raise click.ClickException(str(exc)) from exc
 
     if not canonical and not vendors:
-        raise click.ClickException(
-            "nothing to commit: pass --canonical and/or --vendor <vendor> to select targets"
-        )
+        # Bare invocation defaults to the canonical, but ONLY when the asset has
+        # no registered vendor overrides on disk — with overrides present, a
+        # silent canonical-only commit would leave the user believing they
+        # committed "the asset" while the overrides stay uncommitted (exactly
+        # the dirty-wiki state `mm context install` pins around, #1643/#1648).
+        # Stray files in overrides/ (wrong extension, .bak) do not count: the
+        # runtime resolver never loads them, so they cannot be commit targets.
+        existing = [
+            f"{vendor}.{OVERRIDE_FORMATS[(asset_type, vendor)][1]}"
+            for vendor in override_vendors(asset_type)
+            if (
+                store.root
+                / asset_type
+                / name
+                / "overrides"
+                / f"{vendor}.{OVERRIDE_FORMATS[(asset_type, vendor)][1]}"
+            ).is_file()
+        ]
+        if existing:
+            raise click.ClickException(
+                f"nothing to commit: this asset has overrides on disk ({', '.join(existing)}) "
+                "— pass --canonical and/or --vendor <vendor> to select targets"
+            )
+        canonical = True
+        rel = canonical_asset_file(store, asset_type, name).relative_to(store.root).as_posix()
+        click.echo(f"# no registered vendor overrides on disk — committing the canonical {rel}")
 
     targets: list[ResolvedTarget] = []
     if canonical:
@@ -499,8 +564,32 @@ def pull_cmd() -> None:
 def skill_group() -> None:
     """Manage wiki skills.
 
-    Seed vendor overrides, then diff, lint, and commit selected paths.
+    Create a canonical skill (new), seed vendor overrides, then diff, lint,
+    and commit selected paths.
     """
+
+
+@skill_group.command("new")
+@click.argument("name")
+@click.option(
+    "--editor",
+    "-e",
+    is_flag=True,
+    help="Open $EDITOR on the created file after writing.",
+)
+def skill_new_cmd(name: str, editor: bool) -> None:
+    """Scaffold a new canonical skill in the wiki.
+
+    ``mm wiki skill new <name>`` writes a minimal starter template to
+    ``<wiki>/skills/<name>/SKILL.md`` — the canonical filename is exactly
+    ``SKILL.md`` (case-sensitive; git records the stored case, so a
+    ``skill.md`` authored on macOS is invisible on Linux clones). Edit the
+    file (``--editor`` opens ``$EDITOR``), then record it with
+    ``mm wiki skill commit <name>`` — with no overrides yet, the commit
+    defaults to the canonical, no flags needed. Refuses to overwrite an
+    existing skill.
+    """
+    _run_new("skills", name, editor=editor)
 
 
 @skill_group.command("override")
@@ -591,7 +680,7 @@ def skill_lint_cmd(name: str, vendor: str | None) -> None:
     "--canonical",
     "-c",
     is_flag=True,
-    help="Also commit the canonical SKILL.md.",
+    help="Commit the canonical SKILL.md (the default when no registered vendor overrides exist).",
 )
 @click.option(
     "--message",
@@ -608,7 +697,10 @@ def skill_commit_cmd(
     selected paths layered onto HEAD — never a bare ``git add . && git commit``
     that would sweep unrelated staged changes. Edit the files first (e.g.
     ``mm wiki skill override <name> --vendor <v> --editor``), then select targets
-    with ``--canonical`` and/or one or more ``--vendor`` flags.
+    with ``--canonical`` and/or one or more ``--vendor`` flags. With no flags,
+    the commit defaults to the canonical when — and only when — the skill has
+    no registered vendor overrides on disk; scripts should keep passing
+    ``--canonical`` explicitly.
     """
     _run_commit("skills", name, vendors, canonical=canonical, message=message)
 
@@ -620,8 +712,32 @@ def skill_commit_cmd(
 def agent_group() -> None:
     """Manage wiki agents.
 
-    Seed vendor overrides, then diff, lint, and commit selected paths.
+    Create a canonical agent (new), seed vendor overrides, then diff, lint,
+    and commit selected paths.
     """
+
+
+@agent_group.command("new")
+@click.argument("name")
+@click.option(
+    "--editor",
+    "-e",
+    is_flag=True,
+    help="Open $EDITOR on the created file after writing.",
+)
+def agent_new_cmd(name: str, editor: bool) -> None:
+    """Scaffold a new canonical agent in the wiki.
+
+    ``mm wiki agent new <name>`` writes a minimal starter template to
+    ``<wiki>/agents/<name>/agent.md`` — the canonical filename is exactly
+    ``agent.md`` (lowercase, case-sensitive; git records the stored case, so
+    an ``AGENT.md`` authored on macOS is invisible on Linux clones). Edit the
+    file (``--editor`` opens ``$EDITOR``), then record it with
+    ``mm wiki agent commit <name>`` — with no overrides yet, the commit
+    defaults to the canonical, no flags needed. Refuses to overwrite an
+    existing agent.
+    """
+    _run_new("agents", name, editor=editor)
 
 
 @agent_group.command("override")
@@ -714,7 +830,7 @@ def agent_lint_cmd(name: str, vendor: str | None) -> None:
     "--canonical",
     "-c",
     is_flag=True,
-    help="Also commit the canonical agent.md.",
+    help="Commit the canonical agent.md (the default when no registered vendor overrides exist).",
 )
 @click.option(
     "--message",
@@ -731,7 +847,10 @@ def agent_commit_cmd(
     selected paths layered onto HEAD — never a bare ``git add . && git commit``
     that would sweep unrelated staged changes. Edit the files first (e.g.
     ``mm wiki agent override <name> --vendor <v> --editor``), then select targets
-    with ``--canonical`` and/or one or more ``--vendor`` flags.
+    with ``--canonical`` and/or one or more ``--vendor`` flags. With no flags,
+    the commit defaults to the canonical when — and only when — the agent has
+    no registered vendor overrides on disk; scripts should keep passing
+    ``--canonical`` explicitly.
     """
     _run_commit("agents", name, vendors, canonical=canonical, message=message)
 
@@ -743,8 +862,32 @@ def agent_commit_cmd(
 def command_group() -> None:
     """Manage wiki commands.
 
-    Seed vendor overrides, then diff, lint, and commit selected paths.
+    Create a canonical command (new), seed vendor overrides, then diff, lint,
+    and commit selected paths.
     """
+
+
+@command_group.command("new")
+@click.argument("name")
+@click.option(
+    "--editor",
+    "-e",
+    is_flag=True,
+    help="Open $EDITOR on the created file after writing.",
+)
+def command_new_cmd(name: str, editor: bool) -> None:
+    """Scaffold a new canonical command in the wiki.
+
+    ``mm wiki command new <name>`` writes a minimal starter template to
+    ``<wiki>/commands/<name>/command.md`` — the canonical filename is exactly
+    ``command.md`` (lowercase, case-sensitive; git records the stored case, so
+    a ``COMMAND.md`` authored on macOS is invisible on Linux clones). Edit the
+    file (``--editor`` opens ``$EDITOR``), then record it with
+    ``mm wiki command commit <name>`` — with no overrides yet, the commit
+    defaults to the canonical, no flags needed. Refuses to overwrite an
+    existing command.
+    """
+    _run_new("commands", name, editor=editor)
 
 
 @command_group.command("override")
@@ -839,7 +982,7 @@ def command_lint_cmd(name: str, vendor: str | None) -> None:
     "--canonical",
     "-c",
     is_flag=True,
-    help="Also commit the canonical command.md.",
+    help="Commit the canonical command.md (the default when no registered vendor overrides exist).",
 )
 @click.option(
     "--message",
@@ -856,6 +999,9 @@ def command_commit_cmd(
     selected paths layered onto HEAD — never a bare ``git add . && git commit``
     that would sweep unrelated staged changes. Edit the files first (e.g.
     ``mm wiki command override <name> --vendor <v> --editor``), then select
-    targets with ``--canonical`` and/or one or more ``--vendor`` flags.
+    targets with ``--canonical`` and/or one or more ``--vendor`` flags. With no
+    flags, the commit defaults to the canonical when — and only when — the
+    command has no registered vendor overrides on disk; scripts should keep
+    passing ``--canonical`` explicitly.
     """
     _run_commit("commands", name, vendors, canonical=canonical, message=message)

--- a/packages/memtomem/src/memtomem/wiki/inspect.py
+++ b/packages/memtomem/src/memtomem/wiki/inspect.py
@@ -374,6 +374,23 @@ def _lint_canonical_parse(asset_type: str, canonical: Path) -> list[LintFinding]
     return []
 
 
+def _wrong_case_canonical(asset_dir: Path, expected: str) -> str | None:
+    """Stored filename that matches ``expected`` only case-insensitively, else None.
+
+    ``iterdir()`` reveals the *stored* case, so this catches both failure modes:
+    on a case-sensitive filesystem the canonical ``.is_file()`` check already
+    missed (this explains why), and on a case-insensitive one (macOS default)
+    the asset works locally but git records the wrong case, so every
+    case-sensitive clone (Linux) sees no canonical at all.
+    """
+    if not asset_dir.is_dir():
+        return None
+    for p in sorted(asset_dir.iterdir()):
+        if p.is_file() and p.name != expected and p.name.casefold() == expected.casefold():
+            return p.name
+    return None
+
+
 def _scan_overrides(asset_type: str, asset_dir: Path) -> tuple[list[str], list[str]]:
     """Classify the files in ``<asset_dir>/overrides/`` against the registered
     formats.
@@ -480,7 +497,10 @@ def lint_asset(
     1. **Name** — :func:`validate_name`. An invalid name makes every path
        join below unsafe, so this short-circuits to a single error.
     2. **Canonical** — the ``SKILL.md`` / ``agent.md`` / ``command.md`` is
-       present and (agents / commands) parses.
+       present and (agents / commands) parses. A file matching the expected
+       name only case-insensitively (e.g. ``AGENT.md``) draws a warning: git
+       records the stored case, so the asset is invisible on case-sensitive
+       clones even when it works on a macOS checkout.
     3. **Stray override files** — anything in ``overrides/`` that is not a
        registered ``<vendor>.<ext>`` (nor a ``.bak``) is an error: the runtime
        resolver would silently ignore it. Scanned even when the canonical is
@@ -507,22 +527,28 @@ def lint_asset(
     findings: list[LintFinding] = []
     canonical_ok = True
 
-    if asset_type == "skills":
-        if not (asset_dir / "SKILL.md").is_file():
-            findings.append(LintFinding("error", f"missing canonical {asset_type}/{name}/SKILL.md"))
-            canonical_ok = False
-    else:
-        stem = asset_type[:-1]  # "agents" → "agent", "commands" → "command"
-        canonical = asset_dir / f"{stem}.md"
-        if not canonical.is_file():
-            findings.append(
-                LintFinding("error", f"missing canonical {asset_type}/{name}/{stem}.md")
+    # "SKILL.md" for skills; "agents" → "agent.md", "commands" → "command.md".
+    expected = "SKILL.md" if asset_type == "skills" else f"{asset_type[:-1]}.md"
+    canonical = asset_dir / expected
+    if not canonical.is_file():
+        findings.append(LintFinding("error", f"missing canonical {asset_type}/{name}/{expected}"))
+        canonical_ok = False
+    elif asset_type != "skills":
+        parse_findings = _lint_canonical_parse(asset_type, canonical)
+        findings.extend(parse_findings)
+        canonical_ok = not parse_findings
+
+    wrong_case = _wrong_case_canonical(asset_dir, expected)
+    if wrong_case is not None:
+        findings.append(
+            LintFinding(
+                "warning",
+                f"canonical filename is case-sensitive: found {wrong_case}, expected "
+                f"{expected} — rename it (git mv {asset_type}/{name}/{wrong_case} "
+                f"{asset_type}/{name}/{expected}), or the asset is invisible on "
+                "case-sensitive clones (Linux)",
             )
-            canonical_ok = False
-        else:
-            parse_findings = _lint_canonical_parse(asset_type, canonical)
-            findings.extend(parse_findings)
-            canonical_ok = not parse_findings
+        )
 
     valid_vendors, stray = _scan_overrides(asset_type, asset_dir)
     for filename in stray:

--- a/packages/memtomem/src/memtomem/wiki/override.py
+++ b/packages/memtomem/src/memtomem/wiki/override.py
@@ -26,12 +26,14 @@ from pathlib import Path
 
 from memtomem.context._atomic import atomic_write_bytes
 from memtomem.context._names import OVERRIDE_FORMATS, validate_name
-from memtomem.wiki.store import WikiStore
+from memtomem.wiki.store import WIKI_ASSET_TYPES, WikiStore
 
 __all__ = [
+    "AssetExistsError",
     "OverrideExistsError",
     "SeedResult",
     "canonical_asset_file",
+    "create_canonical",
     "render_seed_bytes",
     "seed_override",
     "write_canonical",
@@ -41,6 +43,15 @@ __all__ = [
 
 class OverrideExistsError(RuntimeError):
     """Raised when an override file already exists and ``force`` was not given."""
+
+
+class AssetExistsError(RuntimeError):
+    """Raised by :func:`create_canonical` when the asset's canonical already exists.
+
+    The message is deliberately **path-free** (relative form only): unlike
+    :class:`OverrideExistsError` it is surfaced verbatim by callers that must
+    not leak the absolute wiki path.
+    """
 
 
 @dataclass(frozen=True)
@@ -279,4 +290,91 @@ def write_canonical(
     backup = target.with_suffix(target.suffix + ".bak")
     atomic_write_bytes(backup, target.read_bytes())
     atomic_write_bytes(target, content)
+    return target
+
+
+_CANONICAL_TEMPLATES: dict[str, str] = {
+    "skills": (
+        "---\n"
+        "name: {name}\n"
+        "description: TODO — one line on when to use this skill.\n"
+        "---\n"
+        "\n"
+        "# {name}\n"
+        "\n"
+        "TODO — write the skill instructions.\n"
+    ),
+    "agents": (
+        "---\n"
+        "name: {name}\n"
+        "description: TODO — one line on what this agent does.\n"
+        "---\n"
+        "\n"
+        "TODO — write the agent system prompt.\n"
+    ),
+    "commands": (
+        "---\n"
+        "name: {name}\n"
+        "description: TODO — one line on what this command does.\n"
+        "---\n"
+        "\n"
+        "TODO — write the command prompt ($ARGUMENTS is substituted).\n"
+    ),
+}
+"""Minimal, parse-clean starter content for :func:`create_canonical`.
+
+Each template must keep parsing under the same gate the in-browser editor
+uses (:func:`memtomem.wiki.inspect.validate_canonical_text`) — a lint test
+pins ``new`` → ``lint`` green for every asset type so template and parser
+cannot drift apart.
+"""
+
+
+def create_canonical(store: WikiStore, asset_type: str, name: str) -> Path:
+    """Scaffold a new asset's canonical file (``mm wiki <type> new``).
+
+    Writes the minimal starter template to ``skills/<name>/SKILL.md`` /
+    ``agents/<name>/agent.md`` / ``commands/<name>/command.md`` and returns the
+    path. The complement of :func:`write_canonical`, which *edits* an existing
+    asset and deliberately refuses to create one (ADR-0027 Editor-B) — creation
+    is this wider, wiki-side operation.
+
+    Refuses with :class:`AssetExistsError` when the canonical is already there
+    (no ``force``: clobbering an authored canonical from a scaffold has no
+    legitimate use; edit the file directly instead). On a case-insensitive
+    filesystem a wrong-case canonical (``AGENT.md``) also counts as existing —
+    ``mm wiki <type> lint`` is the diagnostic for that state. An asset directory
+    that exists *without* a canonical is allowed: scaffolding repairs the
+    half-authored dir. All preconditions run before any mutation; the rendered
+    template is parse-gated so a broken template never reaches disk.
+    """
+    if asset_type not in WIKI_ASSET_TYPES:
+        raise ValueError(f"unsupported asset_type for canonical creation: {asset_type!r}")
+    store.require_exists()
+    validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
+    target = canonical_asset_file(store, asset_type, name)
+    # ``exists()`` not ``is_file()``: a directory squatting on the canonical
+    # path is also a collision — falling through would surface a raw
+    # IsADirectoryError instead of a classified, path-free message.
+    if target.exists():
+        raise AssetExistsError(
+            f"{asset_type}/{name} already has a canonical "
+            f"({target.relative_to(store.root).as_posix()}) — edit the file directly, "
+            f"or seed a vendor override with `mm wiki {asset_type.removesuffix('s')} override`"
+        )
+    if target.parent.exists() and not target.parent.is_dir():
+        # A stray FILE at <type>/<name> would make mkdir below raise a raw
+        # FileExistsError; classify it the same way.
+        raise AssetExistsError(
+            f"{asset_type}/{name} already exists in the wiki but is not an asset "
+            "directory — remove or rename it first"
+        )
+    content = _CANONICAL_TEMPLATES[asset_type].format(name=name)
+    # Function-body import dodges the wiki-internal cycle: ``wiki.inspect``
+    # imports ``canonical_asset_file`` from this module at import time.
+    from memtomem.wiki.inspect import validate_canonical_text
+
+    validate_canonical_text(asset_type, name, content)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_bytes(target, content.encode("utf-8"))
     return target

--- a/packages/memtomem/tests/test_wiki_cmd_commit.py
+++ b/packages/memtomem/tests/test_wiki_cmd_commit.py
@@ -174,15 +174,94 @@ def test_commit_message_privacy_warning_is_soft(wiki_root: Path) -> None:
 # ── classified errors (no traceback leaks) ─────────────────────────────────
 
 
-def test_no_targets_errors(wiki_root: Path) -> None:
+def test_no_targets_errors_when_overrides_exist(wiki_root: Path) -> None:
+    # With a registered override on disk, a bare commit must NOT default to the
+    # canonical: silently omitting the override would leave the user believing
+    # they committed "the asset". The error enumerates what is there.
     _init_wiki()
     _seed_skill(wiki_root)
     runner = CliRunner()
+    runner.invoke(wiki_group, ["skill", "override", "demo", "--vendor", "claude"])
 
     result = runner.invoke(wiki_group, ["skill", "commit", "demo"])
 
     assert result.exit_code != 0
-    assert "nothing to commit: pass --canonical" in result.output
+    assert "nothing to commit: this asset has overrides on disk (claude.md)" in result.output
+    assert "pass --canonical and/or --vendor" in result.output
+
+
+def test_bare_commit_defaults_to_canonical(wiki_root: Path) -> None:
+    # First-authoring flow (#1648): no registered overrides on disk → a bare
+    # commit selects the canonical, and says so (the note line is the pinned
+    # evidence this is an announced default, not a silent behavior change).
+    _init_wiki()
+    _seed_skill(wiki_root)
+    (wiki_root / "skills/demo/SKILL.md").write_bytes(b"# canonical v2\n")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "commit", "demo"])
+
+    assert result.exit_code == 0, _combined(result)
+    assert "no registered vendor overrides on disk" in result.output
+    assert "Committed" in result.output
+    head = _git(wiki_root, "rev-parse", "HEAD").strip()
+    assert _git(wiki_root, "show", f"{head}:skills/demo/SKILL.md") == "# canonical v2\n"
+    files = _git(wiki_root, "show", "--name-only", "--format=", head).split()
+    assert files == ["skills/demo/SKILL.md"]
+
+
+def test_bare_commit_ignores_stray_override_files(wiki_root: Path) -> None:
+    # Stray files in overrides/ (wrong extension, .bak) are not commit targets
+    # (the runtime resolver never loads them), so they must not block the
+    # canonical default — same membership rule lint's _scan_overrides uses.
+    _init_wiki()
+    _seed_skill(wiki_root)
+    (wiki_root / "skills/demo/SKILL.md").write_bytes(b"# canonical v2\n")
+    stray_dir = wiki_root / "skills/demo/overrides"
+    stray_dir.mkdir()
+    (stray_dir / "gemini.bad").write_bytes(b"wrong extension\n")
+    (stray_dir / "claude.md.bak").write_bytes(b"backup\n")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "commit", "demo"])
+
+    assert result.exit_code == 0, _combined(result)
+    assert "no registered vendor overrides on disk" in result.output
+
+
+def test_bare_commit_missing_canonical_friendly_error(wiki_root: Path) -> None:
+    # The default may select a canonical that was never authored — the existing
+    # "create it first" pre-check stays the safety net.
+    _init_wiki()
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "commit", "ghost"])
+
+    assert result.exit_code != 0
+    out = result.output.replace("\\", "/")
+    assert "no such file in the wiki: skills/ghost/SKILL.md" in out
+
+
+def test_agent_bare_commit_defaults_to_canonical(wiki_root: Path) -> None:
+    # Type parity: the default lives in the shared _run_commit helper.
+    _init_wiki()
+    d = wiki_root / "agents" / "beta"
+    d.mkdir(parents=True)
+    (d / "agent.md").write_text(
+        "---\nname: beta\ndescription: a test agent\n---\n\nBody.\n", encoding="utf-8"
+    )
+    _git(wiki_root, "add", ".")
+    _git(wiki_root, "commit", "-m", "add agent beta")
+    (d / "agent.md").write_text(
+        "---\nname: beta\ndescription: edited\n---\n\nBody v2.\n", encoding="utf-8"
+    )
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["agent", "commit", "beta"])
+
+    assert result.exit_code == 0, _combined(result)
+    assert "no registered vendor overrides on disk" in result.output
+    assert "edited" in _git(wiki_root, "show", "HEAD:agents/beta/agent.md")
 
 
 def test_missing_file_friendly_error(wiki_root: Path) -> None:

--- a/packages/memtomem/tests/test_wiki_cmd_diff_lint.py
+++ b/packages/memtomem/tests/test_wiki_cmd_diff_lint.py
@@ -10,6 +10,7 @@ errors (no traceback leaks), and the lint exit-code gate.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -374,6 +375,57 @@ def test_command_lint_missing_wiki_classified_error(monkeypatch, tmp_path: Path)
 
     assert result.exit_code != 0
     assert "wiki not found" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_lint_wrong_case_canonical_warns_agent(wiki_root: Path) -> None:
+    """A canonical stored under the wrong case (AGENT.md) draws a warning on
+    every platform: on a case-insensitive FS (macOS) the asset works locally
+    but git records the wrong case, so case-sensitive clones (Linux) see no
+    canonical; there, the missing-canonical error additionally fails lint."""
+    _initialized_wiki()
+    _seed_agent(wiki_root, "beta")
+    agent_dir = wiki_root / "agents" / "beta"
+    os.rename(agent_dir / "agent.md", agent_dir / "AGENT.md")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["agent", "lint", "beta"])
+
+    assert (
+        "canonical filename is case-sensitive: found AGENT.md, expected agent.md" in result.output
+    )
+    if not (agent_dir / "agent.md").is_file():  # case-sensitive FS
+        assert result.exit_code != 0
+        assert "missing canonical agents/beta/agent.md" in result.output
+    else:  # case-insensitive FS: works locally, warning-only
+        assert result.exit_code == 0
+
+
+def test_lint_wrong_case_canonical_warns_skill(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello")
+    skill_dir = wiki_root / "skills" / "hello"
+    os.rename(skill_dir / "SKILL.md", skill_dir / "skill.md")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "lint", "hello"])
+
+    assert (
+        "canonical filename is case-sensitive: found skill.md, expected SKILL.md" in result.output
+    )
+
+
+def test_lint_missing_asset_dir_stays_classified(wiki_root: Path) -> None:
+    """Linting a name with no asset dir must stay a lint finding, never an
+    unclassified FileNotFoundError from scanning a nonexistent directory."""
+    _initialized_wiki()
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["agent", "lint", "ghost"])
+
+    assert result.exit_code != 0
+    assert "missing canonical agents/ghost/agent.md" in result.output
+    assert not isinstance(result.exception, FileNotFoundError)
     assert "Traceback" not in result.output
 
 

--- a/packages/memtomem/tests/test_wiki_cmd_new.py
+++ b/packages/memtomem/tests/test_wiki_cmd_new.py
@@ -1,0 +1,234 @@
+"""Tests for ``mm wiki {skill,agent,command} new`` — the authoring scaffold (#1648).
+
+``new`` writes the minimal starter template to the asset's canonical path via
+:func:`memtomem.wiki.override.create_canonical`. Tests pin: the exact canonical
+filename per type (the case-sensitivity contract), the template ↔ parser
+agreement (``new`` → ``lint`` green), the flag-free first-authoring flow
+(``new`` → bare ``commit``), the refuse-to-overwrite guard (path-free message,
+original bytes intact), and the classified errors.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli.wiki_cmd import wiki as wiki_group
+from memtomem.wiki.override import AssetExistsError, create_canonical
+from memtomem.wiki.store import WikiStore
+
+# ``wiki_root`` / ``git_identity`` fixtures come from conftest.py (which imports
+# them from _wiki_fixtures), so they need no import here.
+
+_CANONICAL_BY_TYPE = {
+    "skill": ("skills", "SKILL.md"),
+    "agent": ("agents", "agent.md"),
+    "command": ("commands", "command.md"),
+}
+
+
+def _init_wiki() -> WikiStore:
+    store = WikiStore.at_default()
+    store.init()
+    return store
+
+
+def _combined(result) -> str:  # noqa: ANN001
+    """stdout + stderr, robust across Click's pre/post-8.2 ``mix_stderr`` change."""
+    out = result.output or ""
+    try:
+        out += result.stderr  # Click ≥8.2 exposes stderr separately
+    except ValueError:
+        pass  # Click <8.2 already mixed stderr into output
+    return out
+
+
+# ── happy path (all three types) ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize("verb", sorted(_CANONICAL_BY_TYPE))
+def test_new_scaffolds_canonical(wiki_root: Path, verb: str) -> None:
+    _init_wiki()
+    plural, filename = _CANONICAL_BY_TYPE[verb]
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, [verb, "new", "demo"])
+
+    assert result.exit_code == 0, _combined(result)
+    assert f"Created {plural}/demo/{filename}" in result.output
+    assert f"# next: edit the file, then: mm wiki {verb} commit demo" in result.output
+    assert f"mm context install {verb} demo" in result.output
+    asset_dir = wiki_root / plural / "demo"
+    # The stored filename must match exactly — iterdir (not is_file) so a
+    # case-insensitive filesystem cannot mask a wrong-case write.
+    assert [p.name for p in asset_dir.iterdir()] == [filename]
+    content = (asset_dir / filename).read_text(encoding="utf-8")
+    assert content.startswith("---\nname: demo\n")
+    assert "TODO" in content
+
+
+@pytest.mark.parametrize("verb", sorted(_CANONICAL_BY_TYPE))
+def test_new_then_lint_is_green(wiki_root: Path, verb: str) -> None:
+    # Template ↔ parser pin: the scaffold must parse under the same gate lint
+    # and the vendor renderers use, for every asset type.
+    _init_wiki()
+    runner = CliRunner()
+    assert runner.invoke(wiki_group, [verb, "new", "demo"]).exit_code == 0
+
+    result = runner.invoke(wiki_group, [verb, "lint", "demo"])
+
+    assert result.exit_code == 0, _combined(result)
+    assert "OK" in result.output
+
+
+def test_new_then_bare_commit_flows(wiki_root: Path) -> None:
+    # The whole #1648 first-authoring path, end to end and flag-free:
+    # scaffold → (edit) → bare commit defaults to the canonical.
+    _init_wiki()
+    runner = CliRunner()
+    assert runner.invoke(wiki_group, ["skill", "new", "demo"]).exit_code == 0
+    (wiki_root / "skills/demo/SKILL.md").write_bytes(b"# authored\n")
+
+    result = runner.invoke(wiki_group, ["skill", "commit", "demo"])
+
+    assert result.exit_code == 0, _combined(result)
+    assert "Committed" in result.output
+
+
+# ── refuse-to-overwrite ──────────────────────────────────────────────────
+
+
+def test_new_refuses_existing_asset(wiki_root: Path) -> None:
+    _init_wiki()
+    runner = CliRunner()
+    assert runner.invoke(wiki_group, ["agent", "new", "beta"]).exit_code == 0
+    authored = wiki_root / "agents/beta/agent.md"
+    authored.write_bytes(b"---\nname: beta\ndescription: authored\n---\n\nBody.\n")
+
+    result = runner.invoke(wiki_group, ["agent", "new", "beta"])
+
+    assert result.exit_code != 0
+    assert "agents/beta already has a canonical" in result.output
+    assert "edit the file directly" in result.output
+    # Path-free contract: the absolute wiki path never appears in the message.
+    assert str(wiki_root) not in result.output
+    # The refused scaffold left the authored bytes untouched.
+    assert authored.read_bytes() == b"---\nname: beta\ndescription: authored\n---\n\nBody.\n"
+
+
+def test_new_refuses_directory_squatting_on_canonical_path(wiki_root: Path) -> None:
+    # A DIRECTORY at the canonical path is also a collision — it must classify,
+    # never surface a raw IsADirectoryError (or leak the absolute wiki path).
+    _init_wiki()
+    (wiki_root / "skills" / "demo" / "SKILL.md").mkdir(parents=True)
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "new", "demo"])
+
+    assert result.exit_code != 0
+    assert "skills/demo already has a canonical" in result.output
+    assert "Traceback" not in result.output
+    assert str(wiki_root) not in result.output
+
+
+def test_new_refuses_file_squatting_on_asset_dir(wiki_root: Path) -> None:
+    # A FILE at <type>/<name> would make the scaffold's mkdir raise a raw
+    # FileExistsError — it must classify the same way.
+    _init_wiki()
+    (wiki_root / "skills").mkdir(exist_ok=True)
+    (wiki_root / "skills" / "demo").write_bytes(b"not a directory\n")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "new", "demo"])
+
+    assert result.exit_code != 0
+    assert "skills/demo already exists in the wiki but is not an asset directory" in result.output
+    assert "Traceback" not in result.output
+    assert str(wiki_root) not in result.output
+
+
+# ── classified errors ────────────────────────────────────────────────────
+
+
+def test_new_absent_wiki_errors(wiki_root: Path) -> None:
+    # wiki_root sets MEMTOMEM_WIKI_PATH but we never init → require_exists fails
+    runner = CliRunner()
+    result = runner.invoke(wiki_group, ["skill", "new", "demo"])
+    assert result.exit_code != 0
+    assert "wiki not found" in result.output
+
+
+def test_new_invalid_name_errors(wiki_root: Path) -> None:
+    _init_wiki()
+    runner = CliRunner()
+    result = runner.invoke(wiki_group, ["skill", "new", "bad/name"])
+    assert result.exit_code != 0
+    assert "invalid skill name" in result.output
+
+
+def test_create_canonical_rejects_unknown_asset_type(wiki_root: Path) -> None:
+    # Library-level guard: the public primitive must not derive paths from an
+    # arbitrary asset_type string (CLI callers pass literals, direct callers
+    # may not).
+    store = _init_wiki()
+    with pytest.raises(ValueError, match="unsupported asset_type"):
+        create_canonical(store, "bogus", "demo")
+
+
+def test_create_canonical_repairs_half_authored_dir(wiki_root: Path) -> None:
+    # An asset dir without a canonical (e.g. an abandoned hand-authoring
+    # attempt) is scaffoldable — only an existing canonical refuses.
+    store = _init_wiki()
+    (wiki_root / "skills" / "demo").mkdir(parents=True)
+
+    path = create_canonical(store, "skills", "demo")
+
+    assert path == wiki_root / "skills/demo/SKILL.md"
+    assert path.is_file()
+
+
+def test_create_canonical_exists_error_is_path_free(wiki_root: Path) -> None:
+    store = _init_wiki()
+    create_canonical(store, "skills", "demo")
+    with pytest.raises(AssetExistsError) as excinfo:
+        create_canonical(store, "skills", "demo")
+    assert str(wiki_root) not in str(excinfo.value)
+
+
+# ── editor flag ──────────────────────────────────────────────────────────
+
+
+def test_new_invokes_editor(wiki_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _init_wiki()
+    opened: list[str] = []
+
+    def fake_edit(*args, **kwargs) -> None:  # noqa: ANN002, ANN003
+        opened.append(kwargs.get("filename") or args[0])
+
+    monkeypatch.setattr("click.edit", fake_edit)
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "new", "demo", "--editor"])
+
+    assert result.exit_code == 0, _combined(result)
+    assert opened == [str(wiki_root / "skills/demo/SKILL.md")]
+
+
+def test_new_does_not_invoke_editor_by_default(
+    wiki_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _init_wiki()
+    opened: list[str] = []
+
+    def fake_edit(*args, **kwargs) -> None:  # noqa: ANN002, ANN003
+        opened.append("called")
+
+    monkeypatch.setattr("click.edit", fake_edit)
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "new", "demo"])
+
+    assert result.exit_code == 0, _combined(result)
+    assert opened == []


### PR DESCRIPTION
Paves the wiki first-authoring path. Previously, authoring a first asset required reading source: `commit` refused bare invocations even for canonical-only assets, nothing scaffolded the expected on-disk layout, and the exact (case-sensitive) canonical filenames were undocumented — leaving new assets uncommitted, exactly the state where `mm context install` refuses (dirty wiki, #1643).

## Changes

**1. `mm wiki {skill,agent,command} new <name>` — scaffold verb**

Writes a minimal parse-clean starter template to the asset's canonical path (`skills/<name>/SKILL.md` / `agents/<name>/agent.md` / `commands/<name>/command.md`), backed by a new `create_canonical()` primitive in `wiki/override.py`. It refuses to overwrite an existing asset (`AssetExistsError`, path-free message), classifies directory/file squatting on the target paths, and parse-gates the template through the same gate the in-browser editor uses. `write_canonical` stays edit-only (ADR-0027 Editor-B untouched); a web create endpoint is an explicit follow-up (`web/routes/wiki_mutations.py` reserves it).

**2. Bare `commit <name>` defaults to `--canonical` — conditionally**

⚠️ **Behavior change.** With neither `--canonical` nor `--vendor`, the commit now defaults to the canonical **when — and only when — the asset has no registered vendor override on disk**, announced via a note line (pinned by a test). With overrides present, the previous error remains and now enumerates what is on disk, so a bare commit can never silently omit an edited override (the dirty-wiki install-pin hazard). Scripts that relied on the bare-invocation error as a guard should keep passing `--canonical` explicitly — docs updated accordingly.

**3. Wrong-case canonical lint warning**

`lint` now warns when a file matches the expected canonical name only case-insensitively (`AGENT.md` vs `agent.md`): such an asset works on a macOS checkout but git records the stored case, so it is invisible on case-sensitive clones. Warning severity — on case-sensitive filesystems the existing missing-canonical error already fails the report.

**4. Docs**

ADR-0008 amended (subcommand set + commit default); "Authoring a new asset" paragraph in the context-gateway guide; CLI reference first-asset flow now uses `new`.

## Tests

- `test_wiki_cmd_new.py` (new): happy path ×3 types, `new` → `lint` green ×3 (template↔parser pin), `new` → bare `commit` end-to-end, overwrite/squatting refusals (path-free, no traceback), classified errors, `--editor` parity.
- `test_wiki_cmd_commit.py`: bare-commit default + note line, stray-file membership rule, override-present refusal (enumerating), missing-canonical safety net, agent parity.
- `test_wiki_cmd_diff_lint.py`: wrong-case warning (agents + skills), written to pass on both case-sensitive and case-insensitive filesystems; missing-asset lint stays classified.

Full suite (`-m "not ollama"`) green; `ruff check` + `format --check` clean; mypy clean on touched files. E2E exercised against an isolated wiki: `init → new → lint → bare commit (note + commit) → seed override → bare commit refuses (enumerates) → wrong-case lint warns`.

Closes #1648

🤖 Generated with [Claude Code](https://claude.com/claude-code)
