### PR TITLE
fix(context): make `mm context update` forward-only so a wiki reset can't move the pin backward (#1685)

### DIFF
--- a/docs/guides/context-gateway.md
+++ b/docs/guides/context-gateway.md
@@ -116,9 +116,17 @@ wiki (~/.memtomem-wiki)  ──install──▶  project Store (<project>/.memto
   to the wiki's latest HEAD. Update is commit-true like install: it extracts
   the committed bytes at HEAD, and refuses (with a `mm wiki <type> commit`
   hint; `--force` does not bypass) if the asset has uncommitted changes in
-  the wiki working tree. Add `--dry-run` to print the would-update /
-  unchanged / refuse preview without writing anything (also works with
-  `--all`, where it prints the batch table and skips the confirm prompt).
+  the wiki working tree. It is also **forward-only**: it advances the pin only
+  when the recorded pin is an ancestor of HEAD. If the wiki was `reset` or
+  force-pulled to older/divergent history so HEAD no longer descends from the
+  pin, update refuses rather than moving the pin **backward** (a silent
+  downgrade) — the same drift `mm context status` reports as `stale-pin`;
+  `--force` does not bypass this either (it overrides project-side edits, not
+  wiki history). Add `--dry-run` to print the would-update / unchanged /
+  refuse / stale-pin preview without writing anything (also works with
+  `--all`, where it prints the batch table and skips the confirm prompt; a
+  stale-pin row there is skipped per-project while forward siblings still
+  update).
 
 > **`--all` means different axes on `install` vs `update`.** They are not the
 > same batch. `mm context install --all` fixes the **project** and restores

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -42,6 +42,7 @@ from memtomem.context.install import (
     AssetNotFoundError,
     CommitNotFoundError,
     NotInstalledError,
+    PinNotAncestorError,
     ProjectClassification,
     ProjectInstallClassification,
     StaleInstallError,
@@ -2115,6 +2116,7 @@ def update_cmd(
         NotInstalledError,
         StaleInstallError,
         UncommittedAssetError,
+        PinNotAncestorError,
         InvalidNameError,
         LockfileError,
         PrivacyScanError,
@@ -2199,6 +2201,14 @@ def _run_update_dry_run_single(
     _print_classification_table(classifications, asset_type_plural, name, new_commit)
 
     row = classifications[0]
+
+    # Forward-only gate (#1685): a stale pin (HEAD does not descend from it)
+    # exits non-zero like the real run's PinNotAncestorError. Checked BEFORE
+    # the wiki-dirty gate to mirror _update_asset's order (ancestry precedes
+    # the dirty gate). Non-force-able — the reason names the wiki-history fix,
+    # not --force.
+    if row.state == "stale-pin":
+        raise click.ClickException(f"{asset_type_plural}/{name}: {row.reason}")
 
     # Wiki-side dirty gate (#1652): fires only when the real run would
     # write (parity with the single wet path, where the no-op returns
@@ -2311,9 +2321,10 @@ def _run_update_all(
 
     needs_update = [c for c in classifications if c.state == "update"]
     needs_force = [c for c in classifications if c.state == "refuse"]
+    stale_pins = [c for c in classifications if c.state == "stale-pin"]
     has_errors = [c for c in classifications if c.state == "error"]
 
-    if not needs_update and not needs_force and not has_errors:
+    if not needs_update and not needs_force and not stale_pins and not has_errors:
         click.echo("\nAll projects are up to date.")
         _maybe_hint_dirty_noop(wiki, asset_type_plural, name)
         return
@@ -2351,6 +2362,8 @@ def _run_update_all(
         parts = [f"{len(needs_update)} would update"]
         if needs_force:
             parts.append(f"{len(needs_force)} would refuse without --force")
+        if stale_pins:
+            parts.append(f"{len(stale_pins)} stale pin (wiki diverged, not force-able)")
         if has_errors:
             parts.append(f"{len(has_errors)} in error")
         click.echo(f"\nDry run — nothing written; {', '.join(parts)}.")
@@ -2386,6 +2399,15 @@ def _run_update_all(
             continue
         if c.state == "error":
             click.secho(f"  ✗ {c.project_root}: {c.reason}", fg="red")
+            failures += 1
+            continue
+        if c.state == "stale-pin":
+            # Forward-only gate (#1685): HEAD does not descend from this
+            # project's pin — advancing would downgrade it. Per-project skip
+            # (never force-able), counted as a failure so the batch exits
+            # non-zero: the user asked to update and this one could not be
+            # safely advanced. Siblings that ARE forward keep updating.
+            click.secho(f"  ⚠ {c.project_root}: {c.reason}", fg="red")
             failures += 1
             continue
 
@@ -2465,6 +2487,7 @@ def _print_classification_table(
         "update": "green",
         "unchanged": "cyan",
         "refuse": "yellow",
+        "stale-pin": "red",
         "error": "red",
     }
     for c in classifications:

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -76,6 +76,7 @@ __all__ = [
     "CommitNotFoundError",
     "InstallResult",
     "NotInstalledError",
+    "PinNotAncestorError",
     "ProjectInstallClassification",
     "StaleInstallError",
     "UncommittedAssetError",
@@ -158,6 +159,25 @@ class StaleInstallError(RuntimeError):
     The dest tree has at least one file with ``mtime > installed_at`` and
     ``--force`` was not set. The message includes the count and points
     the user at ``--force`` (which preserves dirty files as ``.bak``).
+    """
+
+
+class PinNotAncestorError(RuntimeError):
+    """Raised by ``_update_asset`` when wiki HEAD does not descend from the pin (#1685).
+
+    ``mm context update`` is forward-only: it advances the lockfile pin to wiki
+    HEAD only when the recorded pin is an ancestor of HEAD. After a wiki
+    ``reset`` / force-pull to older or divergent history the pin is newer than
+    (or divergent from) HEAD, so recording HEAD would move the pin BACKWARD — a
+    silent downgrade. This is the write-path counterpart of the ``stale-pin``
+    state ``mm context status`` already reports; both share the forward-only
+    guard :meth:`WikiStore.commit_is_ancestor` (see :func:`_pin_backward_reason`).
+
+    Deliberately NOT bypassed by ``--force`` — that flag overrides project-side
+    dest edits, never wiki-side history (the same asymmetry the wiki-dirty gate
+    keeps). The remedy is to investigate the wiki: advance HEAD past the pin, or
+    re-install at the intended commit. A degraded ``--force-head`` escape hatch
+    is deferred, mirroring the ``install --all`` orphan handling.
     """
 
 
@@ -258,6 +278,13 @@ class ProjectClassification:
       would be shadowed, or the entry's ``installed_at`` is unusable
       over an existing dest (#1247). Without ``--force`` the entire
       batch refuses.
+    - ``"stale-pin"`` — wiki HEAD ≠ lockfile pin AND HEAD does not
+      descend from the pin (wiki reset / force-pull past the pin, #1685).
+      Advancing would move the pin BACKWARD, so this row is skipped
+      per-project (never force-able — the write-path counterpart of the
+      ``mm context status`` ``stale-pin`` state, see
+      :func:`_pin_backward_reason`); ``dirty_report`` stays ``None``
+      because the dirty walk is short-circuited before it runs.
     - ``"error"`` — the project's lockfile is corrupt or unreadable;
       ``reason`` carries the detail. Propagates as a row-level failure
       in the execute summary.
@@ -269,7 +296,7 @@ class ProjectClassification:
     """
 
     project_root: Path
-    state: Literal["update", "unchanged", "refuse", "error"]
+    state: Literal["update", "unchanged", "refuse", "stale-pin", "error"]
     reason: str | None
     lock_entry: dict[str, Any] | None
     dirty_report: DirtyReport | None
@@ -1112,6 +1139,51 @@ def update_command(
     )
 
 
+def _pin_backward_reason(wiki: WikiStore, pin: object, new_commit: str) -> str | None:
+    """Refusal reason when advancing ``pin`` to ``new_commit`` would move it backward (#1685).
+
+    ``mm context update`` records ``new_commit`` (the wiki HEAD read once at the
+    start of the operation) as the new pin only when the update is genuinely
+    *forward* — i.e. the recorded pin is an ancestor of ``new_commit`` (the
+    ``behind`` case :func:`classify_status` reports as "update available").
+    After a wiki ``reset`` / force-pull to older or divergent history the pin is
+    newer than (or off to the side of) ``new_commit``, so recording it is a
+    silent DOWNGRADE, not an update. This is the same forward-only guard
+    ``classify_status`` applies via :meth:`WikiStore.commit_is_ancestor`; the
+    update paths (:func:`_update_asset` single, :func:`_classify_for_all_update`
+    batch) call this so both refuse on the condition status merely reports.
+
+    The ancestry target is the caller's already-pinned ``new_commit``, NOT a
+    freshly-resolved symbolic ``HEAD``: the pin we would record and the pin we
+    check against are then the SAME commit, so a wiki mutation racing between
+    ``current_commit()`` and this check can't let a backward move slip through
+    (the recorded pin is provably forward of the old pin or we refuse).
+
+    Returns ``None`` when the pin is an ancestor of ``new_commit`` (update may
+    proceed), otherwise a human-readable reason naming the case: a missing pin,
+    a pin no longer reachable (history rewrite / force-push), or a reachable-
+    but-divergent pin (wiki reset / force-pull). Callers must have already
+    short-circuited the no-op (pin == new_commit) case — a commit is its own
+    ancestor, so this never fires on an up-to-date pin. The two reachable-vs-
+    divergent branches mirror ``classify_status``'s two ``stale-pin`` reasons.
+    """
+    if not isinstance(pin, str) or not pin:
+        return "lockfile entry has no wiki_commit pin to prove the update is forward"
+    if wiki.commit_is_ancestor(pin, of=new_commit):
+        return None
+    if not wiki.commit_is_reachable(pin):
+        return (
+            f"pinned commit {pin[:12]} is not reachable in the wiki — history was "
+            f"rewritten or force-pushed past the pin, so update would move the pin "
+            f"backward"
+        )
+    return (
+        f"wiki HEAD does not descend from pinned commit {pin[:12]} — the wiki was "
+        f"reset or force-pulled to older/divergent history, so update would move "
+        f"the pin backward"
+    )
+
+
 def _update_asset(
     project_root: Path | str,
     asset_type: str,
@@ -1180,15 +1252,6 @@ def _update_asset(
     new_commit = wiki.current_commit()
     dest = project_root / ".memtomem" / asset_type / validated
 
-    # RESIDUAL (follow-up): update moves the pin to HEAD whenever it differs
-    # from the recorded pin, WITHOUT checking that HEAD descends from it. After
-    # a wiki reset / force-pull to older-or-divergent history HEAD is behind (or
-    # off to the side of) the pin, so this would move the pin BACKWARD — a
-    # silent downgrade, the same forward-only gap `classify_status` now guards
-    # against via `WikiStore.commit_is_ancestor`. Fixing it here (and in
-    # `_classify_for_all_update`'s preview parity) needs a new refuse verdict
-    # threaded through both the single-asset and `--all` state machines, so it
-    # is deliberately left out of the status-classification change.
     if lock_entry.get("wiki_commit") == new_commit:
         # True no-op: lockfile bytes untouched, installed_at echoed.
         return UpdateResult(
@@ -1219,6 +1282,19 @@ def _update_asset(
                 f"would not contain it; {commit_hint}"
             ) from None
         raise AssetNotFoundError(f"{asset_type}/{validated} not in wiki at {wiki.root}") from None
+
+    # Forward-only gate (#1685): update records wiki HEAD as the new pin only
+    # when the recorded pin is an ancestor of HEAD. After a wiki reset /
+    # force-pull to older-or-divergent history HEAD does not descend from the
+    # pin, so advancing to HEAD would move the pin BACKWARD — a silent
+    # downgrade. Runs BEFORE the dirty gate (the pin is stale regardless of
+    # worktree state) and AFTER HEAD-presence (so it mirrors
+    # `_classify_for_all_update`, whose HEAD-presence gate fires batch-global up
+    # front). NOT force-able — same wiki-side/project-side asymmetry the dirty
+    # gate keeps; the remedy is to fix the wiki, not to clobber the pin.
+    backward = _pin_backward_reason(wiki, lock_entry.get("wiki_commit"), new_commit)
+    if backward is not None:
+        raise PinNotAncestorError(f"{asset_type}/{validated}: {backward}")
 
     # Same-asset dirty gate (#1652): worktree state must equal HEAD for THIS
     # asset — otherwise the user-visible wiki bytes and the refreshed bytes
@@ -1608,6 +1684,25 @@ def _classify_for_all_update(
             )
             continue
 
+        # Forward-only gate (#1685): HEAD ≠ pin, but if HEAD does not descend
+        # from this project's pin, advancing would move the pin backward — a
+        # silent downgrade. Mirrors the single-asset _update_asset guard so the
+        # --all preview agrees with what the wet run would refuse. Checked
+        # BEFORE the dirty walk (the pin is stale regardless of dest state);
+        # a non-force-able per-project skip, not a batch-blocking refuse.
+        backward = _pin_backward_reason(wiki, lock_entry.get("wiki_commit"), new_commit)
+        if backward is not None:
+            out.append(
+                ProjectClassification(
+                    project_root=project_root,
+                    state="stale-pin",
+                    reason=backward,
+                    lock_entry=lock_entry,
+                    dirty_report=None,
+                )
+            )
+            continue
+
         # Wiki advanced — classify dirty/clean for this project.
         report = is_asset_dirty(project_root, asset_type, name, lock_entry=lock_entry)
         dest = project_root / ".memtomem" / asset_type / name
@@ -1617,7 +1712,7 @@ def _classify_for_all_update(
             else (None, False)
         )
         if report.reason == "dirty":
-            state: Literal["update", "unchanged", "refuse", "error"] = "refuse"
+            state: Literal["update", "unchanged", "refuse", "stale-pin", "error"] = "refuse"
             reason: str | None = f"{report.summary()} since install"
         elif flat_path is not None and flat_dirty:
             # Preview parity with _apply_update's flat-layout guard

--- a/packages/memtomem/src/memtomem/web/routes/context_mutations.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mutations.py
@@ -32,6 +32,7 @@ from memtomem.context.install import (
     AssetNotFoundError,
     InstallResult,
     NotInstalledError,
+    PinNotAncestorError,
     ProjectRootMissingError,
     StaleInstallError,
     UncommittedAssetError,
@@ -290,6 +291,20 @@ async def update_asset(
             f"commit-true and records HEAD's bytes only); commit them — e.g. "
             f"`mm wiki <type> commit <name> --canonical` — and retry",
             reason_code="wiki_uncommitted",
+        ) from exc
+    except PinNotAncestorError as exc:
+        # Forward-only gate (#1685): wiki HEAD does not descend from this
+        # project's pin (wiki reset / force-pull), so update would move the pin
+        # backward. Fixed message (the engine text names the pinned SHA only,
+        # not a host path, but keep the envelope contract uniform); NOT
+        # force-able — the remedy is to fix the wiki, not to re-run with force.
+        raise _error(
+            409,
+            "conflict",
+            f"{asset_type}/{name}: the wiki history diverged from this project's "
+            f"pin (reset or force-pull past it); update would move the pin "
+            f"backward. Investigate the wiki before retrying",
+            reason_code="pin_not_ancestor",
         ) from exc
     except PrivacyScanError as exc:
         raise _privacy_blocked() from exc

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -29,9 +29,11 @@ from memtomem.context.install import (
     AlreadyInstalledError,
     AssetNotFoundError,
     NotInstalledError,
+    PinNotAncestorError,
     StaleInstallError,
     UncommittedAssetError,
     _classify_for_all_update,
+    _pin_backward_reason,
     install_skill,
     update_agent,
     update_command,
@@ -84,6 +86,20 @@ def _modify_wiki_skill(wiki_root_path: Path, name: str, files: dict[str, bytes])
     return WikiStore.at_default().current_commit()
 
 
+def _reset_wiki_hard(wiki_root_path: Path, commit: str) -> None:
+    """``git reset --hard <commit>`` in the wiki — simulate a reset / force-pull.
+
+    HEAD moves to *commit*; any commit made after it becomes unreferenced but
+    stays in the object DB (still reachable to ``cat-file``, no longer an
+    ancestor of HEAD) — exactly the ``stale-pin`` shape (#1685).
+    """
+    subprocess.run(
+        ["git", "-C", str(wiki_root_path), "reset", "--hard", commit],
+        check=True,
+        capture_output=True,
+    )
+
+
 def _bump_mtime(path: Path, *, seconds_in_future: float = 1.0) -> None:
     """Force *path*'s mtime to ``now + seconds_in_future``.
 
@@ -118,6 +134,93 @@ def test_clean_drift_updates(wiki_root: Path, tmp_path: Path) -> None:
     lock_doc = json.loads((project / ".memtomem" / "lock.json").read_text())
     assert lock_doc["skills"]["foo"]["wiki_commit"] == new_commit
     assert lock_doc["skills"]["foo"]["installed_at"] == result.installed_at
+
+
+# ── forward-only gate (#1685) ────────────────────────────────────────────
+
+
+def test_update_refuses_when_wiki_reset_behind_pin(wiki_root: Path, tmp_path: Path) -> None:
+    """Wiki reset to older history → pin not an ancestor of HEAD → refuse.
+
+    After ``git reset --hard`` past the recorded pin, HEAD no longer descends
+    from it, so advancing to HEAD would move the pin BACKWARD. Update must
+    refuse with :class:`PinNotAncestorError` (#1685) instead of silently
+    downgrading — the write-path counterpart of the ``stale-pin`` status state.
+    """
+    _initialized_wiki(wiki_root)
+    commit1 = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+    install_skill(project, "foo")
+
+    # Advance HEAD and move the project's pin forward to commit2.
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    update_skill(project, "foo")
+    lock_doc = json.loads((project / ".memtomem" / "lock.json").read_text())
+    pinned = lock_doc["skills"]["foo"]["wiki_commit"]
+
+    # Reset the wiki HARD back to commit1 — HEAD is now behind the pin.
+    _reset_wiki_hard(wiki_root, commit1)
+
+    with pytest.raises(PinNotAncestorError) as exc:
+        update_skill(project, "foo")
+    assert "backward" in str(exc.value)
+
+    # The lockfile pin is untouched — no silent downgrade.
+    lock_doc = json.loads((project / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == pinned
+
+
+def test_update_force_does_not_bypass_stale_pin(wiki_root: Path, tmp_path: Path) -> None:
+    """``--force`` overrides project-side edits, never wiki-side history (#1685)."""
+    _initialized_wiki(wiki_root)
+    commit1 = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+    install_skill(project, "foo")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    update_skill(project, "foo")
+    _reset_wiki_hard(wiki_root, commit1)
+
+    with pytest.raises(PinNotAncestorError):
+        update_skill(project, "foo", force=True)
+
+
+def test_update_refuses_when_pin_unreachable(wiki_root: Path, tmp_path: Path) -> None:
+    """A pin no longer reachable (history rewrite) also refuses forward (#1685)."""
+    from memtomem.context.lockfile import Lockfile
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+    install_skill(project, "foo")
+    # Repin to an unreachable SHA, then advance HEAD so pin != HEAD.
+    Lockfile.at(project).upsert_entry(
+        "skills", "foo", wiki_commit="0" * 40, installed_at="2030-01-01T00:00:00.000000Z"
+    )
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    with pytest.raises(PinNotAncestorError) as exc:
+        update_skill(project, "foo")
+    assert "not reachable" in str(exc.value)
+
+
+def test_pin_backward_reason_allows_forward_and_noop(wiki_root: Path, tmp_path: Path) -> None:
+    """``_pin_backward_reason`` returns None for an ancestor pin, a reason otherwise.
+
+    The ancestry target is the caller's ``new_commit`` (the exact commit that
+    would be recorded), not a re-resolved symbolic HEAD (#1685).
+    """
+    _initialized_wiki(wiki_root)
+    commit1 = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    wiki = WikiStore.at_default()
+    commit2 = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    assert _pin_backward_reason(wiki, commit1, commit2) is None  # ancestor → forward OK
+    assert _pin_backward_reason(wiki, commit2, commit2) is None  # == target (own ancestor)
+    # commit2 is NOT an ancestor of the older commit1 → a backward move.
+    assert _pin_backward_reason(wiki, commit2, commit1) is not None
+    assert _pin_backward_reason(wiki, "0" * 40, commit2) is not None  # unreachable
+    assert _pin_backward_reason(wiki, "", commit2) is not None  # missing pin
+    assert _pin_backward_reason(wiki, None, commit2) is not None  # non-str pin
 
 
 def test_dirty_refuse_without_force(wiki_root: Path, tmp_path: Path) -> None:
@@ -402,6 +505,49 @@ def test_cli_update_stale_refuse_message(
     assert "--force" in result.output
 
 
+def test_cli_update_stale_pin_refuse_message(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    """CLI single update surfaces the forward-only refusal + non-zero exit (#1685)."""
+    _initialized_wiki(wiki_root)
+    commit1 = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project_cwd, "foo")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    update_skill(project_cwd, "foo")  # move pin forward to commit2
+    _reset_wiki_hard(wiki_root, commit1)  # HEAD now behind the pin
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo"])
+
+    assert result.exit_code != 0
+    assert "backward" in result.output
+    # --force must NOT bypass it (wiki-side, not project-side).
+    forced = runner.invoke(context_group, ["update", "skill", "foo", "--force"])
+    assert forced.exit_code != 0
+    assert "backward" in forced.output
+
+
+def test_cli_update_dry_run_stale_pin_exits_nonzero(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    """``--dry-run`` of a stale-pin update exits non-zero like the wet run (#1685)."""
+    _initialized_wiki(wiki_root)
+    commit1 = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project_cwd, "foo")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    update_skill(project_cwd, "foo")
+    _reset_wiki_hard(wiki_root, commit1)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--dry-run"])
+
+    assert result.exit_code != 0
+    assert "stale-pin" in result.output  # the preview row
+    assert "backward" in result.output
+
+
 # ── coverage: silence unused-import warnings on agent/command wrappers ──
 
 
@@ -534,59 +680,68 @@ def test_classify_for_all_update_calls_current_commit_once(
     assert len(classifications) == 2
 
 
-def test_classify_for_all_update_4_state_coverage(wiki_root: Path, tmp_path: Path) -> None:
-    """One project per state — verifies all 4 states are reachable.
+def test_classify_for_all_update_5_state_coverage(wiki_root: Path, tmp_path: Path) -> None:
+    """One project per state — verifies all 5 states are reachable.
 
-    Setup strategy: wiki has a single commit. All 4 projects install
-    against that commit. Then 3 of them have their lockfile entries
-    back-dated (or corrupted) to simulate drift / dirty / error states.
-    The 4th stays at the live HEAD and classifies as ``unchanged``.
+    Setup strategy: the wiki has two commits (``commit1`` then ``commit2``
+    = HEAD). The ``update`` / ``refuse`` projects pin ``commit1`` — a REAL
+    ancestor of HEAD, so they classify as forward drift (an all-zeros pin
+    would now be ``stale-pin``, #1685, which is exactly the fifth project's
+    setup). Their ``installed_at`` is overridden to control the dirty walk.
     """
     from memtomem.context.lockfile import Lockfile
 
     _initialized_wiki(wiki_root)
-    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    commit1 = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
 
     wiki = WikiStore.at_default()
-    head_commit = wiki.current_commit()
 
-    # State 1: "unchanged" — fresh install, lockfile pin == HEAD.
+    # State "update": install at commit1 (a real ancestor once HEAD advances),
+    # clean dest via a far-future installed_at.
+    proj_update = tmp_path / "update_clean"
+    proj_update.mkdir()
+    install_skill(proj_update, "foo")
+
+    # State "refuse": install at commit1, dirty dest via a far-past installed_at.
+    proj_refuse = tmp_path / "refuse"
+    proj_refuse.mkdir()
+    install_skill(proj_refuse, "foo")
+
+    # State "stale-pin": install at commit1, then repin to an unreachable SHA so
+    # HEAD does not descend from it (wiki reset / force-push past the pin).
+    proj_stale = tmp_path / "stale"
+    proj_stale.mkdir()
+    install_skill(proj_stale, "foo")
+
+    # Advance wiki HEAD → commit1 is now a strict ancestor of commit2.
+    head_commit = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    assert head_commit != commit1
+
+    # State "unchanged": install AFTER the advance so its pin == HEAD.
     proj_unchanged = tmp_path / "unchanged"
     proj_unchanged.mkdir()
     install_skill(proj_unchanged, "foo")
 
-    # State 2: "update" — install, then back-date lockfile pin so HEAD
-    # looks like a newer commit. Dest mtimes are ahead of installed_at
-    # (just installed → fresh), so we also back-date installed_at to
-    # ensure files are NOT classified dirty. Use a fixed past timestamp.
-    # Wait — we WANT the dest tree to be clean (= reason="clean"), but
-    # back-dating installed_at to far past makes ALL current files look
-    # dirty. We need the OPPOSITE: future installed_at OR explicit clean
-    # mtimes. Easiest: back-date both lockfile fields, then bump every
-    # dest file's mtime to BEFORE installed_at_epoch via os.utime.
-    proj_update = tmp_path / "update_clean"
-    proj_update.mkdir()
-    install_skill(proj_update, "foo")
     Lockfile.at(proj_update).upsert_entry(
         "skills",
         "foo",
-        wiki_commit="0" * 40,  # ≠ HEAD → drift
-        installed_at="2030-01-01T00:00:00.000000Z",  # future → all current files are clean
+        wiki_commit=commit1,  # real ancestor of HEAD → forward drift
+        installed_at="2030-01-01T00:00:00.000000Z",  # future → all current files clean
     )
-
-    # State 3: "refuse" — drift + dirty.
-    proj_refuse = tmp_path / "refuse"
-    proj_refuse.mkdir()
-    install_skill(proj_refuse, "foo")
     Lockfile.at(proj_refuse).upsert_entry(
         "skills",
         "foo",
-        wiki_commit="0" * 40,
-        # Past installed_at so every current file is dirty.
-        installed_at="2020-01-01T00:00:00.000000Z",
+        wiki_commit=commit1,
+        installed_at="2020-01-01T00:00:00.000000Z",  # past → every current file dirty
+    )
+    Lockfile.at(proj_stale).upsert_entry(
+        "skills",
+        "foo",
+        wiki_commit="0" * 40,  # unreachable → HEAD cannot descend from it
+        installed_at="2030-01-01T00:00:00.000000Z",  # clean, but the walk is short-circuited
     )
 
-    # State 4: "error" — unknown lockfile version.
+    # State "error" — unknown lockfile version.
     proj_error = tmp_path / "error"
     proj_error.mkdir()
     (proj_error / ".memtomem").mkdir()
@@ -599,7 +754,7 @@ def test_classify_for_all_update_4_state_coverage(wiki_root: Path, tmp_path: Pat
         "skills",
         "foo",
         wiki=wiki,
-        projects=[proj_unchanged, proj_update, proj_refuse, proj_error],
+        projects=[proj_unchanged, proj_update, proj_refuse, proj_stale, proj_error],
     )
 
     assert new_commit == head_commit
@@ -608,12 +763,16 @@ def test_classify_for_all_update_4_state_coverage(wiki_root: Path, tmp_path: Pat
         "unchanged": "unchanged",
         "update_clean": "update",
         "refuse": "refuse",
+        "stale": "stale-pin",
         "error": "error",
     }
-    # Cache pin: unchanged + error have no dirty_report; update + refuse do.
+    # Cache pin: unchanged + stale-pin + error have no dirty_report (the walk
+    # runs only for update + refuse).
     by_name = {c.project_root.name: c for c in classifications}
     assert by_name["unchanged"].dirty_report is None
     assert by_name["error"].dirty_report is None
+    assert by_name["stale"].dirty_report is None
+    assert by_name["stale"].reason and "backward" in by_name["stale"].reason
     assert by_name["update_clean"].dirty_report is not None
     assert by_name["update_clean"].dirty_report.reason == "clean"
     assert by_name["refuse"].dirty_report is not None
@@ -827,6 +986,89 @@ def test_cli_update_all_refuse_without_force_blocks_batch(
     # (not the new wiki HEAD) — the entire batch refused before any write.
     assert (proj_clean / ".memtomem" / "skills" / "foo" / "SKILL.md").read_bytes() == b"v1\n"
     assert lock_doc["skills"]["foo"]["wiki_commit"] != WikiStore.at_default().current_commit()
+
+
+def test_cli_update_all_stale_pin_skipped_forward_sibling_updates(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale-pin project is skipped per-row (non-zero exit) while a forward
+    sibling still updates — the downgrade guard must not block clean rows (#1685)."""
+    from memtomem.context.lockfile import Lockfile
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+
+    proj_forward = tmp_path / "forward"
+    proj_forward.mkdir()
+    install_skill(proj_forward, "foo")  # pinned commit1 (real ancestor after advance)
+
+    proj_stale = tmp_path / "stale"
+    proj_stale.mkdir()
+    install_skill(proj_stale, "foo")
+    # Repin to an unreachable SHA — HEAD cannot descend from it.
+    Lockfile.at(proj_stale).upsert_entry(
+        "skills", "foo", wiki_commit="0" * 40, installed_at="2030-01-01T00:00:00.000000Z"
+    )
+
+    new_commit = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj_forward, proj_stale])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--yes"])
+
+    # Non-zero: the batch could not fulfill the stale-pin row.
+    assert result.exit_code != 0, result.output
+    assert "stale-pin" in result.output  # preview table row
+    assert "backward" in result.output
+
+    # Forward sibling DID update to the new commit.
+    fwd_lock = json.loads((proj_forward / ".memtomem" / "lock.json").read_text())
+    assert fwd_lock["skills"]["foo"]["wiki_commit"] == new_commit
+    assert (proj_forward / ".memtomem" / "skills" / "foo" / "SKILL.md").read_bytes() == b"v2\n"
+
+    # Stale project's pin is untouched — no downgrade.
+    stale_lock = json.loads((proj_stale / ".memtomem" / "lock.json").read_text())
+    assert stale_lock["skills"]["foo"]["wiki_commit"] == "0" * 40
+
+
+def test_cli_update_all_dry_run_reports_stale_pin(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--all --dry-run`` counts a stale-pin row and writes nothing (exit 0, #1685)."""
+    from memtomem.context.lockfile import Lockfile
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    proj_stale = tmp_path / "stale"
+    proj_stale.mkdir()
+    install_skill(proj_stale, "foo")
+    Lockfile.at(proj_stale).upsert_entry(
+        "skills", "foo", wiki_commit="0" * 40, installed_at="2030-01-01T00:00:00.000000Z"
+    )
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj_stale])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--dry-run"])
+
+    # Dry run is a preview verb: exit 0, table shows the row, nothing written.
+    assert result.exit_code == 0, result.output
+    assert "stale-pin" in result.output
+    assert "stale pin" in result.output  # summary line
+    stale_lock = json.loads((proj_stale / ".memtomem" / "lock.json").read_text())
+    assert stale_lock["skills"]["foo"]["wiki_commit"] == "0" * 40
 
 
 # ── CLI --all: --yes invariants (no WARN unless --force) ────────────────

--- a/packages/memtomem/tests/test_web_routes_context_mutations.py
+++ b/packages/memtomem/tests/test_web_routes_context_mutations.py
@@ -364,6 +364,31 @@ async def test_update_uncommitted_wiki_is_409(
 
 
 @pytest.mark.asyncio
+async def test_update_stale_pin_is_409(client, seeded_wiki: Path, project_root: Path) -> None:
+    """Forward-only gate (#1685): a wiki reset behind the pin returns 409
+    ``pin_not_ancestor`` (fixed message, no host path) — the pin is untouched."""
+    assert (await client.post("/api/context/skills/alpha/install")).status_code == 200
+    base = WikiStore.at_default().current_commit()
+    # Advance + update so the project's pin moves forward, then reset behind it.
+    _advance_wiki(seeded_wiki)
+    assert (await client.post("/api/context/skills/alpha/update")).status_code == 200
+    new_pin = _lock_entry(project_root, "skills", "alpha")["wiki_commit"]
+    subprocess.run(
+        ["git", "-C", str(seeded_wiki), "reset", "--hard", base], check=True, capture_output=True
+    )
+
+    resp = await client.post("/api/context/skills/alpha/update")
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["reason_code"] == "pin_not_ancestor"
+    assert str(seeded_wiki) not in resp.text  # no host-path leak
+    # --force must NOT bypass it, and the pin stays put (no downgrade).
+    forced = await client.post("/api/context/skills/alpha/update", json={"force": True})
+    assert forced.status_code == 409
+    assert forced.json()["detail"]["reason_code"] == "pin_not_ancestor"
+    assert _lock_entry(project_root, "skills", "alpha")["wiki_commit"] == new_pin
+
+
+@pytest.mark.asyncio
 async def test_update_never_installed_is_404(client, seeded_wiki) -> None:
     resp = await client.post("/api/context/skills/alpha/update")
     assert resp.status_code == 404


### PR DESCRIPTION
## What

Makes `mm context update <type> <name>` **forward-only**: it advances the
lockfile pin to wiki HEAD only when the recorded pin is an ancestor of HEAD.
After a wiki `reset` / force-pull to older-or-divergent history, HEAD no longer
descends from the pin, so update previously moved the pin **backward** — a
silent downgrade. Closes #1685 (the `RESIDUAL (follow-up)` comment in
`_update_asset`).

`mm context status` already reports this drift as `stale-pin` via
`WikiStore.commit_is_ancestor`; this PR is the write-path counterpart of that
same guard.

## How

- **New `PinNotAncestorError` + `_pin_backward_reason(wiki, pin, new_commit)`**
  in `context/install.py`. The ancestry target is the exact `new_commit` we
  would record (not a re-resolved symbolic `HEAD`), so a wiki mutation racing
  between `current_commit()` and the check can't let a backward move slip
  through. Missing / unreachable (history rewrite) / reachable-but-divergent
  (reset) pins all refuse, mirroring `classify_status`'s two `stale-pin`
  reasons.
- **Single-asset** `_update_asset` raises before the dirty gate — order is
  `no-op → HEAD-presence → ancestry → dirty`, matching the `--all` classifier.
- **`--all`** `_classify_for_all_update` emits a new per-project `"stale-pin"`
  `ProjectClassification` state (the pin is per-project, so this is row-level,
  not a batch-global gate). `--all --dry-run` previews it; the wet run skips a
  stale-pin row per-project (counted as a failure → non-zero exit) while
  forward siblings still update.
- **Single `--dry-run`** exits non-zero before the wiki-dirty gate, matching the
  wet path.
- **Web parity**: the update route maps the error to a fixed `409
  pin_not_ancestor` envelope (no host-path leak).

### Not force-able (by design)

`--force` overrides project-side dest edits, never wiki-side history — the same
asymmetry the wiki-dirty gate keeps. The remedy is to fix the wiki (advance HEAD
past the pin, or re-install at the intended commit). A degraded `--force-head`
escape hatch is left as a follow-up, mirroring the `install --all` orphan
handling.

### Behavior change

Update now refuses on a **missing or unreachable** pin instead of silently
"healing" it by pinning an arbitrary HEAD. This matches what `mm context status`
already reports for those entries. No existing test relied on the old healing
behavior (full suite green).

## Tests

- Engine: reset-behind-pin refusal, unreachable-pin refusal, `--force`
  no-bypass, and a `_pin_backward_reason` unit (forward/no-op vs backward).
- CLI: single wet + single `--dry-run` refusal, `--all` mixed forward/stale-pin
  (forward sibling updates, stale pin untouched, non-zero exit), `--all
  --dry-run` reporting.
- Web: `409 pin_not_ancestor` (no host-path leak, `--force` no-bypass, pin
  untouched).
- The prior 4-state classifier coverage test used synthetic all-zeros pins to
  simulate drift; those are now correctly `stale-pin` (unreachable), so it is
  rebuilt as **5-state coverage** using a real ancestor commit for the forward
  `update`/`refuse` rows.
- Docs: the public `context-gateway.md` guide documents the forward-only refusal
  and the `stale-pin` preview state.

`test_context_update.py` + `test_web_routes_context_mutations.py`: **113
passed**. Broad context/install/status suite: **3176 passed**. ruff + mypy clean
on the edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
