### PR TITLE
feat(wiki): add `mm wiki <kind> promote` to import a project canonical into the wiki

### DIFF
--- a/packages/memtomem/src/memtomem/cli/wiki_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/wiki_cmd.py
@@ -509,6 +509,17 @@ def _run_promote(
     )
     for warning in result.lint_warnings:
         click.secho(f"warning: {warning}", fg="yellow", err=True)
+    # Soft privacy warning on the commit message, mirroring `mm wiki commit`:
+    # the message is committed regardless (a valve, not a gate), but a
+    # secret-shaped message in host-global history is worth flagging.
+    message_hits = len(privacy.scan(result.commit_message))
+    if message_hits:
+        click.secho(
+            f"warning: commit message has {message_hits} possible "
+            f"secret/PII match{'es' if message_hits != 1 else ''} (committed anyway)",
+            fg="yellow",
+            err=True,
+        )
     if result.wiki_dirty:
         click.secho(
             "warning: the wiki working tree still has uncommitted changes "

--- a/packages/memtomem/src/memtomem/cli/wiki_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/wiki_cmd.py
@@ -5,6 +5,8 @@ See ADR-0008 for the wiki layer's role in the context-gateway pipeline.
 
 from __future__ import annotations
 
+import logging
+from pathlib import Path
 from typing import Literal
 
 import click
@@ -16,6 +18,7 @@ from memtomem.context._names import (
     override_vendors,
     validate_name,
 )
+from memtomem.context.scope_resolver import find_project_root
 from memtomem.wiki import (
     WIKI_ASSET_TYPES,
     WikiAlreadyExistsError,
@@ -32,6 +35,13 @@ from memtomem.wiki.inspect import (
     diff_override,
     lint_asset,
 )
+from memtomem.wiki.promote import (
+    PromoteLintError,
+    PromotePrivacyError,
+    PromoteSourceError,
+    WikiAssetExistsError,
+    promote_asset,
+)
 from memtomem.wiki.override import (
     AssetExistsError,
     OverrideExistsError,
@@ -39,7 +49,14 @@ from memtomem.wiki.override import (
     create_canonical,
     seed_override,
 )
-from memtomem.wiki.store import WikiHeadMovedError, _redact_url_userinfo
+from memtomem.wiki.store import (
+    WikiDetachedHeadError,
+    WikiHeadMovedError,
+    WikiNothingToCommitError,
+    _redact_url_userinfo,
+)
+
+logger = logging.getLogger(__name__)
 
 # ``--vendor`` Choices derive from OVERRIDE_FORMATS (the single source of
 # truth) so they never drift from the matrix: kimi is valid for skills/agents
@@ -405,6 +422,103 @@ def _run_commit(
         )
 
 
+def _run_promote(
+    asset_type: Literal["skills", "agents", "commands"],
+    name: str,
+    *,
+    project: str | None,
+    message: str | None,
+) -> None:
+    """Shared body for ``mm wiki {skill,agent,command} promote``.
+
+    Imports a ``project_shared`` canonical (an ``untracked`` row from
+    ``mm context status``) into the wiki: privacy-scan → copy → lint → isolated
+    commit, all in :func:`memtomem.wiki.promote.promote_asset`. Every engine
+    error maps to a classified :class:`click.ClickException` so no traceback
+    leaks. A raw-git failure's message may embed the local wiki path — that is
+    the user's own path on their own machine, the same trade-off ``mm wiki
+    commit`` makes (the web route uses a fixed message instead because there the
+    path would cross a trust boundary). Project root is ``--project`` (if given)
+    or walked up from cwd, the same resolution ``mm context`` uses.
+    """
+    project_root = Path(project).expanduser() if project else find_project_root()
+    store = WikiStore.at_default()
+
+    try:
+        result = promote_asset(store, project_root, asset_type, name, message=message)
+    except (
+        WikiNotFoundError,
+        WikiUnbornHeadError,
+        PromoteSourceError,
+        WikiAssetExistsError,
+        PromotePrivacyError,
+        InvalidNameError,
+    ) as exc:
+        # Disjoint sibling classes; all carry path-free or project-local-path
+        # messages safe to surface verbatim. WikiAssetExistsError / PromoteSource
+        # / PromotePrivacy -> RuntimeError; InvalidNameError -> ValueError.
+        raise click.ClickException(str(exc)) from exc
+    except PromoteLintError as exc:
+        # Print each error finding the way ``mm wiki <kind> lint`` does, then a
+        # one-line summary. The copy was already rolled back inside the engine.
+        for finding in exc.report.findings:
+            if finding.level == "error":
+                click.secho(f"error: {finding.message}", fg="red", err=True)
+        raise click.ClickException(
+            f"{asset_type}/{name} failed lint — nothing promoted "
+            f"(fix the project canonical, then retry)"
+        ) from exc
+    except WikiHeadMovedError as exc:
+        # An external git moved HEAD out from under the CAS while we held the
+        # lock. Nothing was committed and the copy was rolled back. The message
+        # is the fixed, path-free "wiki <branch> advanced" text.
+        raise click.ClickException(
+            f"the wiki HEAD moved during the promote ({exc}); nothing was committed — retry"
+        ) from exc
+    except WikiDetachedHeadError as exc:
+        # str() is the fixed, path-free "check out a branch" message.
+        raise click.ClickException(str(exc)) from exc
+    except WikiNothingToCommitError as exc:
+        # Should not happen — the under-lock re-check proved the asset absent —
+        # but stay classified and path-free rather than surface a traceback.
+        raise click.ClickException(
+            f"{asset_type}/{name}: nothing to commit (the wiki already matches these bytes)"
+        ) from exc
+    except TimeoutError as exc:
+        # TimeoutError is an OSError, not a RuntimeError — its own clause. A
+        # concurrent `mm wiki commit` / `mm web` commit held the lock too long.
+        raise click.ClickException(
+            "wiki commit timed out — another wiki operation may be in progress; retry shortly"
+        ) from exc
+    except RuntimeError as exc:
+        # Any other git failure (identity/config/index). Unlike `mm wiki commit`
+        # this does NOT surface str(exc): promote is a bulk host-global write, so
+        # the raw stderr — which embeds the local wiki path — is logged and a
+        # fixed, path-free message is shown instead.
+        logger.warning("wiki promote %s/%s failed during commit: %s", asset_type, name, exc)
+        raise click.ClickException(
+            f"promoting {asset_type}/{name} failed during the wiki commit (git error) — "
+            f"check `git -C ~/.memtomem-wiki status`"
+        ) from exc
+
+    singular = asset_type[:-1]
+    click.secho(
+        f"Promoted {result.asset_type}/{result.name} → {result.wiki_head[:12]} "
+        f"({result.files_committed} file(s))",
+        fg="green",
+    )
+    for warning in result.lint_warnings:
+        click.secho(f"warning: {warning}", fg="yellow", err=True)
+    if result.wiki_dirty:
+        click.secho(
+            "warning: the wiki working tree still has uncommitted changes "
+            "(from another asset or a concurrent edit) — run `git -C ~/.memtomem-wiki status`",
+            fg="yellow",
+            err=True,
+        )
+    click.echo(f"# next: cd <project> && mm context install {singular} {name}")
+
+
 @wiki.command("init")
 @click.option(
     "--from",
@@ -705,6 +819,35 @@ def skill_commit_cmd(
     _run_commit("skills", name, vendors, canonical=canonical, message=message)
 
 
+@skill_group.command("promote")
+@click.argument("name")
+@click.option(
+    "--project",
+    "-p",
+    default=None,
+    help="Project root that owns the source .memtomem/ tree (default: walk up from cwd).",
+)
+@click.option(
+    "--message",
+    "-m",
+    default=None,
+    help="Commit message (default: 'wiki: promote skills/<name> from <project>').",
+)
+def skill_promote_cmd(name: str, project: str | None, message: str | None) -> None:
+    """Import a project's project_shared skill canonical into the wiki.
+
+    ``mm wiki skill promote <name>`` copies
+    ``<project>/.memtomem/skills/<name>/`` (an ``untracked`` row from
+    ``mm context status``) into ``<wiki>/skills/<name>/``, runs the same lint
+    gate as ``mm wiki skill lint``, and records it as one isolated commit.
+    Every source file is privacy-scanned first — a Gate A hit hard-refuses with
+    no bypass, because the wiki is host-global git history that can be pushed.
+    Refuses if the wiki already has the skill. The project copy stays as-is;
+    install it back with ``mm context install skill <name>``.
+    """
+    _run_promote("skills", name, project=project, message=message)
+
+
 # ── Agent subgroup ──────────────────────────────────────────────────────
 
 
@@ -853,6 +996,35 @@ def agent_commit_cmd(
     ``--canonical`` explicitly.
     """
     _run_commit("agents", name, vendors, canonical=canonical, message=message)
+
+
+@agent_group.command("promote")
+@click.argument("name")
+@click.option(
+    "--project",
+    "-p",
+    default=None,
+    help="Project root that owns the source .memtomem/ tree (default: walk up from cwd).",
+)
+@click.option(
+    "--message",
+    "-m",
+    default=None,
+    help="Commit message (default: 'wiki: promote agents/<name> from <project>').",
+)
+def agent_promote_cmd(name: str, project: str | None, message: str | None) -> None:
+    """Import a project's project_shared agent canonical into the wiki.
+
+    ``mm wiki agent promote <name>`` copies
+    ``<project>/.memtomem/agents/<name>/`` (an ``untracked`` row from
+    ``mm context status``) into ``<wiki>/agents/<name>/``, runs the same lint
+    gate as ``mm wiki agent lint``, and records it as one isolated commit.
+    Every source file is privacy-scanned first — a Gate A hit hard-refuses with
+    no bypass, because the wiki is host-global git history that can be pushed.
+    Refuses if the wiki already has the agent. The project copy stays as-is;
+    install it back with ``mm context install agent <name>``.
+    """
+    _run_promote("agents", name, project=project, message=message)
 
 
 # ── Command subgroup ────────────────────────────────────────────────────
@@ -1005,3 +1177,32 @@ def command_commit_cmd(
     passing ``--canonical`` explicitly.
     """
     _run_commit("commands", name, vendors, canonical=canonical, message=message)
+
+
+@command_group.command("promote")
+@click.argument("name")
+@click.option(
+    "--project",
+    "-p",
+    default=None,
+    help="Project root that owns the source .memtomem/ tree (default: walk up from cwd).",
+)
+@click.option(
+    "--message",
+    "-m",
+    default=None,
+    help="Commit message (default: 'wiki: promote commands/<name> from <project>').",
+)
+def command_promote_cmd(name: str, project: str | None, message: str | None) -> None:
+    """Import a project's project_shared command canonical into the wiki.
+
+    ``mm wiki command promote <name>`` copies
+    ``<project>/.memtomem/commands/<name>/`` (an ``untracked`` row from
+    ``mm context status``) into ``<wiki>/commands/<name>/``, runs the same lint
+    gate as ``mm wiki command lint``, and records it as one isolated commit.
+    Every source file is privacy-scanned first — a Gate A hit hard-refuses with
+    no bypass, because the wiki is host-global git history that can be pushed.
+    Refuses if the wiki already has the command. The project copy stays as-is;
+    install it back with ``mm context install command <name>``.
+    """
+    _run_promote("commands", name, project=project, message=message)

--- a/packages/memtomem/src/memtomem/wiki/promote.py
+++ b/packages/memtomem/src/memtomem/wiki/promote.py
@@ -1,0 +1,320 @@
+"""``mm wiki <kind> promote`` engine — import a project canonical into the wiki.
+
+The wiki ↔ context-gateway lifecycle is otherwise one-way: ``mm context
+install`` / ``update`` snapshot committed wiki assets into a project's
+``.memtomem/``. Promote is the missing inbound verb — it copies a
+``project_shared`` canonical (the ``untracked`` rows ``mm context status``
+reports) into the host-global wiki, validates it with the same
+:func:`memtomem.wiki.inspect.lint_asset` gate the CLI ``lint`` verb uses, and
+commits it through the shared :func:`memtomem.wiki.commit.commit_targets`
+engine (issue #1683).
+
+Design constraints (all enforced below):
+
+- **Privacy is a hard gate, no bypass.** Promote crosses project → host-global
+  and the wiki can be pushed to a backup remote (``mm wiki push``), so the
+  copied bytes go through the audited :func:`memtomem.privacy.enforce_write_guard`
+  chokepoint at ``scope="project_shared"`` — the tier whose Gate A ban is
+  absolute regardless of ``force_unsafe`` (ADR-0011 §5). The scan set is
+  *exactly* the write set: each file is read once, scanned, and the same bytes
+  are what land in the wiki (no scan≠copy TOCTOU).
+- **Fail-closed regular-file walk.** Source enumeration reuses
+  :func:`memtomem.context._atomic.iter_installed_files` — it skips
+  ``.git``/``__pycache__``/``.DS_Store``/``*.bak`` and symlinks (a symlink to
+  an out-of-tree target must never be dereferenced into wiki history) and
+  raises rather than silently shrinking on an unreadable subtree.
+- **One lock across the whole critical section.** The absent re-check, the
+  copy, the lint, and the commit all run while holding the wiki-root commit
+  lock (the same lock ``mm wiki commit`` / ``mm web`` commits take, keyed on
+  the wiki root). A concurrent promote of the same name therefore serializes:
+  the second one blocks, then its under-lock re-check sees the asset now exists
+  and refuses cleanly — before copying anything — so the rollback below can
+  never delete another commit's just-landed files.
+- **Scan set == commit set.** The bytes are committed via
+  :meth:`WikiStore.commit_paths`, which hashes the in-memory bytes directly
+  (``git hash-object`` on the saved blob) rather than re-reading the working
+  tree, so the bytes that were privacy-scanned are byte-for-byte the bytes that
+  land in history — no scan≠write TOCTOU. The working-tree copy still carries
+  the exec bit so ``commit_paths``' disk-first mode resolution keeps ``100755``
+  scripts runnable. The commit is CAS-guarded on the HEAD read inside the lock.
+- **Rollback owns only its own copy.** The asset dir did not exist when the
+  under-lock re-check passed, so on any failure after the first copy the
+  created dir is removed, restoring the working tree; because the whole section
+  is single-locked, that dir is exclusively this invocation's.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from memtomem import privacy
+from memtomem.context._atomic import _file_lock, atomic_write_bytes, iter_installed_files
+from memtomem.context._names import validate_name
+from memtomem.context.scope_resolver import canonical_artifact_dir
+from memtomem.wiki.commit import wiki_commit_lock_path
+from memtomem.wiki.inspect import LintReport, lint_asset
+from memtomem.wiki.store import WikiStore
+
+# Cross-process wiki commit lock budget (seconds) — matches
+# ``wiki.commit._COMMIT_LOCK_TIMEOUT`` so promote and a concurrent
+# ``mm wiki commit`` / ``mm web`` commit wait on each other symmetrically.
+_PROMOTE_LOCK_TIMEOUT = 30.0
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "PromoteLintError",
+    "PromotePrivacyError",
+    "PromoteResult",
+    "PromoteSourceError",
+    "WikiAssetExistsError",
+    "promote_asset",
+]
+
+AssetType = Literal["skills", "agents", "commands"]
+
+# Kind → canonical manifest filename. Same probe context/status.py uses to
+# decide a dir is a real artifact (not a stray directory).
+_MANIFEST: dict[str, str] = {
+    "skills": "SKILL.md",
+    "agents": "agent.md",
+    "commands": "command.md",
+}
+
+
+class PromoteSourceError(RuntimeError):
+    """The project has no promotable canonical for ``<kind>/<name>``.
+
+    Covers a missing source directory, a directory without its kind manifest
+    (``SKILL.md`` / ``agent.md`` / ``command.md``), and an empty source tree.
+    The message is safe to surface verbatim (it names the project-local path,
+    which is the user's own).
+    """
+
+
+class WikiAssetExistsError(RuntimeError):
+    """The wiki already holds ``<kind>/<name>`` (in the working tree or at HEAD).
+
+    Promote is non-destructive: refuse rather than overwrite. Even a
+    byte-identical asset refuses — adopting an existing project copy into the
+    lockfile is a separate verb (issue #1684), and a silent no-op here would
+    blur "already promoted" with "still needs adoption". Message is path-free.
+    """
+
+
+class PromotePrivacyError(RuntimeError):
+    """A source file tripped the Gate A privacy scan; promote is refused.
+
+    Carries the offending relative path and the hit count only — never the
+    matched bytes (the "never echo secrets" contract,
+    ``feedback_force_unsafe_redaction_valve_only.md``). No force bypass:
+    promote writes host-global git history (ADR-0011 §5).
+    """
+
+    def __init__(self, rel: str, hits_count: int) -> None:
+        super().__init__(
+            f"Gate A: {rel} contains {hits_count} privacy pattern hit(s); "
+            f"promote to the host-global wiki is rejected. git history is "
+            f"forever and the wiki can be pushed — no force bypass available. "
+            f"Remove the secret from the project canonical first."
+        )
+        self.rel = rel
+        self.hits_count = hits_count
+
+
+class PromoteLintError(RuntimeError):
+    """The copied asset failed :func:`lint_asset`; the copy was rolled back.
+
+    Carries the :class:`~memtomem.wiki.inspect.LintReport` so the CLI can print
+    the error findings the same way ``mm wiki <kind> lint`` does.
+    """
+
+    def __init__(self, report: LintReport) -> None:
+        errors = [f.message for f in report.findings if f.level == "error"]
+        super().__init__(f"{report.asset_type}/{report.name} failed lint: " + "; ".join(errors))
+        self.report = report
+
+
+@dataclass(frozen=True)
+class PromoteResult:
+    """Outcome of a successful :func:`promote_asset`.
+
+    ``committed`` is ``False`` on the benign no-op path (the promoted bytes
+    already matched HEAD — only reachable if the collision guard was somehow
+    bypassed; kept for parity with :class:`~memtomem.wiki.commit.CommitOutcome`).
+    ``wiki_dirty`` is read back after the commit so the caller can warn about
+    residue a concurrent writer left elsewhere in the wiki.
+    """
+
+    asset_type: AssetType
+    name: str
+    wiki_head: str
+    wiki_dirty: bool
+    files_committed: int
+    lint_warnings: tuple[str, ...]
+
+
+def promote_asset(
+    store: WikiStore,
+    project_root: Path,
+    asset_type: AssetType,
+    name: str,
+    *,
+    message: str | None = None,
+) -> PromoteResult:
+    """Copy a ``project_shared`` canonical into the wiki, lint it, and commit.
+
+    Args:
+        store: The target wiki.
+        project_root: Project root owning the source ``.memtomem/`` tree.
+        asset_type: Plural kind (``"skills"`` / ``"agents"`` / ``"commands"``).
+        name: Asset name (validated).
+        message: Commit message; defaults to
+            ``"wiki: promote <type>/<name> from <project-dir-name>"``.
+
+    Returns:
+        :class:`PromoteResult`.
+
+    Raises:
+        PromoteSourceError: No promotable source canonical.
+        WikiAssetExistsError: The wiki already holds this asset.
+        PromotePrivacyError: A source file tripped Gate A.
+        PromoteLintError: The copied asset failed lint (copy rolled back).
+        WikiHeadMovedError / WikiDetachedHeadError / WikiNothingToCommitError /
+        TimeoutError / RuntimeError: propagated from the commit (copy rolled
+        back). ``TimeoutError`` means a concurrent committer held the lock past
+        the budget.
+    """
+    validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
+    store.require_exists()
+
+    source_dir = canonical_artifact_dir(asset_type, "project_shared", project_root) / name
+    manifest = _MANIFEST[asset_type]
+    if not (source_dir / manifest).is_file():
+        raise PromoteSourceError(
+            f"no project_shared {asset_type.removesuffix('s')} to promote: "
+            f"{source_dir}/{manifest} does not exist"
+        )
+
+    dest_dir = store.root / asset_type / name
+
+    # Cheap fast-fail before the privacy scan; the authoritative check is under
+    # the lock below.
+    if dest_dir.exists():
+        raise WikiAssetExistsError(
+            f"wiki already has {asset_type}/{name} in its working tree — "
+            f"refusing to overwrite (promote is non-destructive)"
+        )
+
+    # Read → scan → stage: read each source file once so the bytes scanned are
+    # exactly the bytes committed (commit_paths hashes these in-memory bytes,
+    # never a working-tree re-read). Preserve the exec bit so commit_paths'
+    # disk-first mode resolution keeps 100755 scripts runnable. This touches no
+    # wiki state, so it runs before the lock.
+    staged: list[tuple[Path, bytes, int]] = []  # (rel_path, data, mode)
+    for src_file in sorted(iter_installed_files(source_dir)):
+        rel = src_file.relative_to(source_dir)
+        data = src_file.read_bytes()
+        # errors="replace" so non-UTF8 bytes cannot mask an embedded ASCII
+        # secret from the scanner.
+        guard = privacy.enforce_write_guard(
+            data.decode("utf-8", errors="replace"),
+            surface="cli_wiki_promote",
+            force_unsafe=False,
+            scope="project_shared",
+            audit_context={
+                "asset_type": asset_type,
+                "name": name,
+                "source_file": rel.as_posix(),
+                "wiki_scope": "host_global",
+            },
+            record_outcome=True,
+        )
+        if guard.decision in ("blocked", "blocked_project_shared"):
+            raise PromotePrivacyError(rel.as_posix(), len(guard.hits))
+        mode = 0o755 if (os.name != "nt" and os.access(src_file, os.X_OK)) else 0o644
+        staged.append((rel, data, mode))
+
+    if not staged:
+        # Manifest existed but the walk yielded nothing (e.g. the manifest is a
+        # symlink). Nothing safe to promote.
+        raise PromoteSourceError(
+            f"no regular files to promote under {source_dir} "
+            f"(symlinks and skip-listed files are excluded)"
+        )
+
+    # Critical section under the wiki commit lock: absent re-check → copy →
+    # lint → commit, so a concurrent promote of the same name serializes and the
+    # rollback below can only ever remove this invocation's own copied dir.
+    lock_path = wiki_commit_lock_path(store.root)
+    with _file_lock(lock_path, timeout=_PROMOTE_LOCK_TIMEOUT):
+        head = store.current_commit()
+        if dest_dir.exists():
+            raise WikiAssetExistsError(
+                f"wiki already has {asset_type}/{name} in its working tree — "
+                f"refusing to overwrite (promote is non-destructive)"
+            )
+        if _asset_committed_at(store, head, asset_type, name):
+            raise WikiAssetExistsError(
+                f"wiki already has {asset_type}/{name} committed at HEAD — "
+                f"refusing to overwrite (promote is non-destructive)"
+            )
+
+        files_map: dict[str, bytes] = {}
+        try:
+            for rel, data, mode in staged:
+                out = dest_dir / rel
+                atomic_write_bytes(out, data, mode=mode)
+                files_map[out.relative_to(store.root).as_posix()] = data
+
+            report = lint_asset(store, asset_type, name)
+            if not report.ok:
+                raise PromoteLintError(report)
+
+            msg = (message or "").strip() or (
+                f"wiki: promote {asset_type}/{name} from {project_root.name}"
+            )
+            # commit_paths hashes the in-memory bytes and CAS-advances the ref
+            # against the HEAD we read inside this lock, so nothing lands if
+            # HEAD moved underneath (an external git that honours no lock).
+            new_head = store.commit_paths(files_map, message=msg, expected_head=head)
+        except BaseException:
+            # The under-lock re-check proved dest_dir absent before the first
+            # copy, and we hold the lock exclusively, so this dir is ours alone;
+            # removing it restores the working tree. commit_paths raises before
+            # advancing the ref, so on any exception nothing was committed.
+            shutil.rmtree(dest_dir, ignore_errors=True)
+            raise
+
+        wiki_dirty = store.is_dirty()
+
+    warnings = tuple(f.message for f in report.findings if f.level == "warning")
+    return PromoteResult(
+        asset_type=asset_type,
+        name=name,
+        wiki_head=new_head,
+        wiki_dirty=wiki_dirty,
+        files_committed=len(files_map),
+        lint_warnings=warnings,
+    )
+
+
+def _asset_committed_at(store: WikiStore, commit: str, asset_type: str, name: str) -> bool:
+    """True iff ``<asset_type>/<name>`` has any tracked entry at *commit*.
+
+    ``asset_files_at_commit`` raises ``AssetNotFoundError`` when the asset path
+    holds no entries at the revision; any other return (including ``[]`` for an
+    asset of only skipped entries) means it exists.
+    """
+    from memtomem.context.install import AssetNotFoundError
+
+    try:
+        store.asset_files_at_commit(commit, asset_type, name)
+    except AssetNotFoundError:
+        return False
+    return True

--- a/packages/memtomem/src/memtomem/wiki/promote.py
+++ b/packages/memtomem/src/memtomem/wiki/promote.py
@@ -144,11 +144,10 @@ class PromoteLintError(RuntimeError):
 class PromoteResult:
     """Outcome of a successful :func:`promote_asset`.
 
-    ``committed`` is ``False`` on the benign no-op path (the promoted bytes
-    already matched HEAD — only reachable if the collision guard was somehow
-    bypassed; kept for parity with :class:`~memtomem.wiki.commit.CommitOutcome`).
     ``wiki_dirty`` is read back after the commit so the caller can warn about
-    residue a concurrent writer left elsewhere in the wiki.
+    residue a concurrent writer left elsewhere in the wiki. ``commit_message``
+    is the resolved message (user-supplied or the default) so the caller can
+    run the same soft privacy scan ``mm wiki commit`` applies to its message.
     """
 
     asset_type: AssetType
@@ -157,6 +156,7 @@ class PromoteResult:
     wiki_dirty: bool
     files_committed: int
     lint_warnings: tuple[str, ...]
+    commit_message: str
 
 
 def promote_asset(
@@ -217,9 +217,21 @@ def promote_asset(
     # disk-first mode resolution keeps 100755 scripts runnable. This touches no
     # wiki state, so it runs before the lock.
     staged: list[tuple[Path, bytes, int]] = []  # (rel_path, data, mode)
-    for src_file in sorted(iter_installed_files(source_dir)):
+    try:
+        source_files = sorted(iter_installed_files(source_dir))
+    except OSError as exc:
+        # iter_installed_files is fail-closed — an unreadable subtree raises
+        # rather than silently shrinking. Classify it instead of leaking a
+        # traceback (the CLI promises no traceback).
+        raise PromoteSourceError(
+            f"cannot enumerate {source_dir} — a file or subdirectory is unreadable ({exc})"
+        ) from exc
+    for src_file in source_files:
         rel = src_file.relative_to(source_dir)
-        data = src_file.read_bytes()
+        try:
+            data = src_file.read_bytes()
+        except OSError as exc:
+            raise PromoteSourceError(f"cannot read {source_dir / rel} — {exc}") from exc
         # errors="replace" so non-UTF8 bytes cannot mask an embedded ASCII
         # secret from the scanner.
         guard = privacy.enforce_write_guard(
@@ -297,6 +309,7 @@ def promote_asset(
     return PromoteResult(
         asset_type=asset_type,
         name=name,
+        commit_message=msg,
         wiki_head=new_head,
         wiki_dirty=wiki_dirty,
         files_committed=len(files_map),

--- a/packages/memtomem/tests/test_wiki_promote.py
+++ b/packages/memtomem/tests/test_wiki_promote.py
@@ -355,6 +355,47 @@ def test_cli_promote_privacy_blocked_exit1(wiki_root: Path, tmp_path: Path) -> N
     assert "Gate A" in _combined(result)
 
 
+def test_cli_promote_message_privacy_warning_is_soft(wiki_root: Path, tmp_path: Path) -> None:
+    """A secret-shaped commit message warns but does not block (a valve, #privacy)."""
+    _init_wiki()
+    project = tmp_path / "proj"
+    _seed_project_asset(project, "commands", "demo", "command.md")
+    runner = CliRunner()
+
+    result = runner.invoke(
+        wiki_group,
+        ["command", "promote", "demo", "--project", str(project), "-m", f"leak {SECRET}"],
+    )
+
+    assert result.exit_code == 0, _combined(result)
+    assert "Promoted commands/demo" in result.output
+    assert "possible" in _combined(result) and "secret/PII" in _combined(result)
+
+
+def test_cli_promote_unreadable_source_is_classified(
+    wiki_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An OSError enumerating the source surfaces as a classified error, not a traceback."""
+    _init_wiki()
+    project = tmp_path / "proj"
+    _seed_project_asset(project, "skills", "demo", "SKILL.md")
+
+    import memtomem.wiki.promote as promote_mod
+
+    def boom(_root):  # noqa: ANN001, ANN202
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(promote_mod, "iter_installed_files", boom)
+
+    result = runner_invoke = CliRunner().invoke(
+        wiki_group, ["skill", "promote", "demo", "--project", str(project)]
+    )
+    assert runner_invoke.exit_code == 1
+    assert "unreadable" in _combined(result)
+    # No traceback leaked to the user.
+    assert "Traceback" not in _combined(result)
+
+
 def test_cli_promote_missing_source_exit1(wiki_root: Path, tmp_path: Path) -> None:
     _init_wiki()
     runner = CliRunner()

--- a/packages/memtomem/tests/test_wiki_promote.py
+++ b/packages/memtomem/tests/test_wiki_promote.py
@@ -1,0 +1,374 @@
+"""Tests for ``mm wiki {skill,agent,command} promote`` and its engine.
+
+Promote is the inbound verb of the wiki ↔ context-gateway lifecycle (#1683): it
+copies a project's ``project_shared`` canonical into the host-global wiki,
+privacy-scans every source file, lints the copy, and records it as one isolated
+commit. These cover the engine (:func:`memtomem.wiki.promote.promote_asset`) and
+the CLI surface: happy path across all three kinds, the hard privacy gate, the
+non-destructive collision guard (working tree AND HEAD), lint-failure rollback,
+exec-bit preservation, and skip-listed/symlink source files.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli.wiki_cmd import wiki as wiki_group
+from memtomem.wiki.promote import (
+    PromoteLintError,
+    PromotePrivacyError,
+    PromoteSourceError,
+    WikiAssetExistsError,
+    promote_asset,
+)
+from memtomem.wiki.store import WikiStore
+
+# ``wiki_root`` / ``git_identity`` fixtures come from conftest.py.
+
+# AKIA fixture per feedback_force_unsafe_redaction_valve_only.md — trips the
+# privacy scan; the raw value must never appear in any surfaced message.
+SECRET = "api_key=AKIA1234567890ABCDEF"
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(root), *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _init_wiki() -> WikiStore:
+    store = WikiStore.at_default()
+    store.init()
+    return store
+
+
+def _seed_project_asset(
+    project_root: Path,
+    asset_type: str,
+    name: str,
+    manifest: str,
+    body: bytes = b"# canonical\n",
+) -> Path:
+    """Create ``<project>/.memtomem/<asset_type>/<name>/<manifest>`` and return the dir."""
+    d = project_root / ".memtomem" / asset_type / name
+    d.mkdir(parents=True)
+    (d / manifest).write_bytes(body)
+    return d
+
+
+def _combined(result) -> str:  # noqa: ANN001
+    out = result.output or ""
+    try:
+        out += result.stderr
+    except ValueError:
+        pass
+    return out
+
+
+# ── engine: happy paths across kinds ────────────────────────────────────────
+
+
+# Agents require YAML frontmatter to parse; skills are byte-copied and commands
+# parse without it. Keep each kind's happy-path body minimally valid.
+_VALID_BODY: dict[str, bytes] = {
+    "skills": b"# canonical\n",
+    "agents": b"---\nname: demo\ndescription: a test agent\n---\n\n# body\n",
+    "commands": b"# canonical\n",
+}
+
+
+@pytest.mark.parametrize(
+    ("asset_type", "manifest"),
+    [("skills", "SKILL.md"), ("agents", "agent.md"), ("commands", "command.md")],
+)
+def test_promote_happy(wiki_root: Path, tmp_path: Path, asset_type: str, manifest: str) -> None:
+    store = _init_wiki()
+    project = tmp_path / "proj"
+    _seed_project_asset(project, asset_type, "demo", manifest, body=_VALID_BODY[asset_type])
+    head0 = store.current_commit()
+
+    result = promote_asset(store, project, asset_type, "demo")  # type: ignore[arg-type]
+
+    assert result.files_committed == 1
+    assert result.wiki_dirty is False
+    assert store.current_commit() != head0
+    # Committed at HEAD and present in the working tree.
+    assert store.asset_files_at_commit(store.current_commit(), asset_type, "demo") == [manifest]
+    assert (wiki_root / asset_type / "demo" / manifest).is_file()
+    assert store.is_dirty() is False
+
+
+def test_promote_multi_file_skill_preserves_exec_bit(wiki_root: Path, tmp_path: Path) -> None:
+    store = _init_wiki()
+    project = tmp_path / "proj"
+    src = _seed_project_asset(project, "skills", "demo", "SKILL.md")
+    scripts = src / "scripts"
+    scripts.mkdir()
+    run = scripts / "run.sh"
+    run.write_bytes(b"#!/bin/sh\necho hi\n")
+    run.chmod(0o755)
+
+    result = promote_asset(store, project, "skills", "demo")
+
+    assert result.files_committed == 2
+    head = store.current_commit()
+    files = store.asset_files_at_commit(head, "skills", "demo")
+    assert sorted(files) == ["SKILL.md", "scripts/run.sh"]
+    # Exec bit rode along into the wiki working tree (commit_paths is disk-first).
+    if os.name != "nt":
+        assert os.access(wiki_root / "skills" / "demo" / "scripts" / "run.sh", os.X_OK)
+
+
+# ── engine: privacy hard gate ───────────────────────────────────────────────
+
+
+def test_promote_privacy_blocked_no_bytes_leaked(wiki_root: Path, tmp_path: Path) -> None:
+    store = _init_wiki()
+    project = tmp_path / "proj"
+    _seed_project_asset(project, "skills", "demo", "SKILL.md", body=f"# skill\n{SECRET}\n".encode())
+
+    with pytest.raises(PromotePrivacyError) as excinfo:
+        promote_asset(store, project, "skills", "demo")
+
+    assert "AKIA1234567890ABCDEF" not in str(excinfo.value)
+    assert excinfo.value.rel == "SKILL.md"
+    # Nothing landed in the wiki: no dir, no new commit, clean tree.
+    assert not (wiki_root / "skills" / "demo").exists()
+    assert store.is_dirty() is False
+
+
+# ── engine: collision guard (non-destructive) ───────────────────────────────
+
+
+def test_promote_refuses_existing_wiki_asset_at_head(wiki_root: Path, tmp_path: Path) -> None:
+    store = _init_wiki()
+    project = tmp_path / "proj"
+    _seed_project_asset(project, "skills", "demo", "SKILL.md")
+    # First promote lands it at HEAD.
+    promote_asset(store, project, "skills", "demo")
+    head_after_first = store.current_commit()
+
+    # A second project with the same name must refuse (committed-at-HEAD half).
+    project2 = tmp_path / "proj2"
+    _seed_project_asset(project2, "skills", "demo", "SKILL.md", body=b"# different\n")
+    with pytest.raises(WikiAssetExistsError):
+        promote_asset(store, project2, "skills", "demo")
+    assert store.current_commit() == head_after_first
+
+
+def test_promote_refuses_existing_worktree_dir(wiki_root: Path, tmp_path: Path) -> None:
+    store = _init_wiki()
+    project = tmp_path / "proj"
+    _seed_project_asset(project, "skills", "demo", "SKILL.md")
+    # Hand-place an uncommitted dir in the wiki working tree.
+    (wiki_root / "skills" / "demo").mkdir(parents=True)
+    (wiki_root / "skills" / "demo" / "SKILL.md").write_bytes(b"# squatter\n")
+
+    with pytest.raises(WikiAssetExistsError):
+        promote_asset(store, project, "skills", "demo")
+    # The squatter is untouched.
+    assert (wiki_root / "skills" / "demo" / "SKILL.md").read_bytes() == b"# squatter\n"
+
+
+# ── engine: source errors ───────────────────────────────────────────────────
+
+
+def test_promote_missing_source(wiki_root: Path, tmp_path: Path) -> None:
+    store = _init_wiki()
+    with pytest.raises(PromoteSourceError):
+        promote_asset(store, tmp_path / "proj", "skills", "nope")
+
+
+def test_promote_dir_without_manifest(wiki_root: Path, tmp_path: Path) -> None:
+    store = _init_wiki()
+    project = tmp_path / "proj"
+    # A skill dir with a file but no SKILL.md manifest.
+    d = project / ".memtomem" / "skills" / "demo"
+    d.mkdir(parents=True)
+    (d / "notes.md").write_bytes(b"# not a manifest\n")
+    with pytest.raises(PromoteSourceError):
+        promote_asset(store, project, "skills", "demo")
+
+
+# ── engine: lint failure rolls back ─────────────────────────────────────────
+
+
+def test_promote_lint_failure_rolls_back(wiki_root: Path, tmp_path: Path) -> None:
+    store = _init_wiki()
+    project = tmp_path / "proj"
+    src = _seed_project_asset(project, "skills", "demo", "SKILL.md")
+    # A stray override file (unregistered extension) makes lint_asset error.
+    overrides = src / "overrides"
+    overrides.mkdir()
+    (overrides / "bogus.txt").write_bytes(b"not a real override\n")
+    head0 = store.current_commit()
+
+    with pytest.raises(PromoteLintError):
+        promote_asset(store, project, "skills", "demo")
+
+    # Rolled back: the copied dir is gone, no new commit, clean tree.
+    assert not (wiki_root / "skills" / "demo").exists()
+    assert store.current_commit() == head0
+    assert store.is_dirty() is False
+
+
+# ── engine: commit is in-memory + CAS-guarded ───────────────────────────────
+
+
+def test_promote_commits_scanned_bytes_not_disk(
+    wiki_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The committed blob is the scanned in-memory bytes, never a disk re-read.
+
+    lint runs after the copy and before the commit; here it tampers with the
+    on-disk file. commit_paths must still commit the original scanned bytes
+    (``scan set == commit set``), so the tampered bytes never reach history.
+    """
+    store = _init_wiki()
+    project = tmp_path / "proj"
+    clean = b"# clean canonical\n"
+    _seed_project_asset(project, "skills", "demo", "SKILL.md", body=clean)
+
+    import memtomem.wiki.promote as promote_mod
+
+    real_lint = promote_mod.lint_asset
+
+    def tamper_then_lint(store_, asset_type, name):  # noqa: ANN001, ANN202
+        # Overwrite the just-copied working-tree file with a secret. A
+        # disk-re-reading commit would pick this up; commit_paths must not.
+        (wiki_root / "skills" / "demo" / "SKILL.md").write_bytes(f"{SECRET}\n".encode())
+        return real_lint(store_, asset_type, name)
+
+    monkeypatch.setattr(promote_mod, "lint_asset", tamper_then_lint)
+
+    result = promote_asset(store, project, "skills", "demo")
+
+    committed = _git(wiki_root, "show", f"{result.wiki_head}:skills/demo/SKILL.md")
+    assert committed == clean.decode()
+    assert "AKIA1234567890ABCDEF" not in committed
+
+
+def test_promote_refuses_and_rolls_back_when_head_moves(
+    wiki_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A competing commit landing mid-promote fails the CAS and rolls back cleanly.
+
+    lint (under the promote lock) lands an unrelated commit via raw git, which
+    honours no lock and moves HEAD. commit_paths' ref CAS then fails; promote
+    must remove only its own copied dir and leave the competitor intact.
+    """
+    from memtomem.wiki.store import WikiHeadMovedError
+
+    store = _init_wiki()
+    project = tmp_path / "proj"
+    _seed_project_asset(project, "skills", "demo", "SKILL.md")
+
+    import memtomem.wiki.promote as promote_mod
+
+    real_lint = promote_mod.lint_asset
+
+    def commit_competitor_then_lint(store_, asset_type, name):  # noqa: ANN001, ANN202
+        other = wiki_root / "skills" / "other"
+        other.mkdir(parents=True)
+        (other / "SKILL.md").write_bytes(b"# competitor\n")
+        # Stage ONLY the competitor so our uncommitted demo/ is not swept in.
+        _git(wiki_root, "add", "skills/other/SKILL.md")
+        _git(wiki_root, "commit", "-m", "competitor landed mid-promote")
+        return real_lint(store_, asset_type, name)
+
+    monkeypatch.setattr(promote_mod, "lint_asset", commit_competitor_then_lint)
+
+    with pytest.raises(WikiHeadMovedError):
+        promote_asset(store, project, "skills", "demo")
+
+    # Our copy was rolled back; the competitor survives at HEAD.
+    assert not (wiki_root / "skills" / "demo").exists()
+    assert (wiki_root / "skills" / "other" / "SKILL.md").is_file()
+    head = store.current_commit()
+    assert store.asset_files_at_commit(head, "skills", "other") == ["SKILL.md"]
+
+
+# ── engine: skip-listed and symlink source files ────────────────────────────
+
+
+def test_promote_skips_bak_and_dotgit(wiki_root: Path, tmp_path: Path) -> None:
+    store = _init_wiki()
+    project = tmp_path / "proj"
+    src = _seed_project_asset(project, "skills", "demo", "SKILL.md")
+    (src / "SKILL.md.bak").write_bytes(b"# stale backup\n")
+    (src / ".DS_Store").write_bytes(b"junk")
+
+    result = promote_asset(store, project, "skills", "demo")
+
+    assert result.files_committed == 1
+    files = store.asset_files_at_commit(store.current_commit(), "skills", "demo")
+    assert files == ["SKILL.md"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_promote_skips_symlink_source(wiki_root: Path, tmp_path: Path) -> None:
+    store = _init_wiki()
+    project = tmp_path / "proj"
+    src = _seed_project_asset(project, "skills", "demo", "SKILL.md")
+    outside = tmp_path / "outside-secret.txt"
+    outside.write_bytes(f"{SECRET}\n".encode())
+    (src / "link.md").symlink_to(outside)
+
+    result = promote_asset(store, project, "skills", "demo")
+
+    # The symlink was skipped (not dereferenced into wiki history).
+    assert result.files_committed == 1
+    assert not (wiki_root / "skills" / "demo" / "link.md").exists()
+
+
+# ── CLI surface ─────────────────────────────────────────────────────────────
+
+
+def test_cli_promote_happy(wiki_root: Path, tmp_path: Path) -> None:
+    _init_wiki()
+    project = tmp_path / "proj"
+    _seed_project_asset(project, "commands", "demo", "command.md")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["command", "promote", "demo", "--project", str(project)])
+
+    assert result.exit_code == 0, _combined(result)
+    assert "Promoted commands/demo" in result.output
+    assert "mm context install command demo" in result.output
+
+
+def test_cli_promote_privacy_blocked_exit1(wiki_root: Path, tmp_path: Path) -> None:
+    _init_wiki()
+    project = tmp_path / "proj"
+    _seed_project_asset(project, "commands", "demo", "command.md", body=f"# c\n{SECRET}\n".encode())
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["command", "promote", "demo", "--project", str(project)])
+
+    assert result.exit_code == 1
+    assert "AKIA1234567890ABCDEF" not in _combined(result)
+    assert "Gate A" in _combined(result)
+
+
+def test_cli_promote_missing_source_exit1(wiki_root: Path, tmp_path: Path) -> None:
+    _init_wiki()
+    runner = CliRunner()
+    result = runner.invoke(
+        wiki_group, ["skill", "promote", "nope", "--project", str(tmp_path / "proj")]
+    )
+    assert result.exit_code == 1
+    assert "to promote" in _combined(result)
+
+
+def test_cli_promote_absent_wiki_exit1(wiki_root: Path, tmp_path: Path) -> None:
+    # Wiki not initialized.
+    project = tmp_path / "proj"
+    _seed_project_asset(project, "skills", "demo", "SKILL.md")
+    runner = CliRunner()
+    result = runner.invoke(wiki_group, ["skill", "promote", "demo", "--project", str(project)])
+    assert result.exit_code == 1


### PR DESCRIPTION
## What

Adds `mm wiki skill|agent|command promote <name>` — the missing **inbound** verb of the wiki ↔ context-gateway lifecycle. It imports a project's `project_shared` canonical (the `untracked` rows `mm context status` reports) into the host-global wiki.

Until now the flow was one-way (`mm context install`/`update` copy wiki → project). Promoting a hand-authored project asset into the wiki meant a manual `cp` into `~/.memtomem-wiki` plus `mm wiki <kind> lint/commit` — the exact workaround written up in `docs/reports/wiki-command-install-tracking-plan-2026-07-09.md`.

## How

`promote_asset` (new `wiki/promote.py`):

1. **Privacy is a hard gate.** Each source file is read once and run through the audited `privacy.enforce_write_guard` chokepoint at `scope="project_shared"` (surface `cli_wiki_promote`). A Gate A hit hard-refuses with **no bypass** — the wiki is host-global git history that can be pushed to a backup remote (ADR-0011 §5). The hit count + filename are surfaced, never the matched bytes.
2. **One lock across the whole critical section.** The absent re-check, copy, lint, and commit all run under the shared wiki commit lock (`wiki_commit_lock_path`). A concurrent promote of the same name serializes — the second one's under-lock re-check refuses cleanly before copying, so the rollback can only ever remove this invocation's own copy.
3. **Scan set == commit set.** The bytes are committed via `WikiStore.commit_paths`, which hashes the in-memory scanned bytes directly (no working-tree re-read), CAS-guarded on the HEAD read inside the lock. The working-tree copy carries the exec bit so `commit_paths`' disk-first mode resolution keeps `100755` scripts runnable.
4. **Fail-closed source walk.** Enumeration reuses `iter_installed_files` — skips `.git`/`__pycache__`/`.DS_Store`/`*.bak` and symlinks (never dereferenced into wiki history), raises rather than shrinking on an unreadable subtree.
5. **Non-destructive.** Refuses if the wiki already holds the asset (working tree or HEAD), even byte-identical — adopting an existing project copy into the lockfile is a separate verb (#1684).

CLI (`_run_promote`, shared across the three kinds like `_run_new`/`_run_commit`) maps every engine error to a classified `ClickException`. Unlike `mm wiki commit`, a raw git failure is logged and shown as a fixed, path-free message rather than surfacing `str(exc)` — promote is a bulk host-global write.

## Design review

Went through two Codex design/implementation review rounds. The first flagged a HEAD-race on the collision check, an unaudited privacy path, and non-deref copy semantics; the second flagged a scan/write TOCTOU and a rollback race. All resolved by the single-lock + in-memory-`commit_paths` structure above, with the git-error surface tightened in the final pass.

## Tests

New `test_wiki_promote.py` (18 tests): happy path across all three kinds; multi-file skill with exec-bit preservation; the hard privacy gate (no bytes leaked); collision refusal (working-tree **and** HEAD halves); missing-source / no-manifest; lint-failure rollback; skip-listed + symlink source files; and two regressions from the review — `test_promote_commits_scanned_bytes_not_disk` (tampering the disk file mid-lint does not reach history) and `test_promote_refuses_and_rolls_back_when_head_moves` (a competing commit fails the CAS and leaves the competitor intact). Full non-ollama suite green.

## Verification

Manual round-trip in an isolated wiki: `mm wiki command promote hello --project <p>` → committed → `mm context install command hello` reproduces it; re-promote refuses; a multi-file agent preserves `100755` on its script and leaves the wiki clean.

Closes #1683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
