### PR TITLE
fix(context): classify a failed status probe as error, not drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- **A failed status probe is now an error, not drift** (#1692) — in the
+  Context Gateway fleet view (`GET /api/context/status-all`) and
+  `mm context status --all-projects`, a per-kind diff scan that *raised* was
+  previously folded into the project's `drift` flag. A failed probe cannot
+  establish the sync state, so reporting it as (Sync-remediable) drift was
+  misleading. Such a project is now classified `error`: the web entry status
+  is `error` (its failing kind still carries the error envelope in
+  `diff_counts`), and **the CLI now exits 1** for it (mixed drift+error and
+  error-only both exit 1), where drift alone still exits 0. Scripts that keyed
+  off the previous exit-0 behavior for probe failures should treat the new
+  exit 1 as "could not determine sync state." A corrupt/unreadable `lock.json`
+  already behaved this way; this aligns diff-probe failures with it.
+
 ## [0.3.4] — 2026-07-05
 
 ### Deprecations

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -2713,8 +2713,10 @@ def _run_status_all_projects() -> None:
     Per-project failure isolation: one project's crash prints a red row and
     the batch continues. Exit mirrors the single-project contract — drift
     alone exits 0 (the cron chain ``status && sync`` stays viable); exit 1
-    iff any project had a corrupt/version-mismatched lockfile or its
-    collection crashed. Zero-eligible exits 0 informationally (the batch
+    iff any project had a corrupt/version-mismatched lockfile, a per-kind diff
+    probe that raised, or its collection crashed. A failed probe cannot
+    establish the sync state, so exit 0 would be actively misleading — it is an
+    error, not drift (#1692). Zero-eligible exits 0 informationally (the batch
     precedent).
     """
     cfg = _projects_gateway_cfg()
@@ -2759,13 +2761,15 @@ def _run_status_all_projects() -> None:
 def _render_project_status(status: ProjectStatus) -> bool:
     """Render one project's aggregate block; True when it counts as an error.
 
-    Detail rows render ONLY for :data:`DRIFT_STATES` — the aggregate answers
-    "which projects drifted", so clean/untracked inventory stays in the
-    header counts and the full row list remains the single-project verb's
-    job. The ``runtime drift:`` line enumerates the SAME
-    ``iter_kind_drift_counts`` stream the shared ``drift`` flag is computed
-    from, so the rendered table and the summary classification cannot
-    disagree.
+    An error is a corrupt/unreadable ``lock.json`` OR any per-kind diff probe
+    that raised (#1692): either means the sync state could not be established,
+    so the row is red and the batch exits 1 — not the yellow, exit-0 "drift"
+    class. Detail rows render ONLY for :data:`DRIFT_STATES` — the aggregate
+    answers "which projects drifted", so clean/untracked inventory stays in the
+    header counts and the full row list remains the single-project verb's job.
+    The ``runtime drift:`` line enumerates the SAME ``iter_kind_drift_counts``
+    stream the shared ``drift`` flag is computed from, so the rendered table and
+    the summary classification cannot disagree.
     """
     if status.lockfile_error is not None:
         click.secho(f"  ✗ lock.json: {status.lockfile_error}", fg="red")
@@ -2802,13 +2806,16 @@ def _render_project_status(status: ProjectStatus) -> bool:
         f"{kind.replace('_', '-')} {count} {key.replace('_', ' ')}"
         for kind, key, count in iter_kind_drift_counts(status.diff_counts)
     ]
-    for kind, exc in status.diff_errors.items():
-        runtime_bits.append(f"{kind.replace('_', '-')} diff failed ({exc})")
     if runtime_bits:
         click.secho("  runtime drift: " + "; ".join(runtime_bits), fg="yellow")
-    else:
+    elif not status.diff_errors:
         click.echo("  runtime: in sync")
-    return status.lockfile_error is not None
+    # Diff probe failures are an error condition, rendered red on their own line
+    # (not folded into the yellow "runtime drift" list): a failed probe means the
+    # state is unknown, so "in sync" above is suppressed and the row exits 1.
+    for kind, exc in status.diff_errors.items():
+        click.secho(f"  ✗ {kind.replace('_', '-')} diff failed: {exc}", fg="red")
+    return status.lockfile_error is not None or bool(status.diff_errors)
 
 
 # ── install --all (PR-D C3) ─────────────────────────────────────────────

--- a/packages/memtomem/src/memtomem/context/status.py
+++ b/packages/memtomem/src/memtomem/context/status.py
@@ -577,9 +577,11 @@ class ProjectStatus:
     formats an error envelope, the CLI prints the message).
 
     ``drift`` is the shared roll-up predicate: any row state in
-    :data:`DRIFT_STATES`, any diff error, or any per-kind count outside the
-    kind's clean key set. ``lockfile_error`` does NOT imply drift — surfaces
-    report it as an error condition instead.
+    :data:`DRIFT_STATES`, or any per-kind count outside the kind's clean key
+    set. Neither ``lockfile_error`` NOR a per-kind ``diff_errors`` entry
+    implies drift — both are error conditions (the probe could not establish
+    the state), so surfaces report them as ``error``, not Sync-remediable
+    drift (#1692).
     """
 
     wiki_head: str | None
@@ -693,10 +695,14 @@ def collect_project_status(
     except Exception as exc:
         diff_errors["settings"] = exc
 
-    drift = (
-        any(row.state in DRIFT_STATES for row in rows)
-        or bool(diff_errors)
-        or any(True for _ in iter_kind_drift_counts(diff_counts))
+    # A per-kind diff scan that RAISED is an error condition, NOT drift (#1692):
+    # a failed probe means we could not establish the sync state, so calling it
+    # "drift" would report it as Sync-remediable when Sync cannot fix it. It
+    # rides in ``diff_errors`` and surfaces classify it alongside
+    # ``lockfile_error`` (web entry status ``error``, CLI exit 1). Only genuine
+    # row drift or a positive out-of-clean count sets ``drift``.
+    drift = any(row.state in DRIFT_STATES for row in rows) or any(
+        True for _ in iter_kind_drift_counts(diff_counts)
     )
     return ProjectStatus(
         wiki_head=wiki_head,

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -507,10 +507,11 @@ def _status_all_entry(
 ) -> dict[str, Any]:
     """Serialize one executed project's ``ProjectStatus`` for the wire.
 
-    Entry ``status`` vocabulary: ``error`` (corrupt / version-mismatched
-    lockfile — the aggregate is kept but cannot be trusted as complete, the
-    single-status CLI's exit-1 condition), else ``drift``/``ok`` from the
-    shared predicate. Row ``reason`` strings can embed wiki paths and raw
+    Entry ``status`` vocabulary: ``error`` (a corrupt / version-mismatched
+    lockfile OR any per-kind diff probe that raised, #1692 — the aggregate is
+    kept but cannot be trusted as complete, the single-status CLI's exit-1
+    condition), else ``drift``/``ok`` from the shared predicate. Row ``reason``
+    strings can embed wiki paths and raw
     exception text (this is the first surface serializing ``StatusRow``),
     so they pass through ``sanitize_diff_reason`` — the established
     display-sanitize boundary; ``lockfile_error`` gets the same treatment.
@@ -524,7 +525,12 @@ def _status_all_entry(
     diff_counts: dict[str, Any] = dict(status.diff_counts)
     for kind, exc in status.diff_errors.items():
         diff_counts[kind] = _error_payload(exc, shape="status" if kind == "settings" else "total")
-    if status.lockfile_error:
+    # A failed lockfile read OR any per-kind diff probe that raised is an
+    # ``error`` — the check could not establish drift, so it must not read as
+    # Sync-remediable ``drift`` (#1692). The failing kind's error envelope is
+    # already in ``diff_counts[kind]`` above; the entry-level ``error`` object
+    # stays reserved for a total collector crash (see ``context_status_all``).
+    if status.lockfile_error or status.diff_errors:
         entry_status = "error"
     elif status.drift:
         entry_status = "drift"
@@ -579,9 +585,10 @@ async def context_status_all(
     whenever the loop ran; non-2xx only for the tier gate (400).
 
     Per-project entries: ``skipped`` (shared ``sync_skip_reason`` codes +
-    surface-local prose), ``error`` (corrupt lockfile, or the collector
-    raised — A-9's failed-entry envelope shape), else ``ok``/``drift`` via
-    the shared ``ProjectStatus.drift`` predicate. ``summary`` is counts
+    surface-local prose), ``error`` (corrupt lockfile, a per-kind diff probe
+    that raised (#1692), or the collector itself raised — A-9's failed-entry
+    envelope shape), else ``ok``/``drift`` via the shared
+    ``ProjectStatus.drift`` predicate. ``summary`` is counts
     only — deliberately NO roll-up status string: A-9's ``ok|partial|
     failed`` describe mutation success, while fleet health here is just
     ``drifted + errors == 0``, derivable; a third vocabulary would invite

--- a/packages/memtomem/tests/test_cli_status_all_projects.py
+++ b/packages/memtomem/tests/test_cli_status_all_projects.py
@@ -258,6 +258,34 @@ def test_collector_crash_isolated_and_exits_one(
         assert isinstance(kwargs["wiki"], WikiStore)
 
 
+def test_diff_probe_error_exits_one_not_drift(
+    tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1692: a per-kind diff probe that RAISES is an error, not drift — the
+    row renders red, the batch exits 1, and it is counted under errors (not
+    drifted). A failed probe cannot establish the sync state, so the old exit-0
+    "drift" classification was actively misleading."""
+    a = _project(tmp_path, "proj-a")  # clean store, but its settings diff will explode
+    b = _project(tmp_path, "proj-b")  # genuinely clean sibling
+    _seed_known_projects(known_projects_path, [(a, True), (b, True)])
+    monkeypatch.chdir(a)
+
+    def _boom(project_root, *, scope):
+        if Path(project_root) == a:
+            raise RuntimeError("settings diff exploded")
+        return {}
+
+    monkeypatch.setattr("memtomem.context.settings.diff_settings", _boom)
+
+    result = CliRunner().invoke(context_group, ["status", "--all-projects"])
+
+    assert result.exit_code == 1, result.output
+    assert "settings diff failed: settings diff exploded" in result.output
+    assert f"{b}" in result.output  # sibling still rendered
+    # Counted as an error, NOT drift; drift stays 0 (no row drift, no count drift).
+    assert "Summary: 0 with drift, 1 clean, 1 error(s), 0 skipped." in result.output
+
+
 def test_zero_eligible_informational_exit_zero(
     tmp_path: Path, fake_home: Path, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/packages/memtomem/tests/test_context_status.py
+++ b/packages/memtomem/tests/test_context_status.py
@@ -1374,6 +1374,30 @@ def test_collect_lockfile_error_keeps_partial_aggregate(
     assert status.drift is True
 
 
+def test_collect_diff_probe_error_is_not_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#1692: a per-kind diff scan that RAISES lands in ``diff_errors`` and,
+    like ``lockfile_error``, does NOT by itself flip ``drift`` — a failed probe
+    could not establish the state, so surfaces classify it as an error, not
+    Sync-remediable drift. With no row drift and no positive out-of-clean
+    count, ``drift`` stays False."""
+    _collect_home(tmp_path, monkeypatch)
+    project = tmp_path / "proj"
+    (project / ".memtomem").mkdir(parents=True)
+
+    def _boom(project_root, *, scope):
+        raise RuntimeError("settings diff exploded")
+
+    monkeypatch.setattr("memtomem.context.settings.diff_settings", _boom)
+
+    status = collect_project_status(project)
+
+    assert "settings" in status.diff_errors
+    assert "settings" not in status.diff_counts  # a raised kind is absent from counts
+    assert status.drift is False  # diff error alone is NOT drift (#1692)
+
+
 def test_collect_target_scope_filters_draft_tiers(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/packages/memtomem/tests/test_web_routes_context_status_all.py
+++ b/packages/memtomem/tests/test_web_routes_context_status_all.py
@@ -299,7 +299,9 @@ async def test_settings_diff_error_uses_status_shape_envelope(
     + ``error_kind``/``error_message``), not the artifact kinds'
     count-based ``{"total": 0, "error": true}`` shape — one client must
     not meet two incompatible settings error envelopes across the two
-    routes. The contained error still reads as drift."""
+    routes. A per-kind diff probe that raised makes the ENTRY ``error`` — the
+    check could not establish drift, so it must not read as Sync-remediable
+    ``drift`` (#1692)."""
 
     def _boom(project_root, *, scope):
         raise RuntimeError("settings diff exploded")
@@ -308,14 +310,18 @@ async def test_settings_diff_error_uses_status_shape_envelope(
 
     resp = await client.get("/api/context/status-all")
     assert resp.status_code == 200, resp.text
-    entry = _entry(resp.json(), cwd_root)
+    data = resp.json()
+    entry = _entry(data, cwd_root)
 
     settings_envelope = entry["diff_counts"]["settings"]
     assert settings_envelope["status"] == "error"
     assert settings_envelope["error_kind"] == "internal"
     assert "settings diff exploded" in settings_envelope["error_message"]
     assert "total" not in settings_envelope  # the count-shape marker must NOT leak in
-    assert entry["status"] == "drift"  # contained per-kind error == drift, not entry error
+    # #1692: a contained per-kind probe error classifies the entry as ``error``,
+    # NOT ``drift`` — and it lands in the summary's error column, not drifted.
+    assert entry["status"] == "error"
+    assert data["summary"]["errors"] >= 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

`collect_project_status` folded `bool(diff_errors)` into its `drift`
predicate, so a per-kind diff scan that **raised** — a probe that could not
establish the sync state — was reported as Sync-remediable **drift**. It is
not: Sync cannot fix a probe that failed to run. In the fleet view this
inflated the `drifted` count; in the CLI it exited 0 for a project whose state
was actually unknown.

Reclassify it as an **error**, alongside `lockfile_error`:

- `status.py` drops `bool(diff_errors)` from the drift predicate; only genuine
  row drift or a positive out-of-clean count now sets `drift`.
- Web `_status_all_entry` maps `lockfile_error OR diff_errors` → entry status
  `error`. **No new wire field** — the failing kind's error envelope already
  rides in `diff_counts[kind]`; the entry-level `error` object stays reserved
  for a total collector crash.
- CLI `mm context status --all-projects` renders diff-probe failures on a red
  error line (not the yellow "runtime drift" line), suppresses
  "runtime: in sync" when a probe failed, and now **exits 1** for them (mixed
  drift+error and error-only both exit 1; drift alone still exits 0).

## Why

First-user reliability (#1692). A failed probe reported as drift tells the
user "click Sync to fix" when Sync can't; exit 0 tells a cron chain
`status && sync` that everything is fine when the state is unknown.

## Compatibility

- **Behavior change (CHANGELOG'd):** the CLI now exits 1 for a diff-probe
  failure. A corrupt `lock.json` already behaved this way; this aligns
  diff-probe failures with it. The fleet `drifted + errors == 0` health
  invariant is unchanged — counts only migrate columns.
- No wire schema change; the failing kind's `_error_payload` envelope shape in
  `diff_counts[kind]` is untouched.

## Testing

- `test_context_status.py`: new `test_collect_diff_probe_error_is_not_drift`
  (drift False, `diff_errors` populated).
- `test_web_routes_context_status_all.py:test_settings_diff_error_...` flipped:
  entry `error` (was `drift`) + summary `errors >= 1`.
- `test_cli_status_all_projects.py`: new
  `test_diff_probe_error_exits_one_not_drift` (exit 1, red line, summary
  `1 error(s)`, sibling intact).
- Affected suites: 79 passed. `ctx-portal-drift-badge.test.mjs` (from #1694):
  9 passed — reclassified entries carry the error badge.
- `ruff` + `mypy` clean.
- Codex review: NEEDS-FIX (Portal badge must exist first) → resolved by
  stacking on #1694; 2 Minor docstring findings applied.

Part of #1692 (PR 2). Refs #1353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
