### PR TITLE
feat(mcp): add version enable action — close the last CLI/web parity gap (#1650)

### DIFF
--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -124,7 +124,7 @@ The `mem_context_*` tools (CLI: `mm context`) sync canonical artifacts — skill
 - **All context tools** accept `include="skills,agents,commands"` to scope a canonical artifact workflow.
 - **`init`, `generate`, `sync`, `diff`, `version`, `promote`** accept `scope="project_shared|user|project_local"` — the canonical **tier** (ADR-0016 §2).
 - **`generate` / `sync`** also accept `on_drop="ignore|warn|error"` (the legacy alias `strict=True` ≡ `on_drop="error"`) to control how dropped sub-agent or command fields are reported, and `label="latest|v1|production"` to deploy from a specific version snapshot (agents/commands only).
-- **`version`** manages snapshots via `action="list"|"create"`.
+- **`version`** manages snapshots via `action="list"|"create"|"enable"` — `enable` adopts a flat-layout artifact into directory layout (a byte-identical, same-scope move) so it can be versioned, mirroring `mm context version enable` and the web `POST …/versions/enable` route (`confirm_project_shared=True` for the git-tracked tier).
 - **`promote`** moves or deletes label pointers to versions.
 - **`memory_migrate`** takes `from_scope`/`to_scope` instead of a single `scope` (it has two endpoints), plus `apply=True` to execute and `confirm_project_shared=True` when writing to the git-tracked tier. (`mem_context_migrate` is a deprecated alias for `mem_context_memory_migrate`.)
 - **`artifact_migrate`** migrates agents/commands/skills — flat→dir layout when `to_scope` is omitted, or a scope-tier move when it is set (`apply=True` to execute, `force=True` for a dirty flat→dir, `confirm_project_shared=True` for the git-tracked tier).

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -2180,11 +2180,19 @@ def _resolve_version_artifact(
 
 
 def _flat_layout_hint(artifact_type: str, name: str) -> str:
-    """The shared "no version store on flat layout" remediation line (inv 3)."""
+    """The shared "no version store on flat layout" remediation line (inv 3).
+
+    Leads with the lightweight ``action="enable"`` adopt (the byte-identical
+    flat→dir move) and keeps ``mem_context_artifact_migrate`` for wiki-installed
+    assets, which also consolidate the lockfile manifest — mirrors the CLI
+    ``version create`` hint fix (#1549).
+    """
     return (
         f"{artifact_type}/{name} uses flat layout, which has no per-artifact version "
-        f"store. Run mem_context_artifact_migrate(asset_type='{artifact_type}', "
-        f"name='{name}') to convert it to directory layout first."
+        f"store. Run mem_context_version(artifact_type='{artifact_type}', "
+        f"name='{name}', action='enable') to adopt it into directory layout "
+        f"(wiki-installed assets: mem_context_artifact_migrate("
+        f"asset_type='{artifact_type}', name='{name}'))."
     )
 
 
@@ -2248,8 +2256,10 @@ async def mem_context_version(
         name: Canonical artifact name (the directory under
             ``.memtomem/<type>/``).
         action: ``list`` (default, read-only) to show versions + label
-            pointers, or ``create`` to freeze the current working canonical
-            into a new ``vN`` snapshot.
+            pointers, ``create`` to freeze the current working canonical into a
+            new ``vN`` snapshot, or ``enable`` to adopt a flat-layout artifact
+            into directory layout so it can be versioned (a byte-identical,
+            same-scope move — the MCP twin of ``mm context version enable``).
         note: Optional annotation stored with a ``create`` snapshot; ignored
             for ``list``.
         scope: ADR-0011 canonical residency tier — ``project_shared``
@@ -2263,8 +2273,10 @@ async def mem_context_version(
             default scope does not require it (mirrors ``mem_context_init``).
 
     A flat-layout artifact has no per-artifact ``versions/`` store (ADR-0022
-    invariant 3): ``list`` returns a benign migrate-required hint and
-    ``create`` refuses with a "run mem_context_artifact_migrate first" error.
+    invariant 3): ``list`` returns a benign hint and ``create`` refuses, both
+    pointing at ``action="enable"`` to adopt it into directory layout first;
+    ``enable`` is idempotent on an already-dir artifact and refuses a
+    flat+dir collision or an orphaned version store.
 
     On ``create`` the snapshot bytes are privacy-scanned (Gate A, ADR-0011
     trust boundary): for ``project_shared`` a secret hard-refuses with a
@@ -2275,8 +2287,8 @@ async def mem_context_version(
     ``privacy block:``) so callers can branch on the prefix.
     """
     action = (action or "").strip().lower()
-    if action not in ("list", "create"):
-        return f"error: unknown action {action!r}. Supported: list, create."
+    if action not in ("list", "create", "enable"):
+        return f"error: unknown action {action!r}. Supported: list, create, enable."
 
     root = await asyncio.to_thread(_find_project_root)
     scope_explicit = bool(scope.strip())
@@ -2300,6 +2312,72 @@ async def mem_context_version(
         except versioning.VersionError as exc:
             return f"error: {exc}"
         return _format_version_list(artifact_type, name, artifact_scope, manifest)
+
+    if action == "enable":
+        # Adopt a flat-layout artifact into directory layout so it can be
+        # versioned — the MCP twin of ``mm context version enable`` and the web
+        # ``POST …/versions/enable`` route. The adopt itself is a byte-identical,
+        # same-scope ``os.replace`` (``adopt_flat_to_dir``): the bytes are
+        # unchanged and stay in the same tier, so no privacy re-scan is needed
+        # here — a labeled sync still re-scans the frozen versions/vN.md at
+        # deploy time (ADR-0022 Gate A). Unlike the web route (which hard-limits
+        # to project_shared via ``_reject_non_shared_write``), MCP honors the
+        # ``scope`` arg with the same Gate B as create/promote, matching the CLI
+        # ``--scope`` and the sibling MCP verbs.
+        if scope_explicit and artifact_scope == "project_shared" and not confirm_project_shared:
+            return (
+                "needs confirmation: scope='project_shared' restructures the "
+                "git-tracked tree (flat file → directory layout). Re-call with "
+                "confirm_project_shared=True to proceed."
+            )
+        # ``artifact_dir`` is <root>/<name> on dir layout, <root> on flat — so the
+        # canonical <type> root is its parent only when already dir (mirror of the
+        # web router's ``working_file.parent.parent if dir else parent``).
+        canonical_root = artifact_dir.parent if layout == "dir" else artifact_dir
+        flat_path = canonical_root / f"{name}.md"
+        dir_path = canonical_root / name
+
+        if layout == "dir":
+            # Already dir: idempotent no-op, unless a stray flat sibling lingers —
+            # then refuse rather than report a misleading success (web-route mirror).
+            if await asyncio.to_thread(flat_path.exists):
+                return (
+                    f"error: {artifact_type}/{name} has both flat ({flat_path.name}) and "
+                    f"directory layouts; remove the redundant flat file to resolve the "
+                    f"collision."
+                )
+            return (
+                f"{artifact_type}/{name} [{artifact_scope}] already uses directory layout; "
+                f"nothing to do."
+            )
+
+        # Flat → adopt. Refuse an orphaned version store: adopting into it would
+        # silently attach a prior same-named artifact's history (web-route mirror).
+        orphaned = await asyncio.to_thread(
+            lambda: (
+                versioning.versions_json_path(dir_path).exists()
+                or versioning.versions_dir(dir_path).is_dir()
+            )
+        )
+        if orphaned:
+            return (
+                f"error: {artifact_type}/{name} cannot be adopted: an orphaned version "
+                f"store already exists. Resolve it manually first."
+            )
+
+        from memtomem.context.migrate import adopt_flat_to_dir
+
+        try:
+            await asyncio.to_thread(adopt_flat_to_dir, artifact_type, flat_path, dir_path)
+        except (FileNotFoundError, FileExistsError, OSError, ValueError) as exc:
+            # These messages embed absolute canonical paths (the web twin never
+            # echoes them) — redact before returning.
+            return f"error: {_redact_reason(str(exc), root)}"
+        return (
+            f"Adopted {artifact_type}/{name} [{artifact_scope}] into directory layout — "
+            f"next: mem_context_version(artifact_type='{artifact_type}', name='{name}', "
+            f"action='create')."
+        )
 
     # ── action == "create" ──
     # Gate B: an explicit project_shared write into the git-tracked tree needs

--- a/packages/memtomem/tests/test_server_tools_context_version.py
+++ b/packages/memtomem/tests/test_server_tools_context_version.py
@@ -200,8 +200,96 @@ async def test_flat_layout_create_refuses(layout):
     flat = _seed_flat(layout, "agents", "flatone")
     out = await mem_context_version("agents", "flatone", action="create")
     assert out.startswith("error:") and "flat layout" in out
+    # The refusal now leads with the enable action (the lightweight adopt).
+    assert "action='enable'" in out
     # Nothing was written next to the flat file.
     assert not (flat.parent / "flatone" / "versions.json").exists()
+
+
+# ── enable (flat → dir adopt, ADR-0022) ───────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_enable_flat_adopts_to_dir(layout):
+    # The MCP twin of ``mm context version enable`` / web ``POST …/versions/enable``:
+    # a byte-identical flat→dir move that unlocks versioning.
+    flat = _seed_flat(layout, "agents", "flatone")
+    body = flat.read_text(encoding="utf-8")
+    out = await mem_context_version("agents", "flatone", action="enable")
+    assert out.startswith("Adopted") and "directory layout" in out
+    root = _canonical_root(layout, "agents", "project_shared")
+    # The flat file moved (byte-identical) into <name>/agent.md.
+    assert not flat.exists()
+    adopted = root / "flatone" / "agent.md"
+    assert adopted.is_file() and adopted.read_text(encoding="utf-8") == body
+    # Versioning is now unlocked: create freezes a v1 snapshot.
+    created = await mem_context_version("agents", "flatone", action="create")
+    assert created.startswith("Created")
+    assert (root / "flatone" / "versions" / "v1.md").is_file()
+
+
+@pytest.mark.anyio
+async def test_enable_idempotent_on_dir(layout):
+    _seed_dir(layout, "agents", "foo")
+    out = await mem_context_version("agents", "foo", action="enable")
+    assert not out.startswith("error:")
+    assert "already uses directory layout" in out
+
+
+@pytest.mark.anyio
+async def test_enable_commands_artifact(layout):
+    # Parity across both versionable types (agents + commands).
+    _seed_flat(layout, "commands", "flatcmd")
+    out = await mem_context_version("commands", "flatcmd", action="enable")
+    assert out.startswith("Adopted")
+    root = _canonical_root(layout, "commands", "project_shared")
+    assert (root / "flatcmd" / "command.md").is_file()
+
+
+@pytest.mark.anyio
+async def test_enable_flat_dir_collision_refuses(layout):
+    # Both <name>.md and <name>/agent.md present (resolver picks dir) → refuse
+    # rather than report a misleading idempotent success while a stray flat lingers.
+    _seed_flat(layout, "agents", "foo")
+    _seed_dir(layout, "agents", "foo")
+    out = await mem_context_version("agents", "foo", action="enable")
+    assert out.startswith("error:") and "both flat" in out
+
+
+@pytest.mark.anyio
+async def test_enable_orphaned_store_refuses(layout):
+    # A flat canonical plus a pre-existing version store under <name>/ (no
+    # working canonical) → adopting would silently attach that history; refuse.
+    _seed_flat(layout, "agents", "foo")
+    root = _canonical_root(layout, "agents", "project_shared")
+    (root / "foo" / "versions").mkdir(parents=True)
+    out = await mem_context_version("agents", "foo", action="enable")
+    assert out.startswith("error:") and "orphaned version store" in out
+
+
+@pytest.mark.anyio
+async def test_enable_missing_artifact_errors(layout):
+    out = await mem_context_version("agents", "ghost", action="enable")
+    assert out.startswith("error:") and "not found" in out
+
+
+@pytest.mark.anyio
+async def test_enable_explicit_project_shared_confirm_gate(layout):
+    _seed_flat(layout, "agents", "flatone")
+    gated = await mem_context_version("agents", "flatone", action="enable", scope="project_shared")
+    assert gated.startswith("needs confirmation")
+    root = _canonical_root(layout, "agents", "project_shared")
+    # Untouched until confirmed — the flat file still sits where it was.
+    assert (root / "flatone.md").is_file()
+    ok = await mem_context_version(
+        "agents",
+        "flatone",
+        action="enable",
+        scope="project_shared",
+        confirm_project_shared=True,
+    )
+    assert ok.startswith("Adopted")
+    assert (root / "flatone" / "agent.md").is_file()
 
 
 # ── Gate A privacy scan on create ─────────────────────────────────────────
@@ -353,6 +441,18 @@ async def test_mem_do_routes_version_and_promote(layout):
         {"artifact_type": "agents", "name": "foo", "label": "production", "version": "v1"},
     )
     assert "production → v1" in promoted
+
+
+@pytest.mark.anyio
+async def test_mem_do_routes_enable(layout):
+    from memtomem.server.tools.meta import mem_do
+
+    _seed_flat(layout, "agents", "flatone")
+    out = await mem_do(
+        "context_version",
+        {"artifact_type": "agents", "name": "flatone", "action": "enable"},
+    )
+    assert out.startswith("Adopted")
 
 
 # ── label-aware deploy (mem_context_sync / mem_context_generate --label) ────


### PR DESCRIPTION
## Summary

From the 2026-07-04 gateway audit (MCP surface-parity sweep). #1549 closed the
versioning-parity gaps for CLI (`mm context version enable`, `delete-label`) and
web (`POST …/versions/enable`, `DELETE …/labels/{label}`), but MCP got only half:
`mem_context_promote(delete=True)` covers delete-label, and there was **no MCP
action for enable-versioning**. A headless agent could `create` versions and
`promote`/`delete` labels on dir-layout artifacts but could not adopt a
**flat-layout** artifact into dir layout — its only MCP remedy was the heavier
`mem_context_artifact_migrate`, which `skip_manual`s hand-authored / UI-created
flats, so such a flat was permanently locked out of MCP versioning.

## Decision: add the action (not pin the absence)

The issue offered two options. This PR takes option 1. #1602's "pin-absence"
posture (install/update/projects) was justified by a **trust boundary** — those
verbs write host-global wiki bytes into arbitrary project trees or mutate
cross-project enrollment (`known_projects.json`). enable-versioning crosses no
such boundary: it is a byte-identical, same-scope `os.replace` of an artifact
the agent already fully controls (it can already version it once it is dir
layout), needs no privacy re-scan, and is **lighter** than
`mem_context_artifact_migrate`, which MCP already exposes. It is the last missing
verb of the create/promote/delete family — the asymmetry was arbitrary, not
principled.

## Changes

- **`mem_context_version(action="enable")`** — a third internal action on the
  existing tool (mirroring the CLI `version` subcommand grouping), so the
  registered `@register("context")` action set is unchanged and
  `TestContextSurfacePosture` stays green **without modification** (no new
  registered verb, no `mem_context_version_enable` tool). It reuses
  `adopt_flat_to_dir` and mirrors the web `enable_artifact_versioning` guards:
  idempotent on dir layout, refuses a flat+dir collision or an orphaned version
  store, redacts canonical paths in the error path. Unlike the web route
  (project_shared only via `_reject_non_shared_write`), MCP honors the `scope`
  arg with the same Gate B as create/promote — matching the CLI `--scope` and
  the sibling MCP verbs. No `_gateway_lock` (matches sibling MCP create/promote,
  which also rely on the versioning store's own file lock rather than a gateway
  lock).
- **`_flat_layout_hint`** now leads with the enable action and keeps
  `mem_context_artifact_migrate` for wiki-installed assets — mirrors the #1549
  CLI hint fix. Benefits all three call sites (version list hint, create refusal,
  promote refusal).
- **`docs/guides/reference.md`** — the `version` line documents
  `action="list"|"create"|"enable"` (verified against the implemented tool).

Deliberately unchanged: CLI/web (already shipped), ADR-0022 (parity gap, no new
decision), and `TestContextSurfacePosture`/`_EXPECTED_CONTEXT_ACTIONS` (registered
set unchanged).

## Tests

8 new real-FS integration tests in `test_server_tools_context_version.py`
(alongside the create/promote pins): flat→dir adopt + versioning-unlock
(byte-identical, then `create` freezes v1), idempotent dir no-op, commands
parity, flat+dir collision refusal, orphaned-store refusal, missing-artifact
error, explicit project_shared Gate B (needs-confirmation → confirmed adopt), and
`mem_do` routing. Updated `test_flat_layout_create_refuses` to assert the refusal
now names `action='enable'`.

Verification: `test_server_tools_context_version.py` + `test_meta_tool.py`
66 passed; the full context/meta/docs/instructions subset 2538 passed, 1 skipped;
`ruff check` + `ruff format --check` clean; `mypy` clean on the changed module.

Closes #1650

🤖 Generated with [Claude Code](https://claude.com/claude-code)
