### PR TITLE
feat: add usage examples to --help for search command

### DIFF
--- a/packages/memtomem/src/memtomem/cli/search.py
+++ b/packages/memtomem/src/memtomem/cli/search.py
@@ -22,7 +22,16 @@ from memtomem.server.tools.search import (
 )
 
 
-@click.command()
+@click.command(
+    epilog="""
+Examples:
+
+  mm search "deployment checklist"
+  mm search "redis" --format json
+  mm search "memory" --tags "performance,redis" --limit 5
+  mm search "database" --scope "project_local,user" --top-k 15
+"""
+)
 @click.argument("query")
 @click.option("--top-k", "-k", default=10, help="Number of results")
 @click.option("--source-filter", "-s", default=None, help="Source file filter")


### PR DESCRIPTION
## What this PR does
Adds usage examples to the `--help` output for `mm search` using Click's `epilog=` parameter.

## Changes
- Added `epilog=` to search command with 4 practical examples
- Examples show common use cases (basic search, JSON output, tag filtering, scope filtering)

## Related Issue
Closes #1667

## Testing
- Verified `mm search --help` shows the examples block
- No behavior changes, only help text

Ready for review.