### PR TITLE
fix(docs): correct mem_add tags examples to list form

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -362,7 +362,7 @@ Results are ranked by a combination of keyword relevance and semantic similarity
 
 ```
 "Remember that Redis LRU→LFU reduced cache misses by 40%"
-→  mem_add(content="Redis LRU→LFU migration reduced cache misses by 40%", tags="redis,performance")
+→  mem_add(content="Redis LRU→LFU migration reduced cache misses by 40%", tags=["redis", "performance"])
 ```
 
 ```bash

--- a/docs/guides/reference/core-memory-tools.md
+++ b/docs/guides/reference/core-memory-tools.md
@@ -277,7 +277,7 @@ Like `mem_search`, `mem_recall` hides system namespaces (`archive:*` by default)
 ### `mem_add` — Add a note
 
 ```
-mem_add(content="Redis LRU→LFU migration reduced cache misses by 40%", tags="redis,performance")
+mem_add(content="Redis LRU→LFU migration reduced cache misses by 40%", tags=["redis", "performance"])
 → Saved to ~/.memtomem/memories/2026-03-30.md (1 chunk indexed)
 ```
 
@@ -285,13 +285,13 @@ mem_add(content="Redis LRU→LFU migration reduced cache misses by 40%", tags="r
 |-----------|-------------|
 | `content` | The note text |
 | `title` | Optional heading (becomes `## title` in the file) |
-| `tags` | Comma-separated tags |
+| `tags` | List of tags (`list[str]`) |
 | `file` | Target file path (auto-generates date-stamped file if omitted) |
 | `namespace` | Namespace assignment |
 | `template` | Structured template (`adr`, `meeting`, `debug`, `decision`, `procedure`) |
 
 ```
-mem_add(content="New rate limit: 1000 req/min", file="api-notes.md", tags="api")
+mem_add(content="New rate limit: 1000 req/min", file="api-notes.md", tags=["api"])
 mem_add(content="Sprint decision: use GraphQL", title="Sprint 12", namespace="work")
 ```
 


### PR DESCRIPTION
## What

The `mem_add` MCP tool signature is `tags: list[str] | None`, but two guide
docs showed the flagship first-use example passing a comma-string:

- `docs/guides/getting-started.md` — "First use → Add a memory"
- `docs/guides/reference/core-memory-tools.md` — `mem_add` reference (2 examples
  + the param-table row said "Comma-separated tags")

There is **no** comma-split normalization on the write path (`memory_crud.py`
`tags` flows straight through to `append_entry`), so `tags="redis,performance"`
does not do what the example implies. `README.md` already uses the correct list
form (`tags=["ops"]`).

## Change

- `tags="redis,performance"` → `tags=["redis", "performance"]` (and `tags="api"`
  → `tags=["api"]`)
- Reference param-table: "Comma-separated tags" → "List of tags (`list[str]`)"

## Not changed (intentional)

- The `mm add ... --tags "redis,performance"` **CLI** line — the CLI flag
  legitimately takes a comma-string.
- The `mem_search` `tag_filter` row (`| "redis,cache" |`) — `tag_filter` is a
  genuine `str` comma-list (OR logic) per its signature/docstring.

## Verification

- `rg 'mem_(add|batch_add)\([^)]*tags="' -g '*.md'` → no matches
- `uv run pytest -m "not ollama" packages/memtomem/tests/test_docs_guards.py` → 19 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
