### PR TITLE
docs+init: fix inaccurate mm CLI examples (ingest --source, memory_dirs not mutable)

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -437,7 +437,7 @@ scope model.
 |------|-----------------------|--------------------------|
 | Claude Code | Auto memory is per repository at `~/.claude/projects/<project>/memory/`, with a `MEMORY.md` index plus topic files. Claude also has explicit `CLAUDE.md` / `.claude/rules/` instruction scopes. | `claude:<project>` via the `<project>` folder above `memory/`. `MEMORY.md` is treated as a provider index file, so the topic files carry most searchable detail. |
 | Codex | Generated memories live under `~/.codex/memories/` and include summaries, durable entries, recent inputs, and supporting evidence from prior threads ([official docs](https://developers.openai.com/codex/memories)). | `codex:rollout_summaries` for per-session recap files, `codex:extensions` for ad-hoc/manual note extensions, and `codex:global` for the remaining consolidated top-level memory files. The split follows the on-disk `rollout_summaries/` and `extensions/` subdirectories — an observed layout that Codex's docs don't formally specify, so re-check it if a Codex release reshapes the directory. |
-| Antigravity CLI | Successor to Gemini CLI ([transition notice](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/)). Its global instructional memory is the single file `~/.gemini/GEMINI.md` — the same hardcoded path the legacy Gemini CLI used ([docs](https://antigravity.google/docs/agent-features)). | Not added as a watched `memory_dirs` provider because the canonical memory surface is a file, not a directory. Use `mm ingest gemini-memory` for a one-shot import with `gemini-memory:<slug>` namespaces — the command keeps the `gemini-memory` name because Antigravity's global memory file is still `~/.gemini/GEMINI.md`. |
+| Antigravity CLI | Successor to Gemini CLI ([transition notice](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/)). Its global instructional memory is the single file `~/.gemini/GEMINI.md` — the same hardcoded path the legacy Gemini CLI used ([docs](https://antigravity.google/docs/agent-features)). | Not added as a watched `memory_dirs` provider because the canonical memory surface is a file, not a directory. Use `mm ingest gemini-memory --source ~/.gemini/GEMINI.md` for a one-shot import with `gemini-memory:<slug>` namespaces — the command keeps the `gemini-memory` name because Antigravity's global memory file is still `~/.gemini/GEMINI.md`. |
 
 Accepted categories get appended directly to `indexing.memory_dirs` in
 `~/.memtomem/config.json`. Per-project Claude memory subdirs without any
@@ -464,8 +464,8 @@ Gemini CLI's memory surface is the single file `~/.gemini/GEMINI.md`,
 which doesn't fit a `memory_dirs` (directory) abstraction, and the parent
 `~/.gemini/` directory contains secrets like `oauth_creds.json`. For
 Gemini users — and Antigravity CLI (`agy`) users, which read the same
-`~/.gemini/GEMINI.md` — run `mm ingest gemini-memory` for a one-shot import;
-it applies tool-specific tags and skips the noise.
+`~/.gemini/GEMINI.md` — run `mm ingest gemini-memory --source ~/.gemini/GEMINI.md`
+for a one-shot import; it applies tool-specific tags and skips the noise.
 
 #### Migrating from `auto_discover` (legacy)
 
@@ -496,10 +496,11 @@ It prints a dry-run summary by default; re-run with `--apply` to delete. For
 any leftover source the exclude rules don't cover, remove it directly with
 `mem_delete(source_file=...)`.
 
-> **Tip:** `mm ingest claude-memory`, `mm ingest gemini-memory`, and
-> `mm ingest codex-memory` apply per-tool tagging and namespace assignment
-> on top of indexing — useful when you want richer metadata than the plain
-> `memory_dirs` path-based indexing provides.
+> **Tip:** the `mm ingest claude-memory`, `mm ingest gemini-memory`, and
+> `mm ingest codex-memory` commands (each takes a required `--source PATH`)
+> apply per-tool tagging and namespace assignment on top of indexing — useful
+> when you want richer metadata than the plain `memory_dirs` path-based
+> indexing provides.
 
 > **Cloud-sync mounts** (Google Drive Stream, OneDrive Files-On-Demand ON,
 > iCloud Optimize Storage) generally do **not** emit fs watcher events to

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -443,9 +443,11 @@ Accepted categories get appended directly to `indexing.memory_dirs` in
 `~/.memtomem/config.json`. Per-project Claude memory subdirs without any
 `*.md` files are skipped so empty session scaffolding doesn't pollute your
 index. New Claude Code projects created after the wizard runs are **not**
-auto-indexed — re-run `mm init` or use
-`mm config set indexing.memory_dirs` to add them when you want them
-searchable.
+auto-indexed — re-run `mm init`, set `MEMTOMEM_INDEXING__MEMORY_DIRS`,
+or add the path from the Web UI when you want them searchable.
+(`indexing.memory_dirs` is not a `mm config set` target — only
+`mm config unset indexing.memory_dirs` is supported, for clearing a
+carried-over path during migration.)
 
 Non-interactive mode supports `--include-provider` (repeatable):
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -443,9 +443,9 @@ mm session wrap -- CMD     # wrap a command with session lifecycle
 mm watchdog status         # show latest health check results
 mm watchdog run            # run health checks immediately
 mm watchdog history        # view historical health check results
-mm ingest claude-memory    # index Claude Code auto-memory
-mm ingest gemini-memory    # index Gemini CLI / Antigravity CLI memory (GEMINI.md)
-mm ingest codex-memory     # index Codex CLI memory
+mm ingest claude-memory --source PATH  # index Claude Code auto-memory
+mm ingest gemini-memory --source PATH  # index Gemini CLI / Antigravity CLI memory (GEMINI.md)
+mm ingest codex-memory --source PATH   # index Codex CLI memory
 mm shell                   # interactive REPL
 mm web                     # launch Web UI (http://127.0.0.1:8080)
 ```

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -950,7 +950,9 @@ def _step_provider_dirs(state: dict) -> None:
     if selected:
         click.secho(f"  Added {len(selected)} provider folder(s) to memory_dirs.", fg="green")
         click.echo("  New Claude Code projects created later won't be auto-indexed —")
-        click.echo("  re-run `mm init` or use `mm config set indexing.memory_dirs` to add them.")
+        click.echo(
+            "  re-run `mm init`, set MEMTOMEM_INDEXING__MEMORY_DIRS, or add them in the Web UI."
+        )
     click.echo()
 
 


### PR DESCRIPTION
## What

CLI examples in the public guides — and one string emitted by the `mm init` wizard — fail or mislead when run verbatim. Found while smoke-testing the documented flows against the live CLI, then expanded after a Codex review.

### `mm ingest` missing required `--source`

`--source` is `required=True` on `claude-memory` / `gemini-memory` / `codex-memory`, so bare `mm ingest <x>-memory` errors with `Missing option '--source'`.

- `getting-started.md` cheat sheet: added `--source PATH` to the three lines.
- `configuration.md`: three prose mentions (`mm ingest gemini-memory` in the Antigravity row and the "Why Gemini is not in the list" note, plus the claude/gemini/codex Tip) now carry `--source` or note it. `reference/data-config-cli.md` already used the correct form.

### `mm config set indexing.memory_dirs` is not a valid command

`indexing.memory_dirs` is absent from `MUTABLE_FIELDS` (only `_EXTRA_MUTATION_FIELDS` for `unset`), so `mm config set indexing.memory_dirs` returns `not a mutable field`.

- `configuration.md`: corrected the guidance to `mm init` / `MEMTOMEM_INDEXING__MEMORY_DIRS` / Web UI.
- `init_cmd.py`: the `mm init` wizard's "next steps" printed that exact invalid command — updated to match the doc so the wizard and docs no longer disagree.

## Verification

- Reproduced both failures against the live CLI (`Missing option '--source'`; `not a mutable field`).
- `ruff check` + `ruff format --check` clean on `init_cmd.py`.
- `pytest test_docs_guards.py` — 21 passed; init wizard tests — 91 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
