### PR TITLE
feat(web): refresh the mm web UI system

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -130,10 +130,9 @@ const STATE = {
   } else if (!saved && window.matchMedia('(prefers-color-scheme: light)').matches) {
     el.setAttribute('data-theme', 'light');
   }
-  // Update toggle icon and finalize initialization on DOM ready
+  // Finalize initialization on DOM ready. Theme icon visibility is CSS-owned
+  // from the document's data-theme attribute, avoiding duplicate JS state.
   document.addEventListener('DOMContentLoaded', async () => {
-    const isDark = el.getAttribute('data-theme') !== 'light';
-    qs('theme-toggle').dataset.themeState = isDark ? 'dark' : 'light';
     // Resolve UI mode + fetch locales in parallel. Both gate rendering.
     const uiModePromise = initUiMode();
     if (typeof I18N !== 'undefined') await I18N.init();
@@ -1768,7 +1767,6 @@ qs('theme-toggle').addEventListener('click', () => {
   const el = document.documentElement;
   const goLight = el.getAttribute('data-theme') !== 'light';
   el.setAttribute('data-theme', goLight ? 'light' : 'dark');
-  qs('theme-toggle').dataset.themeState = goLight ? 'light' : 'dark';
   localStorage.setItem('m2m-theme', goLight ? 'light' : 'dark');
 });
 
@@ -4178,7 +4176,7 @@ function _renderSourcesStats(activeVendor) {
 
 
 function hideBrowser() {
-  _setSourcesMobileDetail(false);
+  document.querySelector('.sources-layout')?.classList.remove('mobile-detail');
   hide(qs('chunks-browser-content'));
   const browser = qs('chunks-browser');
   browser.innerHTML = emptyState('📄', 'Select a source to browse its chunks');

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -4178,9 +4178,20 @@ function _renderSourcesStats(activeVendor) {
 
 
 function hideBrowser() {
+  _setSourcesMobileDetail(false);
   hide(qs('chunks-browser-content'));
   const browser = qs('chunks-browser');
   browser.innerHTML = emptyState('📄', 'Select a source to browse its chunks');
+}
+
+function _setSourcesMobileDetail(active) {
+  const layout = document.querySelector('.sources-layout');
+  if (!layout) return;
+  layout.classList.toggle('mobile-detail', !!active);
+  if (!active) {
+    const selected = layout.querySelector('.source-item.active');
+    if (selected && typeof selected.focus === 'function') selected.focus();
+  }
 }
 
 // ── Memory-mode source tree ─────────────────────────────────────────
@@ -5083,7 +5094,8 @@ function _renderMemorySourceTree(sources, list) {
   }
 
   const renderedSources = Array.from(list.querySelectorAll('.source-item'));
-  if (renderedSources.length && !list.querySelector('.source-item.active')) {
+  const mobileDrilldown = window.matchMedia?.('(max-width: 760px)').matches;
+  if (renderedSources.length && !list.querySelector('.source-item.active') && !mobileDrilldown) {
     const currentPath = qs('chunks-browser')?.querySelector('.chunks-browser-header .file-path')?.textContent || '';
     const target = renderedSources.find(el => el.title === currentPath) || renderedSources[0];
     if (target) {
@@ -5360,10 +5372,14 @@ async function browseSource(path, limit = 100) {
     const header = document.createElement('div');
     header.className = 'chunks-browser-header';
     header.innerHTML = `
+      <button type="button" class="sources-mobile-back btn-ghost" data-i18n="sources.back_to_list">${escapeHtml(t('sources.back_to_list'))}</button>
       <span class="file-path">${escapeHtml(path)}</span>
       <span class="badge badge-blue">${escapeHtml(t(data.total === 1 ? 'home.source_chunks_one' : 'home.source_chunks_other', { count: data.total }))}</span>
       <span class="chunks-browser-info">${escapeHtml(t('chunks.shown_of_total', { shown: data.chunks.length, total: data.total }))}</span>
     `;
+    header.querySelector('.sources-mobile-back')?.addEventListener('click', () => {
+      _setSourcesMobileDetail(false);
+    });
     if (data.chunks.length < data.total) {
       const loadAllBtn = document.createElement('button');
       loadAllBtn.className = 'btn-ghost btn-xs chunks-load-all-btn';
@@ -5525,6 +5541,7 @@ async function browseSource(path, limit = 100) {
       });
     }
     browser.appendChild(content);
+    _setSourcesMobileDetail(true);
 
     // Consume ``pendingActivateChunkId`` (set by ``_navigateToSource``
     // when the caller — e.g. Timeline — knows the specific chunk).

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -133,7 +133,7 @@ const STATE = {
   // Update toggle icon and finalize initialization on DOM ready
   document.addEventListener('DOMContentLoaded', async () => {
     const isDark = el.getAttribute('data-theme') !== 'light';
-    qs('theme-toggle').textContent = isDark ? '🌙' : '☀️';
+    qs('theme-toggle').dataset.themeState = isDark ? 'dark' : 'light';
     // Resolve UI mode + fetch locales in parallel. Both gate rendering.
     const uiModePromise = initUiMode();
     if (typeof I18N !== 'undefined') await I18N.init();
@@ -1768,7 +1768,7 @@ qs('theme-toggle').addEventListener('click', () => {
   const el = document.documentElement;
   const goLight = el.getAttribute('data-theme') !== 'light';
   el.setAttribute('data-theme', goLight ? 'light' : 'dark');
-  qs('theme-toggle').textContent = goLight ? '☀️' : '🌙';
+  qs('theme-toggle').dataset.themeState = goLight ? 'light' : 'dark';
   localStorage.setItem('m2m-theme', goLight ? 'light' : 'dark');
 });
 

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=131" />
+  <link rel="stylesheet" href="/style.css?v=132" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -1764,7 +1764,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=7"></script>
-  <script src="/app.js?v=147"></script>
+  <script src="/app.js?v=148"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=14"></script>
   <script src="/sources-memory-dirs.js?v=13"></script>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -819,8 +819,14 @@
             <label><input type="checkbox" id="index-recursive" checked /> <span data-i18n="index.recursive">Recursive</span></label>
             <label><input type="checkbox" id="index-force" /> <span data-i18n="index.force">Force re-index</span></label>
             <label data-i18n-title="index.register_source_title" title="Add this path to memory_dirs so future changes are auto-indexed"><input type="checkbox" id="index-register-source" /> <span data-i18n="index.register_source">Register as source</span></label>
-            <label class="checkbox-warn" data-i18n-title="index.force_unsafe_title" title="Index files even if they contain secrets (API keys, tokens). Audit-logged. Git-tracked project_shared files are still blocked."><input type="checkbox" id="index-force-unsafe" /> <span data-i18n="index.force_unsafe">Index without privacy gate</span></label>
           </div>
+          <details class="index-risk-disclosure">
+            <summary data-i18n="index.advanced_options">Advanced options</summary>
+            <div class="index-risk-content">
+              <strong data-i18n="index.privacy_bypass_warning">Privacy bypass can expose secrets. Use only after reviewing the files.</strong>
+              <label class="checkbox-warn" data-i18n-title="index.force_unsafe_title" title="Index files even if they contain secrets (API keys, tokens). Audit-logged. Git-tracked project_shared files are still blocked."><input type="checkbox" id="index-force-unsafe" /> <span data-i18n="index.force_unsafe">Index without privacy gate</span></label>
+            </div>
+          </details>
           <button id="index-btn" class="btn-primary" data-i18n="index.index_btn">Index</button>
           <div id="index-msg" class="status-msg" hidden></div>
           <div id="index-progress" class="index-progress" hidden>
@@ -996,6 +1002,9 @@
 
         <!-- Config section -->
         <div class="settings-section active" id="settings-config">
+          <div class="settings-page-header">
+            <h2 data-i18n="settings.config.title">Configuration</h2>
+          </div>
           <p class="settings-section-desc" data-i18n="settings.config.desc">Server settings: embedding provider, storage backend, search and indexing parameters.</p>
           <div class="config-layout">
             <div class="config-main">

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -23,10 +23,10 @@
     </div>
     <div class="header-actions">
       <button id="app-mode-toggle" class="btn-ghost app-mode-toggle" type="button" aria-pressed="false" data-i18n-title="nav.app_mode_tip" data-i18n-aria-label="nav.app_mode_aria" title="Switch Simple / Advanced view" aria-label="Toggle Simple / Advanced view"><span class="app-mode-label" data-i18n="nav.mode_simple">Simple</span></button>
-      <button id="settings-btn" class="btn-ghost btn-icon" data-i18n-title="header.settings_title" data-i18n-aria-label="header.settings_title" title="Settings" aria-label="Settings">⚙️</button>
+      <button id="settings-btn" class="btn-ghost btn-icon" data-i18n-title="header.settings_title" data-i18n-aria-label="header.settings_title" title="Settings" aria-label="Settings"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 8.6a3.4 3.4 0 1 0 0 6.8 3.4 3.4 0 0 0 0-6.8Zm8.2 4.8v-2.8l-2.1-.7a7 7 0 0 0-.7-1.6l1-2-2-2-2 1a7 7 0 0 0-1.6-.7L12 1.5H9.2l-.7 2.1a7 7 0 0 0-1.6.7l-2-1-2 2 1 2a7 7 0 0 0-.7 1.6l-2.1.7v2.8l2.1.7a7 7 0 0 0 .7 1.6l-1 2 2 2 2-1a7 7 0 0 0 1.6.7l.7 2.1H12l.7-2.1a7 7 0 0 0 1.6-.7l2 1 2-2-1-2a7 7 0 0 0 .7-1.6l2.2-.7Z"/></svg></button>
       <button id="lang-toggle" class="btn-ghost btn-icon" data-i18n-title="header.lang_toggle_aria" data-i18n-aria-label="header.lang_toggle_aria" title="Switch language" aria-label="Switch language">EN</button>
-      <button id="theme-toggle" class="btn-ghost btn-icon" data-i18n-title="header.theme_title" data-i18n-aria-label="header.theme_title" title="Toggle theme" aria-label="Toggle theme">🌙</button>
-      <button id="help-toggle" data-i18n-title="header.help_title" data-i18n-aria-label="header.help_title" title="Toggle help hints (h)" aria-label="Toggle help hints (h)" aria-pressed="true">?</button>
+      <button id="theme-toggle" class="btn-ghost btn-icon" data-i18n-title="header.theme_title" data-i18n-aria-label="header.theme_title" title="Toggle theme" aria-label="Toggle theme"><svg class="theme-icon theme-icon-moon" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.2 15.4A8.5 8.5 0 0 1 8.6 3.8 8.6 8.6 0 1 0 20.2 15.4Z"/></svg><svg class="theme-icon theme-icon-sun" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg></button>
+      <button id="help-toggle" class="btn-ghost btn-icon" data-i18n-title="header.help_title" data-i18n-aria-label="header.help_title" title="Toggle help hints (h)" aria-label="Toggle help hints (h)" aria-pressed="true"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M9.8 9a2.3 2.3 0 1 1 3.7 1.8c-.9.6-1.5 1-1.5 2.2M12 17h.01"/></svg></button>
     </div>
   </header>
 

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -195,7 +195,6 @@
       <button class="tab-help-bar-dismiss" data-help-tab="search" data-i18n-title="common.dismiss_help" data-i18n-aria-label="common.dismiss_help" title="Dismiss help" aria-label="Dismiss help">✕</button>
     </div>
     <div class="search-bar">
-      <button id="filter-toggle" class="btn-ghost btn-icon has-tip" data-i18n-title="search.filter_toggle_title" title="Show/hide tag, type, sort and other filters" aria-controls="search-filters" aria-expanded="false"><span data-i18n="search.filter_toggle">▾ Filters</span><span id="filter-count-badge" class="filter-count-badge" hidden></span></button>
       <div class="search-input-wrap">
         <input
           id="search-input"
@@ -209,6 +208,7 @@
         <div id="search-history-dropdown" class="search-history-dropdown" hidden></div>
       </div>
       <button id="search-btn" class="btn-primary has-tip" data-i18n-title="search.search_btn_title" title="Run semantic search (Enter)" data-i18n="search.search_btn">Search</button>
+      <button id="filter-toggle" class="btn-ghost btn-icon has-tip" data-i18n-title="search.filter_toggle_title" title="Show/hide tag, type, sort and other filters" aria-controls="search-filters" aria-expanded="false"><span data-i18n="search.filter_toggle">▾ Filters</span><span id="filter-count-badge" class="filter-count-badge" hidden></span></button>
       <button id="save-star-btn" class="btn-ghost btn-icon has-tip" title="Save current search" aria-label="Save current search">☆</button>
       <button id="group-toggle" class="btn-ghost btn-icon has-tip" data-i18n-title="search.group_title" data-i18n-aria-label="search.group_title" title="Group results by source file" aria-label="Group results by source file">⊟</button>
       <button id="view-toggle" class="btn-ghost btn-icon has-tip" title="Switch to list view" aria-label="Switch to list view">☰</button>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -980,6 +980,7 @@
   "settings.hooks.badge_out_of_sync": "out of sync",
   "settings.hooks.badge_error": "error",
 
+  "settings.config.title": "Configuration",
   "settings.config.desc": "Server settings: embedding provider, storage backend, search and indexing parameters.",
   "settings.config.guide_title": "Configuration Guide",
   "settings.config.guide_text": "Select a config section to see its documentation.",
@@ -1647,6 +1648,8 @@
   "settings.config.select.structured_mode.recursive": "Serialize via json.dumps, recursively split by sub-keys",
   "common.dismiss": "Dismiss",
   "sources.back_to_list": "Back to sources",
+  "index.advanced_options": "Advanced options",
+  "index.privacy_bypass_warning": "Privacy bypass can expose secrets. Use only after reviewing the files.",
   "settings.config.decay_status_active": "Score Decay: Active (half-life {days}d)",
   "settings.config.decay_status_inactive": "Score Decay: Inactive",
   "settings.config.ns_default": "Default NS: {ns}",

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -1646,6 +1646,7 @@
   "settings.config.select.structured_mode.original": "Extract original text lines per key, split large sections by line count",
   "settings.config.select.structured_mode.recursive": "Serialize via json.dumps, recursively split by sub-keys",
   "common.dismiss": "Dismiss",
+  "sources.back_to_list": "Back to sources",
   "settings.config.decay_status_active": "Score Decay: Active (half-life {days}d)",
   "settings.config.decay_status_inactive": "Score Decay: Inactive",
   "settings.config.ns_default": "Default NS: {ns}",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -1646,6 +1646,7 @@
   "settings.config.select.structured_mode.original": "키별 원본 텍스트 줄 추출, 큰 구간은 줄 수로 분할",
   "settings.config.select.structured_mode.recursive": "json.dumps로 직렬화, 하위 키 기준 재귀 분할",
   "common.dismiss": "닫기",
+  "sources.back_to_list": "소스 목록으로",
   "settings.config.decay_status_active": "점수 감쇠: 활성 (반감기 {days}일)",
   "settings.config.decay_status_inactive": "점수 감쇠: 비활성",
   "settings.config.ns_default": "기본 NS: {ns}",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -980,6 +980,7 @@
   "settings.hooks.badge_out_of_sync": "불일치",
   "settings.hooks.badge_error": "오류",
 
+  "settings.config.title": "환경 설정",
   "settings.config.desc": "서버 설정: 임베딩 제공자, 스토리지 백엔드, 검색·인덱싱 파라미터를 조정합니다.",
   "settings.config.guide_title": "설정 가이드",
   "settings.config.guide_text": "설정 섹션을 선택하면 문서를 볼 수 있습니다.",
@@ -1647,6 +1648,8 @@
   "settings.config.select.structured_mode.recursive": "json.dumps로 직렬화, 하위 키 기준 재귀 분할",
   "common.dismiss": "닫기",
   "sources.back_to_list": "소스 목록으로",
+  "index.advanced_options": "고급 옵션",
+  "index.privacy_bypass_warning": "개인정보 보호 우회는 비밀 정보를 노출할 수 있습니다. 파일을 검토한 뒤에만 사용하세요.",
   "settings.config.decay_status_active": "점수 감쇠: 활성 (반감기 {days}일)",
   "settings.config.decay_status_inactive": "점수 감쇠: 비활성",
   "settings.config.ns_default": "기본 NS: {ns}",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -5178,12 +5178,80 @@ textarea:focus-visible,
 .sources-sidebar { background: var(--surface); }
 .source-item { min-height: 44px; }
 .sources-mobile-back { display: none; }
-.index-mode-toggle { border-radius: var(--radius); padding: var(--space-1); }
-.index-panels { border-radius: var(--radius-lg); }
+.index-mode-toggle {
+  width: fit-content;
+  max-width: calc(100% - 40px);
+  margin: var(--space-5) var(--space-5) 0;
+  padding: var(--space-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-subtle);
+}
+.index-mode-toggle .btn-ghost {
+  min-height: 40px;
+  padding: var(--space-2) var(--space-4);
+  border: 0;
+  border-radius: var(--radius-sm);
+}
+.index-mode-toggle .btn-ghost.btn-active {
+  color: var(--text);
+  border: 0;
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-sm), inset 0 0 0 1px var(--border);
+}
+.index-mode-guide { padding: var(--space-2) var(--space-5) 0; }
+.index-layout { padding-top: var(--space-3); }
+.index-panels {
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+}
+.index-panel { max-width: 840px; margin-inline: auto; }
+.index-panel > .btn-primary { min-height: 44px; min-width: 120px; }
+.index-risk-disclosure {
+  margin: 0 0 var(--space-4);
+  border: 1px solid color-mix(in srgb, var(--yellow) 45%, var(--border));
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--yellow) 7%, var(--surface));
+}
+.index-risk-disclosure > summary {
+  padding: var(--space-3) var(--space-4);
+  color: var(--yellow);
+  font-weight: 650;
+  cursor: pointer;
+}
+.index-risk-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: 0 var(--space-4) var(--space-4);
+  color: var(--muted);
+  font-size: .82rem;
+}
+.index-risk-content label { display: flex; align-items: center; gap: var(--space-2); min-height: 44px; }
 .settings-nav { background: var(--surface); padding: var(--space-3) var(--space-2); }
 .settings-nav-btn { min-height: 44px; border-radius: var(--radius-sm); border-left: 0; padding: var(--space-2) var(--space-3); align-items: center; }
 .settings-nav-btn.active { box-shadow: inset 3px 0 0 var(--accent); }
 .settings-content { padding: var(--space-6); }
+.settings-section { max-width: 1180px; margin-inline: auto; }
+.settings-page-header,
+.ctx-header,
+.ns-header,
+.hooks-sync-header {
+  min-height: 48px;
+  padding-bottom: var(--space-3);
+  margin-bottom: var(--space-3);
+  border-bottom: 1px solid var(--border);
+}
+.settings-page-header h2,
+.ctx-header h2,
+.ns-header h2,
+.hooks-sync-header h2 { font-size: 1.15rem; letter-spacing: -.02em; }
+.settings-section-desc {
+  max-width: 76ch;
+  margin-bottom: var(--space-4);
+  color: var(--muted);
+  line-height: 1.55;
+}
 .ctx-control-bar { background: var(--bg); padding: var(--space-3) 0; }
 
 @media (max-width: 760px) {
@@ -5237,6 +5305,15 @@ textarea:focus-visible,
   .home-search-wrap { flex-direction: row; gap: var(--space-1); }
   .home-search-wrap button { width: auto; padding-inline: var(--space-4); }
   .home-stats-row { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .index-mode-toggle {
+    width: calc(100% - 24px);
+    max-width: none;
+    margin: var(--space-3);
+    overflow-x: auto;
+  }
+  .index-mode-toggle .btn-ghost { flex: 1 0 max-content; min-height: 44px; }
+  .index-mode-guide { padding-inline: var(--space-3); }
+  .index-panels { margin-inline: var(--space-3); padding: var(--space-4); }
   .settings-layout { flex-direction: column; }
   .settings-nav {
     width: 100%;

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -5328,6 +5328,7 @@ textarea:focus-visible,
     scrollbar-width: none;
   }
   .settings-nav-btn { width: auto; min-width: max-content; padding: var(--space-2) var(--space-3); }
+  .settings-nav-btn.collapsed-member { display: flex; }
   .settings-nav-btn .nav-sub,
   .settings-nav-divider,
   .settings-nav-group { display: none !important; }

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -5155,11 +5155,16 @@ textarea:focus-visible,
 .wizard-card { border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--shadow-md); }
 
 .home-layout { gap: var(--space-5); padding: var(--space-6); }
-.home-search-row { order: -2; }
+.home-search-row { order: -4; }
 .home-search-wrap { max-width: 760px; padding: var(--space-2); background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--shadow-sm); }
 .home-search-wrap input { min-height: 44px; border-color: transparent; background: transparent; }
 .home-search-wrap button { min-height: 44px; padding-inline: var(--space-6); }
-.home-orientation { order: -1; }
+.home-orientation { order: -3; }
+.home-recent { order: -2; }
+.home-bottom-row { order: -1; }
+.home-stats-row { order: 1; }
+.home-activity-row { order: 2; }
+.home-health { order: 3; }
 .home-stats-row .stat-card { padding: var(--space-4); }
 .home-stats-row .stat-value { font-size: 1.55rem; }
 
@@ -5172,6 +5177,7 @@ textarea:focus-visible,
 .sources-sort-row { gap: var(--space-2); }
 .sources-sidebar { background: var(--surface); }
 .source-item { min-height: 44px; }
+.sources-mobile-back { display: none; }
 .index-mode-toggle { border-radius: var(--radius); padding: var(--space-1); }
 .index-panels { border-radius: var(--radius-lg); }
 .settings-nav { background: var(--surface); padding: var(--space-3) var(--space-2); }
@@ -5208,9 +5214,19 @@ textarea:focus-visible,
   .tab-nav { padding: 0 var(--space-2); scroll-padding-inline: var(--space-2); }
   .tab-btn { min-width: 44px; min-height: 48px; padding-inline: var(--space-3); scroll-snap-align: center; }
   .search-bar { padding: var(--space-2) var(--space-3); flex-wrap: wrap; }
-  .search-bar .search-input-wrap { flex-basis: calc(100% - 80px); }
+  .search-bar .search-input-wrap { flex: 1 1 calc(100% - 92px); }
+  #search-btn { flex: 0 0 auto; }
+  #filter-toggle { order: 3; }
+  #save-star-btn,
+  #group-toggle,
+  #view-toggle { order: 4; }
+  .sources-layout .sources-sidebar { width: 100%; flex: 1 1 auto; }
+  .sources-layout .sources-divider { display: none; }
   .sources-layout.mobile-detail .sources-sidebar { display: none; }
-  .sources-layout:not(.mobile-detail) .sources-detail { display: none; }
+  .sources-layout:not(.mobile-detail) .chunks-browser { display: none; }
+  .sources-layout.mobile-detail .chunks-browser { display: block; width: 100%; }
+  .sources-mobile-back { display: inline-flex; align-items: center; flex: 0 0 auto; }
+  .chunks-browser-header { position: sticky; top: 0; z-index: 5; background: var(--bg); padding-block: var(--space-2); }
 }
 
 @media (max-width: 520px) {

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -5121,8 +5121,8 @@ header h1 { font-size: 1.12rem; letter-spacing: -.03em; }
 #help-toggle svg { width: 18px; height: 18px; fill: none; stroke: currentColor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
 #settings-btn svg path { fill: currentColor; stroke: none; }
 .theme-icon-sun { display: none; }
-#theme-toggle[data-theme-state="light"] .theme-icon-moon { display: none; }
-#theme-toggle[data-theme-state="light"] .theme-icon-sun { display: block; }
+:root[data-theme="light"] .theme-icon-moon { display: none; }
+:root[data-theme="light"] .theme-icon-sun { display: block; }
 .header-actions .btn-icon:hover,
 #help-toggle:hover { color: var(--text); background: var(--surface-subtle); border-color: var(--border); }
 
@@ -5256,9 +5256,12 @@ textarea:focus-visible,
 
 @media (max-width: 760px) {
   button,
-  input,
+  input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="file"]),
   select,
   textarea { min-height: 44px; }
+  .checkbox-row label,
+  .index-risk-content label,
+  .bulk-select-all-wrap { min-height: 44px; }
   .skip-link { min-height: 44px; }
   .help-tip[tabindex] {
     display: inline-flex;
@@ -5276,8 +5279,6 @@ textarea:focus-visible,
   .header-actions { gap: var(--space-1); padding-left: var(--space-1); }
   .header-actions .btn-icon,
   #help-toggle { width: 44px; height: 44px; min-width: 44px; }
-  #settings-btn,
-  #help-toggle { display: none; }
   .app-mode-toggle { min-height: 44px; }
   .tab-nav { padding: 0 var(--space-2); scroll-padding-inline: var(--space-2); }
   .tab-btn { min-width: 44px; min-height: 48px; padding-inline: var(--space-3); scroll-snap-align: center; }

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -5039,3 +5039,207 @@ button.ctx-runtime-chip--greyed:focus-visible {
 /* Unified-diff line kinds the shared .diff-* set doesn't cover. */
 .diff-file { color: var(--muted); font-weight: 600; }
 .diff-hunk { color: var(--accent); }
+
+/* =========================================================
+   2026 UI refresh foundation
+   Keep the existing SPA contract while normalizing its visual language.
+   ========================================================= */
+:root {
+  --bg: #0b0d12;
+  --surface: #131722;
+  --surface-raised: #1a2030;
+  --surface-subtle: #10141d;
+  --border: #2a3245;
+  --border-strong: #3a4660;
+  --text: #f1f4f9;
+  --muted: #9aa4b8;
+  --accent: #7c9cff;
+  --accent-rgb: 124, 156, 255;
+  --green: #53c78a;
+  --yellow: #f2b84b;
+  --danger: #f06b72;
+  --danger-rgb: 240, 107, 114;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --radius-sm: 6px;
+  --radius: 10px;
+  --radius-lg: 16px;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, .2);
+  --shadow-md: 0 12px 32px rgba(0, 0, 0, .24);
+  --focus-ring: 0 0 0 3px rgba(var(--accent-rgb), .28);
+  --motion-fast: 120ms;
+  --motion-base: 180ms;
+}
+
+:root[data-theme="light"] {
+  --bg: #f5f7fb;
+  --surface: #ffffff;
+  --surface-raised: #ffffff;
+  --surface-subtle: #eef2f8;
+  --border: #d8deea;
+  --border-strong: #bbc5d8;
+  --text: #1b2433;
+  --muted: #5d687a;
+  --accent: #315fd5;
+  --accent-rgb: 49, 95, 213;
+  --green: #18794e;
+  --yellow: #8f5b00;
+  --danger: #b4232c;
+  --danger-rgb: 180, 35, 44;
+  --shadow-sm: 0 1px 3px rgba(27, 36, 51, .08);
+  --shadow-md: 0 14px 36px rgba(27, 36, 51, .14);
+}
+
+body { line-height: 1.45; }
+header {
+  height: 60px;
+  padding: 0 var(--space-5);
+  gap: var(--space-4);
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  box-shadow: var(--shadow-sm);
+}
+header h1 { font-size: 1.12rem; letter-spacing: -.03em; }
+.header-info-bar { gap: var(--space-2); }
+.header-actions { gap: var(--space-2); padding-left: var(--space-2); border-left: 1px solid var(--border); }
+.header-actions .btn-icon,
+#help-toggle {
+  display: inline-grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  min-width: 36px;
+  padding: 0;
+  border: 1px solid transparent;
+  color: var(--muted);
+}
+.header-actions .btn-icon svg,
+#help-toggle svg { width: 18px; height: 18px; fill: none; stroke: currentColor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+#settings-btn svg path { fill: currentColor; stroke: none; }
+.theme-icon-sun { display: none; }
+#theme-toggle[data-theme-state="light"] .theme-icon-moon { display: none; }
+#theme-toggle[data-theme-state="light"] .theme-icon-sun { display: block; }
+.header-actions .btn-icon:hover,
+#help-toggle:hover { color: var(--text); background: var(--surface-subtle); border-color: var(--border); }
+
+.tab-nav { min-height: 44px; padding: 0 var(--space-5); gap: var(--space-1); scroll-padding-inline: var(--space-5); }
+.tab-btn { min-height: 44px; padding: 0 var(--space-4); font-weight: 600; transition: color var(--motion-fast), background var(--motion-fast), border-color var(--motion-fast); }
+.tab-btn:hover { background: var(--surface-subtle); }
+.tab-btn.active { background: rgba(var(--accent-rgb), .08); }
+
+button { transition: background-color var(--motion-fast), border-color var(--motion-fast), color var(--motion-fast), box-shadow var(--motion-fast), transform var(--motion-fast); }
+button:hover { opacity: 1; }
+button:active:not(:disabled) { opacity: 1; transform: translateY(1px); }
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[tabindex]:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; box-shadow: var(--focus-ring); }
+.btn-primary:hover { background: color-mix(in srgb, var(--accent) 86%, white); }
+.btn-ghost:hover { background: var(--surface-subtle); border-color: var(--border-strong); color: var(--text); }
+.card,
+.ctx-card,
+.ctx-overview-stat { background: var(--surface); border-color: var(--border); box-shadow: var(--shadow-sm); }
+
+.empty-state { min-height: 180px; padding: var(--space-8); flex-direction: column; gap: var(--space-2); text-align: center; }
+.status-msg { border: 1px solid transparent; padding: var(--space-3) var(--space-4); }
+.status-msg.ok { border-color: color-mix(in srgb, var(--green) 38%, transparent); }
+.status-msg.err { border-color: color-mix(in srgb, var(--danger) 38%, transparent); }
+.modal-overlay,
+.wizard-overlay { backdrop-filter: blur(4px); overscroll-behavior: contain; }
+.modal,
+.wizard-card { border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--shadow-md); }
+
+.home-layout { gap: var(--space-5); padding: var(--space-6); }
+.home-search-row { order: -2; }
+.home-search-wrap { max-width: 760px; padding: var(--space-2); background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--shadow-sm); }
+.home-search-wrap input { min-height: 44px; border-color: transparent; background: transparent; }
+.home-search-wrap button { min-height: 44px; padding-inline: var(--space-6); }
+.home-orientation { order: -1; }
+.home-stats-row .stat-card { padding: var(--space-4); }
+.home-stats-row .stat-value { font-size: 1.55rem; }
+
+.search-bar { gap: var(--space-2); padding: var(--space-3) var(--space-5); background: var(--surface); }
+.search-bar input,
+.search-bar button { min-height: 44px; }
+.search-filters { padding: var(--space-3) var(--space-5); gap: var(--space-2); background: var(--surface-subtle); }
+.sources-header,
+.sources-filter-row,
+.sources-sort-row { gap: var(--space-2); }
+.sources-sidebar { background: var(--surface); }
+.source-item { min-height: 44px; }
+.index-mode-toggle { border-radius: var(--radius); padding: var(--space-1); }
+.index-panels { border-radius: var(--radius-lg); }
+.settings-nav { background: var(--surface); padding: var(--space-3) var(--space-2); }
+.settings-nav-btn { min-height: 44px; border-radius: var(--radius-sm); border-left: 0; padding: var(--space-2) var(--space-3); align-items: center; }
+.settings-nav-btn.active { box-shadow: inset 3px 0 0 var(--accent); }
+.settings-content { padding: var(--space-6); }
+.ctx-control-bar { background: var(--bg); padding: var(--space-3) 0; }
+
+@media (max-width: 760px) {
+  button,
+  input,
+  select,
+  textarea { min-height: 44px; }
+  .skip-link { min-height: 44px; }
+  .help-tip[tabindex] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
+  }
+  header { height: 56px; padding: 0 var(--space-3); gap: var(--space-2); }
+  .header-sys-info,
+  .header-sep,
+  .header-info-bar .help-tip { display: none; }
+  .header-info-bar { margin-left: auto; }
+  .stat-pill { padding: 2px var(--space-2); }
+  .header-actions { gap: var(--space-1); padding-left: var(--space-1); }
+  .header-actions .btn-icon,
+  #help-toggle { width: 44px; height: 44px; min-width: 44px; }
+  #settings-btn,
+  #help-toggle { display: none; }
+  .app-mode-toggle { min-height: 44px; }
+  .tab-nav { padding: 0 var(--space-2); scroll-padding-inline: var(--space-2); }
+  .tab-btn { min-width: 44px; min-height: 48px; padding-inline: var(--space-3); scroll-snap-align: center; }
+  .search-bar { padding: var(--space-2) var(--space-3); flex-wrap: wrap; }
+  .search-bar .search-input-wrap { flex-basis: calc(100% - 80px); }
+  .sources-layout.mobile-detail .sources-sidebar { display: none; }
+  .sources-layout:not(.mobile-detail) .sources-detail { display: none; }
+}
+
+@media (max-width: 520px) {
+  .header-info-bar { display: none; }
+  header h1 { font-size: 1rem; }
+  .header-actions { margin-left: auto; border-left: 0; }
+  .home-layout { padding: var(--space-3); }
+  .home-search-wrap { flex-direction: row; gap: var(--space-1); }
+  .home-search-wrap button { width: auto; padding-inline: var(--space-4); }
+  .home-stats-row { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .settings-layout { flex-direction: column; }
+  .settings-nav {
+    width: 100%;
+    max-height: none !important;
+    flex-direction: row;
+    overflow-x: auto;
+    overflow-y: hidden;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+    padding: var(--space-2);
+    gap: var(--space-1);
+    scrollbar-width: none;
+  }
+  .settings-nav-btn { width: auto; min-width: max-content; padding: var(--space-2) var(--space-3); }
+  .settings-nav-btn .nav-sub,
+  .settings-nav-divider,
+  .settings-nav-group { display: none !important; }
+  .settings-nav-btn.active { box-shadow: inset 0 -3px 0 var(--accent); }
+  .settings-content { padding: var(--space-3); }
+  .ctx-control-bar { align-items: stretch; }
+  .ctx-control-bar > * { max-width: 100%; }
+}

--- a/packages/memtomem/tests/web/test_ui_refresh_contract.py
+++ b/packages/memtomem/tests/web/test_ui_refresh_contract.py
@@ -1,0 +1,63 @@
+"""Static guardrails for the shared mm web visual-system refresh."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+STATIC = Path(__file__).parents[2] / "src" / "memtomem" / "web" / "static"
+
+
+def test_refresh_tokens_cover_color_spacing_shape_focus_and_motion() -> None:
+    css = (STATIC / "style.css").read_text(encoding="utf-8")
+
+    for token in (
+        "--surface-raised:",
+        "--surface-subtle:",
+        "--border-strong:",
+        "--space-1:",
+        "--space-8:",
+        "--radius-sm:",
+        "--radius-lg:",
+        "--shadow-sm:",
+        "--shadow-md:",
+        "--focus-ring:",
+        "--motion-fast:",
+        "--motion-base:",
+    ):
+        assert token in css
+
+
+def test_refresh_replaces_global_opacity_hover_and_pins_mobile_targets() -> None:
+    css = (STATIC / "style.css").read_text(encoding="utf-8")
+
+    refresh = css.split("2026 UI refresh foundation", maxsplit=1)[1]
+    assert "button:hover { opacity: 1; }" in refresh
+    assert "button:active:not(:disabled)" in refresh
+    assert "button:focus-visible" in refresh
+    assert "min-height: 44px" in refresh
+    assert ".tab-btn { min-width: 44px;" in refresh
+
+
+def test_header_utility_icons_are_dependency_free_inline_svg() -> None:
+    html = (STATIC / "index.html").read_text(encoding="utf-8")
+
+    for button_id in ("settings-btn", "theme-toggle", "help-toggle"):
+        start = html.index(f'id="{button_id}"')
+        end = html.index("</button>", start)
+        assert "<svg" in html[start:end]
+
+    assert "⚙️" not in html
+    assert ">🌙<" not in html
+    assert ">☀️<" not in html
+
+
+def test_settings_mobile_navigation_is_horizontal_chip_row() -> None:
+    css = (STATIC / "style.css").read_text(encoding="utf-8")
+    refresh = css.split("2026 UI refresh foundation", maxsplit=1)[1]
+    mobile = refresh.split("@media (max-width: 520px)", maxsplit=1)[1]
+
+    assert ".settings-nav" in mobile
+    assert "flex-direction: row" in mobile
+    assert "overflow-x: auto" in mobile
+    assert "max-height: none !important" in mobile

--- a/packages/memtomem/tests/web/test_ui_refresh_contract.py
+++ b/packages/memtomem/tests/web/test_ui_refresh_contract.py
@@ -31,12 +31,15 @@ def test_refresh_tokens_cover_color_spacing_shape_focus_and_motion() -> None:
 def test_refresh_replaces_global_opacity_hover_and_pins_mobile_targets() -> None:
     css = (STATIC / "style.css").read_text(encoding="utf-8")
 
+    assert "2026 UI refresh foundation" in css
     refresh = css.split("2026 UI refresh foundation", maxsplit=1)[1]
     assert "button:hover { opacity: 1; }" in refresh
     assert "button:active:not(:disabled)" in refresh
     assert "button:focus-visible" in refresh
     assert "min-height: 44px" in refresh
     assert ".tab-btn { min-width: 44px;" in refresh
+    assert 'input:not([type="checkbox"]):not([type="radio"])' in refresh
+    assert "#settings-btn,\n  #help-toggle { display: none; }" not in refresh
 
 
 def test_header_utility_icons_are_dependency_free_inline_svg() -> None:
@@ -50,6 +53,23 @@ def test_header_utility_icons_are_dependency_free_inline_svg() -> None:
     assert "⚙️" not in html
     assert ">🌙<" not in html
     assert ">☀️<" not in html
+
+
+def test_changed_static_assets_bump_cache_versions() -> None:
+    html = (STATIC / "index.html").read_text(encoding="utf-8")
+
+    assert "/style.css?v=132" in html
+    assert "/app.js?v=148" in html
+
+
+def test_theme_icon_follows_document_theme_without_duplicate_js_state() -> None:
+    html = (STATIC / "index.html").read_text(encoding="utf-8")
+    css = (STATIC / "style.css").read_text(encoding="utf-8")
+    js = (STATIC / "app.js").read_text(encoding="utf-8")
+
+    assert "data-theme-state" not in html
+    assert "data-theme-state" not in js
+    assert ':root[data-theme="light"] .theme-icon-moon' in css
 
 
 def test_settings_mobile_navigation_is_horizontal_chip_row() -> None:

--- a/packages/memtomem/tests/web/test_ui_refresh_contract.py
+++ b/packages/memtomem/tests/web/test_ui_refresh_contract.py
@@ -61,6 +61,7 @@ def test_settings_mobile_navigation_is_horizontal_chip_row() -> None:
     assert "flex-direction: row" in mobile
     assert "overflow-x: auto" in mobile
     assert "max-height: none !important" in mobile
+    assert ".settings-nav-btn.collapsed-member { display: flex; }" in mobile
 
 
 def test_index_uses_segmented_work_card_and_guarded_risk_disclosure() -> None:

--- a/packages/memtomem/tests/web/test_ui_refresh_contract.py
+++ b/packages/memtomem/tests/web/test_ui_refresh_contract.py
@@ -61,3 +61,17 @@ def test_settings_mobile_navigation_is_horizontal_chip_row() -> None:
     assert "flex-direction: row" in mobile
     assert "overflow-x: auto" in mobile
     assert "max-height: none !important" in mobile
+
+
+def test_index_uses_segmented_work_card_and_guarded_risk_disclosure() -> None:
+    html = (STATIC / "index.html").read_text(encoding="utf-8")
+    css = (STATIC / "style.css").read_text(encoding="utf-8")
+
+    assert 'class="index-mode-toggle" role="tablist"' in html
+    assert 'class="card index-panels"' in html
+    assert 'class="index-risk-disclosure"' in html
+    disclosure = html.split('class="index-risk-disclosure"', maxsplit=1)[1]
+    disclosure = disclosure.split("</details>", maxsplit=1)[0]
+    assert 'id="index-force-unsafe"' in disclosure
+    assert ".index-mode-toggle .btn-ghost.btn-active" in css
+    assert ".index-risk-content" in css

--- a/packages/memtomem/tests/web/test_ui_smoke_matrix.py
+++ b/packages/memtomem/tests/web/test_ui_smoke_matrix.py
@@ -416,18 +416,16 @@ def test_ui_smoke_matrix(page, mode: str, viewport: tuple[int, int]) -> None:
         else:
             assert page.locator('[data-ui-tier="dev"]:visible').count() > 0
 
-        if viewport[0] > 760:
-            page.locator("#settings-btn").click()
-            assert not page.locator("#settings-modal").evaluate("el => el.hidden")
-            page.keyboard.press("Escape")
-            assert page.locator("#settings-modal").evaluate("el => el.hidden")
+        page.locator("#settings-btn").click()
+        assert not page.locator("#settings-modal").evaluate("el => el.hidden")
+        page.keyboard.press("Escape")
+        assert page.locator("#settings-modal").evaluate("el => el.hidden")
 
         theme_before = page.locator("html").get_attribute("data-theme")
         page.locator("#theme-toggle").click()
         assert page.locator("html").get_attribute("data-theme") != theme_before
-        if viewport[0] > 760:
-            page.locator("#help-toggle").click()
-            assert page.locator("#help-toggle").get_attribute("aria-pressed") in {"true", "false"}
+        page.locator("#help-toggle").click()
+        assert page.locator("#help-toggle").get_attribute("aria-pressed") in {"true", "false"}
 
         page.locator('.tab-btn[data-tab="index"]').click()
         for index_mode in ("folder", "upload", "compose"):
@@ -435,6 +433,15 @@ def test_ui_smoke_matrix(page, mode: str, viewport: tuple[int, int]) -> None:
             btn.click()
             assert btn.get_attribute("aria-selected") == "true"
             assert page.locator(f'[data-mode-guide="{index_mode}"]').is_visible()
+            if viewport[0] <= 390 and index_mode == "folder":
+                checkbox_metrics = page.locator("#index-recursive").evaluate(
+                    """el => ({
+                        inputHeight: el.getBoundingClientRect().height,
+                        labelHeight: el.closest('label').getBoundingClientRect().height,
+                    })"""
+                )
+                assert checkbox_metrics["inputHeight"] <= 24
+                assert checkbox_metrics["labelHeight"] >= 44
 
         page.locator('.tab-btn[data-tab="tags"]').click()
         assert page.locator("#tags-search").is_visible()

--- a/packages/memtomem/tests/web/test_ui_smoke_matrix.py
+++ b/packages/memtomem/tests/web/test_ui_smoke_matrix.py
@@ -251,7 +251,7 @@ def _assert_active_panel(page, tab: str) -> None:
 
 
 @pytest.mark.parametrize("mode", ["prod", "dev"])
-@pytest.mark.parametrize("viewport", [(1440, 1000), (390, 844)])
+@pytest.mark.parametrize("viewport", [(1440, 1000), (1024, 768), (390, 844)])
 def test_ui_smoke_matrix(page, mode: str, viewport: tuple[int, int]) -> None:
     """Walk the main tabs and nested menus in prod/dev on desktop/mobile."""
     page.set_viewport_size({"width": viewport[0], "height": viewport[1]})

--- a/packages/memtomem/tests/web/test_ui_smoke_matrix.py
+++ b/packages/memtomem/tests/web/test_ui_smoke_matrix.py
@@ -346,7 +346,12 @@ def test_ui_smoke_matrix(page, mode: str, viewport: tuple[int, int]) -> None:
             assert not page.locator(".sources-layout").evaluate(
                 "el => el.classList.contains('mobile-detail')"
             )
-            page.locator("#sources-list .source-item").first.click()
+            # Exercise the row's production Enter handler as part of the
+            # keyboard-only acceptance path. This also avoids racing the
+            # source tree's async status repaint with a stale pointer point.
+            source_row = page.locator("#sources-list .source-item").first
+            source_row.focus()
+            page.keyboard.press("Enter")
         page.wait_for_function(
             "() => document.querySelector('#chunks-browser .chunks-browser-header .file-path')?.textContent.includes('notes.md')",
             timeout=5_000,
@@ -411,16 +416,18 @@ def test_ui_smoke_matrix(page, mode: str, viewport: tuple[int, int]) -> None:
         else:
             assert page.locator('[data-ui-tier="dev"]:visible').count() > 0
 
-        page.locator("#settings-btn").click()
-        assert not page.locator("#settings-modal").evaluate("el => el.hidden")
-        page.keyboard.press("Escape")
-        assert page.locator("#settings-modal").evaluate("el => el.hidden")
+        if viewport[0] > 760:
+            page.locator("#settings-btn").click()
+            assert not page.locator("#settings-modal").evaluate("el => el.hidden")
+            page.keyboard.press("Escape")
+            assert page.locator("#settings-modal").evaluate("el => el.hidden")
 
         theme_before = page.locator("html").get_attribute("data-theme")
         page.locator("#theme-toggle").click()
         assert page.locator("html").get_attribute("data-theme") != theme_before
-        page.locator("#help-toggle").click()
-        assert page.locator("#help-toggle").get_attribute("aria-pressed") in {"true", "false"}
+        if viewport[0] > 760:
+            page.locator("#help-toggle").click()
+            assert page.locator("#help-toggle").get_attribute("aria-pressed") in {"true", "false"}
 
         page.locator('.tab-btn[data-tab="index"]').click()
         for index_mode in ("folder", "upload", "compose"):

--- a/packages/memtomem/tests/web/test_ui_smoke_matrix.py
+++ b/packages/memtomem/tests/web/test_ui_smoke_matrix.py
@@ -342,10 +342,24 @@ def test_ui_smoke_matrix(page, mode: str, viewport: tuple[int, int]) -> None:
 
         page.locator('.tab-btn[data-tab="sources"]').click()
         assert page.locator(".sources-vendor-tab").count() >= 1
+        if viewport[0] <= 390:
+            assert not page.locator(".sources-layout").evaluate(
+                "el => el.classList.contains('mobile-detail')"
+            )
+            page.locator("#sources-list .source-item").first.click()
         page.wait_for_function(
             "() => document.querySelector('#chunks-browser .chunks-browser-header .file-path')?.textContent.includes('notes.md')",
             timeout=5_000,
         )
+        if viewport[0] <= 390:
+            assert page.locator(".sources-layout").evaluate(
+                "el => el.classList.contains('mobile-detail')"
+            )
+            assert page.locator(".sources-mobile-back").is_visible()
+            page.locator(".sources-mobile-back").click()
+            assert not page.locator(".sources-layout").evaluate(
+                "el => el.classList.contains('mobile-detail')"
+            )
         for vendor in ("user", "claude", "openai"):
             tab = page.locator(f'.sources-vendor-tab[data-vendor="{vendor}"]')
             if tab.count():


### PR DESCRIPTION
## Summary

- normalize the existing Vanilla SPA around shared color, spacing, radius, focus, motion, and state tokens
- streamline Home, Search, and Sources, including a mobile list-to-detail source drilldown
- unify Index, Context Gateway, and Settings workspaces with segmented controls, shared headers, and mobile section chips
- replace header emoji utilities with dependency-free inline SVG and preserve existing IDs, hashes, shortcuts, modes, themes, and locales

## Validation

- `python -m pytest packages/memtomem/tests/web`: 319 passed before the final main sync; the two discovered mobile smoke failures were fixed and covered below
- focused UI browser suite: 16 passed
- `npm test` in `packages/memtomem/tests-js`: 434 passed
- `ruff check packages/memtomem/src packages/memtomem/tests/web`
- `ruff format --check packages/memtomem/src packages/memtomem/tests/web`
- `git diff --check`

## Notes

- no backend API, storage format, URL hash, DOM ID, or Context Gateway sync-semantics changes
- screenshots remain temporary QA artifacts and are not committed