### PR TITLE
docs: bring public docs to the v0.3.4 baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ See [Embeddings](docs/guides/embeddings.md) for the full model/provider matrix.
 "Remember this insight"      →  mem_add(content="...", tags=["ops"])
 ```
 
-> Prefer the terminal? `mm status` is a CLI mirror of `mem_status` — same output, no editor needed.
+> Prefer the terminal? `mm status` is a CLI mirror of `mem_status` — same output, no editor needed. Add `--json` (or `--format json`) for machine-readable output in scripts and CI.
 
 ### 4. Web UI (optional)
 
@@ -134,8 +134,10 @@ See [MCP Client Setup](docs/guides/mcp-clients.md) for Cursor / Windsurf / Claud
 - **Namespaces** — organize memories into scoped groups with auto-derivation from folder names; review and label them (colour, description) from Settings → Namespaces in the Web UI
 - **Maintenance** — near-duplicate detection, time-based decay, TTL expiration, auto-tagging
 - **Web UI** — visual dashboard for search, sources, tags, timeline, dedup, and more (`mm web --dev` for the full maintainer surface)
+- **Context Gateway** — author canonical Skills, Commands, and Subagents once in a wiki-backed Store, then sync them to your AI tools (each artifact type's supported runtimes); a Projects portal in the Web UI tracks per-project drift. See [Context Gateway](docs/guides/context-gateway.md).
 - **MCP tools** — `mem_do` meta-tool routes all non-core actions in `core` mode for minimal context usage
 - **Predictable surface** — memory operations fire only on explicit MCP tool calls (`mem_add`, `mem_index`, etc.), not from background hooks attached to every prompt or session-end. Less magic, fewer surprises.
+- **Scriptable CLI** — `--json` output on `mm status` and write commands (`mm add` / `mm reset` / `mm purge`); `mm warmup` pre-loads local models so the first query skips the cold-start cost
 - **Scheduled jobs** — `mm schedule add/list/run-now/delete` (or `mem_do(action="schedule_*")`) for cron-driven compaction, importance decay, dead-link cleanup, and dedup scans
 
 ---

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -29,7 +29,8 @@ for the reference as you need it.
 ## Power features
 
 6. **[Context Gateway](context-gateway.md)** — keep one Store of Skills,
-   Commands, and Subagents and sync it to every AI tool you use.
+   Commands, and Subagents and sync it to your AI tools (each artifact type's
+   supported runtimes).
 7. **[Multi-device sync](multi-device-sync.md)** — sync your markdown memories
    across personal devices via a private git repo.
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -423,7 +423,7 @@ mm recall --since 2026-04  # recall by date
 mm config show             # view settings
 mm config set key value    # change a setting
 mm config unset key        # drop a pinned override (e.g., mmr.enabled)
-mm status                  # show indexing stats + config (terminal mirror of mem_status)
+mm status                  # show indexing stats + config (terminal mirror of mem_status; --json / --format json for scripts)
 mm embedding-reset         # check/resolve embedding model mismatch
 mm reset                   # delete all data and reinitialize the DB (--backup snapshots first)
 mm context detect          # find agent config files

--- a/docs/guides/reference/data-config-cli.md
+++ b/docs/guides/reference/data-config-cli.md
@@ -247,7 +247,7 @@ mm index ~/notes                       # manual one-shot index (seed pre-existin
 mm index --debounce-window 5 PATH      # record PATH; drain entries silent ≥5s (hook callers)
 mm index --flush                       # synchronously drain queue (correctness primitive)
 mm index --status                      # snapshot queue depth + oldest entry
-mm add "note" --tags "tag1"            # add a memory
+mm add "note" --tags "tag1"            # add a memory (--json prints a machine-readable write ack)
 mm recall --since 2026-03-01           # recall by date (Validity column shown when chunks have valid_from/valid_to)
 
 # Configuration
@@ -259,6 +259,7 @@ mm reset                               # delete all data and reinitialize the DB
 mm reset --yes                         # skip confirmation prompt (safety gates still apply)
 mm reset --backup                      # snapshot the DB to <db>.pre-reset-<ts>.bak before wiping
 mm reset --force                       # bypass the liveness/write-lock gates (stale-pid recovery)
+mm reset --json                        # emit a machine-readable ack instead of prose (also on mm add / mm purge)
 mm upgrade                             # stop the running server, clear the stale pid, reinstall with --refresh
 mm upgrade --version 0.3.1 --dry-run   # preview a pinned upgrade (also: --grace, --extras, -y/--yes, --json)
 

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -50,7 +50,7 @@ Then in your AI editor, ask:
 "Remember this insight"      →  mem_add(content="...", tags=["ops"])
 ```
 
-> Prefer the terminal? `mm status` is a CLI mirror of `mem_status` — same output, no editor needed.
+> Prefer the terminal? `mm status` is a CLI mirror of `mem_status` — same output, no editor needed. Add `--json` (or `--format json`) for machine-readable output in scripts and CI.
 
 That's it. Your agent now has a long-term memory built from plain markdown files.
 
@@ -99,6 +99,8 @@ the editor: `~/.cursor/mcp.json` (Cursor),
 - **🧹 Maintenance** — near-duplicate detection with merge, time-based score decay, TTL expiration, auto-tagging
 - **🔄 Export / import** — JSON bundle backup and restore with re-embedding
 - **🌐 Web UI** — polished SPA dashboard for search, sources, indexing, tags, and timeline (`mm web --dev` unlocks the full maintainer surface including Sessions, Working Memory, and Health Report)
+- **🧭 Context Gateway** — author canonical Skills, Commands, and Subagents once in a wiki-backed Store (`mm wiki …`), then sync them to your AI tools (each artifact type's supported runtimes); a Projects portal in the Web UI tracks per-project drift
+- **⚙️ Scriptable CLI** — `--json` output on `mm status` and write commands (`mm add` / `mm reset` / `mm purge`); `mm warmup` pre-loads local models so the first query skips cold-start
 - **🛠️ 87 MCP tools** — full feature surface as MCP tools, with `mem_do` meta-tool routing all registered actions in `core` mode (default) for minimal context usage
 
 ## Documentation
@@ -111,6 +113,7 @@ Full documentation lives in the [memtomem GitHub repo](https://github.com/memtom
 | [Reference](https://github.com/memtomem/memtomem/blob/main/docs/guides/reference.md) | Complete feature reference — all tools and patterns |
 | [Configuration](https://github.com/memtomem/memtomem/blob/main/docs/guides/configuration.md) | All `MEMTOMEM_*` environment variables |
 | [Embeddings](https://github.com/memtomem/memtomem/blob/main/docs/guides/embeddings.md) | ONNX, Ollama, and OpenAI providers, model dimensions, switching models |
+| [Context Gateway](https://github.com/memtomem/memtomem/blob/main/docs/guides/context-gateway.md) | Author and sync canonical Skills, Commands, and Subagents to each type's supported AI tools |
 | [MCP Client Setup](https://github.com/memtomem/memtomem/blob/main/docs/guides/mcp-clients.md) | Editor-specific configuration |
 | [memtomem-stm](https://github.com/memtomem/memtomem-stm) | Optional STM proxy for proactive memory surfacing (separate package) |
 


### PR DESCRIPTION
## What & why

The v0.3.4 release commit (#1673) bumped the version and CHANGELOG but did
not touch the narrative docs. As a result the two READMEs never surfaced the
biggest 0.3.x product area — the **Context Gateway / wiki-authoring** path —
nor v0.3.4's **automation-friendly CLI**, and a couple of guides missed the
new `--json` surfaces. This brings the public docs to a v0.3.4 baseline.

The CHANGELOG `[0.3.4]` entry and the `0.3.4` version bump are already on
`main` (#1673) and are intentionally left alone here. This PR is additive doc
copy only (+12 / −5).

## Changes

- **README (root + PyPI)** — add **Context Gateway** and **Scriptable CLI**
  bullets to Key Features; add the missing **Context Gateway** row to the PyPI
  documentation table; note `mm status --json` / `--format json` in the
  terminal-mirror callout.
- **Guides** — document the `--json` write acks on `mm add` / `mm reset`
  (`reference/data-config-cli.md`) and `mm status --json` (`getting-started.md`).
- **Accuracy fix** — phrase artifact fan-out as *"your AI tools (each artifact
  type's supported runtimes)"* rather than *"every AI tool"*. Commands fan out
  to Claude/Gemini only (`context/commands.py`), while skills/agents reach
  Claude/Gemini/Codex/Kimi. Also corrected the same overclaim in the guides
  index (`docs/guides/README.md`).

## Verification (docs-as-tests)

- Every command/flag added to the docs verified against `--help` on the working
  tree: `mm wiki`, `mm status --json/--format`, `mm warmup`, `mm add/reset/purge --json`.
- MCP tool count unchanged at **87** (`@mcp.tool()` sweep); no count edited.
- `test_docs_guards.py` — 19 passed.
- Codex review round applied (over-broad fan-out claim fixed).

## Out of scope

CHANGELOG / version (already in #1673), new guide pages, private `memtomem-docs`
edits, and tool-count changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
