### PR TITLE
fix(web): badge Context Gateway projects whose status check failed

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-portal.js
+++ b/packages/memtomem/src/memtomem/web/static/context-portal.js
@@ -74,6 +74,12 @@ let _ctxPortalRuntimesMap = {};
 // this resolves. Reset on every fresh load so a tier flip / refresh can't leave
 // a stale badge. project_shared tier only (the endpoint 400s on other tiers).
 let _ctxPortalDriftMap = {};
+// Parallel to the drift map, keyed the same way: projects whose status-all
+// entry is ``error`` — the per-project status check itself failed (corrupt
+// lockfile or a probe that raised), so drift is *unknown*, not clean. Reset
+// alongside the drift map. Unlike drift, an error is not Sync-remediable, so
+// its badge offers no Sync affordance.
+let _ctxPortalErrorMap = {};
 // Active runtime filter: null | 'claude' | 'antigravity' | 'codex' | 'kimi'
 let _ctxPortalRuntimeFilter = null;
 
@@ -423,6 +429,7 @@ async function loadCtxProjects() {
     // flip or refresh must not carry a stale badge into the new roster. The
     // deferred fetch below (project_shared only) repopulates it.
     _ctxPortalDriftMap = {};
+    _ctxPortalErrorMap = {};
     if (!scopes.length) {
       // Server CWD is always present, so an empty roster means the load
       // failed — render the shared load-error + Retry (#1287; the helper
@@ -512,10 +519,13 @@ async function _ctxPortalLoadDrift(seq, requestedScope, signal) {
   if (seq !== _ctxProjectsSeq || requestedScope !== _ctxTargetScope) return;
   const projects = Array.isArray(data?.projects) ? data.projects : [];
   const driftMap = {};
+  const errorMap = {};
   for (const entry of projects) {
     if (entry?.status === 'drift') driftMap[entry.project_scope_id || ''] = true;
+    else if (entry?.status === 'error') errorMap[entry.project_scope_id || ''] = true;
   }
   _ctxPortalDriftMap = driftMap;
+  _ctxPortalErrorMap = errorMap;
   // Skip the immediate repaint while a row is in inline-rename mode — a full
   // repaint would discard the open input's typed value. The map is already set,
   // so the next natural repaint (save/cancel/langchange) shows the badges.
@@ -726,6 +736,14 @@ function _ctxPortalBadgesHtml(scope) {
   if (!scope.missing && _ctxPortalDriftMap[scope.scope_id || '']) {
     const tip = escapeHtml(t('settings.ctx.portal_drift_tip'));
     parts.push(`<span class="ctx-scope-badge ctx-scope-badge--drift" title="${tip}">${escapeHtml(t('settings.ctx.portal_drift_badge'))}</span>`);
+  } else if (!scope.missing && _ctxPortalErrorMap[scope.scope_id || '']) {
+    // Status check failed for this project (corrupt lockfile / probe raised):
+    // drift is unknown, so we cannot claim clean OR drift. Deliberately no Sync
+    // affordance in the tooltip — an error is not Sync-remediable; point at the
+    // CLI for the failure detail instead. ``else if`` because a status-all entry
+    // is exactly one status, so error and drift are mutually exclusive.
+    const tip = escapeHtml(t('settings.ctx.portal_status_error_tip'));
+    parts.push(`<span class="ctx-scope-badge ctx-scope-badge--status-error" title="${tip}">${escapeHtml(t('settings.ctx.portal_status_error_badge'))}</span>`);
   }
   return parts.join('');
 }

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=130" />
+  <link rel="stylesheet" href="/style.css?v=131" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -1771,7 +1771,7 @@
   <script src="/context-gateway-conflict.js?v=2"></script>
   <script src="/context-gateway-detail.js?v=3"></script>
   <script src="/context-gateway-actions.js?v=2"></script>
-  <script src="/context-portal.js?v=8"></script>
+  <script src="/context-portal.js?v=9"></script>
   <script src="/wiki.js?v=11"></script>
   <script src="/path-picker.js?v=4"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -861,6 +861,8 @@
   "settings.ctx.portal_stale_tip": "This folder has no .memtomem store yet — run mm context init inside it to start tracking.",
   "settings.ctx.portal_drift_badge": "drift",
   "settings.ctx.portal_drift_tip": "This project's synced context no longer matches the Store (wiki pins behind or runtime files changed). Click Sync on this row, or run mm context status --all-projects for details.",
+  "settings.ctx.portal_status_error_badge": "check failed",
+  "settings.ctx.portal_status_error_tip": "This project's status check failed, so its sync state is unknown (not clean, not drift). Run mm context status --all-projects for details.",
   "settings.ctx.portal_root_unknown": "(no path)",
   "settings.ctx.portal_load_failed": "Could not load projects",
   "settings.ctx.portal_add_project_tooltip": "Register a project folder so memtomem can track it",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -861,6 +861,8 @@
   "settings.ctx.portal_stale_tip": "이 폴더에는 아직 .memtomem 저장소가 없습니다 — 폴더 안에서 mm context init 을 실행하면 추적이 시작됩니다.",
   "settings.ctx.portal_drift_badge": "드리프트",
   "settings.ctx.portal_drift_tip": "이 프로젝트의 동기화된 컨텍스트가 저장소와 더 이상 일치하지 않습니다 (wiki 핀이 뒤처졌거나 런타임 파일이 변경됨). 이 행의 Sync 를 누르거나, 자세한 내용은 mm context status --all-projects 를 실행하세요.",
+  "settings.ctx.portal_status_error_badge": "확인 실패",
+  "settings.ctx.portal_status_error_tip": "이 프로젝트의 상태 확인이 실패하여 동기화 상태를 알 수 없습니다 (clean 도 drift 도 아님). 자세한 내용은 mm context status --all-projects 를 실행하세요.",
   "settings.ctx.portal_root_unknown": "(경로 없음)",
   "settings.ctx.portal_load_failed": "프로젝트를 불러오지 못했습니다",
   "settings.ctx.portal_add_project_tooltip": "memtomem이 추적할 수 있도록 프로젝트 폴더를 등록합니다",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -4307,6 +4307,11 @@ body.app-simple [data-ui-adv="advanced"] { display: none; }
 /* Cross-project drift (#1649) — update available, warning tone (mirrors the
    overview wiki-behind badge; not an error like missing). */
 .ctx-scope-badge--drift { background: rgba(243, 156, 18, 0.15); color: var(--yellow); }
+/* Status check failed (#1692) — the per-project status probe raised, so drift
+   is unknown. Error tone (danger, like missing) rather than the drift warning
+   tone, because we can't back a clean/drift claim; unlike missing, this is not
+   about an absent root. */
+.ctx-scope-badge--status-error { background: rgba(224, 90, 90, 0.15); color: var(--danger); }
 
 /* Context Portal (ADR-0021 PR4) — multi-project board */
 .ctx-portal-toolbar {

--- a/packages/memtomem/tests-js/ctx-portal-drift-badge.test.mjs
+++ b/packages/memtomem/tests-js/ctx-portal-drift-badge.test.mjs
@@ -93,6 +93,12 @@ function driftBadge(window, scopeId) {
   );
 }
 
+function statusErrorBadge(window, scopeId) {
+  return window.document.querySelector(
+    `.ctx-portal-row[data-scope-id="${scopeId}"] .ctx-scope-badge--status-error`,
+  );
+}
+
 describe('Projects portal fleet-drift badge (#1649)', () => {
   it('marks the drifted project after the deferred status-all fetch, with a runnable tooltip', async () => {
     const { window } = await boot();
@@ -108,7 +114,7 @@ describe('Projects portal fleet-drift badge (#1649)', () => {
     expect(badge.getAttribute('title')).toContain('mm context status --all-projects');
   });
 
-  it('leaves ok / error projects (and Server CWD) unbadged', async () => {
+  it('leaves ok projects (and Server CWD) unbadged; does not drift-badge the error project', async () => {
     const { window } = await boot();
     installFetch(window);
     await window.loadCtxProjects();
@@ -116,8 +122,49 @@ describe('Projects portal fleet-drift badge (#1649)', () => {
 
     expect(driftBadge(window, 'p-alpha')).not.toBeNull();
     expect(driftBadge(window, 'p-clean')).toBeNull();
+    // The error project must never carry the (Sync-remediable) drift badge...
     expect(driftBadge(window, 'p-err')).toBeNull();
     expect(driftBadge(window, '')).toBeNull();
+  });
+
+  it('marks the error project with a status-error badge (no Sync affordance), not a drift badge (#1692)', async () => {
+    const { window } = await boot();
+    installFetch(window);
+    await window.loadCtxProjects();
+    await flush();
+
+    // ...it carries the distinct status-error badge instead: drift is unknown,
+    // so the board must not read as an all-clear for that row.
+    const badge = statusErrorBadge(window, 'p-err');
+    expect(badge).not.toBeNull();
+    expect(badge.textContent.trim().length).toBeGreaterThan(0);
+    // The tooltip points at the CLI, deliberately NOT at Sync (error ≠ remediable).
+    expect(badge.getAttribute('title')).toContain('mm context status --all-projects');
+    expect(badge.getAttribute('title')).not.toContain('Sync');
+
+    // The error badge is mutually exclusive with drift on the same row, and the
+    // drifted / clean / cwd rows carry no status-error badge.
+    expect(statusErrorBadge(window, 'p-alpha')).toBeNull();
+    expect(statusErrorBadge(window, 'p-clean')).toBeNull();
+    expect(statusErrorBadge(window, '')).toBeNull();
+  });
+
+  it('clears a stale status-error badge when a fresh load reports the project ok (#1692)', async () => {
+    const { window } = await boot();
+    const { state } = installFetch(window);
+    await window.loadCtxProjects();
+    await flush();
+    expect(statusErrorBadge(window, 'p-err')).not.toBeNull();
+
+    // Reload: p-err's status check now succeeds and reports clean.
+    state.statusAll = async () => jsonOk({
+      target_scope: 'project_shared',
+      projects: SCOPES.map(s => ({ project_scope_id: s.scope_id, status: 'ok' })),
+      summary: { projects_total: 4, executed: 4, drifted: 0, clean: 4, errors: 0, skipped: 0 },
+    });
+    await window.loadCtxProjects();
+    await flush();
+    expect(statusErrorBadge(window, 'p-err')).toBeNull();
   });
 
   it('does NOT fetch status-all on a non-project_shared tier', async () => {

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -175,6 +175,25 @@ class TestLocaleFiles:
                 f"an `update --all` form (#1645); got: {tip!r}"
             )
 
+    def test_portal_status_error_keys_present(self, en: dict[str, str], ko: dict[str, str]) -> None:
+        """The Projects-portal status-check-failed badge (#1692) needs both its
+        badge label and tooltip in each locale. Like the drift tip, the tooltip
+        must name the runnable ``mm context status --all-projects`` inspector —
+        but unlike drift it must NOT steer to Sync, because a failed status check
+        is not Sync-remediable (drift is unknown, not confirmed)."""
+        for name, data in [("en", en), ("ko", ko)]:
+            for key in (
+                "settings.ctx.portal_status_error_badge",
+                "settings.ctx.portal_status_error_tip",
+            ):
+                assert key in data, f"{name}.json missing {key}"
+                assert data[key].strip(), f"{name}.json has empty {key}"
+            tip = data["settings.ctx.portal_status_error_tip"]
+            assert "mm context status --all-projects" in tip, (
+                f"{name}.json settings.ctx.portal_status_error_tip must name the "
+                f"runnable `mm context status --all-projects` inspector; got: {tip!r}"
+            )
+
 
 _STATIC_JS_DIR = _LOCALES_DIR.parent
 


### PR DESCRIPTION
## What

The Projects portal consumes `/api/context/status-all` to badge fleet drift,
but it only recognized `status === "drift"`. A project whose **per-project
status check failed** (corrupt lockfile, or a probe that raised) comes back as
`status === "error"` and rendered **entirely unbadged** — visually identical
to a clean, in-sync project.

This PR adds a parallel `_ctxPortalErrorMap` (reset and repainted in lockstep
with the drift map) and a distinct **"check failed"** badge:

- Mutually exclusive with the drift badge (`else if` — a status-all entry is
  exactly one status).
- Skipped for `missing` rows, like drift.
- Error tone; tooltip points at `mm context status --all-projects` for detail
  but **deliberately offers no Sync affordance** — an error is not
  Sync-remediable (drift is unknown, not confirmed).

No wire change — `status: "error"` entries already exist today (corrupt
lockfiles surface this way).

## Why

First-user reliability hardening (#1692). Collapsing `error` into a silent
all-clear is a false-confidence failure mode. It also lands **before** the
error-vs-drift reclassification (next PR): once per-kind probe failures are
reclassified from `"drift"` to `"error"`, those projects would otherwise lose
their badge entirely — shipping the error badge first keeps them visible.

## Changes

- `context-portal.js` — `_ctxPortalErrorMap` state (reset at `:431`,
  populated in `_ctxPortalLoadDrift`, rendered in `_ctxPortalBadgesHtml`).
- `style.css` — `.ctx-scope-badge--status-error` (error tone); `?v=131`.
- `index.html` — `context-portal.js?v=9`.
- `locales/en.json` / `ko.json` — `portal_status_error_badge` /
  `portal_status_error_tip` (parity kept).
- `ctx-portal-drift-badge.test.mjs` — 3 new cases (error badge present, no
  drift badge on error rows, stale-error-badge clears on reload).
- `test_i18n.py` — `test_portal_status_error_keys_present` (badge + tooltip
  presence, tooltip names the CLI inspector).

## Testing

- `ctx-portal-drift-badge.test.mjs`: 9 passed (3 new).
- Full `tests-js` suite: 434 passed.
- `test_i18n.py`: 94 passed (1 new).
- Codex review: SHIP, 0 findings.

Part of #1692 (PR 1). Refs #1353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
