### PR TITLE
feat(plugin): bundle the MCP server so one /plugin install activates everything

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,29 @@
+{
+  "name": "memtomem",
+  "owner": {
+    "name": "memtomem",
+    "url": "https://github.com/memtomem"
+  },
+  "metadata": {
+    "description": "Markdown-first semantic memory plugins for AI agents",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "memtomem",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/memtomem/memtomem.git",
+        "path": "packages/memtomem-claude-plugin"
+      },
+      "description": "Semantic memory with hybrid BM25 + dense search",
+      "version": "0.2.0",
+      "author": { "name": "memtomem" },
+      "repository": "https://github.com/memtomem/memtomem",
+      "license": "Apache-2.0",
+      "keywords": ["memory", "semantic-search", "rag", "mcp"],
+      "category": "productivity",
+      "tags": ["memory", "search", "knowledge-base"]
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -21,11 +21,12 @@ coverage.json
 .mcp.json
 .mcp.json.bak.*
 !.mcp.json.example
+# The Claude Code plugin ships its MCP server declaration — keep it tracked
+!packages/memtomem-claude-plugin/.mcp.json
 
 # Claude Code
 .claude/
 CLAUDE.local.md
-.claude-plugin/
 
 # Other agent harnesses — context gateway outputs (user-local, derived from
 # CLAUDE.md). Regenerate via `mm context init` + `mm context sync`.

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -40,7 +40,44 @@ The most powerful automation pipeline is achieved when combined with Claude Code
 
 ## MCP Server Setup
 
-### Pick an installation scope
+### Option A: Install the plugin (one step)
+
+The memtomem plugin bundles the MCP server, slash commands
+(`/memtomem:status`, `/memtomem:remember`, …), automation hooks, and the
+memory-curator agent in a single install:
+
+```
+/plugin marketplace add memtomem/memtomem
+/plugin install memtomem@memtomem
+```
+
+The plugin launches the server via `uvx --from memtomem memtomem-server`,
+so [uv](https://docs.astral.sh/uv/) must be on your PATH — no separate
+`pip install` needed for the MCP server itself. Hooks additionally need
+the CLI installed (see [Hooks Automation Setup](#hooks-automation-setup)).
+
+> **Already registered via `claude mcp add`?** Nothing runs twice —
+> Claude Code detects that the plugin bundles the same server command
+> and suppresses the plugin-managed copy, so your manual registration
+> keeps winning and tools keep their `mcp__memtomem__mem_*` names.
+> To switch to the plugin-managed server (tools become
+> `mcp__plugin_memtomem_memtomem__mem_*`), remove the manual entry:
+>
+> ```bash
+> claude mcp remove memtomem
+> ```
+>
+> Either way the bundled slash commands and curator agent work — their
+> allowlists cover both tool namespaces. If your own settings
+> allowlist `mcp__memtomem__mem_*`, update it when you remove the
+> manual entry.
+
+Prefer manual registration (no skills/hooks, finer scope control)? Use
+Option B below.
+
+### Option B: Register the MCP server manually
+
+#### Pick an installation scope
 
 Claude Code offers three MCP configuration scopes. Pick the one that
 matches how you want to share this server:
@@ -60,7 +97,7 @@ credentials without editing the committed file.
 workspace-trust approval on first use — cloning an unknown repo never
 silently spawns an MCP server.
 
-### Add via command (`local` / `user`)
+#### Add via command (`local` / `user`)
 
 ```bash
 # User scope — install once, available in every project
@@ -76,7 +113,7 @@ claude mcp add memtomem -s local -- uvx --from memtomem memtomem-server
 Both `-s local` and `-s user` write to `~/.claude.json` — no need to edit
 that file by hand.
 
-### Project scope via `.mcp.json`
+#### Project scope via `.mcp.json`
 
 For a team-shared setup, commit a `.mcp.json` at the project root:
 

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -74,7 +74,7 @@ claude mcp add memtomem -s user -- uvx --from memtomem memtomem-server
 
 Both write to `~/.claude.json` — no need to edit that file by hand.
 
-For the full plugin experience (slash commands, automation hooks, memory curator agent), see the [Claude Code integration guide](integrations/claude-code.md).
+For the full plugin experience (bundled MCP server, slash commands, automation hooks, memory curator agent — one `/plugin install memtomem@memtomem`), see the [Claude Code integration guide](integrations/claude-code.md).
 
 ### Project scope — commit a `.mcp.json`
 

--- a/packages/memtomem-claude-plugin/.claude-plugin/plugin.json
+++ b/packages/memtomem-claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memtomem",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Markdown-first semantic memory for AI agents — hybrid BM25 + dense search across your markdown files",
   "author": {
     "name": "memtomem",

--- a/packages/memtomem-claude-plugin/.mcp.json
+++ b/packages/memtomem-claude-plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "memtomem": {
+      "command": "uvx",
+      "args": ["--from", "memtomem", "memtomem-server"]
+    }
+  }
+}

--- a/packages/memtomem-claude-plugin/README.md
+++ b/packages/memtomem-claude-plugin/README.md
@@ -1,13 +1,36 @@
 # memtomem — Claude Code Plugin
 
-Claude Code plugin that exposes the memtomem long-term memory MCP server
-inside Claude Code (hybrid BM25 + dense search across markdown memories,
-slash commands, automation hooks).
+Claude Code plugin for the memtomem long-term memory MCP server
+(hybrid BM25 + dense search across markdown memories).
 
-Detailed setup, configuration, hook recipes, and feature reference live in
-the private `memtomem/memtomem-docs` repo
-(`packages-archived/claude-plugin.md`).
+One install bundles:
 
-For end-user installation see the public
-[memtomem README](https://github.com/memtomem/memtomem) and
-[`docs/guides/integrations/claude-code.md`](https://github.com/memtomem/memtomem/blob/main/docs/guides/integrations/claude-code.md).
+- **MCP server** — launched on demand via `uvx --from memtomem memtomem-server`
+  (requires [uv](https://docs.astral.sh/uv/) on PATH)
+- **Slash commands** — `/memtomem:setup`, `/memtomem:remember`,
+  `/memtomem:search`, `/memtomem:recall`, `/memtomem:index`,
+  `/memtomem:status`, `/memtomem:summarize`
+- **Automation hooks** — session lifecycle, prompt-time memory surfacing,
+  write-time indexing (these shell out to the `mm` CLI, so install it with
+  `uv tool install 'memtomem[all]'` to activate them)
+- **memory-curator agent** — dedup / auto-tag / decay curation
+
+## Install
+
+```
+/plugin marketplace add memtomem/memtomem
+/plugin install memtomem@memtomem
+```
+
+If you previously registered the server manually, Claude Code suppresses
+the plugin-managed copy (nothing runs twice) and your manual entry keeps
+winning. Remove it (`claude mcp remove memtomem`) to switch to the
+plugin-managed server.
+
+## Docs
+
+- [Claude Code integration guide](https://github.com/memtomem/memtomem/blob/main/docs/guides/integrations/claude-code.md)
+  — setup, hooks reference, CLAUDE.md guidelines
+- [memtomem README](https://github.com/memtomem/memtomem) — project overview
+- [MCP clients guide](https://github.com/memtomem/memtomem/blob/main/docs/guides/mcp-clients.md)
+  — manual registration for other clients

--- a/packages/memtomem-claude-plugin/agents/memory-curator.md
+++ b/packages/memtomem-claude-plugin/agents/memory-curator.md
@@ -1,11 +1,16 @@
 ---
 name: memory-curator
 description: Curate and optimize memory index — deduplicate, tag, and clean up stale entries.
-allowed-tools: mcp__memtomem__mem_search, mcp__memtomem__mem_dedup_scan, mcp__memtomem__mem_dedup_merge, mcp__memtomem__mem_auto_tag, mcp__memtomem__mem_decay_scan, mcp__memtomem__mem_decay_expire, mcp__memtomem__mem_stats, mcp__memtomem__mem_delete
+allowed-tools: mcp__plugin_memtomem_memtomem__mem_search, mcp__memtomem__mem_search, mcp__plugin_memtomem_memtomem__mem_stats, mcp__memtomem__mem_stats, mcp__plugin_memtomem_memtomem__mem_do, mcp__memtomem__mem_do
 model: haiku
 ---
 
 You are a memory curator agent. Your job is to optimize the memtomem index by removing duplicates, ensuring consistent tagging, and identifying stale entries.
+
+Maintenance actions are not individual tools in the default `core` tool mode —
+route them through `mem_do(action=..., params={...})`. Call
+`mem_do(action="help")` if you need parameter details (dedup/decay actions
+live in the `maintenance` category, `auto_tag` in `tags`).
 
 ## Workflow
 
@@ -16,21 +21,21 @@ Run `mem_stats` to understand:
 - Storage backend health
 
 ### 2. Deduplicate
-Run `mem_dedup_scan` to find duplicate or near-duplicate chunks.
+Run `mem_do(action="dedup_scan")` to find duplicate or near-duplicate chunks.
 If duplicates are found:
 - Review each pair — show content previews and similarity scores
-- Merge confirmed duplicates with `mem_dedup_merge` (keep the better version)
+- Merge confirmed duplicates with `mem_do(action="dedup_merge", params=...)` (keep the better version)
 - Report how many duplicates were resolved
 
 ### 3. Auto-Tag
-Run `mem_auto_tag` to extract and apply keyword-based tags.
+Run `mem_do(action="auto_tag")` to extract and apply keyword-based tags.
 This ensures consistent discoverability across all indexed content.
 
 ### 4. Decay Check
-Run `mem_decay_scan` to preview chunks that may be stale.
+Run `mem_do(action="decay_scan")` to preview chunks that may be stale.
 - Show age and last-accessed information
 - Only suggest expiration for clearly outdated content
-- Do NOT auto-expire without reporting first
+- Do NOT auto-expire (`mem_do(action="decay_expire")`) without reporting first
 
 ### 5. Summary
 Report actions taken:

--- a/packages/memtomem-claude-plugin/hooks/hooks.json
+++ b/packages/memtomem-claude-plugin/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "mm session start --idempotent --auto-end-stale 24h --agent-id claude-code 2>>/tmp/mm-hook.log || true",
-            "timeout": 5000
+            "timeout": 5
           }
         ]
       }
@@ -19,7 +19,7 @@
           {
             "type": "command",
             "command": "P=$(printf '%s' \"${prompt}\" | head -c 500); [ ${#P} -gt 20 ] && mm search \"$P\" --top-k 3 --format context 2>>/tmp/mm-hook.log || true",
-            "timeout": 5000
+            "timeout": 5
           }
         ]
       }
@@ -31,7 +31,7 @@
           {
             "type": "command",
             "command": "FP=\"${tool_input.file_path}\"; case \"$FP\" in *.md|*.py|*.ts|*.tsx|*.js|*.jsx|*.go|*.rs|*.rb|*.java|*.kt|*.swift|*.c|*.cpp|*.h|*.hpp|*.sh|*.toml|*.yaml|*.yml|*.json) ;; *) exit 0 ;; esac; case \"$FP\" in node_modules/*|*/node_modules/*|dist/*|*/dist/*|build/*|*/build/*|target/*|*/target/*|.next/*|*/.next/*|.nuxt/*|*/.nuxt/*|__pycache__/*|*/__pycache__/*|.git/*|*/.git/*|.venv/*|*/.venv/*|venv/*|*/venv/*|coverage/*|*/coverage/*|.cache/*|*/.cache/*) exit 0 ;; esac; mm index --debounce-window 5 \"$FP\" 2>>/tmp/mm-hook.log || true",
-            "timeout": 10000
+            "timeout": 10
           }
         ]
       },
@@ -41,7 +41,7 @@
           {
             "type": "command",
             "command": "mm activity log --type tool_call -c \"${tool_name}\" 2>>/tmp/mm-hook.log || true",
-            "timeout": 3000
+            "timeout": 3
           }
         ]
       }
@@ -53,7 +53,7 @@
           {
             "type": "command",
             "command": "mm index --flush 2>>/tmp/mm-hook.log; mm session end --auto 2>>/tmp/mm-hook.log || true",
-            "timeout": 10000
+            "timeout": 10
           }
         ]
       }

--- a/packages/memtomem-claude-plugin/skills/index/SKILL.md
+++ b/packages/memtomem-claude-plugin/skills/index/SKILL.md
@@ -2,7 +2,7 @@
 name: index
 description: Index or re-index memory files for search. Use for initial setup or after bulk file changes.
 argument-hint: [path]
-allowed-tools: mcp__memtomem__mem_index, mcp__memtomem__mem_status
+allowed-tools: mcp__plugin_memtomem_memtomem__mem_index, mcp__memtomem__mem_index, mcp__plugin_memtomem_memtomem__mem_status, mcp__memtomem__mem_status
 ---
 
 Index files at: $ARGUMENTS

--- a/packages/memtomem-claude-plugin/skills/recall/SKILL.md
+++ b/packages/memtomem-claude-plugin/skills/recall/SKILL.md
@@ -2,7 +2,7 @@
 name: recall
 description: Inject relevant memories as structured context for the current task. Use when starting complex work that may benefit from past decisions or notes.
 argument-hint: [topic or question]
-allowed-tools: mcp__memtomem__mem_search, mcp__memtomem__mem_do
+allowed-tools: mcp__plugin_memtomem_memtomem__mem_search, mcp__memtomem__mem_search, mcp__plugin_memtomem_memtomem__mem_do, mcp__memtomem__mem_do
 ---
 
 Search for relevant memories about: $ARGUMENTS

--- a/packages/memtomem-claude-plugin/skills/remember/SKILL.md
+++ b/packages/memtomem-claude-plugin/skills/remember/SKILL.md
@@ -2,7 +2,7 @@
 name: remember
 description: Save a new memory entry. Use when user wants to remember something for later.
 argument-hint: [content to remember]
-allowed-tools: mcp__memtomem__mem_add
+allowed-tools: mcp__plugin_memtomem_memtomem__mem_add, mcp__memtomem__mem_add
 ---
 
 Save this as a memory: $ARGUMENTS

--- a/packages/memtomem-claude-plugin/skills/search/SKILL.md
+++ b/packages/memtomem-claude-plugin/skills/search/SKILL.md
@@ -2,7 +2,7 @@
 name: search
 description: Search memories using semantic search. Use when user asks about past decisions, notes, or context.
 argument-hint: [query]
-allowed-tools: mcp__memtomem__mem_search
+allowed-tools: mcp__plugin_memtomem_memtomem__mem_search, mcp__memtomem__mem_search
 ---
 
 Search memories for: $ARGUMENTS

--- a/packages/memtomem-claude-plugin/skills/setup/SKILL.md
+++ b/packages/memtomem-claude-plugin/skills/setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: setup
 description: Guide through initial memtomem setup and optional hooks activation.
-allowed-tools: mcp__memtomem__mem_status, mcp__memtomem__mem_index, mcp__memtomem__mem_search
+allowed-tools: mcp__plugin_memtomem_memtomem__mem_status, mcp__memtomem__mem_status, mcp__plugin_memtomem_memtomem__mem_index, mcp__memtomem__mem_index, mcp__plugin_memtomem_memtomem__mem_search, mcp__memtomem__mem_search
 disable-model-invocation: true
 ---
 

--- a/packages/memtomem-claude-plugin/skills/status/SKILL.md
+++ b/packages/memtomem-claude-plugin/skills/status/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: status
 description: Show memtomem status including indexed chunks, config, and health.
-allowed-tools: mcp__memtomem__mem_status, mcp__memtomem__mem_stats
+allowed-tools: mcp__plugin_memtomem_memtomem__mem_status, mcp__memtomem__mem_status, mcp__plugin_memtomem_memtomem__mem_stats, mcp__memtomem__mem_stats
 ---
 
 Show memtomem status using `mem_status` and `mem_stats`.

--- a/packages/memtomem-claude-plugin/skills/summarize/SKILL.md
+++ b/packages/memtomem-claude-plugin/skills/summarize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: summarize
 description: Summarize the current conversation and save key decisions, findings, and action items as a memory entry.
-allowed-tools: mcp__memtomem__mem_add, mcp__memtomem__mem_search
+allowed-tools: mcp__plugin_memtomem_memtomem__mem_add, mcp__memtomem__mem_add, mcp__plugin_memtomem_memtomem__mem_search, mcp__memtomem__mem_search
 disable-model-invocation: true
 ---
 

--- a/packages/memtomem/tests/test_docs_guards.py
+++ b/packages/memtomem/tests/test_docs_guards.py
@@ -210,13 +210,14 @@ def _extract_hooks_snippet(claude_code_md: str) -> dict:
     return json.loads(match.group(1))
 
 
-def _commands_by_event_matcher(hooks_doc: dict) -> dict[tuple[str, str], str]:
-    """Flatten a hooks.json shape into ``{(event, matcher): command}``.
+def _commands_by_event_matcher(hooks_doc: dict) -> dict[tuple[str, str], dict]:
+    """Flatten a hooks.json shape into ``{(event, matcher): hook_dict}``
+    where ``hook_dict`` is the single inner hook (``command``, ``timeout``…).
 
     Only entries with a single command are included; multi-command entries
     fail loudly because the parity test isn't designed for them yet.
     """
-    out: dict[tuple[str, str], str] = {}
+    out: dict[tuple[str, str], dict] = {}
     for event, entries in hooks_doc.get("hooks", {}).items():
         for entry in entries:
             matcher = entry.get("matcher", "")
@@ -225,7 +226,7 @@ def _commands_by_event_matcher(hooks_doc: dict) -> dict[tuple[str, str], str]:
                 f"hooks parity helper expected exactly one command per entry, "
                 f"got {len(commands)} at {event}/{matcher!r}"
             )
-            out[(event, matcher)] = commands[0]["command"]
+            out[(event, matcher)] = commands[0]
     return out
 
 
@@ -239,19 +240,19 @@ class TestPluginHooksDocsParity:
     """
 
     @pytest.fixture(scope="class")
-    def plugin_commands(self) -> dict[tuple[str, str], str]:
+    def plugin_commands(self) -> dict[tuple[str, str], dict]:
         plugin_hooks = json.loads(_PLUGIN_HOOKS_JSON.read_text(encoding="utf-8"))
         return _commands_by_event_matcher(plugin_hooks)
 
     @pytest.fixture(scope="class")
-    def docs_commands(self, claude_code: str) -> dict[tuple[str, str], str]:
+    def docs_commands(self, claude_code: str) -> dict[tuple[str, str], dict]:
         snippet = _extract_hooks_snippet(claude_code)
         return _commands_by_event_matcher(snippet)
 
     def test_docs_snippet_is_subset_of_plugin(
         self,
-        plugin_commands: dict[tuple[str, str], str],
-        docs_commands: dict[tuple[str, str], str],
+        plugin_commands: dict[tuple[str, str], dict],
+        docs_commands: dict[tuple[str, str], dict],
     ) -> None:
         missing = [k for k in docs_commands if k not in plugin_commands]
         assert not missing, (
@@ -263,19 +264,51 @@ class TestPluginHooksDocsParity:
 
     def test_docs_snippet_commands_match_plugin(
         self,
-        plugin_commands: dict[tuple[str, str], str],
-        docs_commands: dict[tuple[str, str], str],
+        plugin_commands: dict[tuple[str, str], dict],
+        docs_commands: dict[tuple[str, str], dict],
     ) -> None:
         diffs = [
-            (event_matcher, plugin_commands[event_matcher], docs_cmd)
+            (event_matcher, plugin_commands[event_matcher]["command"], docs_cmd["command"])
             for event_matcher, docs_cmd in docs_commands.items()
-            if plugin_commands.get(event_matcher) != docs_cmd
+            if plugin_commands.get(event_matcher, {}).get("command") != docs_cmd["command"]
         ]
         assert not diffs, (
             "claude-code.md hooks snippet drifted from the plugin's "
             "hooks.json. The two sites must declare byte-identical commands "
             "for every (event, matcher) the docs render. Diffs:\n"
             + "\n".join(f"  {em}:\n    plugin: {p}\n    docs:   {d}" for em, p, d in diffs)
+        )
+
+    def test_docs_snippet_timeouts_match_plugin(
+        self,
+        plugin_commands: dict[tuple[str, str], dict],
+        docs_commands: dict[tuple[str, str], dict],
+    ) -> None:
+        """Claude Code hook ``timeout`` is in seconds; the plugin once
+        shipped millisecond values (5000 → ~83 min hang cap) while the docs
+        said 5. Pin the two sites to identical timeout values so a
+        unit-confusion regression on either side fails loudly."""
+        diffs = [
+            (em, plugin_commands[em].get("timeout"), docs_cmd.get("timeout"))
+            for em, docs_cmd in docs_commands.items()
+            if em in plugin_commands
+            and plugin_commands[em].get("timeout") != docs_cmd.get("timeout")
+        ]
+        assert not diffs, (
+            "hooks timeout drifted between claude-code.md and the plugin "
+            "hooks.json (values are SECONDS — never milliseconds):\n"
+            + "\n".join(f"  {em}: plugin={p} docs={d}" for em, p, d in diffs)
+        )
+
+    def test_plugin_hook_timeouts_are_seconds(
+        self, plugin_commands: dict[tuple[str, str], dict]
+    ) -> None:
+        """Any timeout over 120 almost certainly means someone wrote
+        milliseconds again (Claude Code interprets the field as seconds)."""
+        bad = {em: h["timeout"] for em, h in plugin_commands.items() if h.get("timeout", 0) > 120}
+        assert not bad, (
+            f"plugin hooks.json has timeout values that look like "
+            f"milliseconds (unit is seconds): {bad}"
         )
 
 


### PR DESCRIPTION
## Summary

Completes the Claude Code plugin so a single `/plugin install memtomem@memtomem` activates the MCP server, slash commands, hooks, and the memory-curator agent. Previously the plugin shipped everything **except** the server, and the root marketplace manifest was gitignored — the self-hosted marketplace was never actually published.

## Changes

- **Bundle the MCP server**: new plugin-root `.mcp.json` launching `uvx --from memtomem memtomem-server`. The plugin-root file is the officially supported bundle contract (`plugin.json.mcpServers` is legacy and not guaranteed to load; `claude plugin init --with mcp` scaffolds the same shape).
- **Publish the marketplace**: un-ignore `.claude-plugin/` and negate `packages/memtomem-claude-plugin/.mcp.json` from the global `.mcp.json` ignore — both files were silently untracked.
- **Dual-namespace allowed-tools** in all 7 skills + curator agent (`mcp__plugin_memtomem_memtomem__*` **and** `mcp__memtomem__*`). Measured via `--plugin-dir` debug logs: Claude Code suppresses the plugin-managed server when a manually-configured server has the same command signature (`Suppressing plugin MCP server "plugin:memtomem:…": duplicates manually-configured "memtomem"`), in which case tools keep their old names. A single-namespace allowlist would break skills for every existing `claude mcp add` user.
- **Fix hook timeout units**: `5000/10000/3000` → `5/10/3`. The field is **seconds**; the old millisecond-style values capped hung hooks at ~83 minutes. New `test_docs_guards` cases pin docs↔plugin timeout parity and reject values that look like milliseconds.
- **Core-mode-compatible curator**: maintenance actions route through `mem_do(action=...)` instead of allowlisting tools that don't exist in the default core tool mode.
- **Docs**: plugin install is now Option A in the Claude Code guide with the suppression semantics spelled out; plugin README points at public docs instead of the private archived location. Plugin version 0.1.0 → 0.2.0.

## Verification

- `claude plugin validate` passes for both plugin and marketplace manifests.
- All plugin-scoped tool names ≤ 64 chars (31-char prefix + longest core tool = 41).
- Env-isolated `--plugin-dir` session: server connects (`tools/list` OK), measured prefix `mcp__plugin_memtomem_<server>__mem_*` matches the allowlists, SessionStart/Stop hooks fire, and `/memtomem:status` calls `mem_status` end-to-end.
- `uv run pytest packages/memtomem/tests/test_docs_guards.py` — 21 passed; ruff check/format clean.
- Reviewed by Codex (2 plan rounds + 1 diff round): SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
