### PR TITLE
test(web): pin wire-shape goldens for Context Gateway read endpoints

### DIFF
--- a/packages/memtomem/tests/data/wire/overview.json
+++ b/packages/memtomem/tests/data/wire/overview.json
@@ -1,0 +1,56 @@
+{
+  "target_scope": "str",
+  "project_root": "str",
+  "detected_runtimes": [
+    {
+      "name": "str",
+      "available": "bool",
+      "installed": "bool",
+      "memtomem_registered": "bool"
+    },
+    {
+      "name": "str",
+      "available": "bool",
+      "installed": "bool",
+      "memtomem_registered": "bool"
+    },
+    {
+      "name": "str",
+      "available": "bool",
+      "installed": "bool",
+      "memtomem_registered": "bool"
+    },
+    {
+      "name": "str",
+      "available": "bool",
+      "installed": "bool",
+      "memtomem_registered": "bool"
+    }
+  ],
+  "last_synced_at": "str",
+  "wiki_installs": {
+    "total": "int",
+    "behind": "int"
+  },
+  "skills": {
+    "total": "int"
+  },
+  "commands": {
+    "total": "int"
+  },
+  "agents": {
+    "total": "int",
+    "missing_target": "int"
+  },
+  "mcp_servers": {
+    "total": "int"
+  },
+  "settings": {
+    "total": "int",
+    "in_sync": "int",
+    "out_of_sync": "int",
+    "missing_target": "int",
+    "error": "int",
+    "status": "str"
+  }
+}

--- a/packages/memtomem/tests/data/wire/projects_bare.json
+++ b/packages/memtomem/tests/data/wire/projects_bare.json
@@ -1,0 +1,39 @@
+{
+  "target_scope": "str",
+  "scopes": [
+    {
+      "project_scope_id": "str",
+      "scope_id": "str",
+      "label": "str",
+      "root": "str",
+      "tier": "str",
+      "sources": [
+        "str"
+      ],
+      "missing": "bool",
+      "stale": "bool",
+      "experimental": "bool",
+      "enabled": "bool",
+      "sync_eligible": "bool",
+      "counts": "null",
+      "runtime_coverage": "null"
+    },
+    {
+      "project_scope_id": "str",
+      "scope_id": "str",
+      "label": "str",
+      "root": "str",
+      "tier": "str",
+      "sources": [
+        "str"
+      ],
+      "missing": "bool",
+      "stale": "bool",
+      "experimental": "bool",
+      "enabled": "bool",
+      "sync_eligible": "bool",
+      "counts": "null",
+      "runtime_coverage": "null"
+    }
+  ]
+}

--- a/packages/memtomem/tests/data/wire/projects_include.json
+++ b/packages/memtomem/tests/data/wire/projects_include.json
@@ -1,0 +1,99 @@
+{
+  "target_scope": "str",
+  "scopes": [
+    {
+      "project_scope_id": "str",
+      "scope_id": "str",
+      "label": "str",
+      "root": "str",
+      "tier": "str",
+      "sources": [
+        "str"
+      ],
+      "missing": "bool",
+      "stale": "bool",
+      "experimental": "bool",
+      "enabled": "bool",
+      "sync_eligible": "bool",
+      "counts": {
+        "skills": "int",
+        "commands": "int",
+        "agents": "int",
+        "mcp-servers": "int"
+      },
+      "runtime_coverage": [
+        {
+          "name": "str",
+          "available": "bool",
+          "installed": "bool",
+          "memtomem_registered": "bool"
+        },
+        {
+          "name": "str",
+          "available": "bool",
+          "installed": "bool",
+          "memtomem_registered": "bool"
+        },
+        {
+          "name": "str",
+          "available": "bool",
+          "installed": "bool",
+          "memtomem_registered": "bool"
+        },
+        {
+          "name": "str",
+          "available": "bool",
+          "installed": "bool",
+          "memtomem_registered": "bool"
+        }
+      ]
+    },
+    {
+      "project_scope_id": "str",
+      "scope_id": "str",
+      "label": "str",
+      "root": "str",
+      "tier": "str",
+      "sources": [
+        "str"
+      ],
+      "missing": "bool",
+      "stale": "bool",
+      "experimental": "bool",
+      "enabled": "bool",
+      "sync_eligible": "bool",
+      "counts": {
+        "skills": "int",
+        "commands": "int",
+        "agents": "int",
+        "mcp-servers": "int"
+      },
+      "runtime_coverage": [
+        {
+          "name": "str",
+          "available": "bool",
+          "installed": "bool",
+          "memtomem_registered": "bool"
+        },
+        {
+          "name": "str",
+          "available": "bool",
+          "installed": "bool",
+          "memtomem_registered": "bool"
+        },
+        {
+          "name": "str",
+          "available": "bool",
+          "installed": "bool",
+          "memtomem_registered": "bool"
+        },
+        {
+          "name": "str",
+          "available": "bool",
+          "installed": "bool",
+          "memtomem_registered": "bool"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/memtomem/tests/data/wire/runtimes.json
+++ b/packages/memtomem/tests/data/wire/runtimes.json
@@ -1,0 +1,41 @@
+{
+  "project_root": "str",
+  "runtimes": [
+    {
+      "name": "str",
+      "installed": "bool",
+      "memtomem_registered": "bool",
+      "mms_registered": "bool",
+      "registered_locations": [],
+      "config_paths": [],
+      "error_kind": "null"
+    },
+    {
+      "name": "str",
+      "installed": "bool",
+      "memtomem_registered": "bool",
+      "mms_registered": "bool",
+      "registered_locations": [],
+      "config_paths": [],
+      "error_kind": "null"
+    },
+    {
+      "name": "str",
+      "installed": "bool",
+      "memtomem_registered": "bool",
+      "mms_registered": "bool",
+      "registered_locations": [],
+      "config_paths": [],
+      "error_kind": "null"
+    },
+    {
+      "name": "str",
+      "installed": "bool",
+      "memtomem_registered": "bool",
+      "mms_registered": "bool",
+      "registered_locations": [],
+      "config_paths": [],
+      "error_kind": "null"
+    }
+  ]
+}

--- a/packages/memtomem/tests/data/wire/status_all.json
+++ b/packages/memtomem/tests/data/wire/status_all.json
@@ -1,0 +1,105 @@
+{
+  "target_scope": "str",
+  "projects": [
+    {
+      "project_scope_id": "str",
+      "label": "str",
+      "root": "str",
+      "status": "str",
+      "wiki_head": "null",
+      "lockfile_error": "null",
+      "state_counts": {
+        "ok": "int",
+        "behind": "int",
+        "dirty": "int",
+        "missing": "int",
+        "stale-pin": "int",
+        "local-draft": "int",
+        "untracked": "int"
+      },
+      "diff_counts": {
+        "skills": {
+          "total": "int"
+        },
+        "commands": {
+          "total": "int"
+        },
+        "agents": {
+          "total": "int",
+          "missing_target": "int"
+        },
+        "mcp_servers": {
+          "total": "int"
+        },
+        "settings": {
+          "total": "int",
+          "in_sync": "int",
+          "out_of_sync": "int",
+          "missing_target": "int",
+          "error": "int",
+          "status": "str"
+        }
+      },
+      "rows": [
+        {
+          "asset_type": "str",
+          "name": "str",
+          "pin_commit": "str",
+          "installed_at": "str",
+          "state": "str",
+          "dirty_file_count": "int",
+          "reason": "str",
+          "tier": "str"
+        }
+      ]
+    },
+    {
+      "project_scope_id": "str",
+      "label": "str",
+      "root": "str",
+      "status": "str",
+      "wiki_head": "null",
+      "lockfile_error": "null",
+      "state_counts": {
+        "ok": "int",
+        "behind": "int",
+        "dirty": "int",
+        "missing": "int",
+        "stale-pin": "int",
+        "local-draft": "int",
+        "untracked": "int"
+      },
+      "diff_counts": {
+        "skills": {
+          "total": "int"
+        },
+        "commands": {
+          "total": "int"
+        },
+        "agents": {
+          "total": "int"
+        },
+        "mcp_servers": {
+          "total": "int"
+        },
+        "settings": {
+          "total": "int",
+          "in_sync": "int",
+          "out_of_sync": "int",
+          "missing_target": "int",
+          "error": "int",
+          "status": "str"
+        }
+      },
+      "rows": []
+    }
+  ],
+  "summary": {
+    "projects_total": "int",
+    "executed": "int",
+    "drifted": "int",
+    "clean": "int",
+    "errors": "int",
+    "skipped": "int"
+  }
+}

--- a/packages/memtomem/tests/test_web_wire_fixtures.py
+++ b/packages/memtomem/tests/test_web_wire_fixtures.py
@@ -1,0 +1,202 @@
+"""Golden wire-shape fixtures for the Context Gateway read endpoints (#1692).
+
+#1692 adds additive fields to these responses across several PRs while
+promising that existing field names, types, and positions stay stable through
+the next minor release. These tests pin the *serialized shape* — key sets,
+key order, and value types — of each read endpoint against a checked-in
+golden, so any wire change (additive or not) shows up as an explicit golden
+diff in review instead of riding along silently.
+
+Values are deliberately NOT pinned: every leaf is reduced to a type tag
+(``"str"``, ``"int"``, ``"bool"``, ``"null"``, ...) before comparison, so
+machine-specific roots, timestamps, and git hashes cannot make the goldens
+flaky. The comparison is on the *rendered JSON text*, which is what makes key
+order part of the pin (dict key order survives ``json.dumps``).
+
+Regenerate after an intentional wire change with::
+
+    MEMTOMEM_UPDATE_WIRE_GOLDENS=1 uv run pytest \
+        packages/memtomem/tests/test_web_wire_fixtures.py
+
+and review the golden diff like any other contract change.
+
+The two POST report endpoints (Sync All, Import) are pinned separately when
+they gain typed models — their goldens need seeded-mutation setups this
+read-only file deliberately avoids.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from memtomem.config import ContextGatewayConfig, Mem2MemConfig
+from memtomem.web.app import create_app
+
+from .helpers import set_home
+
+_GOLDEN_DIR = Path(__file__).parent / "data" / "wire"
+
+_AGENT_BODY = b"""---
+name: reviewer
+description: Code review agent
+tools: [Read, Grep]
+---
+You are a code review agent.
+"""
+
+
+# ── Fixtures (mirror test_web_routes_context_status_all.py) ───────────────
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    set_home(monkeypatch, home)
+    monkeypatch.delenv("MEMTOMEM_WIKI_PATH", raising=False)
+    # Kimi's locations honor these env vars (runtime_registry) — a developer
+    # machine that sets either would leak a real config into the runtime
+    # probes and change the golden shapes (mirrors test_runtime_registry.py's
+    # autouse isolation).
+    monkeypatch.delenv("KIMI_SHARE_DIR", raising=False)
+    monkeypatch.delenv("KIMI_CODE_HOME", raising=False)
+    return home
+
+
+@pytest.fixture
+def cwd_root(tmp_path: Path, fake_home: Path) -> Path:
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    (cwd / ".claude").mkdir()
+    (cwd / ".memtomem").mkdir()
+    # One canonical agent so counts/diffs describe a non-empty store.
+    agents = cwd / ".memtomem" / "agents"
+    agents.mkdir(parents=True)
+    (agents / "reviewer.md").write_bytes(_AGENT_BODY)
+    return cwd
+
+
+@pytest.fixture
+def known_projects_path(tmp_path: Path) -> Path:
+    return tmp_path / "kp.json"
+
+
+@pytest.fixture
+def app(cwd_root: Path, known_projects_path: Path):
+    application = create_app(lifespan=None, mode="dev")
+    application.state.project_root = cwd_root
+    application.state.storage = AsyncMock()
+    config = Mem2MemConfig()
+    config.context_gateway = ContextGatewayConfig(
+        known_projects_path=known_projects_path,
+        experimental_claude_projects_scan=False,
+    )
+    application.state.config = config
+    application.state.search_pipeline = None
+    application.state.index_engine = None
+    application.state.embedder = None
+    application.state.dedup_scanner = None
+    application.state.last_reload_error = None
+    return application
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def _register_second_project(client, tmp_path: Path) -> None:
+    """A second (registered) scope so list-shaped responses pin >1 entry."""
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / ".claude").mkdir()
+    (other / ".memtomem").mkdir()
+    resp = await client.post("/api/context/known-projects", json={"root": str(other)})
+    assert resp.status_code == 200, resp.text
+
+
+# ── Golden machinery ──────────────────────────────────────────────────────
+
+
+def _shape(value: object) -> object:
+    """Reduce a decoded JSON payload to its shape: containers keep structure
+    (and key order), every scalar leaf becomes a type tag."""
+    if isinstance(value, dict):
+        return {key: _shape(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_shape(item) for item in value]
+    if value is None:
+        return "null"
+    # bool before int: bool is an int subclass.
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, str):
+        return "str"
+    return type(value).__name__  # pragma: no cover — JSON has no other leaf
+
+
+def _assert_matches_golden(name: str, payload: dict) -> None:
+    rendered = json.dumps(_shape(payload), indent=2) + "\n"
+    path = _GOLDEN_DIR / f"{name}.json"
+    if os.environ.get("MEMTOMEM_UPDATE_WIRE_GOLDENS") == "1":
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(rendered, encoding="utf-8")
+    golden = path.read_text(encoding="utf-8")
+    assert rendered == golden, (
+        f"wire shape of {name!r} changed (key set, key order, or value types).\n"
+        f"If intentional, regenerate with MEMTOMEM_UPDATE_WIRE_GOLDENS=1 and "
+        f"review the golden diff.\n--- golden ---\n{golden}\n--- actual ---\n{rendered}"
+    )
+
+
+# ── Read-endpoint pins ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_overview_wire_shape(client) -> None:
+    resp = await client.get("/api/context/overview")
+    assert resp.status_code == 200
+    _assert_matches_golden("overview", resp.json())
+
+
+@pytest.mark.asyncio
+async def test_projects_wire_shape_bare(client, tmp_path: Path) -> None:
+    await _register_second_project(client, tmp_path)
+    resp = await client.get("/api/context/projects")
+    assert resp.status_code == 200
+    _assert_matches_golden("projects_bare", resp.json())
+
+
+@pytest.mark.asyncio
+async def test_projects_wire_shape_with_includes(client, tmp_path: Path) -> None:
+    await _register_second_project(client, tmp_path)
+    resp = await client.get("/api/context/projects?include=counts,runtime_coverage")
+    assert resp.status_code == 200
+    _assert_matches_golden("projects_include", resp.json())
+
+
+@pytest.mark.asyncio
+async def test_runtimes_wire_shape(client) -> None:
+    resp = await client.get("/api/context/runtimes")
+    assert resp.status_code == 200
+    _assert_matches_golden("runtimes", resp.json())
+
+
+@pytest.mark.asyncio
+async def test_status_all_wire_shape(client, tmp_path: Path) -> None:
+    await _register_second_project(client, tmp_path)
+    resp = await client.get("/api/context/status-all")
+    assert resp.status_code == 200
+    _assert_matches_golden("status_all", resp.json())


### PR DESCRIPTION
## What

Adds golden **wire-shape** fixtures for the Context Gateway read endpoints:

- `GET /api/context/overview`
- `GET /api/context/projects` (bare and `?include=counts,runtime_coverage`)
- `GET /api/context/runtimes`
- `GET /api/context/status-all`

Each golden pins the serialized shape — key sets, key order, and value
types — with every leaf reduced to a type tag (`"str"`, `"int"`, `"bool"`,
`"null"`, ...), so machine-specific roots, timestamps, and git hashes cannot
make the pins flaky. Comparison is on the rendered JSON text, which is what
makes key order part of the pin.

Regeneration after an intentional wire change:

```bash
MEMTOMEM_UPDATE_WIRE_GOLDENS=1 uv run pytest packages/memtomem/tests/test_web_wire_fixtures.py
```

## Why

First slice of #1692: the campaign adds additive fields to these responses
across several PRs while promising that existing field names, types, and
positions stay stable through the next minor release. Pinning today's shapes
first means every later wire change (additive or not) shows up as an explicit
golden diff in review instead of riding along silently.

Sync All / Import goldens are deferred to the typed-response-model PR — they
need seeded-mutation setups this read-only file deliberately avoids.

## Testing

- `uv run pytest packages/memtomem/tests/test_web_wire_fixtures.py -q`: 5 passed,
  including under a polluted `KIMI_SHARE_DIR` (Codex-found flake vector,
  fixed by mirroring `test_runtime_registry.py`'s env isolation).
- Full `uv run pytest -m "not ollama"`: green.
- `ruff check` + `ruff format --check`: clean.
- Codex review: NEEDS-FIX → fixed (`KIMI_SHARE_DIR` isolation), re-verified.

Part of #1692 (PR 0). Refs #1353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
