### PR TITLE
feat(web): show per-project fleet-drift badges on the Projects portal (#1649)

### DIFF
--- a/docs/guides/context-gateway.md
+++ b/docs/guides/context-gateway.md
@@ -226,6 +226,12 @@ the server is running in (marked *current folder*), any roots you registered, an
 — if you opt in — roots discovered under `~/.claude/projects/`. Each runtime
 shows a detection badge (*Not installed* / *Installed* / *Registered*).
 
+Shortly after the list paints, a background fleet check marks any project whose
+synced context has fallen out of step with the Store — wiki pins behind or
+runtime files changed — with a **drift** badge. Click **Sync** on that row to
+resolve it, or run `mm context status --all-projects` for the per-project
+breakdown.
+
 > Note: the `gemini` runtime is shown as **Antigravity** in the UI.
 
 ## From the CLI — the core loop

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -394,12 +394,13 @@ async def context_overview(
 
         # Wiki-install staleness axis (0629 backlog c/d): the count of
         # installed assets whose lockfile pin sits behind wiki HEAD ("update
-        # available"). This is the lockfile↔wiki axis — none of the
-        # canonical→runtime tiles above carry it, and the cross-project
-        # /context/status-all route that does has zero web consumers by
-        # design. ``None`` (not zeros) on failure: the badge is a pure header
-        # enhancement, but "0 behind" is a clean-state claim we can't back
-        # when the classifier itself raised.
+        # available"). This is the single-project lockfile↔wiki axis — none of
+        # the canonical→runtime tiles above carry it. The cross-project roll-up
+        # of the same drift lives on /context/status-all, which the Projects
+        # portal consumes for its per-project drift badge (#1649); this overview
+        # axis stays the single-project view. ``None`` (not zeros) on failure:
+        # the badge is a pure header enhancement, but "0 behind" is a
+        # clean-state claim we can't back when the classifier itself raised.
         wiki_installs: dict[str, int] | None
         try:
             if target_scope == "project_shared":

--- a/packages/memtomem/src/memtomem/web/static/context-portal.js
+++ b/packages/memtomem/src/memtomem/web/static/context-portal.js
@@ -67,6 +67,13 @@ let _ctxPortalHideUninit = true;
 // Map of scope_id -> runtimes list (one GET /api/context/runtimes per scope; the
 // endpoint resolves per-scope via resolve_scope_root's project_scope_id param).
 let _ctxPortalRuntimesMap = {};
+// Set of scope_ids whose synced context has drifted from the Store, from the
+// deferred GET /api/context/status-all fetch (#1649). Kept out of the initial
+// render path: status-all shells out to git per project (sequential), so the
+// board paints from projects+runtimes first and the drift badge fills in when
+// this resolves. Reset on every fresh load so a tier flip / refresh can't leave
+// a stale badge. project_shared tier only (the endpoint 400s on other tiers).
+let _ctxPortalDriftMap = {};
 // Active runtime filter: null | 'claude' | 'antigravity' | 'codex' | 'kimi'
 let _ctxPortalRuntimeFilter = null;
 
@@ -412,6 +419,10 @@ async function loadCtxProjects() {
     // any render reads it.
     _ctxPortalEditingId = null;
     _ctxPortalScopes = scopes;
+    // Drop any drift badges from the previous load before it repaints — a tier
+    // flip or refresh must not carry a stale badge into the new roster. The
+    // deferred fetch below (project_shared only) repopulates it.
+    _ctxPortalDriftMap = {};
     if (!scopes.length) {
       // Server CWD is always present, so an empty roster means the load
       // failed — render the shared load-error + Retry (#1287; the helper
@@ -453,6 +464,13 @@ async function loadCtxProjects() {
     _ctxPortalRenderHeadingChips();
     _ctxPortalRenderScaffold(listEl);
     _ctxPortalRenderRows();
+    // Fire-and-forget the cross-project drift check (#1649). Not awaited: the
+    // board is already painted and status-all runs sequential per-project git
+    // work, so the drift badge fills in when it resolves. Gated on
+    // project_shared — the only tier the endpoint serves (400 otherwise).
+    if (requestedScope === 'project_shared') {
+      _ctxPortalLoadDrift(seq, requestedScope, signal);
+    }
     return true;
   } catch (err) {
     // Aborted = a newer portal load superseded us (#1286); its seq guard owns
@@ -468,6 +486,40 @@ async function loadCtxProjects() {
     );
     return true; // owned the (error) render — ran to completion as the latest
   }
+}
+
+// Deferred cross-project drift check (#1649) — the sole web consumer of
+// GET /api/context/status-all. Called (not awaited) after the board paints, so
+// its sequential per-project git work never blocks the initial render. Best
+// effort throughout: any abort / non-OK / network failure leaves the board as
+// painted (no badge, no toast), mirroring the overview wiki-behind badge's
+// defensive-reader posture (#1546). ``seq``/``requestedScope``/``signal`` are
+// captured from the enclosing loadCtxProjects invocation so a superseded load's
+// late result is discarded by the same guard the projects+runtimes fetches use.
+async function _ctxPortalLoadDrift(seq, requestedScope, signal) {
+  let data;
+  try {
+    const res = await fetch(
+      '/api/context/status-all?target_scope=project_shared', { signal },
+    );
+    if (!res.ok) return;
+    data = await res.json();
+  } catch (err) {
+    return; // abort (superseded load) or network error — leave the board as-is
+  }
+  // A newer load started or the tier flipped mid-fetch: this payload was
+  // computed for a roster that is no longer on screen.
+  if (seq !== _ctxProjectsSeq || requestedScope !== _ctxTargetScope) return;
+  const projects = Array.isArray(data?.projects) ? data.projects : [];
+  const driftMap = {};
+  for (const entry of projects) {
+    if (entry?.status === 'drift') driftMap[entry.project_scope_id || ''] = true;
+  }
+  _ctxPortalDriftMap = driftMap;
+  // Skip the immediate repaint while a row is in inline-rename mode — a full
+  // repaint would discard the open input's typed value. The map is already set,
+  // so the next natural repaint (save/cancel/langchange) shows the badges.
+  if (_ctxPortalEditingId === null) _ctxPortalRenderRows();
 }
 
 // Header (search + sort) is painted once and kept across row repaints so the
@@ -666,6 +718,14 @@ function _ctxPortalBadgesHtml(scope) {
   } else if (scope.stale) {
     const tip = escapeHtml(t('settings.ctx.portal_stale_tip'));
     parts.push(`<span class="ctx-scope-badge ctx-scope-badge--stale" title="${tip}">${escapeHtml(t('settings.ctx.portal_stale'))}</span>`);
+  }
+  // Cross-project drift (#1649) — this scope's synced context no longer matches
+  // the Store, per the deferred status-all fetch. Skipped for missing rows (no
+  // synced context to drift). Populated only under project_shared; the map is
+  // empty otherwise, so this renders nothing on other tiers.
+  if (!scope.missing && _ctxPortalDriftMap[scope.scope_id || '']) {
+    const tip = escapeHtml(t('settings.ctx.portal_drift_tip'));
+    parts.push(`<span class="ctx-scope-badge ctx-scope-badge--drift" title="${tip}">${escapeHtml(t('settings.ctx.portal_drift_badge'))}</span>`);
   }
   return parts.join('');
 }

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=129" />
+  <link rel="stylesheet" href="/style.css?v=130" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -1771,7 +1771,7 @@
   <script src="/context-gateway-conflict.js?v=1"></script>
   <script src="/context-gateway-detail.js?v=2"></script>
   <script src="/context-gateway-actions.js?v=1"></script>
-  <script src="/context-portal.js?v=7"></script>
+  <script src="/context-portal.js?v=8"></script>
   <script src="/wiki.js?v=11"></script>
   <script src="/path-picker.js?v=4"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -855,6 +855,8 @@
   "settings.ctx.portal_label_placeholder": "Project label",
   "settings.ctx.portal_stale": "uninitialized",
   "settings.ctx.portal_stale_tip": "This folder has no .memtomem store yet — run mm context init inside it to start tracking.",
+  "settings.ctx.portal_drift_badge": "drift",
+  "settings.ctx.portal_drift_tip": "This project's synced context no longer matches the Store (wiki pins behind or runtime files changed). Click Sync on this row, or run mm context status --all-projects for details.",
   "settings.ctx.portal_root_unknown": "(no path)",
   "settings.ctx.portal_load_failed": "Could not load projects",
   "settings.ctx.portal_add_project_tooltip": "Register a project folder so memtomem can track it",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -855,6 +855,8 @@
   "settings.ctx.portal_label_placeholder": "프로젝트 라벨",
   "settings.ctx.portal_stale": "미초기화",
   "settings.ctx.portal_stale_tip": "이 폴더에는 아직 .memtomem 저장소가 없습니다 — 폴더 안에서 mm context init 을 실행하면 추적이 시작됩니다.",
+  "settings.ctx.portal_drift_badge": "드리프트",
+  "settings.ctx.portal_drift_tip": "이 프로젝트의 동기화된 컨텍스트가 저장소와 더 이상 일치하지 않습니다 (wiki 핀이 뒤처졌거나 런타임 파일이 변경됨). 이 행의 Sync 를 누르거나, 자세한 내용은 mm context status --all-projects 를 실행하세요.",
   "settings.ctx.portal_root_unknown": "(경로 없음)",
   "settings.ctx.portal_load_failed": "프로젝트를 불러오지 못했습니다",
   "settings.ctx.portal_add_project_tooltip": "memtomem이 추적할 수 있도록 프로젝트 폴더를 등록합니다",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -4304,6 +4304,9 @@ body.app-simple [data-ui-adv="advanced"] { display: none; }
 .ctx-scope-badge--stale { background: rgba(var(--accent-rgb), 0.15); color: var(--accent); }
 /* Sync paused (enrolled but enabled:false) — neutral/muted, not an error state. */
 .ctx-scope-badge--paused { background: rgba(128, 128, 128, 0.15); color: var(--text-secondary); }
+/* Cross-project drift (#1649) — update available, warning tone (mirrors the
+   overview wiki-behind badge; not an error like missing). */
+.ctx-scope-badge--drift { background: rgba(243, 156, 18, 0.15); color: var(--yellow); }
 
 /* Context Portal (ADR-0021 PR4) — multi-project board */
 .ctx-portal-toolbar {

--- a/packages/memtomem/tests-js/ctx-portal-drift-badge.test.mjs
+++ b/packages/memtomem/tests-js/ctx-portal-drift-badge.test.mjs
@@ -1,0 +1,207 @@
+/* Projects-portal fleet-drift badge (#1649) — the sole web consumer of
+ * GET /api/context/status-all.
+ *
+ * The board paints from /api/context/projects (+ per-scope /runtimes) first,
+ * then fires a NOT-awaited status-all fetch whose result marks drifted projects
+ * with a ``ctx-scope-badge--drift`` chip. These tests drive the real
+ * ``context-portal.js`` in the jsdom harness and assert the rendered DOM (the
+ * ``_ctxPortalDriftMap`` state is a module ``let``, pinned through the badge it
+ * produces, not poked directly).
+ *
+ * Mutation that bites: dropping the ``requestedScope === 'project_shared'`` gate
+ * makes the tier-gate test fetch status-all on project_local; dropping the seq
+ * guard makes the race test paint a badge from the superseded payload.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+function scope(id, label, extra = {}) {
+  return {
+    scope_id: id, project_scope_id: id, label, root: id ? `/work/${label}` : '/srv',
+    tier: 'project', sources: id ? ['known-projects'] : ['server-cwd'],
+    missing: false, stale: false, experimental: false,
+    counts: { skills: 1, commands: 0, agents: 0, 'mcp-servers': 0 },
+    ...extra,
+  };
+}
+
+// All visible (not stale, not missing) so every row renders under the default
+// "Initialized only" toggle.
+const CWD = scope('', 'Server CWD');
+const P_ALPHA = scope('p-alpha', 'Alpha');
+const P_CLEAN = scope('p-clean', 'Clean');
+const P_ERR = scope('p-err', 'Err');
+const SCOPES = [CWD, P_ALPHA, P_CLEAN, P_ERR];
+
+// status-all payload: p-alpha drifted; the rest ok/error (neither is drift, so
+// neither gets a badge). Server CWD ('') clean.
+function driftPayload() {
+  return {
+    target_scope: 'project_shared',
+    projects: [
+      { project_scope_id: '', status: 'ok' },
+      { project_scope_id: 'p-alpha', status: 'drift' },
+      { project_scope_id: 'p-clean', status: 'ok' },
+      { project_scope_id: 'p-err', status: 'error', error: { error_kind: 'x', message: 'y', http_status: 500 } },
+    ],
+    summary: { projects_total: 4, executed: 4, drifted: 1, clean: 2, errors: 1, skipped: 0 },
+  };
+}
+
+function jsonOk(body) {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+/* Records every fetched URL and routes the portal's three endpoints. status-all
+ * is settable: a fixed payload by default, or a deferred promise a test resolves
+ * to control resolution order. */
+function installFetch(window, opts = {}) {
+  const upstream = window.fetch;
+  const urls = [];
+  const state = {
+    statusAll: opts.statusAll || (async () => jsonOk(driftPayload())),
+  };
+  window.fetch = (input, init) => {
+    const url = typeof input === 'string' ? input : input?.url || '';
+    urls.push(url);
+    if (url.startsWith('/api/context/status-all')) return state.statusAll(url, init);
+    if (url.startsWith('/api/context/projects')) {
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ scopes: SCOPES, target_scope: 'project_shared' }) });
+    }
+    if (url.startsWith('/api/context/runtimes')) return Promise.resolve(jsonOk({ runtimes: [] }));
+    return upstream(input, init);
+  };
+  return { urls, state };
+}
+
+// Drain pending microtasks/timers so the not-awaited status-all fetch settles.
+function flush() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function boot() {
+  // Section intentionally left inactive: i18n's post-boot locale load fires a
+  // 'langchange' that, with the section active, would trigger a second
+  // loadCtxProjects racing the explicit call. Tests drive it directly.
+  return bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js', 'context-portal.js'] });
+}
+
+function driftBadge(window, scopeId) {
+  return window.document.querySelector(
+    `.ctx-portal-row[data-scope-id="${scopeId}"] .ctx-scope-badge--drift`,
+  );
+}
+
+describe('Projects portal fleet-drift badge (#1649)', () => {
+  it('marks the drifted project after the deferred status-all fetch, with a runnable tooltip', async () => {
+    const { window } = await boot();
+    installFetch(window);
+    await window.loadCtxProjects();
+    // Not painted yet — status-all is deferred past the initial render.
+    expect(driftBadge(window, 'p-alpha')).toBeNull();
+    await flush();
+
+    const badge = driftBadge(window, 'p-alpha');
+    expect(badge).not.toBeNull();
+    expect(badge.textContent.trim().length).toBeGreaterThan(0);
+    expect(badge.getAttribute('title')).toContain('mm context status --all-projects');
+  });
+
+  it('leaves ok / error projects (and Server CWD) unbadged', async () => {
+    const { window } = await boot();
+    installFetch(window);
+    await window.loadCtxProjects();
+    await flush();
+
+    expect(driftBadge(window, 'p-alpha')).not.toBeNull();
+    expect(driftBadge(window, 'p-clean')).toBeNull();
+    expect(driftBadge(window, 'p-err')).toBeNull();
+    expect(driftBadge(window, '')).toBeNull();
+  });
+
+  it('does NOT fetch status-all on a non-project_shared tier', async () => {
+    const { window } = await boot();
+    const { urls } = installFetch(window);
+    // Flip the tier to project_local via the real toggle wiring, then load.
+    window.loadCtxOverview = async () => {};
+    const bar = window.document.createElement('div');
+    bar.innerHTML = '<div class="ctx-tier-filter" data-type="overview">'
+      + '<button type="button" data-scope="project_local">local</button></div>';
+    window.document.body.appendChild(bar);
+    window._ctxWireTierControls();
+    bar.querySelector('button').dispatchEvent(new window.Event('click', { bubbles: true }));
+
+    await window.loadCtxProjects();
+    await flush();
+    expect(urls.some(u => u.startsWith('/api/context/status-all'))).toBe(false);
+  });
+
+  it('discards a superseded status-all payload (seq guard)', async () => {
+    const { window } = await boot();
+    // First load's status-all is parked; we resolve it AFTER a newer load.
+    let releaseOld;
+    const parked = new Promise((resolve) => { releaseOld = resolve; });
+    const { state } = installFetch(window, { statusAll: () => parked });
+
+    const older = window.loadCtxProjects(); // seq 1 — status-all parked
+    await older;
+    // Newer load resolves status-all immediately with the drift payload.
+    state.statusAll = async () => jsonOk(driftPayload());
+    await window.loadCtxProjects(); // seq 2
+    await flush();
+    expect(driftBadge(window, 'p-alpha')).not.toBeNull();
+
+    // Now release the stale (seq 1) fetch. Even though it also reports drift,
+    // the seq guard must drop it — and here it would repaint from the SAME
+    // payload, so to prove the guard we assert the map wasn't rebuilt by it: an
+    // all-clean stale payload must not clear the badge the newer load set.
+    state.statusAll = async () => jsonOk(driftPayload());
+    releaseOld(jsonOk({ target_scope: 'project_shared', projects: [], summary: {} }));
+    await flush();
+    expect(driftBadge(window, 'p-alpha')).not.toBeNull();
+  });
+
+  it('survives a status-all failure with the board intact and no badge', async () => {
+    const { window } = await boot();
+    installFetch(window, { statusAll: async () => ({ ok: false, status: 500, json: async () => ({}) }) });
+    await window.loadCtxProjects();
+    await flush();
+    // Board rendered, no throw, no badge.
+    expect(window.document.querySelectorAll('.ctx-portal-row').length).toBe(SCOPES.length);
+    expect(driftBadge(window, 'p-alpha')).toBeNull();
+  });
+
+  it('re-renders the badge with the active locale on langchange', async () => {
+    const { window } = await boot();
+    installFetch(window);
+    await window.loadCtxProjects();
+    await flush();
+    const before = driftBadge(window, 'p-alpha');
+    expect(before).not.toBeNull();
+
+    window.dispatchEvent(new window.Event('langchange'));
+    // langchange repaints the whole board from the drift map — badge persists.
+    const after = driftBadge(window, 'p-alpha');
+    expect(after).not.toBeNull();
+    expect(after.textContent.trim().length).toBeGreaterThan(0);
+  });
+
+  it('clears a stale badge when a fresh load reports all clean', async () => {
+    const { window } = await boot();
+    const { state } = installFetch(window);
+    await window.loadCtxProjects();
+    await flush();
+    expect(driftBadge(window, 'p-alpha')).not.toBeNull();
+
+    // Reload: status-all now reports every project clean.
+    state.statusAll = async () => jsonOk({
+      target_scope: 'project_shared',
+      projects: SCOPES.map(s => ({ project_scope_id: s.scope_id, status: 'ok' })),
+      summary: { projects_total: 4, executed: 4, drifted: 0, clean: 4, errors: 0, skipped: 0 },
+    });
+    await window.loadCtxProjects();
+    await flush();
+    expect(driftBadge(window, 'p-alpha')).toBeNull();
+  });
+});

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -151,6 +151,30 @@ class TestLocaleFiles:
                 f"per-asset `mm context update` remediation; got: {tip!r}"
             )
 
+    def test_portal_drift_keys_present(self, en: dict[str, str], ko: dict[str, str]) -> None:
+        """The Projects-portal fleet-drift badge (#1649) needs both its badge
+        label and tooltip in each locale, and the tooltip must recommend a
+        runnable remediation: ``mm context status --all-projects`` (the read-only
+        cross-project inspector the badge is fed from), not any ``--all`` update
+        form (#1645 lesson — a usage error / wrong axis)."""
+        for name, data in [("en", en), ("ko", ko)]:
+            for key in (
+                "settings.ctx.portal_drift_badge",
+                "settings.ctx.portal_drift_tip",
+            ):
+                assert key in data, f"{name}.json missing {key}"
+                assert data[key].strip(), f"{name}.json has empty {key}"
+            tip = data["settings.ctx.portal_drift_tip"]
+            assert "mm context status --all-projects" in tip, (
+                f"{name}.json settings.ctx.portal_drift_tip must name the "
+                f"runnable `mm context status --all-projects` inspector; "
+                f"got: {tip!r}"
+            )
+            assert "update --all" not in tip, (
+                f"{name}.json settings.ctx.portal_drift_tip must not steer to "
+                f"an `update --all` form (#1645); got: {tip!r}"
+            )
+
 
 _STATIC_JS_DIR = _LOCALES_DIR.parent
 


### PR DESCRIPTION
## What

Builds the web consumer for `GET /api/context/status-all` (cross-project drift
aggregation, A-10 #1280/#1306) that #1649 asked for — a per-project **drift**
badge on the Projects portal rows. This was the original B-track dashboard
intent; the endpoint had been a maintained aggregate with zero shipped
consumers, which kept re-surfacing in gateway audits.

## How

- **Deferred, non-blocking fetch.** The board paints from `/api/context/projects`
  (+ per-scope `/runtimes`) first, then fires a not-awaited `status-all` fetch.
  The endpoint shells out to git per project sequentially, so blocking the
  initial render on it would be a visible regression.
- **Stale-proof state.** Results populate a module-scoped drift map, reset on
  every fresh load (tier flip / refresh never shows a stale badge) and repainted
  declaratively so the badge survives search/sort/langchange repaints. Reuses the
  existing `seq` / `requestedScope` / abort-signal guard the projects+runtimes
  fetches already use, so a superseded load's late result is discarded.
- **Gated on `project_shared`** — the only tier `status-all` serves (400
  otherwise) — and skipped while a row is in inline-rename mode.
- **Silent on failure** — abort / non-OK / network errors leave the board as
  painted, mirroring the #1546 overview wiki-behind badge's defensive posture.
- Tooltip recommends the runnable `mm context status --all-projects`, not any
  `--all` update form (#1645 lesson, pinned by a new i18n guard test).

### Scope cut

`error` / `skipped` entries render no badge — skipped rows already carry
paused/stale/missing badges for the same causes, and surfacing corrupt lockfiles
from a best-effort background fleet fetch is out of scope here.

## Tests / verification

- New `ctx-portal-drift-badge.test.mjs` (7 cases: render on drift, silent on
  ok/error/CWD, tier-gate no-fetch, seq-guard discard, failure-safe, langchange
  re-render, stale-badge clear). Mutation-checked: removing the tier gate or the
  seq guard fails the corresponding case.
- New i18n guard `test_portal_drift_keys_present` (both locales, runnable tip).
- Full `tests-js` suite (426) + `test_i18n` / `test_web_a11y` /
  `test_web_routes_context_status_all` / `test_docs_guards` green; ruff clean.
- End-to-end on a real `mm web` server: index serves the bumped cache-bust,
  `status-all` returns 200 (400 on other tiers), and the badge renders on the
  actual fleet's drifted projects with the correct tooltip.

Closes #1649

🤖 Generated with [Claude Code](https://claude.com/claude-code)
