### PR TITLE
cli: add empty-state hint for mm search / mm recall on zero results

### DIFF
--- a/packages/memtomem/src/memtomem/cli/memory.py
+++ b/packages/memtomem/src/memtomem/cli/memory.py
@@ -371,7 +371,7 @@ async def _recall(
             project_context_root=project_context_root,
         )
 
-    if not chunks and fmt != "json":
+    if not chunks and fmt in ("table", "plain"):
         click.secho(
             "No results found. See `mm status` to confirm your index has chunks.",
             fg="yellow", err=True,

--- a/packages/memtomem/src/memtomem/cli/memory.py
+++ b/packages/memtomem/src/memtomem/cli/memory.py
@@ -371,6 +371,12 @@ async def _recall(
             project_context_root=project_context_root,
         )
 
+    if not chunks and fmt != "json":
+        click.secho(
+            "No results found. See `mm status` to confirm your index has chunks.",
+            fg="yellow", err=True,
+        )
+
     if fmt == "json":
         out = [
             {

--- a/packages/memtomem/src/memtomem/cli/memory.py
+++ b/packages/memtomem/src/memtomem/cli/memory.py
@@ -374,7 +374,8 @@ async def _recall(
     if not chunks and fmt in ("table", "plain"):
         click.secho(
             "No results found. See `mm status` to confirm your index has chunks.",
-            fg="yellow", err=True,
+            fg="yellow",
+            err=True,
         )
 
     if fmt == "json":

--- a/packages/memtomem/src/memtomem/cli/search.py
+++ b/packages/memtomem/src/memtomem/cli/search.py
@@ -114,7 +114,8 @@ async def _search(
     if not results and fmt in ("table", "plain"):
         click.secho(
             "No results found. See `mm status` to confirm your index has chunks.",
-            fg="yellow", err=True,
+            fg="yellow",
+            err=True,
         )
 
     if fmt == "context":

--- a/packages/memtomem/src/memtomem/cli/search.py
+++ b/packages/memtomem/src/memtomem/cli/search.py
@@ -111,6 +111,12 @@ async def _search(
             project_context_root=project_context_root,
         )
 
+    if not results and fmt != "json":
+        click.secho(
+            "No results found. See `mm status` to confirm your index has chunks.",
+            fg="yellow", err=True,
+        )
+
     if fmt == "context":
         if not results:
             return

--- a/packages/memtomem/src/memtomem/cli/search.py
+++ b/packages/memtomem/src/memtomem/cli/search.py
@@ -111,7 +111,7 @@ async def _search(
             project_context_root=project_context_root,
         )
 
-    if not results and fmt != "json":
+    if not results and fmt in ("table", "plain"):
         click.secho(
             "No results found. See `mm status` to confirm your index has chunks.",
             fg="yellow", err=True,

--- a/packages/memtomem/tests/test_cli_empty_state.py
+++ b/packages/memtomem/tests/test_cli_empty_state.py
@@ -49,7 +49,7 @@ HINT = "No results found. See `mm status` to confirm your index has chunks."
 class TestSearchEmptyState:
     """mm search prints a friendly hint on stderr when results are empty."""
 
-    @pytest.mark.parametrize("fmt", ["table", "plain", "context", "smart"])
+    @pytest.mark.parametrize("fmt", ["table", "plain"])
     def test_non_json_formats_print_hint_to_stderr(self, monkeypatch, fmt: str) -> None:
         fake, _ = _mock_empty_search()
         monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", fake)

--- a/packages/memtomem/tests/test_cli_empty_state.py
+++ b/packages/memtomem/tests/test_cli_empty_state.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+from memtomem.search.pipeline import RetrievalStats
+
+
+def _mock_empty_search() -> tuple:
+    """Mock cli_components returning empty search results."""
+    pipeline_mock = AsyncMock(return_value=([], RetrievalStats()))
+    config = SimpleNamespace(indexing=SimpleNamespace(project_memory_dirs=[]))
+    comp = SimpleNamespace(
+        search_pipeline=SimpleNamespace(search=pipeline_mock),
+        config=config,
+    )
+
+    @asynccontextmanager
+    async def fake():
+        yield comp
+
+    return fake, pipeline_mock
+
+
+def _mock_empty_recall() -> tuple:
+    """Mock cli_components returning empty recall results."""
+    storage = SimpleNamespace(recall_chunks=AsyncMock(return_value=[]))
+    config = SimpleNamespace(
+        search=SimpleNamespace(system_namespace_prefixes=()),
+        indexing=SimpleNamespace(project_memory_dirs=[]),
+    )
+    comp = SimpleNamespace(storage=storage, config=config)
+
+    @asynccontextmanager
+    async def fake():
+        yield comp
+
+    return fake, storage
+
+
+HINT = "No results found. See `mm status` to confirm your index has chunks."
+
+
+class TestSearchEmptyState:
+    """mm search prints a friendly hint on stderr when results are empty."""
+
+    @pytest.mark.parametrize("fmt", ["table", "plain", "context", "smart"])
+    def test_non_json_formats_print_hint_to_stderr(self, monkeypatch, fmt: str) -> None:
+        fake, _ = _mock_empty_search()
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", fake)
+
+        result = CliRunner().invoke(cli, ["search", "--format", fmt, "hello"])
+
+        assert result.exit_code == 0
+        assert HINT in result.stderr
+
+    def test_json_format_stdout_unchanged(self, monkeypatch) -> None:
+        fake, _ = _mock_empty_search()
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", fake)
+
+        result = CliRunner().invoke(cli, ["search", "--format", "json", "hello"])
+
+        assert result.exit_code == 0
+        assert result.output.strip() == "[]"
+        assert result.stderr == ""
+
+
+class TestRecallEmptyState:
+    """mm recall prints a friendly hint on stderr when results are empty."""
+
+    @pytest.mark.parametrize("fmt", ["table", "plain"])
+    def test_non_json_formats_print_hint_to_stderr(self, monkeypatch, fmt: str) -> None:
+        fake, _ = _mock_empty_recall()
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", fake)
+
+        result = CliRunner().invoke(cli, ["recall", "--format", fmt])
+
+        assert result.exit_code == 0
+        assert HINT in result.stderr
+
+    def test_json_format_stdout_unchanged(self, monkeypatch) -> None:
+        fake, _ = _mock_empty_recall()
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", fake)
+
+        result = CliRunner().invoke(cli, ["recall", "--format", "json"])
+
+        assert result.exit_code == 0
+        assert result.output.strip() == "[]"
+        assert result.stderr == ""


### PR DESCRIPTION
Print a yellow 'No results found. See `mm status` to confirm your index
has chunks.' hint to stderr when search or recall returns nothing,
matching the interactive REPL behavior.

- gated to human-readable formats (table, plain, context, smart) only
- --format json stdout stays byte-clean [] on empty results
- adds tests for all formats and the JSON invariance constraint

Closes #1666
