### PR TITLE
feat(web): surface known_projects.json read failures on GET /api/context/projects

### DIFF
--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -35,10 +35,12 @@ __all__ = [
     "ProjectScope",
     "ProjectHealth",
     "KnownProjectsCorruptError",
+    "KnownProjectsLoadReport",
     "KnownProjectsStore",
     "UnknownProjectSelectorError",
     "compute_scope_id",
     "discover_project_scopes",
+    "discover_project_scopes_with_report",
     "annotate_project_health",
     "resolve_project_selector",
     "sync_skip_reason",
@@ -169,6 +171,55 @@ class _KnownProjectEntry:
     extra: dict[str, Any] = field(default_factory=dict, compare=False)
 
 
+@dataclass(frozen=True)
+class KnownProjectsLoadReport:
+    """Outcome of a tolerant ``known_projects.json`` read.
+
+    ``ok`` is ``False`` iff the file *exists* but was unusable as a whole
+    (unreadable, invalid JSON, unexpected version, unexpected shape) — a
+    missing file is the normal pre-registration state and reads as ok.
+    ``reason_code`` is ``"registry_corrupt"`` whenever there is something to
+    surface (whole-file degradation, or rows the tolerant parser skipped) and
+    ``None`` on a clean read. ``detail`` is the human-readable cause; it may
+    embed filesystem paths and OS error text, so web surfaces must pass it
+    through ``_redact_message`` before serving. ``skipped_rows`` counts rows
+    the tolerant parser dropped; non-zero only when the document itself parsed
+    (``ok`` stays ``True``). ``error_kind`` classifies the degradation at the
+    catch site — one of ``parse`` / ``permission`` / ``missing`` / ``internal``,
+    deliberately the web layer's ``_classify_exception`` vocabulary so the
+    wire value is identical to what classifying the live exception would have
+    produced. Classifying here (and discarding the exception) keeps a caught
+    ``OSError`` — with its traceback and retained frame locals — from being
+    transported across the context/web boundary; it is ``None`` on a clean
+    read.
+    """
+
+    entries: list[_KnownProjectEntry]
+    ok: bool
+    reason_code: str | None
+    detail: str | None
+    skipped_rows: int
+    error_kind: str | None = None
+
+
+def _classify_registry_os_error(exc: OSError) -> str:
+    """Neutral error-kind for an unreadable registry file.
+
+    Mirrors the OSError subset of the web layer's ``_classify_exception``
+    mapping (``PermissionError`` → permission; path-type errors → missing;
+    anything else → internal, since ``errno`` may be EIO/EMFILE/ELOOP etc.)
+    so :class:`KnownProjectsLoadReport.error_kind` carries the same wire value
+    without this module importing web-layer helpers or the report transporting
+    the live exception. ``FileNotFoundError`` never reaches here — the caller
+    treats a missing file as the clean pre-registration state.
+    """
+    if isinstance(exc, PermissionError):
+        return "permission"
+    if isinstance(exc, (FileNotFoundError, NotADirectoryError, IsADirectoryError)):
+        return "missing"
+    return "internal"
+
+
 class KnownProjectsStore:
     """Read / append / delete entries in ``known_projects.json``.
 
@@ -201,6 +252,17 @@ class KnownProjectsStore:
         """
         return self._load_doc(strict=strict)[0]
 
+    def load_with_report(self) -> KnownProjectsLoadReport:
+        """Tolerant :meth:`load` that also reports how the read degraded.
+
+        The entries are identical to ``load(strict=False)``; the report makes
+        the previously log-only degradation contract inspectable so read-only
+        surfaces (``GET /api/context/projects``) can say "registry
+        unavailable" instead of presenting the empty fallback as the truth
+        (#1692). Mutators keep using strict loads — this never raises.
+        """
+        return self._load_doc_with_report(strict=False)[2]
+
     def _load_doc(self, *, strict: bool = False) -> tuple[list[_KnownProjectEntry], dict[str, Any]]:
         """Like :meth:`load`, but also return unknown document-level keys.
 
@@ -211,18 +273,53 @@ class KnownProjectsStore:
         always ``{}`` on any degradation path (missing / corrupt file), so a
         tolerant caller never resurrects partial document state.
         """
+        entries, doc_extra, _ = self._load_doc_with_report(strict=strict)
+        return entries, doc_extra
+
+    def _load_doc_with_report(
+        self, *, strict: bool = False
+    ) -> tuple[list[_KnownProjectEntry], dict[str, Any], KnownProjectsLoadReport]:
+        """:meth:`_load_doc` plus a :class:`KnownProjectsLoadReport`.
+
+        In strict mode every degradation raises before a report could carry
+        it, so a strict return is always a clean report.
+        """
         hint = "fix or remove it (e.g. restore it from version control), then retry"
+
+        def _degraded(
+            detail: str, error_kind: str = "parse"
+        ) -> tuple[list[_KnownProjectEntry], dict[str, Any], KnownProjectsLoadReport]:
+            # "parse" default: decode/version/shape refusals are document
+            # -contract violations with no exception kind of their own.
+            report = KnownProjectsLoadReport(
+                entries=[],
+                ok=False,
+                reason_code="registry_corrupt",
+                detail=detail,
+                skipped_rows=0,
+                error_kind=error_kind,
+            )
+            return [], {}, report
+
+        def _clean_empty() -> tuple[
+            list[_KnownProjectEntry], dict[str, Any], KnownProjectsLoadReport
+        ]:
+            report = KnownProjectsLoadReport(
+                entries=[], ok=True, reason_code=None, detail=None, skipped_rows=0
+            )
+            return [], {}, report
+
         try:
             raw = self._path.read_bytes()
         except FileNotFoundError:
-            return [], {}
+            # Normal pre-registration state — nothing to surface.
+            return _clean_empty()
         except OSError as exc:
+            detail = f"known_projects file at {self._path} is unreadable ({exc}); {hint}"
             if strict:
-                raise KnownProjectsCorruptError(
-                    f"known_projects file at {self._path} is unreadable ({exc}); {hint}"
-                ) from exc
+                raise KnownProjectsCorruptError(detail) from exc
             logger.warning("known_projects: read failed: %s", exc)
-            return [], {}
+            return _degraded(detail, _classify_registry_os_error(exc))
 
         try:
             doc = json.loads(raw)
@@ -230,22 +327,22 @@ class KnownProjectsStore:
             # UnicodeDecodeError: json.loads(bytes) decodes before parsing,
             # so invalid UTF-8 raises it instead of JSONDecodeError — same
             # corrupt-file class, same handling (Codex design review).
+            detail = f"known_projects file at {self._path} is not valid JSON ({exc}); {hint}"
             if strict:
-                raise KnownProjectsCorruptError(
-                    f"known_projects file at {self._path} is not valid JSON ({exc}); {hint}"
-                ) from exc
+                raise KnownProjectsCorruptError(detail) from exc
             logger.warning("known_projects: invalid JSON, ignoring file: %s", exc)
-            return [], {}
+            return _degraded(detail)
 
         if not isinstance(doc, dict) or doc.get("version") != _KNOWN_PROJECTS_VERSION:
             version = doc.get("version") if isinstance(doc, dict) else None
+            detail = (
+                f"known_projects file at {self._path} has unexpected version "
+                f"{version!r} (this build writes version {_KNOWN_PROJECTS_VERSION}); {hint}"
+            )
             if strict:
-                raise KnownProjectsCorruptError(
-                    f"known_projects file at {self._path} has unexpected version "
-                    f"{version!r} (this build writes version {_KNOWN_PROJECTS_VERSION}); {hint}"
-                )
+                raise KnownProjectsCorruptError(detail)
             logger.warning("known_projects: unexpected version %r, ignoring", version)
-            return [], {}
+            return _degraded(detail)
 
         # Past the version gate: capture forward-compat document-level keys.
         doc_extra = {k: v for k, v in doc.items() if k not in ("version", "projects")}
@@ -259,14 +356,16 @@ class KnownProjectsStore:
         # ``label`` / ``enabled``) are NOT corruption and parse normally.
         projects_member = doc.get("projects", [])
         if not isinstance(projects_member, list):
+            detail = (
+                f"known_projects file at {self._path} has a non-list 'projects' "
+                f"member ({type(projects_member).__name__}); {hint}"
+            )
             if strict:
-                raise KnownProjectsCorruptError(
-                    f"known_projects file at {self._path} has a non-list 'projects' "
-                    f"member ({type(projects_member).__name__}); {hint}"
-                )
+                raise KnownProjectsCorruptError(detail)
             logger.warning("known_projects: 'projects' is not a list, ignoring file")
-            return [], {}
+            return _degraded(detail)
 
+        skipped_rows = 0
         entries: list[_KnownProjectEntry] = []
         for item in projects_member:
             if not isinstance(item, dict):
@@ -275,6 +374,7 @@ class KnownProjectsStore:
                         f"known_projects file at {self._path} has a non-object project "
                         f"row ({type(item).__name__}); {hint}"
                     )
+                skipped_rows += 1
                 continue
             root = item.get("root")
             if not isinstance(root, str) or not root:
@@ -283,6 +383,7 @@ class KnownProjectsStore:
                         f"known_projects file at {self._path} has a project row without "
                         f"a usable 'root'; {hint}"
                     )
+                skipped_rows += 1
                 continue
             entries.append(
                 _KnownProjectEntry(
@@ -306,7 +407,25 @@ class KnownProjectsStore:
                     extra={k: v for k, v in item.items() if k not in _KNOWN_ROW_KEYS},
                 )
             )
-        return entries, doc_extra
+        if skipped_rows:
+            # Row skips previously had no signal at all; the document itself
+            # parsed, so this is a warning-with-count, not "unavailable".
+            logger.warning("known_projects: skipped %d unparsable project row(s)", skipped_rows)
+        report = KnownProjectsLoadReport(
+            entries=entries,
+            ok=True,
+            reason_code="registry_corrupt" if skipped_rows else None,
+            detail=(
+                f"known_projects file at {self._path} has {skipped_rows} unparsable "
+                f"project row(s), skipped; {hint}"
+                if skipped_rows
+                else None
+            ),
+            skipped_rows=skipped_rows,
+            # Skipped rows are shape violations inside a document that parsed.
+            error_kind="parse" if skipped_rows else None,
+        )
+        return entries, doc_extra, report
 
     def add(self, root: Path, label: str | None = None) -> _KnownProjectEntry:
         """Register *root*. Idempotent — re-registering an existing root is a no-op
@@ -818,7 +937,34 @@ def discover_project_scopes(
     experimental_claude_projects_scan: bool,
     auto_display_configured_projects: bool = True,
 ) -> list[ProjectScope]:
+    """:func:`discover_project_scopes_with_report` without the registry report.
+
+    For callers that only render the roster; surfaces that must distinguish
+    "empty registry" from "registry unreadable" (#1692) use the ``_with_report``
+    variant.
+    """
+    return discover_project_scopes_with_report(
+        cwd,
+        known_projects_file,
+        experimental_claude_projects_scan=experimental_claude_projects_scan,
+        auto_display_configured_projects=auto_display_configured_projects,
+    )[0]
+
+
+def discover_project_scopes_with_report(
+    cwd: Path,
+    known_projects_file: Path,
+    *,
+    experimental_claude_projects_scan: bool,
+    auto_display_configured_projects: bool = True,
+) -> tuple[list[ProjectScope], KnownProjectsLoadReport]:
     """Enumerate all project scopes the UI should render, in display order.
+
+    Also returns the :class:`KnownProjectsLoadReport` from the tolerant
+    registry read, so the Projects route can surface a degraded registry
+    instead of serving the empty fallback as a truthful roster (#1692). The
+    scope list itself is unchanged by degradation — server cwd (and any scan
+    hits) still appear.
 
     Server cwd is always first (so the user's primary working tree is
     visible even before Add Project is used). Entries with the same
@@ -866,7 +1012,8 @@ def discover_project_scopes(
 
     # 2. User-registered roots from known_projects.json.
     store = KnownProjectsStore(known_projects_file)
-    known_entries = store.load()
+    load_report = store.load_with_report()
+    known_entries = load_report.entries
     # Sync enrollment (``enabled``) is read strictly from the known_projects
     # entry, keyed the same way ``_add`` keys ``by_resolved`` so the lookup at
     # emit time matches. cwd / scan sources never contribute enablement.
@@ -939,7 +1086,7 @@ def discover_project_scopes(
                 sync_eligible=sync_eligible,
             )
         )
-    return scopes
+    return scopes, load_report
 
 
 # ── Validation helpers ──────────────────────────────────────────────────

--- a/packages/memtomem/src/memtomem/web/routes/context_projects.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_projects.py
@@ -37,9 +37,11 @@ from memtomem.context.projects import (
     _MARKER_DIRS,
     KnownProjectsCorruptError,
     KnownProjectsStore,
+    KnownProjectsLoadReport,
     ProjectScope,
     compute_scope_id,
     discover_project_scopes,
+    discover_project_scopes_with_report,
     has_runtime_marker,
 )
 from memtomem.context.mcp_servers import diff_mcp_servers, list_canonical_mcp_servers
@@ -77,6 +79,49 @@ def _discover_for(request: Request) -> list[ProjectScope]:
         experimental_claude_projects_scan=cfg.experimental_claude_projects_scan,
         auto_display_configured_projects=cfg.auto_display_configured_projects,
     )
+
+
+def _discover_with_report(
+    request: Request,
+) -> tuple[list[ProjectScope], KnownProjectsLoadReport]:
+    """:func:`_discover_for` plus the registry load report (#1692).
+
+    Used only by ``list_projects`` — the roster surface where a silently
+    degraded registry reads as false confidence. Selector resolution and
+    status-all keep :func:`_discover_for`.
+    """
+    cfg = _gateway_config(request)
+    cwd = _default_project_root(request)
+    return discover_project_scopes_with_report(
+        cwd,
+        Path(cfg.known_projects_path).expanduser(),
+        experimental_claude_projects_scan=cfg.experimental_claude_projects_scan,
+        auto_display_configured_projects=cfg.auto_display_configured_projects,
+    )
+
+
+def _registry_warnings(report: KnownProjectsLoadReport) -> list[dict]:
+    """Serialize the registry load report as wire warning items.
+
+    Item shape: ``{reason_code, error_kind, message, retryable, skipped_rows}``
+    — ``skipped_rows`` is non-null only for row-level degradation (document
+    parsed, some rows dropped). ``error_kind`` comes pre-classified from the
+    store report in the ``_classify_exception`` vocabulary (the store
+    classifies at the catch site so no live exception crosses the
+    context/web boundary).
+    """
+    if report.reason_code is None:
+        return []
+    error_kind = report.error_kind or "parse"
+    return [
+        {
+            "reason_code": report.reason_code,
+            "error_kind": error_kind,
+            "message": _redact_message(report.detail or ""),
+            "retryable": True,
+            "skipped_rows": report.skipped_rows or None,
+        }
+    ]
 
 
 def _default_project_root(request: Request) -> Path:
@@ -422,16 +467,27 @@ async def list_projects(
     Response shape (RFC §Decision 4, extended by ADR-0021 PR2):
 
     ``{target_scope, scopes: [{project_scope_id, scope_id, label, root, tier,
-    sources, missing, stale, experimental, enabled, sync_eligible, counts}]}``
+    sources, missing, stale, experimental, enabled, sync_eligible, counts}],
+    registry_status, warnings}``
     where ``counts`` is ``{skills, commands, agents, mcp-servers}`` only when
     ``?include=counts`` is requested (else ``null``). ``enabled`` is the
     known_projects sync-enrollment flag; ``sync_eligible`` is the derived
     server-cwd-OR-enrolled-and-enabled gate.
+
+    ``registry_status`` (#1692) is ``"unavailable"`` iff ``known_projects.json``
+    *exists* but was unusable (a missing file is the normal pre-registration
+    state and stays ``"ok"``); the response is still 200 and ``scopes`` still
+    carries server-cwd / scan rows. ``warnings`` items are
+    ``{reason_code, error_kind, message, retryable, skipped_rows}``;
+    ``skipped_rows`` is non-null only when the document parsed but rows were
+    dropped (``registry_status`` stays ``"ok"`` then). Warning items carry no
+    ``remediation_action`` by design (D3) — remediation presentation is owned
+    by the UI.
     """
     include_tokens = {tok.strip() for tok in include.split(",") if tok.strip()}
     with_counts = "counts" in include_tokens
     with_coverage = "runtime_coverage" in include_tokens
-    scopes = _discover_for(request)
+    scopes, registry_report = _discover_with_report(request)
 
     def _build() -> list[dict]:
         return [
@@ -453,6 +509,8 @@ async def list_projects(
     return {
         "target_scope": target_scope,
         "scopes": scope_dicts,
+        "registry_status": "ok" if registry_report.ok else "unavailable",
+        "warnings": _registry_warnings(registry_report),
     }
 
 

--- a/packages/memtomem/src/memtomem/web/static/context-portal.js
+++ b/packages/memtomem/src/memtomem/web/static/context-portal.js
@@ -80,6 +80,12 @@ let _ctxPortalDriftMap = {};
 // alongside the drift map. Unlike drift, an error is not Sync-remediable, so
 // its badge offers no Sync affordance.
 let _ctxPortalErrorMap = {};
+// Registry read report from the last projects payload (#1692): null when the
+// registry read was clean, else {status: 'ok'|'unavailable', warnings: [...]}.
+// Drives the non-blocking banner above the board — the roster below still
+// renders (server-cwd / scan rows survive a degraded registry). Reset on every
+// fresh load so a repaired registry clears the banner on Retry.
+let _ctxPortalRegistryWarning = null;
 // Active runtime filter: null | 'claude' | 'antigravity' | 'codex' | 'kimi'
 let _ctxPortalRuntimeFilter = null;
 
@@ -430,6 +436,13 @@ async function loadCtxProjects() {
     // deferred fetch below (project_shared only) repopulates it.
     _ctxPortalDriftMap = {};
     _ctxPortalErrorMap = {};
+    // Registry read report (#1692). Warnings may be present while status stays
+    // "ok" (row-level skips), so gate on either signal.
+    const registryWarnings = Array.isArray(data.warnings) ? data.warnings : [];
+    _ctxPortalRegistryWarning =
+      data.registry_status === 'unavailable' || registryWarnings.length
+        ? { status: data.registry_status || 'ok', warnings: registryWarnings }
+        : null;
     if (!scopes.length) {
       // Server CWD is always present, so an empty roster means the load
       // failed — render the shared load-error + Retry (#1287; the helper
@@ -535,10 +548,36 @@ async function _ctxPortalLoadDrift(seq, requestedScope, signal) {
 // Header (search + sort) is painted once and kept across row repaints so the
 // search field never loses focus mid-type; only #ctx-projects-rows is rebuilt
 // on search/sort input.
+// Non-blocking registry read-failure banner (#1692). Unlike
+// _ctxScopesLoadError this never replaces the board — a degraded registry
+// only hides *registered* rows, so the roster (server-cwd / scan) still
+// renders below it. Message keys off registry_status: "unavailable" is the
+// whole-file failure; "ok"-with-warning is the row-skip case, whose count
+// rides in the warning item's skipped_rows.
+function _ctxPortalRegistryBannerHtml() {
+  const warn = _ctxPortalRegistryWarning;
+  if (!warn) return '';
+  const first = warn.warnings[0] || {};
+  const msg = warn.status === 'unavailable'
+    ? t('settings.ctx.portal_registry_unavailable')
+    : t('settings.ctx.portal_registry_rows_skipped', {
+        count: typeof first.skipped_rows === 'number' ? first.skipped_rows : 0,
+      });
+  const reason = first.message
+    ? `<div class="ctx-diagnostic-detail"><div class="ctx-diagnostic-reason">${escapeHtml(first.message)}</div></div>`
+    : '';
+  return `
+    <div class="ctx-portal-registry-banner" role="alert">
+      <div class="ctx-portal-registry-banner-msg">${escapeHtml(msg)}${reason}</div>
+      <button type="button" class="btn-ghost ctx-scopes-retry">${escapeHtml(t('settings.ctx.retry'))}</button>
+    </div>`;
+}
+
 function _ctxPortalRenderScaffold(listEl) {
   const sortName = escapeHtml(t('settings.ctx.portal_sort_name'));
   const sortItems = escapeHtml(t('settings.ctx.portal_sort_items'));
   listEl.innerHTML = `
+    ${_ctxPortalRegistryBannerHtml()}
     <div class="ctx-portal-toolbar">
       <input type="search" id="ctx-portal-search" class="ctx-portal-search"
              value="${escapeHtml(_ctxPortalSearch)}"
@@ -578,6 +617,10 @@ function _ctxPortalRenderScaffold(listEl) {
       _ctxPortalHideUninit = hideUninit.checked;
       _ctxPortalRenderRows();
     });
+  }
+  const registryRetry = listEl.querySelector('.ctx-portal-registry-banner .ctx-scopes-retry');
+  if (registryRetry) {
+    registryRetry.addEventListener('click', () => { loadCtxProjects(); });
   }
 }
 

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=132" />
+  <link rel="stylesheet" href="/style.css?v=133" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -1780,7 +1780,7 @@
   <script src="/context-gateway-conflict.js?v=2"></script>
   <script src="/context-gateway-detail.js?v=3"></script>
   <script src="/context-gateway-actions.js?v=2"></script>
-  <script src="/context-portal.js?v=9"></script>
+  <script src="/context-portal.js?v=10"></script>
   <script src="/wiki.js?v=11"></script>
   <script src="/path-picker.js?v=4"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -863,6 +863,8 @@
   "settings.ctx.portal_drift_tip": "This project's synced context no longer matches the Store (wiki pins behind or runtime files changed). Click Sync on this row, or run mm context status --all-projects for details.",
   "settings.ctx.portal_status_error_badge": "check failed",
   "settings.ctx.portal_status_error_tip": "This project's status check failed, so its sync state is unknown (not clean, not drift). Run mm context status --all-projects for details.",
+  "settings.ctx.portal_registry_unavailable": "The project registry could not be read, so registered projects are hidden. Discovered projects are still shown below.",
+  "settings.ctx.portal_registry_rows_skipped": "{count} project registry entry(ies) could not be read and were skipped. The remaining projects are shown below.",
   "settings.ctx.portal_root_unknown": "(no path)",
   "settings.ctx.portal_load_failed": "Could not load projects",
   "settings.ctx.portal_add_project_tooltip": "Register a project folder so memtomem can track it",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -863,6 +863,8 @@
   "settings.ctx.portal_drift_tip": "이 프로젝트의 동기화된 컨텍스트가 저장소와 더 이상 일치하지 않습니다 (wiki 핀이 뒤처졌거나 런타임 파일이 변경됨). 이 행의 Sync 를 누르거나, 자세한 내용은 mm context status --all-projects 를 실행하세요.",
   "settings.ctx.portal_status_error_badge": "확인 실패",
   "settings.ctx.portal_status_error_tip": "이 프로젝트의 상태 확인이 실패하여 동기화 상태를 알 수 없습니다 (clean 도 drift 도 아님). 자세한 내용은 mm context status --all-projects 를 실행하세요.",
+  "settings.ctx.portal_registry_unavailable": "프로젝트 레지스트리를 읽을 수 없어 등록된 프로젝트가 표시되지 않습니다. 자동 발견된 프로젝트는 아래에 계속 표시됩니다.",
+  "settings.ctx.portal_registry_rows_skipped": "프로젝트 레지스트리 항목 {count}개를 읽을 수 없어 건너뛰었습니다. 나머지 프로젝트는 아래에 표시됩니다.",
   "settings.ctx.portal_root_unknown": "(경로 없음)",
   "settings.ctx.portal_load_failed": "프로젝트를 불러오지 못했습니다",
   "settings.ctx.portal_add_project_tooltip": "memtomem이 추적할 수 있도록 프로젝트 폴더를 등록합니다",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -4313,6 +4313,25 @@ body.app-simple [data-ui-adv="advanced"] { display: none; }
    about an absent root. */
 .ctx-scope-badge--status-error { background: rgba(224, 90, 90, 0.15); color: var(--danger); }
 
+/* Registry read-failure banner (#1692) — non-blocking warning above the
+   Portal board; the roster still renders below it (server-cwd / scan rows
+   survive a degraded registry). Warning tone, matching the header banners. */
+.ctx-portal-registry-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 8px 12px;
+  margin-bottom: 12px;
+  background: color-mix(in srgb, var(--yellow, #f39c12) 12%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--yellow, #f39c12) 40%, var(--border));
+  border-radius: 6px;
+  font-size: 0.82rem;
+  color: var(--text);
+}
+.ctx-portal-registry-banner-msg { flex: 1; min-width: 0; }
+.ctx-portal-registry-banner .ctx-scopes-retry { flex-shrink: 0; }
+
 /* Context Portal (ADR-0021 PR4) — multi-project board */
 .ctx-portal-toolbar {
   display: flex;

--- a/packages/memtomem/tests-js/ctx-portal-registry-warning.test.mjs
+++ b/packages/memtomem/tests-js/ctx-portal-registry-warning.test.mjs
@@ -1,0 +1,184 @@
+/* Projects-portal registry read-failure banner (#1692).
+ *
+ * GET /api/context/projects now carries ``registry_status`` + ``warnings``:
+ * a corrupt/unreadable known_projects.json degrades the roster (registered
+ * rows vanish) instead of failing the request, so the Portal must say so.
+ * These tests drive the real ``context-portal.js`` in the jsdom harness and
+ * assert the rendered banner (the ``_ctxPortalRegistryWarning`` state is a
+ * module ``let``, pinned through the DOM it produces, not poked directly).
+ *
+ * Mutation that bites: dropping the banner from ``_ctxPortalRenderScaffold``
+ * renders the degraded roster with no signal (the exact false-confidence bug
+ * being fixed); dropping the reset in ``loadCtxProjects`` leaves a stale
+ * banner after Retry repaired the registry.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+function scope(id, label, extra = {}) {
+  return {
+    scope_id: id, project_scope_id: id, label, root: id ? `/work/${label}` : '/srv',
+    tier: 'project', sources: id ? ['known-projects'] : ['server-cwd'],
+    missing: false, stale: false, experimental: false,
+    counts: { skills: 1, commands: 0, agents: 0, 'mcp-servers': 0 },
+    ...extra,
+  };
+}
+
+const CWD = scope('', 'Server CWD');
+const P_ALPHA = scope('p-alpha', 'Alpha');
+const SCOPES = [CWD, P_ALPHA];
+
+function jsonOk(body) {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+function projectsPayload(extra = {}) {
+  return {
+    target_scope: 'project_shared',
+    scopes: SCOPES,
+    registry_status: 'ok',
+    warnings: [],
+    ...extra,
+  };
+}
+
+// Whole-file degradation: registered rows are gone, only server-cwd survives.
+function unavailablePayload() {
+  return projectsPayload({
+    scopes: [CWD],
+    registry_status: 'unavailable',
+    warnings: [{
+      reason_code: 'registry_corrupt', error_kind: 'parse',
+      message: 'known_projects file at ~/kp.json is not valid JSON', retryable: true,
+      skipped_rows: null,
+    }],
+  });
+}
+
+// Row-level degradation: the document parsed, so the roster and status stay
+// intact and the warning carries only the skip count.
+function rowSkipPayload() {
+  return projectsPayload({
+    warnings: [{
+      reason_code: 'registry_corrupt', error_kind: 'parse',
+      message: 'known_projects file at ~/kp.json has 2 unparsable project row(s), skipped',
+      retryable: true, skipped_rows: 2,
+    }],
+  });
+}
+
+/* Records every fetched URL and routes the portal's three endpoints. projects
+ * is settable so a test can repair the registry between loads. */
+function installFetch(window, opts = {}) {
+  const upstream = window.fetch;
+  const urls = [];
+  const state = {
+    projects: opts.projects || (async () => jsonOk(projectsPayload())),
+  };
+  window.fetch = (input, init) => {
+    const url = typeof input === 'string' ? input : input?.url || '';
+    urls.push(url);
+    if (url.startsWith('/api/context/status-all')) {
+      return Promise.resolve(jsonOk({ target_scope: 'project_shared', projects: [], summary: {} }));
+    }
+    if (url.startsWith('/api/context/projects')) return state.projects(url, init);
+    if (url.startsWith('/api/context/runtimes')) return Promise.resolve(jsonOk({ runtimes: [] }));
+    return upstream(input, init);
+  };
+  return { urls, state };
+}
+
+// Drain pending microtasks/timers (Retry's un-awaited loadCtxProjects).
+function flush() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function boot() {
+  // Section intentionally left inactive: i18n's post-boot locale load fires a
+  // 'langchange' that, with the section active, would trigger a second
+  // loadCtxProjects racing the explicit call. Tests drive it directly.
+  return bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js', 'context-portal.js'] });
+}
+
+function banner(window) {
+  return window.document.querySelector('.ctx-portal-registry-banner');
+}
+
+describe('Projects portal registry read-failure banner (#1692)', () => {
+  it('renders a role="alert" banner when the registry is unavailable — board still paints', async () => {
+    const { window } = await boot();
+    installFetch(window, { projects: async () => jsonOk(unavailablePayload()) });
+    await window.loadCtxProjects();
+
+    const el = banner(window);
+    expect(el).not.toBeNull();
+    expect(el.getAttribute('role')).toBe('alert');
+    const msg = el.querySelector('.ctx-portal-registry-banner-msg');
+    expect(msg.textContent.trim().length).toBeGreaterThan(0);
+    // The (server-redacted) cause shows as the diagnostic reason line.
+    expect(el.querySelector('.ctx-diagnostic-reason').textContent).toContain('known_projects');
+    expect(el.querySelector('.ctx-scopes-retry')).not.toBeNull();
+    // Non-blocking: the surviving server-cwd row still renders below the
+    // banner — the banner must never replace the board the way the
+    // load-error surface does.
+    expect(window.document.querySelectorAll('.ctx-portal-row').length).toBe(1);
+  });
+
+  it('renders the skip count when rows were dropped but the registry stayed ok', async () => {
+    const { window } = await boot();
+    installFetch(window, { projects: async () => jsonOk(rowSkipPayload()) });
+    await window.loadCtxProjects();
+
+    const el = banner(window);
+    expect(el).not.toBeNull();
+    // The {count} placeholder is substituted with the wire skipped_rows.
+    expect(el.querySelector('.ctx-portal-registry-banner-msg').textContent).toContain('2');
+    // Row-skip does not hide the roster: every scope row renders.
+    expect(window.document.querySelectorAll('.ctx-portal-row').length).toBe(SCOPES.length);
+  });
+
+  it('renders no banner on a clean payload', async () => {
+    const { window } = await boot();
+    installFetch(window);
+    await window.loadCtxProjects();
+
+    expect(banner(window)).toBeNull();
+    expect(window.document.querySelectorAll('.ctx-portal-row').length).toBe(SCOPES.length);
+  });
+
+  it('tolerates payloads without the new fields (older server)', async () => {
+    const { window } = await boot();
+    installFetch(window, {
+      projects: async () => jsonOk({ target_scope: 'project_shared', scopes: SCOPES }),
+    });
+    await window.loadCtxProjects();
+
+    expect(banner(window)).toBeNull();
+    expect(window.document.querySelectorAll('.ctx-portal-row').length).toBe(SCOPES.length);
+  });
+
+  it('Retry re-fetches, and a repaired registry clears the banner', async () => {
+    const { window } = await boot();
+    const { urls, state } = installFetch(window, {
+      projects: async () => jsonOk(unavailablePayload()),
+    });
+    await window.loadCtxProjects();
+    expect(banner(window)).not.toBeNull();
+
+    const projectsFetches = () =>
+      urls.filter((u) => u.startsWith('/api/context/projects')).length;
+    const before = projectsFetches();
+    state.projects = async () => jsonOk(projectsPayload());
+    banner(window)
+      .querySelector('.ctx-scopes-retry')
+      .dispatchEvent(new window.Event('click', { bubbles: true }));
+    await flush();
+
+    expect(projectsFetches()).toBe(before + 1);
+    expect(banner(window)).toBeNull();
+    // The repaired registry's registered row is back on the board.
+    expect(window.document.querySelectorAll('.ctx-portal-row').length).toBe(SCOPES.length);
+  });
+});

--- a/packages/memtomem/tests/data/wire/projects_bare.json
+++ b/packages/memtomem/tests/data/wire/projects_bare.json
@@ -35,5 +35,7 @@
       "counts": "null",
       "runtime_coverage": "null"
     }
-  ]
+  ],
+  "registry_status": "str",
+  "warnings": []
 }

--- a/packages/memtomem/tests/data/wire/projects_include.json
+++ b/packages/memtomem/tests/data/wire/projects_include.json
@@ -95,5 +95,7 @@
         }
       ]
     }
-  ]
+  ],
+  "registry_status": "str",
+  "warnings": []
 }

--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -21,9 +21,11 @@ from memtomem.context.projects import (
     KnownProjectsStore,
     ProjectHealth,
     ProjectScope,
+    _classify_registry_os_error,
     annotate_project_health,
     compute_scope_id,
     discover_project_scopes,
+    discover_project_scopes_with_report,
     has_runtime_marker,
     sync_skip_reason,
 )
@@ -439,6 +441,129 @@ def test_store_projects_not_list_recovers_to_empty(tmp_path: Path) -> None:
 
     kp.write_text(json.dumps({"version": 1, "projects": 5}))
     assert store.load() == []
+
+
+# ── tolerant load report (#1692) ─────────────────────────────────────────
+
+
+def test_load_with_report_missing_file_is_ok(tmp_path: Path) -> None:
+    """A missing file is the normal pre-registration state — nothing to surface."""
+    report = KnownProjectsStore(tmp_path / "kp.json").load_with_report()
+    assert report.ok is True
+    assert report.reason_code is None
+    assert report.detail is None
+    assert report.skipped_rows == 0
+    assert report.entries == []
+
+
+def test_load_with_report_healthy_file_is_ok(tmp_path: Path) -> None:
+    project = tmp_path / "alpha"
+    project.mkdir()
+    store = KnownProjectsStore(tmp_path / "kp.json")
+    store.add(project)
+    report = store.load_with_report()
+    assert report.ok is True
+    assert report.reason_code is None
+    assert report.skipped_rows == 0
+    assert len(report.entries) == 1
+
+
+@pytest.mark.parametrize(
+    "corrupt",
+    [
+        pytest.param(b"not valid {json", id="invalid-json"),
+        pytest.param(b"\xff", id="invalid-utf8"),
+        pytest.param(b'{"version": 999, "projects": []}', id="future-version"),
+        pytest.param(b'{"version": 1, "projects": {"root": "/old"}}', id="projects-not-list"),
+    ],
+)
+def test_load_with_report_whole_file_degradation(tmp_path: Path, corrupt: bytes) -> None:
+    """Whole-file failures report not-ok with a ``registry_corrupt`` reason;
+    the entries stay the same ``[]`` fallback ``load(strict=False)`` returns."""
+    kp = tmp_path / "kp.json"
+    kp.write_bytes(corrupt)
+    store = KnownProjectsStore(kp)
+    report = store.load_with_report()
+    assert report.ok is False
+    assert report.reason_code == "registry_corrupt"
+    assert report.detail is not None and "known_projects" in report.detail
+    assert report.skipped_rows == 0
+    # Decode/version/shape refusals are document-contract violations.
+    assert report.error_kind == "parse"
+    assert report.entries == [] == store.load()
+
+
+def test_load_with_report_unreadable_file_classifies_error_kind(tmp_path: Path) -> None:
+    """An existing-but-unreadable path degrades with the OSError classified at
+    the catch site — no live exception rides in the report. A directory raises
+    from ``read_bytes`` on every platform (IsADirectoryError on POSIX,
+    PermissionError on Windows)."""
+    kp = tmp_path / "kp.json"
+    kp.mkdir()
+    report = KnownProjectsStore(kp).load_with_report()
+    assert report.ok is False
+    assert report.reason_code == "registry_corrupt"
+    assert report.error_kind in {"missing", "permission"}
+
+
+@pytest.mark.parametrize(
+    ("exc", "kind"),
+    [
+        pytest.param(PermissionError(13, "denied"), "permission", id="permission"),
+        pytest.param(IsADirectoryError(21, "is a directory"), "missing", id="is-a-directory"),
+        pytest.param(NotADirectoryError(20, "not a directory"), "missing", id="not-a-directory"),
+        pytest.param(OSError(5, "io error"), "internal", id="generic-oserror"),
+    ],
+)
+def test_classify_registry_os_error(exc: OSError, kind: str) -> None:
+    """The store-side OSError classifier mirrors the web layer's
+    ``_classify_exception`` mapping for the OSError subset, so the wire
+    ``error_kind`` is identical to what classifying the live exception would
+    have produced."""
+    assert _classify_registry_os_error(exc) == kind
+
+
+def test_load_with_report_row_skips_counted(tmp_path: Path) -> None:
+    """Row-level degradation: the document parses, bad rows are skipped and
+    counted, and the read is still ok (the registry itself was usable)."""
+    kp = tmp_path / "kp.json"
+    good = tmp_path / "good"
+    good.mkdir()
+    kp.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "projects": [
+                    {"root": str(good), "added_at": "2026-01-01T00:00:00Z"},
+                    "stray-string",
+                    {"label": "no-root"},
+                ],
+            }
+        )
+    )
+    report = KnownProjectsStore(kp).load_with_report()
+    assert report.ok is True
+    assert report.reason_code == "registry_corrupt"
+    assert report.skipped_rows == 2
+    assert report.error_kind == "parse"
+    assert [e.root for e in report.entries] == [good.resolve()]
+
+
+def test_discover_with_report_threads_registry_report(tmp_path: Path) -> None:
+    """``discover_project_scopes_with_report`` surfaces the registry report
+    while the scope list still carries the non-registry rows (server cwd)."""
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    kp = tmp_path / "kp.json"
+    kp.write_text("not valid {json")
+    scopes, report = discover_project_scopes_with_report(
+        cwd, kp, experimental_claude_projects_scan=False
+    )
+    assert report.ok is False
+    assert report.reason_code == "registry_corrupt"
+    assert [s.label for s in scopes if "server-cwd" in s.sources] != []
+    # The tolerant delegate returns the identical roster.
+    assert scopes == discover_project_scopes(cwd, kp, experimental_claude_projects_scan=False)
 
 
 # ── corrupt-file mutation refusal (#1247 id 16) ──────────────────────────

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -194,6 +194,24 @@ class TestLocaleFiles:
                 f"runnable `mm context status --all-projects` inspector; got: {tip!r}"
             )
 
+    def test_portal_registry_warning_keys_present(
+        self, en: dict[str, str], ko: dict[str, str]
+    ) -> None:
+        """The Projects-portal registry read-failure banner (#1692) needs both
+        of its messages in each locale; the row-skip variant must carry the
+        ``{count}`` placeholder the banner substitutes."""
+        for name, data in [("en", en), ("ko", ko)]:
+            for key in (
+                "settings.ctx.portal_registry_unavailable",
+                "settings.ctx.portal_registry_rows_skipped",
+            ):
+                assert key in data, f"{name}.json missing {key}"
+                assert data[key].strip(), f"{name}.json has empty {key}"
+            assert "{count}" in data["settings.ctx.portal_registry_rows_skipped"], (
+                f"{name}.json settings.ctx.portal_registry_rows_skipped must carry "
+                f"the {{count}} placeholder"
+            )
+
 
 _STATIC_JS_DIR = _LOCALES_DIR.parent
 

--- a/packages/memtomem/tests/test_web_routes_context_projects.py
+++ b/packages/memtomem/tests/test_web_routes_context_projects.py
@@ -9,6 +9,7 @@ Covers:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -986,3 +987,136 @@ async def test_delete_over_corrupt_store_500_preserves_bytes(
     resp = await client.delete(f"/api/context/known-projects/{sid}")
     assert resp.status_code == 500, resp.text
     assert known_projects_path.read_bytes() == corrupt
+
+
+# ── GET /context/projects registry read-failure surfacing (#1692) ────────
+
+
+@pytest.mark.asyncio
+async def test_get_projects_registry_ok_when_missing_or_healthy(client, tmp_path: Path) -> None:
+    """Missing registry (pre-registration) and a healthy registered one both
+    report ok with no warnings — the degradation surface stays quiet."""
+    resp = await client.get("/api/context/projects")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["registry_status"] == "ok"
+    assert data["warnings"] == []
+
+    await _register(client, tmp_path / "healthy")
+    data = (await client.get("/api/context/projects")).json()
+    assert data["registry_status"] == "ok"
+    assert data["warnings"] == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("corrupt", CORRUPT_STORE_VARIANTS)
+async def test_get_projects_over_corrupt_registry_stays_200_with_warning(
+    client, known_projects_path: Path, tmp_path: Path, corrupt: bytes
+) -> None:
+    """A corrupt registry must not serve an empty roster as the truth: the
+    GET stays 200 (the read path is tolerant by design), the degradation is
+    surfaced as ``registry_status`` + a structured warning, and the
+    non-registry scopes (server cwd) still render."""
+    await _register(client, tmp_path / "registered")
+    known_projects_path.write_bytes(corrupt)
+
+    resp = await client.get("/api/context/projects")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["registry_status"] == "unavailable"
+    assert len(data["warnings"]) == 1
+    warning = data["warnings"][0]
+    assert warning["reason_code"] == "registry_corrupt"
+    assert warning["error_kind"] == "parse"
+    assert warning["retryable"] is True
+    assert warning["skipped_rows"] is None
+    assert "known_projects" in warning["message"]
+    # Degraded, not gone: the server-cwd row survives a broken registry.
+    assert [s for s in data["scopes"] if "server-cwd" in s["sources"]]
+
+
+@pytest.mark.asyncio
+async def test_get_projects_row_skip_reports_count_not_unavailable(
+    client, known_projects_path: Path, tmp_path: Path
+) -> None:
+    """Row-level degradation: the registry stays ok (the document parsed) and
+    the warning carries only the skip count — no row content leaks."""
+    good = tmp_path / "good"
+    good.mkdir()
+    known_projects_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "projects": [
+                    {"root": str(good)},
+                    "stray-string",
+                    {"label": "no-root", "note": "row-content-must-not-leak"},
+                ],
+            }
+        )
+    )
+    resp = await client.get("/api/context/projects")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["registry_status"] == "ok"
+    assert len(data["warnings"]) == 1
+    warning = data["warnings"][0]
+    assert warning["reason_code"] == "registry_corrupt"
+    assert warning["skipped_rows"] == 2
+    assert warning["retryable"] is True
+    # Count only — skipped row content must not appear in the message.
+    assert "stray-string" not in warning["message"]
+    assert "row-content-must-not-leak" not in warning["message"]
+    # The parsable row still made it into the roster.
+    assert any(s["label"] == "good" for s in data["scopes"])
+
+
+@pytest.mark.asyncio
+async def test_get_projects_unreadable_registry_classifies_os_error(
+    client, known_projects_path: Path
+) -> None:
+    """OSError-class degradation (not just parse): the registry path being a
+    directory makes ``read_bytes`` raise on every platform, and the warning's
+    ``error_kind`` carries the store-side classification (IsADirectoryError →
+    missing on POSIX, PermissionError → permission on Windows)."""
+    known_projects_path.mkdir()
+
+    resp = await client.get("/api/context/projects")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["registry_status"] == "unavailable"
+    warning = data["warnings"][0]
+    assert warning["reason_code"] == "registry_corrupt"
+    assert warning["error_kind"] in {"missing", "permission"}
+    assert warning["retryable"] is True
+    assert warning["skipped_rows"] is None
+    assert "unreadable" in warning["message"]
+    assert [s for s in data["scopes"] if "server-cwd" in s["sources"]]
+
+
+@pytest.mark.asyncio
+async def test_get_projects_permission_denied_registry_classifies_permission(
+    client, known_projects_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A permission-denied read must be classified ``permission`` (not folded
+    into ``parse``/``internal``) so the operator knows it is a chmod problem,
+    not a corrupt document."""
+    known_projects_path.write_text(json.dumps({"version": 1, "projects": []}))
+    real_read_bytes = Path.read_bytes
+
+    def _deny(self: Path) -> bytes:
+        if self == known_projects_path:
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", _deny)
+    resp = await client.get("/api/context/projects")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["registry_status"] == "unavailable"
+    warning = data["warnings"][0]
+    assert warning["reason_code"] == "registry_corrupt"
+    assert warning["error_kind"] == "permission"
+    assert warning["retryable"] is True
+    assert warning["skipped_rows"] is None
+    assert "unreadable" in warning["message"]

--- a/packages/memtomem/tests/web/test_ui_refresh_contract.py
+++ b/packages/memtomem/tests/web/test_ui_refresh_contract.py
@@ -58,7 +58,7 @@ def test_header_utility_icons_are_dependency_free_inline_svg() -> None:
 def test_changed_static_assets_bump_cache_versions() -> None:
     html = (STATIC / "index.html").read_text(encoding="utf-8")
 
-    assert "/style.css?v=132" in html
+    assert "/style.css?v=133" in html
     assert "/app.js?v=148" in html
 
 


### PR DESCRIPTION
Part of #1692 (§1 read-failure surfacing, PR 4 of the campaign).

## Problem

A corrupt, unreadable, or future-version `known_projects.json` silently degrades the Projects roster to the tolerant `[]` fallback: `GET /api/context/projects` returns 200 with an empty (or partial) roster and the only signal is a server-side log line. The Portal renders that as a truthful board — false confidence, especially for a first-time user. (Mutators are already strict — 500 with original bytes preserved, pinned — and are untouched here.)

## Change

**Store** (`context/projects.py`)
- New frozen dataclass `KnownProjectsLoadReport(entries, ok, reason_code, detail, skipped_rows, error_kind)`; the tolerant `_load_doc` path now builds it via `_load_doc_with_report()`. `load()` / `_load_doc()` delegate, so the tolerant-load and strict/mutator byte-preservation pins stay green unchanged.
- `error_kind` is classified at the catch site by `_classify_registry_os_error()` (mirrors the OSError subset of the web `_classify_exception` vocabulary; decode/version/shape/row-skip degradations are `parse`), so no live exception object crosses the context/web boundary.
- `discover_project_scopes_with_report()` threads the report; the old name delegates.

**Route** (`web/routes/context_projects.py`) — additive wire fields on `list_projects` only (selector resolution and status-all keep `_discover_for`):

```json
{"target_scope": ..., "scopes": [...],
 "registry_status": "ok" | "unavailable",
 "warnings": [{"reason_code": "registry_corrupt", "error_kind": "...",
               "message": "<redacted>", "retryable": true, "skipped_rows": null}]}
```

- `"unavailable"` iff the file **exists** but is unusable; a missing file is the normal pre-registration state and stays `"ok"`.
- Row-level skips: status stays `"ok"`, one warning with `skipped_rows: <int>` (count only — no row content; messages pass `_redact_message`).
- `remediation_action` deliberately omitted per D3 (UI owns remediation) — documented in the route docstring.

**Portal** (`context-portal.js` + `style.css` + i18n en/ko)
- Non-blocking `role="alert"` banner above the board with the redacted cause and a Retry wired to `loadCtxProjects()`; the roster below still paints (server-cwd / scan rows survive a degraded registry). Reset on every fresh load so a repaired registry clears the banner on Retry.
- Cache-busts: `context-portal.js?v=10`, `style.css?v=132`.

## Tests

- Store: `load_with_report` over missing / healthy / 4 whole-file corrupt shapes / unreadable (directory) / row skips; `_classify_registry_os_error` 4-case table; `discover_project_scopes_with_report` threading + delegate-parity.
- Route: corrupt registry → 200 + `unavailable` + full warning shape + scopes non-empty (parametrized over `CORRUPT_STORE_VARIANTS`); row-skip → `ok` + count-only warning (no row-content leak); unreadable-directory and monkeypatched `PermissionError` reads → OSError classification (`missing`/`permission`); healthy/missing → `ok` + `[]`.
- Wire goldens regenerated — diff is exactly the two new top-level keys.
- i18n: en/ko key pair + presence test with `{count}` placeholder guard.
- JS: new `ctx-portal-registry-warning.test.mjs` (5 specs: banner + a11y + non-blocking board, skip count, clean, absent-fields tolerance, Retry re-fetch + clear).

## Verification

- Full `pytest -m "not ollama"`: 8225 passed. Full vitest: 439 passed (63 files). `ruff check` + `ruff format --check` clean.
- E2E (isolated `HOME`, real `mm web`): corrupt registry → banner (role=alert, redacted `~/.memtomem/...` path) + board still painted; repaired file + Retry → banner clears, roster restored.
- Codex review: two Major findings (live-exception transport, missing OSError-classification route tests) fixed and re-reviewed — no Blocker/Major remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
