### PR TITLE
feat(context): adopt verb — lockfile-track an existing project canonical that matches wiki HEAD

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -37,6 +37,7 @@ from memtomem.context.detector import (
     detect_skill_dirs,
 )
 from memtomem.context.install import (
+    AdoptMismatchError,
     AlreadyInstalledError,
     AssetNotFoundError,
     CommitNotFoundError,
@@ -51,6 +52,9 @@ from memtomem.context.install import (
     _classify_for_all_update,
     _classify_for_install_all,
     _commit_hint,
+    adopt_agent,
+    adopt_command,
+    adopt_skill,
     install_agent,
     install_command,
     install_skill,
@@ -1920,6 +1924,56 @@ def install_cmd(
     click.echo(f"  {result.files_written} file(s) copied")
 
 
+@context.command("adopt")
+@click.argument("asset_type", type=click.Choice(["skill", "agent", "command"]))
+@click.argument("name")
+def adopt_cmd(asset_type: str, name: str) -> None:
+    """Lockfile-track an existing ``.memtomem/<type>/<name>/`` that matches wiki HEAD.
+
+    The explicit exit for the state install refuses (#1684): the dest
+    directory exists but has no lockfile entry — hand-placed content, an
+    install interrupted before its lockfile write, or a cross-project
+    transfer that landed untracked. Adopt verifies the dest bytes
+    file-by-file against the asset at wiki HEAD and, only on full
+    equality, records the provenance entry (commit pin + per-file
+    digests) — no dest byte is ever written or moved. Any difference
+    refuses with a per-file report; there is deliberately no ``--force``
+    (take HEAD's bytes via install, or push local edits wiki-ward via
+    ``mm wiki <type> promote`` first).
+    """
+    root = _find_project_root()
+    # PrivacyScanError here is a Gate A refusal over the pinned wiki bytes —
+    # adopt must not bless content the install ingress scan refuses (#1684).
+    with _translate_to_click(
+        WikiNotFoundError,
+        WikiUnbornHeadError,
+        AssetNotFoundError,
+        AlreadyInstalledError,
+        NotInstalledError,
+        UncommittedAssetError,
+        InvalidNameError,
+        LockfileError,
+        PrivacyScanError,
+        AdoptMismatchError,
+    ):
+        if asset_type == "skill":
+            result = adopt_skill(root, name)
+        elif asset_type == "agent":
+            result = adopt_agent(root, name)
+        elif asset_type == "command":
+            result = adopt_command(root, name)
+        else:  # pragma: no cover — guarded by click.Choice
+            raise click.ClickException(f"unknown asset type: {asset_type}")
+
+    click.secho(
+        f"Adopted {result.asset_type}/{result.name} (wiki {result.wiki_commit[:12]})",
+        fg="green",
+    )
+    rel_dest = result.dest.relative_to(root) if result.dest.is_relative_to(root) else result.dest
+    click.echo(f"  → {rel_dest}/")
+    click.echo(f"  {result.files_verified} file(s) verified byte-identical — dest untouched")
+
+
 def _maybe_hint_dirty_noop(wiki: WikiStore, asset_type_plural: str, name: str) -> None:
     """Asset-scoped stderr note on a no-op update whose wiki asset is dirty (#1652).
 
@@ -3726,6 +3780,25 @@ def _transfer_dispatch(
         _ensure_local_tier_gitignored(dst_root)
 
 
+def _maybe_hint_adopt_untracked(result: TransferResult | McpServerCopyResult) -> None:
+    """One-line adopt follow-up under a transfer's untracked-landing warning (#1684).
+
+    A shared→shared transfer whose provenance carry-over was refused lands
+    exactly in adopt's quadrant (dest without a lockfile entry); when the
+    destination bytes still match the wiki HEAD asset, adopt re-establishes
+    the pin without reinstalling. mcp-servers have no lockfile tracking, so
+    the hint is scoped to the artifact kinds.
+    """
+    if result.kind == "mcp-servers":
+        return
+    singular = result.kind.removesuffix("s")
+    click.echo(
+        f"  if the destination bytes match its wiki HEAD, "
+        f"`mm context adopt {singular} {result.dst_name}` there re-establishes "
+        f"the pin without reinstalling"
+    )
+
+
 def _print_transfer_result(result: TransferResult | McpServerCopyResult, *, apply_: bool) -> None:
     """User-facing summary for one copy/move transfer (#1274).
 
@@ -3774,6 +3847,7 @@ def _print_transfer_result(result: TransferResult | McpServerCopyResult, *, appl
                 f"lands untracked: {result.provenance_reason}",
                 fg="yellow",
             )
+            _maybe_hint_adopt_untracked(result)
         # Engine caveats (copy-rename overrides, mcp .mcp.json disclosure)
         # render in the PLAN too — a caveat the user only learns about
         # after --apply is not a plan they confirmed.
@@ -3817,6 +3891,7 @@ def _print_transfer_result(result: TransferResult | McpServerCopyResult, *, appl
             f"untracked at the destination: {result.provenance_reason}",
             fg="yellow",
         )
+        _maybe_hint_adopt_untracked(result)
     for note in result.notes:
         click.secho(f"  note: {note}", fg="yellow")
     if result.needs_sync and result.sync_command:

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -25,6 +25,13 @@ classified error (see step 6 of the install pipeline). This forward-
 protects ADR-0008 Invariant 2 ("manual edits are detected, not silently
 clobbered") without depending on PR-D's mtime/dirty detection. PR-D's
 ``mm context update`` is the supported way to refresh an installed asset.
+
+Adopt (#1684) — :func:`adopt_skill` / :func:`adopt_agent` /
+:func:`adopt_command`, delegating to :func:`_adopt_asset` — is the
+explicit exit for the dest-without-entry quadrant install refuses: it
+verifies an existing project canonical byte-by-byte against the asset at
+wiki HEAD and, only on full equality, records the lockfile entry without
+touching a single dest byte.
 """
 
 from __future__ import annotations
@@ -62,6 +69,8 @@ from memtomem.wiki.store import WikiStore
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "AdoptMismatchError",
+    "AdoptResult",
     "AlreadyInstalledError",
     "AssetNotFoundError",
     "CommitNotFoundError",
@@ -71,6 +80,9 @@ __all__ = [
     "StaleInstallError",
     "UncommittedAssetError",
     "UpdateResult",
+    "adopt_agent",
+    "adopt_command",
+    "adopt_skill",
     "install_agent",
     "install_command",
     "install_skill",
@@ -120,6 +132,17 @@ class AlreadyInstalledError(RuntimeError):
     """Raised when install would overwrite an existing lockfile entry or dest."""
 
 
+class AdoptMismatchError(RuntimeError):
+    """Raised when adopt's byte compare finds dest ≠ the wiki HEAD asset (#1684).
+
+    Adopt records provenance only for content proven byte-identical to the
+    pinned commit — any per-file difference (content mismatch, dest-only
+    file, HEAD-only file, or an unreadable dest file) refuses with a
+    categorized per-file report in the message. There is deliberately no
+    ``--force``: a wrong guess must stay impossible by construction.
+    """
+
+
 class NotInstalledError(RuntimeError):
     """Raised by ``_update_asset`` when there is no lockfile entry to refresh.
 
@@ -165,6 +188,24 @@ class InstallResult:
     files_written: int
     files_removed: tuple[Path, ...] = ()
     was_no_op: bool = False
+
+
+@dataclass(frozen=True)
+class AdoptResult:
+    """Outcome of a successful adopt (#1684). Display-oriented; not persisted.
+
+    Adopt never writes dest bytes — ``files_verified`` counts the files
+    proven byte-identical to the wiki HEAD asset before the lockfile entry
+    was recorded (the compare set, i.e. exactly the files a fresh install
+    of this asset would have written).
+    """
+
+    asset_type: Literal["skills", "agents", "commands"]
+    name: str
+    wiki_commit: str
+    installed_at: str
+    dest: Path
+    files_verified: int
 
 
 @dataclass(frozen=True)
@@ -626,10 +667,14 @@ def _install_asset(
             # NotInstalledError without an entry and points back at
             # install — a circle, #1247 id 4). No auto-adopt either:
             # install can't tell a leftover from hand-placed content it
-            # must not clobber.
+            # must not clobber — the explicit, verifying exit is
+            # `mm context adopt` (#1684).
             hint = (
                 f"dest exists with no lockfile entry — hand-placed files or an "
-                f"install interrupted before its lockfile write; inspect {dest}, "
+                f"install interrupted before its lockfile write; if the "
+                f"directory's bytes match wiki HEAD, run "
+                f"`mm context adopt {asset_type_singular} {validated}` to record "
+                f"the pin without reinstalling; otherwise inspect {dest}, "
                 f"remove the directory if it's disposable, then re-run "
                 f"`mm context install {asset_type_singular} {validated}`"
             )
@@ -726,6 +771,267 @@ def _install_asset(
         installed_at=installed_at,
         dest=dest,
         files_written=len(digest_map),
+    )
+
+
+def adopt_skill(
+    project_root: Path | str,
+    name: str,
+    *,
+    wiki: WikiStore | None = None,
+    lock_timeout: float | None = None,
+    surface: str = "cli_context_adopt",
+) -> AdoptResult:
+    """Lockfile-track an existing ``skills/<name>`` canonical that matches wiki HEAD (#1684).
+
+    The inverse-gate sibling of :func:`install_skill`: requires the dest to
+    exist WITHOUT a lockfile entry, verifies the dest bytes file-by-file
+    against the asset at wiki HEAD, and on full equality records the
+    provenance entry — no dest byte is ever written or moved, so a wrong
+    guess is impossible by construction. Any difference refuses with a
+    per-file report (:class:`AdoptMismatchError`).
+    """
+    return _adopt_asset(
+        project_root, "skills", name, wiki=wiki, lock_timeout=lock_timeout, surface=surface
+    )
+
+
+def adopt_agent(
+    project_root: Path | str,
+    name: str,
+    *,
+    wiki: WikiStore | None = None,
+    lock_timeout: float | None = None,
+    surface: str = "cli_context_adopt",
+) -> AdoptResult:
+    """Lockfile-track an existing ``agents/<name>`` canonical that matches wiki HEAD (#1684)."""
+    return _adopt_asset(
+        project_root, "agents", name, wiki=wiki, lock_timeout=lock_timeout, surface=surface
+    )
+
+
+def adopt_command(
+    project_root: Path | str,
+    name: str,
+    *,
+    wiki: WikiStore | None = None,
+    lock_timeout: float | None = None,
+    surface: str = "cli_context_adopt",
+) -> AdoptResult:
+    """Lockfile-track an existing ``commands/<name>`` canonical that matches wiki HEAD (#1684)."""
+    return _adopt_asset(
+        project_root, "commands", name, wiki=wiki, lock_timeout=lock_timeout, surface=surface
+    )
+
+
+def _mismatch_part(label: str, rels: list[str]) -> str:
+    """One ``label: a, b, +N more`` clause of the adopt mismatch report."""
+    shown = ", ".join(rels[:10])
+    more = "" if len(rels) <= 10 else f", +{len(rels) - 10} more"
+    return f"{label}: {shown}{more}"
+
+
+def _adopt_asset(
+    project_root: Path | str,
+    asset_type: str,
+    name: str,
+    *,
+    wiki: WikiStore | None,
+    lock_timeout: float | None = None,
+    surface: str = "cli_context_adopt",
+) -> AdoptResult:
+    """Internal: adopt a single asset of any type — verify, then record (#1684).
+
+    Install's no-auto-adopt decision (see ``_install_asset``) is about the
+    *implicit* case: install can't tell a half-install leftover from
+    hand-placed content. Adopt is the explicit, verifying contract — it
+    runs install's own reproducible-pin gates (HEAD-presence, same-asset
+    dirty), then a full byte compare, then Gate A over the pinned bytes,
+    so the recorded entry makes exactly the claims a fresh install of the
+    same asset would have made (``wiki_commit``/``files``/``files_commit``/
+    ``digests`` all HEAD-derived AND proven equal to the dest).
+
+    Gate A runs even though adopt writes no dest bytes: without it,
+    hand-copy-then-adopt would reach a tracked state (secret-bearing asset
+    with a lockfile pin) that install itself refuses — the verb must not
+    be a bypass around the ingress scan. It runs AFTER the byte compare
+    (unlike install, which must scan before extraction residue) so a
+    mismatched dest always gets the contract's per-file diff report, and
+    the scan's remediation text can truthfully say the dest bytes are
+    identical.
+
+    All refusals fire before the lockfile write — the only mutation this
+    function ever performs. Concurrency: the single ``upsert_entry`` holds
+    the lockfile sidecar lock; a racing install/adopt of the same asset is
+    last-write-wins on the entry, and both racers verified against
+    immutable commit objects, so an entry written under the SAME observed
+    HEAD is identical regardless of interleaving.
+    """
+    validated = validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
+    project_root = Path(project_root).expanduser()
+    if not project_root.is_dir():
+        raise ProjectRootMissingError(f"project root does not exist: {project_root}")
+
+    wiki = wiki if wiki is not None else WikiStore.at_default()
+    wiki.require_exists()
+
+    src = wiki.root / asset_type / validated
+    worktree_present = src.is_dir()
+
+    wiki_commit = wiki.current_commit()
+
+    dest = project_root / ".memtomem" / asset_type / validated
+    lock = Lockfile.at(project_root)
+    asset_type_singular = asset_type.removesuffix("s")
+
+    # State gate — the exact inverse of install's (#1684): adopt exists for
+    # the dest-without-entry quadrant only.
+    if lock.read_entry(asset_type, validated) is not None:
+        raise AlreadyInstalledError(
+            f"{asset_type}/{validated}: already lockfile-tracked — adopt records "
+            f"provenance for an untracked dest only; run "
+            f"`mm context update {asset_type_singular} {validated}` to refresh "
+            f"from wiki HEAD"
+        )
+    if not dest.is_dir():
+        raise NotInstalledError(
+            f"{asset_type}/{validated}: nothing to adopt — {dest} does not exist; "
+            f"run `mm context install {asset_type_singular} {validated}` to "
+            f"install from wiki HEAD"
+        )
+
+    commit_hint = _commit_hint(wiki, asset_type, validated)
+
+    # HEAD-presence gate — same as install (#1643): the recorded pin must
+    # CONTAIN the asset, otherwise the entry claims provenance from a commit
+    # that lacks the bytes entirely.
+    try:
+        head_rels = wiki.asset_files_at_commit(wiki_commit, asset_type, validated)
+    except AssetNotFoundError:
+        if worktree_present:
+            raise UncommittedAssetError(
+                f"{asset_type}/{validated}: exists in the wiki working tree but "
+                f"has never been committed, so the HEAD pin would not contain "
+                f"it; {commit_hint}"
+            ) from None
+        raise AssetNotFoundError(f"{asset_type}/{validated} not in wiki at {wiki.root}") from None
+
+    # Same-asset dirty gate — same as install (#1643): the user-visible wiki
+    # bytes must equal the HEAD bytes the compare (and the pin) are based on.
+    dirty_rels = _asset_dirty_rels(wiki, asset_type, validated)
+    if dirty_rels:
+        shown = ", ".join(dirty_rels[:5])
+        more = "" if len(dirty_rels) <= 5 else f", +{len(dirty_rels) - 5} more"
+        raise UncommittedAssetError(
+            f"{asset_type}/{validated}: wiki working tree differs from HEAD for "
+            f"this asset ({len(dirty_rels)} file(s): {shown}{more}); adopt "
+            f"verifies against HEAD's bytes and records that pin only — "
+            f"{commit_hint}"
+        )
+
+    # Byte compare — the verb's core. HEAD side and disk side both apply the
+    # copier's skip rules (is_copy_skipped_rel / iter_installed_files), so
+    # the compare set is exactly the file set a fresh install would write.
+    # An asset whose committed files are ALL skip-listed compares as empty
+    # on both sides and adopts with files=[]/digests={} — the same entry a
+    # fresh install of it records (parity; do not refuse what install
+    # accepts).
+    expected: dict[str, str] = {}
+    for rel in head_rels:
+        if is_copy_skipped_rel(rel):
+            continue
+        expected[rel] = hashlib.sha256(
+            wiki.read_asset_file_at_commit(wiki_commit, asset_type, validated, rel)
+        ).hexdigest()
+
+    actual: dict[str, str] = {}
+    unreadable: list[str] = []
+    try:
+        for f in iter_installed_files(dest):
+            rel = f.relative_to(dest).as_posix()
+            try:
+                actual[rel] = hashlib.sha256(f.read_bytes()).hexdigest()
+            except OSError:
+                unreadable.append(rel)  # can't prove equal → mismatch, not a crash
+    except OSError as exc:
+        # iter_installed_files is fail-closed by contract: an unreadable
+        # DIRECTORY raises mid-walk rather than silently shrinking the set.
+        # For adopt that still classifies as "can't prove equal" — a
+        # categorized refusal, never a raw traceback at the CLI boundary.
+        failed = exc.filename or str(dest)
+        raise AdoptMismatchError(
+            f"{asset_type}/{validated}: cannot verify dest against wiki HEAD "
+            f"{wiki_commit[:12]} — unreadable path during the dest walk: "
+            f"{failed}; fix permissions and re-run adopt"
+        ) from None
+
+    differs = sorted(r for r in expected.keys() & actual.keys() if expected[r] != actual[r])
+    only_on_disk = sorted(actual.keys() - expected.keys())
+    only_at_head = sorted(expected.keys() - actual.keys() - set(unreadable))
+    unreadable.sort()
+    if differs or only_on_disk or only_at_head or unreadable:
+        parts = [
+            _mismatch_part(label, rels)
+            for label, rels in (
+                ("differs", differs),
+                ("only on disk", only_on_disk),
+                ("only at HEAD", only_at_head),
+                ("unreadable", unreadable),
+            )
+            if rels
+        ]
+        total = len(differs) + len(only_on_disk) + len(only_at_head) + len(unreadable)
+        raise AdoptMismatchError(
+            f"{asset_type}/{validated}: dest bytes differ from wiki HEAD "
+            f"{wiki_commit[:12]} ({total} file(s)) — {'; '.join(parts)}. adopt "
+            f"records provenance only for byte-identical content; either take "
+            f"HEAD's bytes (move {dest} aside, then "
+            f"`mm context install {asset_type_singular} {validated}`) or push "
+            f"the local edits wiki-ward first "
+            f"(`mm wiki {asset_type_singular} promote {validated}`, #1683)"
+        )
+
+    # Gate A (ADR-0011 §5) over the pinned bytes, the same scan install runs:
+    # adopt writes no dest bytes, but blessing them with a lockfile entry
+    # must not be reachable for content the install ingress scan refuses.
+    # Equality is proven at this point, so the hint's claim is literal.
+    _gate_a_scan_pinned_asset(
+        wiki,
+        wiki_commit,
+        asset_type,
+        validated,
+        surface=surface,
+        project_root=project_root,
+        remediation_hint=(
+            f"The wiki HEAD commit {wiki_commit[:12]} ships a secret in "
+            f"{asset_type}/{validated}, and the byte-identical content already "
+            f"sits in the project tree at {dest}; remove the secret from both, "
+            f"commit the wiki fix, and re-run adopt."
+        ),
+    )
+
+    # Full match → record provenance only. The digests are the proven-equal
+    # hashes, so update's dirty check reads the asset as clean and
+    # install --all treats the entry as a normal pin.
+    installed_at = installed_at_from_dest(dest)
+    lock.upsert_entry(
+        asset_type,
+        validated,
+        wiki_commit=wiki_commit,
+        installed_at=installed_at,
+        files=sorted(expected),
+        files_commit=wiki_commit,
+        digests=expected,
+        lock_timeout=lock_timeout,
+    )
+
+    return AdoptResult(
+        asset_type=cast('Literal["skills", "agents", "commands"]', asset_type),
+        name=validated,
+        wiki_commit=wiki_commit,
+        installed_at=installed_at,
+        dest=dest,
+        files_verified=len(expected),
     )
 
 

--- a/packages/memtomem/tests/test_cli_context_transfer.py
+++ b/packages/memtomem/tests/test_cli_context_transfer.py
@@ -510,6 +510,8 @@ def test_provenance_not_carried_line_names_the_reason(cli_projects) -> None:
     assert result.exit_code == 0, result.output
     assert "install provenance not carried" in result.output
     assert "local edits" in result.output
+    # The untracked landing offers the explicit re-tracking exit (#1684).
+    assert "mm context adopt agent foo" in result.output
     # Dry-run previews the same refusal.
     _seed_agent(cli_projects, "project_shared", name="bar", root_key="a")
     _wiki_install_entry_cli(cli_projects["a"], name="bar")
@@ -521,6 +523,7 @@ def test_provenance_not_carried_line_names_the_reason(cli_projects) -> None:
     )
     assert preview.exit_code == 0, preview.output
     assert "install provenance will not be carried" in preview.output
+    assert "mm context adopt agent bar" in preview.output
 
 
 # ── mcp-servers copy (A-12 #1282) ────────────────────────────────────

--- a/packages/memtomem/tests/test_context_adopt.py
+++ b/packages/memtomem/tests/test_context_adopt.py
@@ -1,0 +1,489 @@
+"""Tests for ``mm context adopt`` — verify-then-record provenance (#1684).
+
+Adopt lockfile-tracks an existing ``project_shared`` canonical whose bytes
+match the wiki HEAD asset, without writing a single dest byte. These cover
+the engine (:func:`memtomem.context.install._adopt_asset` via its three
+public wrappers) and the CLI surface: happy path across all three kinds
+(dest untouched, entry shape identical to a fresh install's), the per-file
+mismatch refusal in every category, the inverse state gate (already
+tracked / nothing to adopt), install's reproducible-pin gates (HEAD
+presence, same-asset wiki dirt), Gate A over the pinned bytes, skip-filter
+parity with the copier, and the post-adopt invariants (update sees the
+asset clean at HEAD; the untracked status row disappears).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem import privacy
+from memtomem.cli.context_cmd import context as context_group
+from memtomem.context.install import (
+    AdoptMismatchError,
+    AlreadyInstalledError,
+    AssetNotFoundError,
+    NotInstalledError,
+    UncommittedAssetError,
+    adopt_agent,
+    adopt_command,
+    adopt_skill,
+    install_skill,
+    update_skill,
+)
+from memtomem.context.lockfile import LOCKFILE_VERSION, Lockfile
+from memtomem.context.privacy_scan import PrivacyBlockedError
+from memtomem.context.status import classify_status
+from memtomem.wiki.store import WikiStore
+
+# ``wiki_root`` / ``git_identity`` fixtures come from conftest.py.
+
+# AKIA fixture per feedback_force_unsafe_redaction_valve_only.md — a clean
+# string never trips the scan, so the Gate A assertions below would
+# false-pass without it.
+SECRET = "api_key=AKIA1234567890ABCDEF"
+
+_ADOPT_VERB = {"skills": adopt_skill, "agents": adopt_agent, "commands": adopt_command}
+_MANIFEST = {"skills": "SKILL.md", "agents": "agent.md", "commands": "command.md"}
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _git_commit_all(wiki_root_path: Path, message: str) -> None:
+    subprocess.run(["git", "-C", str(wiki_root_path), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root_path), "commit", "-m", message],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _write_wiki_files(
+    wiki_root_path: Path, asset_type: str, name: str, files: dict[str, bytes]
+) -> None:
+    """Drop asset files into the wiki working tree WITHOUT committing."""
+    asset_dir = wiki_root_path / asset_type / name
+    asset_dir.mkdir(parents=True, exist_ok=True)
+    for relpath, data in files.items():
+        target = asset_dir / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+
+
+def _seed_wiki_asset(
+    wiki_root_path: Path, asset_type: str, name: str, files: dict[str, bytes]
+) -> None:
+    """Drop an asset into an initialized wiki and commit."""
+    _write_wiki_files(wiki_root_path, asset_type, name, files)
+    _git_commit_all(wiki_root_path, f"add {asset_type}/{name}")
+
+
+def _initialized_wiki(wiki_root_path: Path) -> WikiStore:
+    store = WikiStore.at_default()
+    store.init()
+    return store
+
+
+def _place_dest(project: Path, asset_type: str, name: str, files: dict[str, bytes]) -> Path:
+    """Hand-place a dest tree at ``<project>/.memtomem/<asset_type>/<name>/``."""
+    dest = project / ".memtomem" / asset_type / name
+    dest.mkdir(parents=True, exist_ok=True)
+    for relpath, data in files.items():
+        target = dest / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    return dest
+
+
+def _tree_snapshot(dest: Path) -> dict[str, tuple[int, bytes]]:
+    """rel → (mtime_ns, bytes) for every file under dest — adopt must not move it."""
+    return {
+        f.relative_to(dest).as_posix(): (f.stat().st_mtime_ns, f.read_bytes())
+        for f in sorted(dest.rglob("*"))
+        if f.is_file()
+    }
+
+
+_FILES = {
+    "SKILL.md": b"# demo\n",
+    "scripts/run.sh": b"#!/bin/bash\necho hi\n",
+}
+
+
+# ── happy path across kinds ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("asset_type", ["skills", "agents", "commands"])
+def test_adopt_records_install_shaped_entry_without_touching_dest(
+    wiki_root: Path, tmp_path: Path, asset_type: str
+) -> None:
+    store = _initialized_wiki(wiki_root)
+    files = {_MANIFEST[asset_type]: b"# demo\n", "extra/notes.md": b"notes\n"}
+    _seed_wiki_asset(wiki_root, asset_type, "demo", files)
+    project = tmp_path / "proj"
+    dest = _place_dest(project, asset_type, "demo", files)
+    before = _tree_snapshot(dest)
+
+    result = _ADOPT_VERB[asset_type](project, "demo")
+
+    head = store.current_commit()
+    assert result.asset_type == asset_type
+    assert result.name == "demo"
+    assert result.wiki_commit == head
+    assert result.files_verified == 2
+    assert result.dest == dest
+    # No dest byte written or moved — bytes AND mtimes identical.
+    assert _tree_snapshot(dest) == before
+
+    entry = Lockfile.at(project).read_entry(asset_type, "demo")
+    assert entry is not None
+    assert entry["wiki_commit"] == head
+    assert entry["files_commit"] == head
+    assert entry["files"] == sorted(files)
+    assert entry["digests"] == {
+        rel: hashlib.sha256(data).hexdigest() for rel, data in files.items()
+    }
+    assert entry["installed_at"] == result.installed_at
+
+    lock_doc = json.loads((project / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["version"] == LOCKFILE_VERSION
+
+
+def test_adopt_flips_status_untracked_to_ok(wiki_root: Path, tmp_path: Path) -> None:
+    """The verb converts exactly the ``untracked`` status row into a tracked one."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "skills", "demo", _FILES)
+    project = tmp_path / "proj"
+    _place_dest(project, "skills", "demo", _FILES)
+
+    def _states() -> dict[tuple[str, str], str]:
+        _, rows = classify_status(project)
+        return {(r.asset_type, r.name): r.state for r in rows}
+
+    assert _states()[("skills", "demo")] == "untracked"
+    adopt_skill(project, "demo")
+    assert _states()[("skills", "demo")] == "ok"
+
+
+def test_adopted_asset_is_clean_at_head_for_update(wiki_root: Path, tmp_path: Path) -> None:
+    """Post-adopt invariant: the recorded digests are the proven-equal hashes,
+    so ``mm context update`` classifies the asset as pin-at-HEAD no-op —
+    not dirty, not behind."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "skills", "demo", _FILES)
+    project = tmp_path / "proj"
+    _place_dest(project, "skills", "demo", _FILES)
+
+    adopt_skill(project, "demo")
+    result = update_skill(project, "demo")
+
+    assert result.was_no_op is True
+    assert result.files_written == 0
+
+
+# ── mismatch refusal — every category, zero lockfile residue ─────────────
+
+
+def test_adopt_refuses_content_diff_with_per_file_report(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "skills", "demo", _FILES)
+    project = tmp_path / "proj"
+    dest = _place_dest(
+        project, "skills", "demo", {**_FILES, "SKILL.md": b"# demo (edited locally)\n"}
+    )
+    before = _tree_snapshot(dest)
+
+    with pytest.raises(AdoptMismatchError) as excinfo:
+        adopt_skill(project, "demo")
+
+    msg = str(excinfo.value)
+    assert "differs: SKILL.md" in msg
+    # Both exits are offered: take HEAD's bytes, or promote the local edits.
+    assert "mm context install skill demo" in msg
+    assert "mm wiki skill promote demo" in msg
+    assert Lockfile.at(project).read_entry("skills", "demo") is None
+    assert _tree_snapshot(dest) == before  # refusal is read-only too
+
+
+def test_adopt_refuses_dest_only_and_head_only_files(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "skills", "demo", _FILES)
+    project = tmp_path / "proj"
+    _place_dest(
+        project,
+        "skills",
+        "demo",
+        {"SKILL.md": _FILES["SKILL.md"], "local-addition.md": b"mine\n"},
+    )
+
+    with pytest.raises(AdoptMismatchError) as excinfo:
+        adopt_skill(project, "demo")
+
+    msg = str(excinfo.value)
+    assert "only on disk: local-addition.md" in msg
+    assert "only at HEAD: scripts/run.sh" in msg
+    assert "2 file(s)" in msg
+    assert Lockfile.at(project).read_entry("skills", "demo") is None
+
+
+# ── inverse state gate ───────────────────────────────────────────────────
+
+
+def test_adopt_refuses_already_tracked_asset(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "skills", "demo", _FILES)
+    project = tmp_path / "proj"
+    project.mkdir()
+    install_skill(project, "demo")
+
+    with pytest.raises(AlreadyInstalledError) as excinfo:
+        adopt_skill(project, "demo")
+
+    assert "already lockfile-tracked" in str(excinfo.value)
+    assert "mm context update skill demo" in str(excinfo.value)
+
+
+def test_adopt_refuses_missing_dest(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "skills", "demo", _FILES)
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    with pytest.raises(NotInstalledError) as excinfo:
+        adopt_skill(project, "demo")
+
+    assert "nothing to adopt" in str(excinfo.value)
+    assert "mm context install skill demo" in str(excinfo.value)
+    assert Lockfile.at(project).read_entry("skills", "demo") is None
+
+
+# ── reproducible-pin gates (shared contract with install, #1643) ─────────
+
+
+def test_adopt_refuses_worktree_only_asset(wiki_root: Path, tmp_path: Path) -> None:
+    """An asset never committed can't be pinned — same gate as install."""
+    _initialized_wiki(wiki_root)
+    _write_wiki_files(wiki_root, "skills", "demo", _FILES)  # no commit
+    project = tmp_path / "proj"
+    _place_dest(project, "skills", "demo", _FILES)
+
+    with pytest.raises(UncommittedAssetError) as excinfo:
+        adopt_skill(project, "demo")
+
+    assert "never been committed" in str(excinfo.value)
+    assert Lockfile.at(project).read_entry("skills", "demo") is None
+
+
+def test_adopt_refuses_asset_absent_from_wiki(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki(wiki_root)
+    project = tmp_path / "proj"
+    _place_dest(project, "skills", "demo", _FILES)
+
+    with pytest.raises(AssetNotFoundError):
+        adopt_skill(project, "demo")
+
+
+def test_adopt_refuses_dirty_wiki_asset(wiki_root: Path, tmp_path: Path) -> None:
+    """Wiki worktree ≠ HEAD for THIS asset refuses even when dest matches
+    HEAD exactly — the user-visible wiki bytes must equal the verified pin."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "skills", "demo", _FILES)
+    (wiki_root / "skills" / "demo" / "SKILL.md").write_bytes(b"# demo (wiki edit)\n")
+    project = tmp_path / "proj"
+    _place_dest(project, "skills", "demo", _FILES)  # matches HEAD, not worktree
+
+    with pytest.raises(UncommittedAssetError) as excinfo:
+        adopt_skill(project, "demo")
+
+    assert "differs from HEAD" in str(excinfo.value)
+    assert Lockfile.at(project).read_entry("skills", "demo") is None
+
+
+# ── skip-filter parity with the copier ───────────────────────────────────
+
+
+def test_adopt_ignores_skip_listed_files_on_both_sides(wiki_root: Path, tmp_path: Path) -> None:
+    """Compare set == the copier's write set: a wiki-side ``.bak`` (gitignored
+    there anyway) and a dest-side ``.bak`` are both outside it, so neither
+    blocks the adopt."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(
+        wiki_root, "skills", "demo", {"SKILL.md": b"# demo\n", "old.md.bak": b"wiki bak\n"}
+    )
+    project = tmp_path / "proj"
+    _place_dest(project, "skills", "demo", {"SKILL.md": b"# demo\n", "local.md.bak": b"dest bak\n"})
+
+    result = adopt_skill(project, "demo")
+
+    assert result.files_verified == 1
+    entry = Lockfile.at(project).read_entry("skills", "demo")
+    assert entry is not None
+    assert entry["files"] == ["SKILL.md"]
+
+
+def test_adopt_all_skipped_asset_matches_install_parity(wiki_root: Path, tmp_path: Path) -> None:
+    """An asset whose committed files are ALL skip-listed installs with
+    ``files=[]``/``digests={}`` — adopt must accept the same asset the same
+    way, not refuse it (Codex review fold)."""
+    _initialized_wiki(wiki_root)
+    ds = wiki_root / "skills" / "dsonly" / ".DS_Store"
+    ds.parent.mkdir(parents=True)
+    ds.write_bytes(b"finder junk")
+    subprocess.run(
+        ["git", "-C", str(wiki_root), "add", "-f", "skills/dsonly/.DS_Store"],
+        check=True,
+        capture_output=True,
+    )
+    _git_commit_all(wiki_root, "add dsonly")
+    project = tmp_path / "proj"
+    # Dest holds only skip-listed content too — compares empty on both sides.
+    _place_dest(project, "skills", "dsonly", {"local.md.bak": b"dest bak\n"})
+
+    result = adopt_skill(project, "dsonly")
+
+    assert result.files_verified == 0
+    entry = Lockfile.at(project).read_entry("skills", "dsonly")
+    assert entry is not None
+    assert entry["files"] == []
+    assert entry["digests"] == {}
+
+
+requires_posix_perms = pytest.mark.skipif(
+    os.name == "nt" or (hasattr(os, "geteuid") and os.geteuid() == 0),
+    reason="needs POSIX permissions and a non-root user",
+)
+
+
+@requires_posix_perms
+def test_adopt_unreadable_dest_subdir_is_classified_refusal(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """``iter_installed_files`` is fail-closed and raises mid-walk on an
+    unreadable directory; adopt must surface that as its own classified
+    refusal (can't prove equal), never a raw ``PermissionError`` traceback."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "skills", "demo", _FILES)
+    project = tmp_path / "proj"
+    dest = _place_dest(project, "skills", "demo", _FILES)
+    locked = dest / "scripts"
+    locked.chmod(0o000)
+    try:
+        with pytest.raises(AdoptMismatchError) as excinfo:
+            adopt_skill(project, "demo")
+    finally:
+        locked.chmod(0o755)
+
+    assert "unreadable path during the dest walk" in str(excinfo.value)
+    assert Lockfile.at(project).read_entry("skills", "demo") is None
+
+
+# ── Gate A over the pinned bytes ─────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_privacy_counters():
+    """Zeroed counters so surface-attribution asserts see only their own test."""
+    privacy.reset_for_tests()
+    yield
+    privacy.reset_for_tests()
+
+
+def test_adopt_blocks_secret_asset_no_bypass(wiki_root: Path, tmp_path: Path) -> None:
+    """Hand-copy-then-adopt must not reach a tracked state install refuses:
+    Gate A scans the pinned bytes and blocks BEFORE the lockfile write,
+    attributed to the adopt ingress surface."""
+    _initialized_wiki(wiki_root)
+    files = {"SKILL.md": b"# leak\n" + SECRET.encode() + b"\n"}
+    _seed_wiki_asset(wiki_root, "skills", "leak", files)
+    project = tmp_path / "proj"
+    _place_dest(project, "skills", "leak", files)
+
+    with pytest.raises(PrivacyBlockedError) as excinfo:
+        adopt_skill(project, "leak")
+
+    assert Lockfile.at(project).read_entry("skills", "leak") is None
+    # Matched bytes never reach the error message.
+    assert "AKIA1234567890ABCDEF" not in excinfo.value.message
+    by_tool = privacy.snapshot()["by_tool"]
+    assert by_tool.get("cli_context_adopt", {}).get("blocked", 0) == 1
+    assert "cli_context_install" not in by_tool
+
+
+def test_adopt_mismatch_report_wins_over_gate_a(wiki_root: Path, tmp_path: Path) -> None:
+    """Gate A runs after the byte compare: a mismatched dest gets the
+    contract's per-file diff report even when the pinned wiki bytes carry a
+    secret — the privacy refusal is reserved for the case adopt would
+    actually bless (Codex review fold)."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "skills", "leak", {"SKILL.md": b"# leak\n" + SECRET.encode()})
+    project = tmp_path / "proj"
+    _place_dest(project, "skills", "leak", {"SKILL.md": b"# different\n"})
+
+    with pytest.raises(AdoptMismatchError) as excinfo:
+        adopt_skill(project, "leak")
+
+    assert "differs: SKILL.md" in str(excinfo.value)
+    assert "AKIA1234567890ABCDEF" not in str(excinfo.value)
+    assert Lockfile.at(project).read_entry("skills", "leak") is None
+    # The scan never ran — nothing was about to be blessed.
+    assert privacy.snapshot()["by_tool"].get("cli_context_adopt", {}).get("blocked", 0) == 0
+
+
+# ── CLI surface ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def project_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Tmp project root (with a sentinel ``.git``) wired as cwd so
+    ``_find_project_root`` resolves there."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".git").mkdir()
+    monkeypatch.chdir(project)
+    return project
+
+
+def test_cli_adopt_success(wiki_root: Path, project_cwd: Path) -> None:
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "skills", "demo", _FILES)
+    _place_dest(project_cwd, "skills", "demo", _FILES)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["adopt", "skill", "demo"])
+
+    assert result.exit_code == 0, result.output
+    assert "Adopted skills/demo" in result.output
+    assert "2 file(s) verified byte-identical" in result.output
+
+
+def test_cli_adopt_mismatch_exit_and_report(wiki_root: Path, project_cwd: Path) -> None:
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "skills", "demo", _FILES)
+    _place_dest(project_cwd, "skills", "demo", {**_FILES, "SKILL.md": b"edited\n"})
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["adopt", "skill", "demo"])
+
+    assert result.exit_code == 1, result.output
+    assert "differs: SKILL.md" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_cli_install_refusal_hints_adopt(wiki_root: Path, project_cwd: Path) -> None:
+    """The dest-exists-no-lock refusal now names the explicit exit (#1684)."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_asset(wiki_root, "skills", "demo", _FILES)
+    _place_dest(project_cwd, "skills", "demo", _FILES)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["install", "skill", "demo"])
+
+    assert result.exit_code == 1, result.output
+    assert "mm context adopt skill demo" in result.output


### PR DESCRIPTION
## Problem

A `project_shared` canonical whose bytes already match the wiki HEAD asset cannot be converted into a lockfile-tracked install in place: `mm context install` refuses whenever the dest dir or a lockfile entry exists, so the only route was mv-aside → reinstall → manual `diff -ru` — delete-and-rewrite of the exact same bytes. This bit a real operational run (docs/reports/wiki-command-install-tracking-plan-2026-07-09.md) and is the workflow's other half next to promote (#1683, PR #1686).

## What this adds

`mm context adopt <kind> <name>` — the explicit, verifying exit for the dest-without-entry quadrant install refuses. Install's no-auto-adopt decision stays intact: that reasoning is about *implicit* adoption (install can't tell a half-install leftover from hand-placed content); adopt only records provenance that has been **proven**:

- **Reproducible-pin gates reused from install** — HEAD-presence and same-asset wiki-dirty gates (#1643 contract), so the recorded pin always reproduces the verified bytes.
- **Byte compare is the core** — dest files are hashed against the HEAD manifest (`asset_files_at_commit` + `read_asset_file_at_commit`) with the copier's skip filters applied on both sides (`is_copy_skipped_rel` / `iter_installed_files`), so the compare set is exactly the file set a fresh install would write. An asset whose committed files are all skip-listed adopts with `files=[]` / `digests={}`, matching install's entry for the same asset.
- **Any difference refuses** with a per-file categorized report (`differs` / `only on disk` / `only at HEAD` / `unreadable`) plus both exits: mv-aside + install (take HEAD's bytes) or `mm wiki <kind> promote` (push local edits wiki-ward, #1683). The fail-closed dest walk is classified into the same refusal — never a raw traceback. There is deliberately no `--force`: no dest byte is ever written or moved, so a wrong guess is impossible by construction.
- **Gate A runs on adopt too**, over the pinned bytes, after equality is proven — hand-copy-then-adopt must not reach a tracked state (secret-bearing asset with a lockfile pin) that install itself refuses. A mismatched dest always gets the diff report; the scan fires only when adopt would actually bless.
- **On full match**: one `Lockfile.upsert_entry` (under the sidecar lock) with `wiki_commit` / `files` / `files_commit` / `digests` — the install-shaped entry, with digests being the proven-equal hashes, so `mm context update` reads the asset as clean-at-HEAD and `install --all` treats it as a normal pin.

Discoverability: install's dest-exists-no-lock refusal hint and the transfer "lands untracked" warnings (both plan and apply) now name the new verb.

## Testing

- New `test_context_adopt.py` (20 tests): happy path ×3 kinds with dest byte+mtime immutability, entry-shape parity, status `untracked`→`ok` flip, post-adopt `update` no-op, every mismatch category with zero lockfile residue, inverse state gate, pin gates, Gate A block + attribution (`cli_context_adopt`) + mismatch-wins ordering, skip-filter parity incl. the all-skipped case, unreadable-subdir classified refusal, and the CLI surface.
- `test_cli_context_transfer.py` extended: both untracked-landing warnings hint adopt.
- Full suite: 8183 passed, 11 skipped (`-m "not ollama"`); ruff check+format clean; mypy clean on touched files.
- Manual e2e in an isolated HOME/wiki: adopt happy path (issue's exact scenario), re-adopt refusal, one-byte mismatch report, install-hint rendering.
- Codex review: round 1 NEEDS-FIX (3 Major: all-skipped parity, walker OSError classification, Gate A ordering) — all applied; round 2 **SHIP**, no findings.

Closes #1684

🤖 Generated with [Claude Code](https://claude.com/claude-code)
