### PR TITLE
fix(web): localize write-time Gate A editor block in localized sessions (#1651)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   open unchanged — additive idempotent migrations remain the forward
   mechanism; this adds only the downgrade guard.
 
+### Fixed
+
+- **Write-time Gate A block reads as localized, jargon-free copy in the web
+  editors** (#1651) — saving a canonical skill/command/agent that trips the
+  project_shared privacy gate (#1509) previously surfaced the raw-English
+  engine string ("Gate A: … no force bypass available for project_shared
+  (ADR-0011 §5) … target_scope=user") verbatim in a localized session. The
+  422 now carries a top-level `reason_code: "privacy_blocked"` sibling (the
+  #1409 hoist mechanism; the string `detail` is byte-identical), so the web
+  UI shows a plain-language, translated hint (en/ko) and keeps the raw
+  English detail in a hover tooltip for fidelity. CLI/MCP wording is
+  unchanged.
+
 ## [0.3.3] — 2026-07-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,15 +74,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Fixed
 
 - **Write-time Gate A block reads as localized, jargon-free copy in the web
-  editors** (#1651) — saving a canonical skill/command/agent that trips the
-  project_shared privacy gate (#1509) previously surfaced the raw-English
-  engine string ("Gate A: … no force bypass available for project_shared
-  (ADR-0011 §5) … target_scope=user") verbatim in a localized session. The
-  422 now carries a top-level `reason_code: "privacy_blocked"` sibling (the
-  #1409 hoist mechanism; the string `detail` is byte-identical), so the web
-  UI shows a plain-language, translated hint (en/ko) and keeps the raw
-  English detail in a hover tooltip for fidelity. CLI/MCP wording is
-  unchanged.
+  editors** (#1651) — saving a canonical skill/command/agent/MCP-server that
+  trips the project_shared privacy gate (#1509) previously surfaced the
+  raw-English engine string ("Gate A: … no force bypass available for
+  project_shared (ADR-0011 §5) … target_scope=user") verbatim in a localized
+  session. Every editor 422 now carries a top-level
+  `reason_code: "privacy_blocked"` sibling (the #1409 hoist mechanism; the
+  string `detail` is byte-identical), so the web UI shows a plain-language,
+  translated hint (en/ko) and keeps the raw English detail in a hover tooltip
+  for fidelity. MCP servers, which are project_shared-only, get a hint that
+  omits the user-tier remediation. CLI/MCP-tool wording is unchanged.
 
 ## [0.3.3] — 2026-07-04
 

--- a/packages/memtomem/src/memtomem/web/routes/_artifact_common.py
+++ b/packages/memtomem/src/memtomem/web/routes/_artifact_common.py
@@ -18,7 +18,6 @@ them into one ``ImportRequest`` component; sharing the class keeps that name.
 
 from __future__ import annotations
 
-from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 
@@ -28,6 +27,7 @@ from memtomem.context._sync_atomic import ON_DROP_LEVELS
 from memtomem.context.privacy_scan import FileScan, format_scan_block_message
 from memtomem.context.scope_resolver import ArtifactKind
 from memtomem.web.routes._errors import _error
+from memtomem.web.routes._sync_phase import SyncPhaseError
 
 # ── Mtime conflict envelope ──────────────────────────────────────────────
 
@@ -95,9 +95,21 @@ def raise_if_privacy_blocked(scan: FileScan, *, kind: str, artifact_name: str) -
     """
     if scan.decision not in ("blocked", "blocked_project_shared"):
         return
-    raise HTTPException(
-        status_code=422,
-        detail=format_scan_block_message(
+    # Raise via SyncPhaseError (not bare HTTPException) so the app-wide
+    # ``_sync_phase_error_handler`` hoists ``reason_code`` to a top-level sibling
+    # of the string ``detail`` (#1409 mechanism), letting the localized web UI
+    # disambiguate a privacy block from a parse/validation 422 and translate it
+    # (#1651) — the editor Gate A 422 was the last privacy 422 without the
+    # sibling, so a ko session saw the raw English jargon wall verbatim. The
+    # ``detail`` string stays byte-identical (path-free count + basename, the
+    # issue-pinned string convention), so every CLI/MCP/web wording pin holds.
+    # The class is historically sync-named, but its handler is the general
+    # string-detail reason_code hoist, and editor create/update routes are never
+    # aggregated by ``sync-all`` (no cross-contamination). ``reason_code`` reuses
+    # the value the sync/import/wiki privacy 422s already emit.
+    raise SyncPhaseError(
+        422,
+        format_scan_block_message(
             scan,
             scope="project_shared",
             kind=kind,
@@ -107,6 +119,8 @@ def raise_if_privacy_blocked(scan: FileScan, *, kind: str, artifact_name: str) -
                 f"in your private user tier (target_scope=user)."
             ),
         ),
+        error_kind="validation",
+        reason_code="privacy_blocked",
     )
 
 

--- a/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mcp_servers.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
@@ -210,7 +210,14 @@ async def create_mcp_server(
         # keeps the full message in the server log.
         raise _error(422, "parse", exc.safe_message) from exc
     except McpServerPrivacyError as exc:
-        raise HTTPException(422, str(exc)) from exc
+        # #1651: hoist reason_code as a top-level sibling (the byte-identical
+        # string detail stays issue-pinned) so the web editor localizes the
+        # block, matching the sync path below and the per-kind editors. MCP
+        # servers are project_shared-only (ADR-0011 §1), so the client picks an
+        # MCP-specific hint that omits the user-tier remediation.
+        raise SyncPhaseError(
+            422, str(exc), error_kind="validation", reason_code="privacy_blocked"
+        ) from exc
     return {"name": name, "canonical_path": _safe_rel(path, project_root)}
 
 
@@ -265,7 +272,14 @@ async def _update_mcp_server_impl(
         # Path-free detail at the loopback boundary (#1412); see create route.
         raise _error(422, "parse", exc.safe_message) from exc
     except McpServerPrivacyError as exc:
-        raise HTTPException(422, str(exc)) from exc
+        # #1651: hoist reason_code as a top-level sibling (the byte-identical
+        # string detail stays issue-pinned) so the web editor localizes the
+        # block, matching the sync path below and the per-kind editors. MCP
+        # servers are project_shared-only (ADR-0011 §1), so the client picks an
+        # MCP-specific hint that omits the user-tier remediation.
+        raise SyncPhaseError(
+            422, str(exc), error_kind="validation", reason_code="privacy_blocked"
+        ) from exc
     return JSONResponse(content={"name": name, "mtime_ns": str(new_mtime_ns)})
 
 

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1241,6 +1241,11 @@ function showToast(message, type = 'success', options = {}) {
   const msgSpan = document.createElement('span');
   msgSpan.className = 'toast-msg';
   msgSpan.textContent = message;
+  // ``options.title`` keeps a raw/verbatim string in a hover tooltip while the
+  // visible text stays a short localized message — e.g. the privacy-block toast
+  // shows a jargon-free hint but preserves the raw English server detail for
+  // fidelity (#1651). Mirrors the overview error tile's ``title=`` tooltip.
+  if (options.title) msgSpan.title = options.title;
   toast.appendChild(msgSpan);
   const delay = type === 'error' ? 5000 : 3000;
   let timer;

--- a/packages/memtomem/src/memtomem/web/static/context-gateway-actions.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway-actions.js
@@ -459,6 +459,7 @@ document.querySelectorAll('.ctx-create-btn').forEach(btn => {
         let r = await createOnce({});
         if (!r.ok) {
           const err = await r.json().catch(() => ({}));
+          if (_ctxMaybePrivacyToast(err)) return;
           showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
           return;
         }
@@ -469,6 +470,7 @@ document.querySelectorAll('.ctx-create-btn').forEach(btn => {
           if (!r) return;
           if (!r.ok) {
             const err = await r.json().catch(() => ({}));
+            if (_ctxMaybePrivacyToast(err)) return;
             showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
             return;
           }

--- a/packages/memtomem/src/memtomem/web/static/context-gateway-actions.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway-actions.js
@@ -459,7 +459,7 @@ document.querySelectorAll('.ctx-create-btn').forEach(btn => {
         let r = await createOnce({});
         if (!r.ok) {
           const err = await r.json().catch(() => ({}));
-          if (_ctxMaybePrivacyToast(err)) return;
+          if (_ctxMaybePrivacyToast(err, type)) return;
           showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
           return;
         }
@@ -470,7 +470,7 @@ document.querySelectorAll('.ctx-create-btn').forEach(btn => {
           if (!r) return;
           if (!r.ok) {
             const err = await r.json().catch(() => ({}));
-            if (_ctxMaybePrivacyToast(err)) return;
+            if (_ctxMaybePrivacyToast(err, type)) return;
             showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
             return;
           }

--- a/packages/memtomem/src/memtomem/web/static/context-gateway-conflict.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway-conflict.js
@@ -780,6 +780,10 @@ async function _ctxHandleConflict(type, name, userBuffer, staleMtimeNs, detailEl
       let r2 = await forcePut({});
       if (!r2.ok) {
         const err = await r2.json().catch(() => ({}));
+        // force=true bypasses only the mtime guard, never Gate A (#1509), so a
+        // secret in the resolved buffer still trips the write-time privacy 422 —
+        // localize it here too, not just on the plain save path (#1651).
+        if (_ctxMaybePrivacyToast(err, type)) return;
         showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
         return;
       }
@@ -792,6 +796,7 @@ async function _ctxHandleConflict(type, name, userBuffer, staleMtimeNs, detailEl
         if (!r2) return;
         if (!r2.ok) {
           const err = await r2.json().catch(() => ({}));
+          if (_ctxMaybePrivacyToast(err, type)) return;
           showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
           return;
         }

--- a/packages/memtomem/src/memtomem/web/static/context-gateway-detail.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway-detail.js
@@ -684,7 +684,7 @@ async function loadCtxDetail(type, name, opts = {}) {
         }
         if (!r.ok) {
           const err = await r.json().catch(() => ({}));
-          if (_ctxMaybePrivacyToast(err)) return;
+          if (_ctxMaybePrivacyToast(err, type)) return;
           showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
           return;
         }
@@ -701,7 +701,7 @@ async function loadCtxDetail(type, name, opts = {}) {
           }
           if (!r.ok) {
             const err = await r.json().catch(() => ({}));
-            if (_ctxMaybePrivacyToast(err)) return;
+            if (_ctxMaybePrivacyToast(err, type)) return;
             showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
             return;
           }

--- a/packages/memtomem/src/memtomem/web/static/context-gateway-detail.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway-detail.js
@@ -684,6 +684,7 @@ async function loadCtxDetail(type, name, opts = {}) {
         }
         if (!r.ok) {
           const err = await r.json().catch(() => ({}));
+          if (_ctxMaybePrivacyToast(err)) return;
           showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
           return;
         }
@@ -700,6 +701,7 @@ async function loadCtxDetail(type, name, opts = {}) {
           }
           if (!r.ok) {
             const err = await r.json().catch(() => ({}));
+            if (_ctxMaybePrivacyToast(err)) return;
             showToast(_ctxErrDetail(err.detail, t('toast.request_failed')), 'error');
             return;
           }

--- a/packages/memtomem/src/memtomem/web/static/context-gateway-list.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway-list.js
@@ -167,6 +167,23 @@ function _ctxErrDetail(detail, fallback) {
   return fallback;
 }
 
+// The write-time Gate A privacy block (#1509) is the one editor 422 that ships a
+// path-free but raw-ENGLISH, jargon-heavy string ``detail`` ("Gate A: … ADR-0011
+// §5 … target_scope=user"). The server hoists ``reason_code: "privacy_blocked"``
+// to a top-level sibling of that string (``_sync_phase`` handler, #1409), so we
+// can show a localized, jargon-free hint here and keep the raw English detail in
+// a tooltip for fidelity (#1651). ``err`` is the parsed 422 body. Returns true
+// when it handled a privacy block (caller should stop and not toast again).
+function _ctxMaybePrivacyToast(err) {
+  if (err && err.reason_code === 'privacy_blocked') {
+    showToast(t('settings.ctx.privacy_blocked_editor_hint'), 'error', {
+      title: typeof err.detail === 'string' ? err.detail : undefined,
+    });
+    return true;
+  }
+  return false;
+}
+
 // Sync All fans out over the ACTIVE scope's artifact types, so it must honor the
 // same eligibility gate as the per-row matrix Sync button — otherwise an
 // ineligible active project (paused / not enrolled) is still syncable via Sync

--- a/packages/memtomem/src/memtomem/web/static/context-gateway-list.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway-list.js
@@ -167,16 +167,21 @@ function _ctxErrDetail(detail, fallback) {
   return fallback;
 }
 
-// The write-time Gate A privacy block (#1509) is the one editor 422 that ships a
+// The write-time Gate A privacy block (#1509) is the editor 422 that ships a
 // path-free but raw-ENGLISH, jargon-heavy string ``detail`` ("Gate A: … ADR-0011
 // §5 … target_scope=user"). The server hoists ``reason_code: "privacy_blocked"``
 // to a top-level sibling of that string (``_sync_phase`` handler, #1409), so we
 // can show a localized, jargon-free hint here and keep the raw English detail in
-// a tooltip for fidelity (#1651). ``err`` is the parsed 422 body. Returns true
-// when it handled a privacy block (caller should stop and not toast again).
-function _ctxMaybePrivacyToast(err) {
+// a tooltip for fidelity (#1651). ``err`` is the parsed 422 body; ``type`` is the
+// artifact kind. MCP servers are project_shared-only (ADR-0011 §1), so they get a
+// hint that omits the "save to your user library" remediation (invalid there).
+// Returns true when it handled a privacy block (caller should stop, not re-toast).
+function _ctxMaybePrivacyToast(err, type) {
   if (err && err.reason_code === 'privacy_blocked') {
-    showToast(t('settings.ctx.privacy_blocked_editor_hint'), 'error', {
+    const key = type === 'mcp-servers'
+      ? 'settings.ctx.privacy_blocked_mcp_hint'
+      : 'settings.ctx.privacy_blocked_editor_hint';
+    showToast(t(key), 'error', {
       title: typeof err.detail === 'string' ? err.detail : undefined,
     });
     return true;

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1768,7 +1768,7 @@
   <script src="/context-gateway-controls.js?v=1"></script>
   <script src="/context-gateway-overview.js?v=2"></script>
   <script src="/context-gateway-list.js?v=2"></script>
-  <script src="/context-gateway-conflict.js?v=1"></script>
+  <script src="/context-gateway-conflict.js?v=2"></script>
   <script src="/context-gateway-detail.js?v=3"></script>
   <script src="/context-gateway-actions.js?v=2"></script>
   <script src="/context-portal.js?v=8"></script>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1755,7 +1755,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=7"></script>
-  <script src="/app.js?v=146"></script>
+  <script src="/app.js?v=147"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=14"></script>
   <script src="/sources-memory-dirs.js?v=13"></script>
@@ -1767,10 +1767,10 @@
   <script src="/context-gateway-core.js?v=2"></script>
   <script src="/context-gateway-controls.js?v=1"></script>
   <script src="/context-gateway-overview.js?v=2"></script>
-  <script src="/context-gateway-list.js?v=1"></script>
+  <script src="/context-gateway-list.js?v=2"></script>
   <script src="/context-gateway-conflict.js?v=1"></script>
-  <script src="/context-gateway-detail.js?v=2"></script>
-  <script src="/context-gateway-actions.js?v=1"></script>
+  <script src="/context-gateway-detail.js?v=3"></script>
+  <script src="/context-gateway-actions.js?v=2"></script>
   <script src="/context-portal.js?v=8"></script>
   <script src="/wiki.js?v=11"></script>
   <script src="/path-picker.js?v=4"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -754,6 +754,7 @@
   "settings.ctx.force_unsafe_sync_btn": "Sync anyway",
   "settings.ctx.privacy_blocked_shared_hint": "Shared (project) imports can't override a flagged secret — git history is permanent. Open the skill and use 'Import to user library' instead, or remove the flagged line.",
   "settings.ctx.privacy_blocked_shared_sync_hint": "Shared (project) sync can't override a flagged secret — git history is permanent. Remove the flagged line, then re-run sync.",
+  "settings.ctx.privacy_blocked_editor_hint": "A secret was detected in this content, so it can't be saved to the shared (project) tier — git history is permanent, with no force override. Remove the secret, or save it to your private user library instead.",
   "settings.ctx.import_to_user": "Import to user library",
   "settings.ctx.import_to_user_success": "Imported into your user library (~/.memtomem)",
   "settings.ctx.runtime_only_detail_hint": "Runtime preview — not yet in .memtomem/.",

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -755,6 +755,7 @@
   "settings.ctx.privacy_blocked_shared_hint": "Shared (project) imports can't override a flagged secret — git history is permanent. Open the skill and use 'Import to user library' instead, or remove the flagged line.",
   "settings.ctx.privacy_blocked_shared_sync_hint": "Shared (project) sync can't override a flagged secret — git history is permanent. Remove the flagged line, then re-run sync.",
   "settings.ctx.privacy_blocked_editor_hint": "A secret was detected in this content, so it can't be saved to the shared (project) tier — git history is permanent, with no force override. Remove the secret, or save it to your private user library instead.",
+  "settings.ctx.privacy_blocked_mcp_hint": "A secret was detected in this MCP server config, so it can't be saved to the shared project .mcp.json — git history is permanent, with no force override. Remove the secret before saving.",
   "settings.ctx.import_to_user": "Import to user library",
   "settings.ctx.import_to_user_success": "Imported into your user library (~/.memtomem)",
   "settings.ctx.runtime_only_detail_hint": "Runtime preview — not yet in .memtomem/.",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -755,6 +755,7 @@
   "settings.ctx.privacy_blocked_shared_hint": "공유(프로젝트) 가져오기는 표시된 시크릿을 우회할 수 없습니다 — git 기록은 영구적입니다. 스킬을 열어 '사용자 라이브러리로 가져오기'를 쓰거나, 표시된 줄을 제거하세요.",
   "settings.ctx.privacy_blocked_shared_sync_hint": "공유(프로젝트) 동기화는 표시된 시크릿을 우회할 수 없습니다 — git 기록은 영구적입니다. 표시된 줄을 제거한 뒤 다시 동기화하세요.",
   "settings.ctx.privacy_blocked_editor_hint": "이 콘텐츠에서 비밀값(secret)이 감지되어 공유(프로젝트) 티어에 저장할 수 없습니다 — git 기록은 영구적이라 강제 저장할 수 없습니다. 비밀값을 제거하거나, 개인 사용자 라이브러리에 저장하세요.",
+  "settings.ctx.privacy_blocked_mcp_hint": "이 MCP 서버 설정에서 비밀값(secret)이 감지되어 공유 프로젝트 .mcp.json 에 저장할 수 없습니다 — git 기록은 영구적이라 강제 저장할 수 없습니다. 저장하기 전에 비밀값을 제거하세요.",
   "settings.ctx.import_to_user": "사용자 라이브러리로 가져오기",
   "settings.ctx.import_to_user_success": "사용자 라이브러리(~/.memtomem)로 가져왔습니다",
   "settings.ctx.runtime_only_detail_hint": "런타임 미리보기 — 아직 .memtomem/ 에 없습니다.",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -754,6 +754,7 @@
   "settings.ctx.force_unsafe_sync_btn": "그대로 동기화",
   "settings.ctx.privacy_blocked_shared_hint": "공유(프로젝트) 가져오기는 표시된 시크릿을 우회할 수 없습니다 — git 기록은 영구적입니다. 스킬을 열어 '사용자 라이브러리로 가져오기'를 쓰거나, 표시된 줄을 제거하세요.",
   "settings.ctx.privacy_blocked_shared_sync_hint": "공유(프로젝트) 동기화는 표시된 시크릿을 우회할 수 없습니다 — git 기록은 영구적입니다. 표시된 줄을 제거한 뒤 다시 동기화하세요.",
+  "settings.ctx.privacy_blocked_editor_hint": "이 콘텐츠에서 비밀값(secret)이 감지되어 공유(프로젝트) 티어에 저장할 수 없습니다 — git 기록은 영구적이라 강제 저장할 수 없습니다. 비밀값을 제거하거나, 개인 사용자 라이브러리에 저장하세요.",
   "settings.ctx.import_to_user": "사용자 라이브러리로 가져오기",
   "settings.ctx.import_to_user_success": "사용자 라이브러리(~/.memtomem)로 가져왔습니다",
   "settings.ctx.runtime_only_detail_hint": "런타임 미리보기 — 아직 .memtomem/ 에 없습니다.",

--- a/packages/memtomem/tests-js/ctx-editor-privacy-localize.test.mjs
+++ b/packages/memtomem/tests-js/ctx-editor-privacy-localize.test.mjs
@@ -1,0 +1,91 @@
+/* Localized write-time Gate A editor privacy-block toast (#1651).
+ *
+ * The per-kind (skills/commands/agents) and MCP-server editor save 422 keeps a
+ * path-free ENGLISH string ``detail`` ("Gate A: … ADR-0011 §5 …") and now rides
+ * a top-level ``reason_code: "privacy_blocked"`` sibling (the #1409 hoist).
+ * ``_ctxMaybePrivacyToast`` maps that reason_code to a localized, jargon-free
+ * hint (keeping the raw detail in a tooltip) and picks an MCP-specific hint for
+ * mcp-servers — which are project_shared-only (ADR-0011 §1), so the per-kind
+ * "save to your user library" remediation is invalid there. These pin the
+ * reason_code → hint mapping, the kind split, and the tooltip fidelity.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+async function boot() {
+  const dom = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+  const { window } = dom;
+  await window.I18N.init();
+  return window;
+}
+
+// Capture the last showToast(message, type, options) call instead of rendering.
+function stubToast(window) {
+  const calls = [];
+  window.showToast = (message, type, options = {}) => {
+    calls.push({ message, type, options });
+  };
+  return calls;
+}
+
+describe('localized editor privacy-block toast (#1651)', () => {
+  it('maps reason_code privacy_blocked → the localized editor hint (non-MCP)', async () => {
+    const window = await boot();
+    const { I18N } = window;
+    const calls = stubToast(window);
+    const handled = window._ctxMaybePrivacyToast(
+      {
+        detail: 'Gate A: leaky contains 1 privacy pattern hit(s); write to scope=…',
+        reason_code: 'privacy_blocked',
+      },
+      'skills',
+    );
+    expect(handled).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].message).toBe(I18N.t('settings.ctx.privacy_blocked_editor_hint'));
+    expect(calls[0].message).not.toContain('Gate A'); // localized, not the raw wall
+    expect(calls[0].type).toBe('error');
+    // The raw English detail is preserved in the tooltip for fidelity.
+    expect(calls[0].options.title).toContain('Gate A: leaky');
+  });
+
+  it('picks the MCP-specific hint for mcp-servers (no user-tier remediation)', async () => {
+    const window = await boot();
+    const { I18N } = window;
+    const calls = stubToast(window);
+    window._ctxMaybePrivacyToast(
+      {
+        detail: 'Gate A: leaky.json contains 1 privacy pattern hit(s); MCP server fan-out …',
+        reason_code: 'privacy_blocked',
+      },
+      'mcp-servers',
+    );
+    const mcpHint = I18N.t('settings.ctx.privacy_blocked_mcp_hint');
+    const editorHint = I18N.t('settings.ctx.privacy_blocked_editor_hint');
+    expect(mcpHint).not.toBe(editorHint); // distinct copy
+    expect(calls[0].message).toBe(mcpHint);
+    // The "user library" remediation is wrong for project_shared-only MCP servers.
+    expect(calls[0].message).not.toContain('user library');
+  });
+
+  it('returns false and does not toast for non-privacy errors', async () => {
+    const window = await boot();
+    const calls = stubToast(window);
+    expect(
+      window._ctxMaybePrivacyToast({ detail: 'boom', reason_code: 'parse_error' }, 'skills'),
+    ).toBe(false);
+    expect(window._ctxMaybePrivacyToast(null, 'skills')).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('omits the tooltip when detail is not a string', async () => {
+    const window = await boot();
+    const calls = stubToast(window);
+    window._ctxMaybePrivacyToast(
+      { detail: { nested: true }, reason_code: 'privacy_blocked' },
+      'skills',
+    );
+    expect(calls[0].options.title).toBeUndefined();
+  });
+});

--- a/packages/memtomem/tests/test_web_routes_context_mcp_servers.py
+++ b/packages/memtomem/tests/test_web_routes_context_mcp_servers.py
@@ -167,7 +167,11 @@ async def test_create_rejects_secret_shaped_content(client: AsyncClient) -> None
         },
     )
     assert r.status_code == 422
+    assert isinstance(r.json()["detail"], str), r.text
     assert "privacy pattern" in r.json()["detail"]
+    # #1651: reason_code hoisted as a top-level sibling (string detail unchanged)
+    # so the web editor localizes the MCP block like the per-kind editors.
+    assert r.json()["reason_code"] == "privacy_blocked", r.text
     assert secret not in r.text
 
 
@@ -193,7 +197,9 @@ async def test_update_rejects_secret_shaped_content(client: AsyncClient, tmp_pat
         },
     )
     assert r.status_code == 422
+    assert isinstance(r.json()["detail"], str), r.text
     assert "privacy pattern" in r.json()["detail"]
+    assert r.json()["reason_code"] == "privacy_blocked", r.text  # #1651 sibling
     assert secret not in r.text
     assert path.read_bytes() == before_bytes
 

--- a/packages/memtomem/tests/test_web_routes_context_mutators.py
+++ b/packages/memtomem/tests/test_web_routes_context_mutators.py
@@ -830,6 +830,9 @@ async def test_POST_rejects_secret_shaped_content(
     assert "privacy pattern" in detail
     assert secret not in r.text
     assert str(gateway_root) not in detail
+    # #1651: reason_code is hoisted to a top-level sibling (detail string stays
+    # byte-identical) so the localized web UI can translate the block.
+    assert r.json()["reason_code"] == "privacy_blocked", r.text
     # Nothing landed: no working file and no artifact dir — which also
     # proves the ADR-0022 create_version snapshot never fired.
     assert not adapter["created_working"](gateway_root, "leaky").exists()
@@ -859,7 +862,9 @@ async def test_PUT_rejects_secret_shaped_content_even_with_force(
         },
     )
     assert r.status_code == 422, (adapter["type"], r.text)
+    assert isinstance(r.json()["detail"], str), r.text
     assert "privacy pattern" in r.json()["detail"]
+    assert r.json()["reason_code"] == "privacy_blocked", r.text  # #1651 sibling
     assert secret not in r.text
     assert manifest.read_bytes() == before_bytes
     assert manifest.stat().st_mtime_ns == before_mtime_ns

--- a/packages/memtomem/tests/web/test_context_gateway_privacy_block.py
+++ b/packages/memtomem/tests/web/test_context_gateway_privacy_block.py
@@ -86,6 +86,42 @@ def _mount_and_save(page) -> None:
     page.locator("#ctx-skills-detail .ctx-edit-save").click()
 
 
+def _stub_conflict_then_privacy(page) -> dict:
+    """GET serves detail; the 1st PUT returns a 409 stale-mtime (opens the
+    conflict modal), the 2nd PUT (Force save) returns the privacy 422 — force
+    bypasses only the mtime guard, never Gate A."""
+    state = {"puts": 0}
+
+    def _handler(route):
+        if route.request.method == "PUT":
+            state["puts"] += 1
+            if state["puts"] == 1:
+                route.fulfill(
+                    status=409,
+                    content_type="application/json",
+                    body=json.dumps(
+                        {
+                            "status": "aborted",
+                            "reason": "File was modified by another process. Reload and retry.",
+                            "mtime_ns": "1700000000000000001",
+                            "error_kind": "conflict",
+                            "reason_code": "stale_mtime",
+                        }
+                    ),
+                )
+            else:
+                route.fulfill(
+                    status=422,
+                    content_type="application/json",
+                    body=json.dumps({"detail": _GATE_A_DETAIL, "reason_code": "privacy_blocked"}),
+                )
+            return
+        route.fulfill(status=200, content_type="application/json", body=json.dumps(_SKILL_DETAIL))
+
+    page.route("**/api/context/skills/demo-skill**", _handler)
+    return state
+
+
 def _toast_text(page) -> str:
     toast = page.wait_for_selector("#toast-container .toast", timeout=3_000)
     return (toast.text_content() or "").strip()
@@ -127,3 +163,24 @@ def test_editor_privacy_block_localized_ko(page, mm_web_url: str) -> None:
     assert KO_HINT in text, f"KO toast must surface the KO hint; got {text!r}"
     assert "Gate A" not in text, f"raw jargon must not reach the visible toast; got {text!r}"
     assert EN_HINT not in text, f"EN copy must not leak under the KO locale; got {text!r}"
+
+
+def test_editor_privacy_block_localized_on_conflict_force_save(page, mm_web_url: str) -> None:
+    """force=true bypasses only the mtime guard, never Gate A: a secret saved
+    through the conflict dialog's Force-save path must still surface the
+    localized hint, not the raw English wall (#1651 conflict-path coverage)."""
+    install_default_stubs(page)
+    _stub_conflict_then_privacy(page)
+    page.goto(mm_web_url)
+    _open_skills(page)
+    _mount_and_save(page)
+    # First save → 409 → the conflict modal opens; choose Force save, which
+    # re-PUTs with force=true and trips Gate A.
+    force = page.wait_for_selector("#ctx-conflict-force-btn", state="visible", timeout=4_000)
+    force.click()
+
+    text = _toast_text(page)
+    assert EN_HINT in text, f"conflict Force-save must localize the privacy block; got {text!r}"
+    assert "Gate A" not in text, f"raw jargon must not reach the visible toast; got {text!r}"
+    title = page.locator("#toast-container .toast-msg").get_attribute("title") or ""
+    assert "Gate A: demo-skill" in title, f"raw detail must survive in the tooltip; got {title!r}"

--- a/packages/memtomem/tests/web/test_context_gateway_privacy_block.py
+++ b/packages/memtomem/tests/web/test_context_gateway_privacy_block.py
@@ -1,0 +1,129 @@
+"""Browser tests for the localized write-time Gate A privacy block (#1651).
+
+The canonical skills/commands/agents editor save (#1509 write-time Gate A)
+refuses secret-shaped ``project_shared`` content with a 422 whose STRING
+``detail`` is a raw-English, jargon-heavy Gate A message ("Gate A: … ADR-0011
+§5 … target_scope=user"). #1651 hoists a top-level ``reason_code:
+"privacy_blocked"`` sibling (the #1409 ``_sync_phase`` mechanism) so the client
+shows a localized, jargon-free hint while keeping the raw English detail in a
+hover tooltip for fidelity. These specs pin:
+
+* EN save 422 → the localized editor hint, NOT the raw "Gate A"/"ADR-0011 §5"
+  wall.
+* The raw server detail survives verbatim in the toast ``.toast-msg`` ``title=``.
+* KO locale renders its own hint (no English leak).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from .conftest import install_default_stubs
+
+pytestmark = pytest.mark.browser
+
+
+# The raw server detail the editor 422 carries — the path-free, issue-pinned
+# string produced by ``format_scan_block_message`` (remediation_hint branch).
+_GATE_A_DETAIL = (
+    "Gate A: demo-skill contains 1 privacy pattern hit(s); write to "
+    "scope='project_shared' rejected. git history is forever — no force bypass "
+    "available for project_shared (ADR-0011 §5).\n"
+    "  Remove the secret from the editor content, or keep the skill in your "
+    "private user tier (target_scope=user)."
+)
+
+# Locale-pinned copy (en.json / ko.json are the source of truth).
+EN_HINT = "A secret was detected in this content"
+KO_HINT = "비밀값(secret)이 감지되어"
+
+
+_SKILL_DETAIL = {
+    "name": "demo-skill",
+    "canonical_path": "/srv/cwd/.memtomem/skills/demo-skill.md",
+    "content": "name: demo\n",
+    "mtime_ns": "1700000000000000000",
+    "files": [],
+}
+
+
+def _open_skills(page) -> None:
+    """Land on Settings → Skills and wait for the detail container to mount."""
+    page.evaluate("() => activateTab('settings')")
+    page.evaluate("() => switchSettingsSection('ctx-skills')")
+    page.wait_for_selector("#ctx-skills-detail", state="attached", timeout=5_000)
+
+
+def _stub_editor_save(page) -> None:
+    """Method-branching handler for ``/api/context/skills/demo-skill`` — GET
+    serves the detail payload (so the editor mounts); PUT returns the write-time
+    Gate A privacy 422 with the hoisted ``reason_code`` sibling."""
+
+    def _handler(route):
+        if route.request.method == "PUT":
+            route.fulfill(
+                status=422,
+                content_type="application/json",
+                body=json.dumps({"detail": _GATE_A_DETAIL, "reason_code": "privacy_blocked"}),
+            )
+            return
+        route.fulfill(status=200, content_type="application/json", body=json.dumps(_SKILL_DETAIL))
+
+    page.route("**/api/context/skills/demo-skill**", _handler)
+
+
+def _mount_and_save(page) -> None:
+    """Open the demo-skill detail, enter edit mode, type, and click Save."""
+    page.evaluate("() => { loadCtxDetail('skills', 'demo-skill'); }")
+    page.wait_for_selector("#ctx-skills-detail .ctx-detail-edit-btn", timeout=4_000)
+    page.locator("#ctx-skills-detail .ctx-detail-edit-btn").click()
+    page.wait_for_selector("#ctx-skills-detail #ctx-edit-content", state="visible", timeout=3_000)
+    page.locator("#ctx-skills-detail #ctx-edit-content").fill(
+        "name: demo\nOPENAI_API_KEY=sk-secret\n"
+    )
+    page.locator("#ctx-skills-detail .ctx-edit-save").click()
+
+
+def _toast_text(page) -> str:
+    toast = page.wait_for_selector("#toast-container .toast", timeout=3_000)
+    return (toast.text_content() or "").strip()
+
+
+def test_editor_privacy_block_localized_en(page, mm_web_url: str) -> None:
+    """A save-time Gate A 422 renders the localized editor hint, and the raw
+    English detail is preserved in the toast tooltip (never the visible text)."""
+    install_default_stubs(page)
+    _stub_editor_save(page)
+    page.goto(mm_web_url)
+    _open_skills(page)
+    _mount_and_save(page)
+
+    text = _toast_text(page)
+    assert EN_HINT in text, f"toast must surface the localized editor hint; got {text!r}"
+    assert "Gate A" not in text, f"raw jargon must not reach the visible toast; got {text!r}"
+    assert "ADR-0011" not in text, f"raw jargon must not reach the visible toast; got {text!r}"
+    # The raw English server detail survives verbatim in the tooltip.
+    title = page.locator("#toast-container .toast-msg").get_attribute("title") or ""
+    assert "Gate A: demo-skill" in title, (
+        f"raw detail must survive in the toast tooltip; got {title!r}"
+    )
+
+
+def test_editor_privacy_block_localized_ko(page, mm_web_url: str) -> None:
+    """KO locale renders its own hint; the English copy must not leak."""
+    install_default_stubs(page)
+    _stub_editor_save(page)
+    page.goto(mm_web_url)
+    _open_skills(page)
+    # The hint is resolved via ``t()`` at error time, so switch locale first.
+    # ``setLang`` is async (it fetches ``/locales/ko.json``); awaiting it means
+    # the KO catalog is loaded and active by the time we save.
+    page.evaluate("async () => { await I18N.setLang('ko'); }")
+    _mount_and_save(page)
+
+    text = _toast_text(page)
+    assert KO_HINT in text, f"KO toast must surface the KO hint; got {text!r}"
+    assert "Gate A" not in text, f"raw jargon must not reach the visible toast; got {text!r}"
+    assert EN_HINT not in text, f"EN copy must not leak under the KO locale; got {text!r}"


### PR DESCRIPTION
## What

Localize the **write-time Gate A privacy block** in the web editors so a localized (e.g. Korean) session no longer sees a raw-English, internal-jargon wall when saving a canonical skill/command/agent that contains a secret.

Before (ko session, editor save with a seeded fake key):

> Gate A: hello contains 1 privacy pattern hit(s); write to scope='project_shared' rejected. git history is forever — no force bypass available for project_shared (ADR-0011 §5). Remove the secret from the editor content, or keep the command in your private user tier (target_scope=user).

Every token — "Gate A", "ADR-0011 §5", `scope='project_shared'`, `target_scope=user` — was untranslated internal vocabulary. This is the roughest jargon surface a normal editing flow can reach and cuts against the ADR-0026 jargon-free goal.

## Why this is display-layer safe

The issue framed the constraint as "the privacy-422 detail is pinned as a string, so wire shape must not change." That pin is a **type** contract (`isinstance(detail, str)` — never an object envelope; ADR-0024, `_errors.py`), **not a wording contract**. And every *other* privacy 422 in the codebase already hoists a top-level `reason_code` sibling via the #1409 `_sync_phase` handler (which hoists **only** for string details, keeping `detail` byte-identical) — the editor Gate A 422 was the **last** privacy 422 without it, so the client could only pattern-match the brittle `"Gate A:"` prefix.

## How

- **Server** (`_artifact_common.raise_if_privacy_blocked`): raise `SyncPhaseError(422, …, error_kind="validation", reason_code="privacy_blocked")` instead of a bare `HTTPException`. The app-wide handler hoists `reason_code` to a top-level sibling of the **byte-identical** string `detail`. No engine wording changed → every CLI/MCP/web message pin stays green.
- **Client**: `_ctxMaybePrivacyToast(err, type)` (new, next to `_ctxErrDetail`) fires on `reason_code === 'privacy_blocked'`, shows a localized jargon-free hint, and keeps the raw English `detail` in the toast tooltip. Wired into **all six** editor write-time error branches — plain create/update, host-write confirm retries, and the mtime-conflict **Force-save** path (`force:true` bypasses only mtime, never Gate A). `showToast` gains an additive `options.title` tooltip affordance (mirrors the overview error tile).
- **Coverage**: MCP servers (`context_mcp_servers` create/update) and the conflict Force-save path were the two editor surfaces the first cut missed — both now emit the sibling and localize. MCP is project_shared-only (ADR-0011 §1), so it gets a dedicated `privacy_blocked_mcp_hint` that omits the user-tier remediation.
- **Locale**: new `settings.ctx.privacy_blocked_editor_hint` + `privacy_blocked_mcp_hint` in en.json + ko.json; cache-bust bumps on the five edited JS files.

CLI/MCP-tool surfaces stay English by policy. Server-side wording de-jargon (issue Option 2) was rejected — it would re-pin ~54 assertions across 21 files and still wouldn't localize (the server is English-only).

## Tests

- Server (`test_web_routes_context_mutators.py`): the create + force-update Gate A refusals now also assert `reason_code == "privacy_blocked"` while keeping `isinstance(detail, str)` + `"privacy pattern"` (proves the sibling is additive and the string is byte-identical).
- New browser spec (`tests/web/test_context_gateway_privacy_block.py`): editor save → 422 → localized hint (en **and** ko), raw English detail preserved in the `.toast-msg` `title=`, no `"Gate A"` in the visible toast; plus a **conflict Force-save** case (save → 409 → Force → 422 → localized).
- New vitest (`tests-js/ctx-editor-privacy-localize.test.mjs`): the `reason_code → hint` mapping, the MCP/per-kind hint split, tooltip fidelity, and non-privacy fallthrough.
- MCP route tests (`test_web_routes_context_mcp_servers.py`): create/update secret-shaped saves assert the `reason_code` sibling + string detail.

## Verification

- `ruff check` + `ruff format --check`: pass · `mypy` (advisory): clean
- `pytest -m "not ollama"`: **8111 passed**, 11 skipped · full vitest: **426 passed** · i18n en/ko parity guard: pass

Closes #1651

🤖 Generated with [Claude Code](https://claude.com/claude-code)
