### PR TITLE
feat(cli): add `mm mem init` to register project memory tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   --confirm-project-shared` for the shared tier) and registers it in
   `indexing.project_memory_dirs`, which previously required hand-editing
   `~/.memtomem/config.json`. Requires a project marker (`.git` /
-  `pyproject.toml`); for `project_local` the `.gitignore` guard block is
-  written **before** registration and a failed write aborts. The
+  `pyproject.toml`); `project_local` specifically requires a git repo (the
+  `.gitignore` guard block is written **before** registration and a failed
+  write aborts — a pyproject-only project is refused so a later `git init`
+  can't start tracking the draft tier). The
   registration append runs inside the config write lock (concurrent
   registrations can't clobber each other) and persists the fragment-merged
   aggregate list. Unregistered project-tier write refusals now point at the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **`mm mem init` — project memory tier opt-in** (#1700) — creates
+  `<project>/.memtomem/memories.local/` (default; `--scope project_shared
+  --confirm-project-shared` for the shared tier) and registers it in
+  `indexing.project_memory_dirs`, which previously required hand-editing
+  `~/.memtomem/config.json`. Requires a project marker (`.git` /
+  `pyproject.toml`); for `project_local` the `.gitignore` guard block is
+  written **before** registration and a failed write aborts. The
+  registration append runs inside the config write lock (concurrent
+  registrations can't clobber each other) and persists the fragment-merged
+  aggregate list. Unregistered project-tier write refusals now point at the
+  command first (manual `config.json` editing remains the fallback).
+  Deliberately CLI-only: no MCP twin, so an agent blocked by the
+  registration gate cannot self-authorize; a running MCP server / `mm web`
+  picks up the new tier after restart.
+
 ### Changed
 
 - **A failed status probe is now an error, not drift** (#1692) — in the

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -360,7 +360,7 @@ running).
 | `MEMTOMEM_INDEXING__EXCLUDE_PATTERNS` | `[]` | Pathspec (gitignore-style) globs for files the indexer should skip |
 | `MEMTOMEM_INDEXING__STARTUP_BACKFILL` | `false` | When `true`, `mm web` runs a one-shot backfill scan over `memory_dirs` on boot to catch files added while the server was down. Off by default — multi-minute embed jobs blocked the server on a multi-GB memory_dir during 0.1.24 testing, so the wizard offers it as opt-in. `mm index <dir>` and the Web UI per-dir Reindex button cover ad-hoc backfills idempotently without flipping this. |
 | `MEMTOMEM_INDEXING__TARGET_CHUNK_TOKENS` | `384` | Pass-2 semantic-packing target chunk size; `0` disables packing |
-| `MEMTOMEM_INDEXING__PROJECT_MEMORY_DIRS` | `[]` | Additional project-tier index roots (ADR-0011); APPEND-merged across `config.d/` fragments |
+| `MEMTOMEM_INDEXING__PROJECT_MEMORY_DIRS` | `[]` | Additional project-tier index roots (ADR-0011); APPEND-merged across `config.d/` fragments. Register per-project with `mm mem init` (run from the project root; a running server/web UI picks the new tier up after restart). Deliberately outside `mm config set`/`unset` — to deregister, edit `indexing.project_memory_dirs` in `~/.memtomem/config.json` directly |
 | `MEMTOMEM_INDEXING__AUTO_SUMMARIZE` | `false` | Generate a per-source LLM summary chunk at index time (requires LLM enabled) |
 | `MEMTOMEM_INDEXING__SUMMARY_LANGUAGE` | `en` | Language for auto-generated per-source summaries |
 | `MEMTOMEM_INDEXING__SUMMARY_MAX_INPUT_CHARS` | `3000` | Skip the per-source summary when the source body exceeds this many characters |

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -479,6 +479,11 @@ nothing.
 2. To index a new folder, register it first — re-run `mm init` and set it at
    the *Memory directory* step (or add it to `indexing.memory_dirs` in
    `~/.memtomem/config.json`) — then `mm index ~/that-folder`.
+   For a **project** tier, run `mm mem init` from the project root instead: it
+   creates `.memtomem/memories.local/` (or `.memtomem/memories/` with
+   `--scope project_shared --confirm-project-shared`) and registers it in
+   `indexing.project_memory_dirs`, which also unlocks
+   `mm add --scope project_local|project_shared` there.
 3. Make sure the folder has at least one supported file. Only these extensions
    are indexed (`.md`, `.json`, `.yaml`, `.py`, `.js`, `.ts`, …) — a folder of
    only `.pdf` or `.docx` files indexes nothing.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -483,7 +483,8 @@ nothing.
    creates `.memtomem/memories.local/` (or `.memtomem/memories/` with
    `--scope project_shared --confirm-project-shared`) and registers it in
    `indexing.project_memory_dirs`, which also unlocks
-   `mm add --scope project_local|project_shared` there.
+   `mm add --scope project_local|project_shared` there. `project_local`
+   requires a git repo (`git init` first) so the draft tier is gitignored.
 3. Make sure the folder has at least one supported file. Only these extensions
    are indexed (`.md`, `.json`, `.yaml`, `.py`, `.js`, `.ts`, …) — a folder of
    only `.pdf` or `.docx` files indexes nothing.

--- a/docs/guides/reference/data-config-cli.md
+++ b/docs/guides/reference/data-config-cli.md
@@ -239,6 +239,8 @@ mm embedding-reset --mode revert-to-stored  # switch runtime to match DB
 ```bash
 # Setup
 mm init                                # preset picker; `--advanced` opens the full 10-step wizard (b: back, q: quit)
+mm mem init                            # opt this project into project-tier memory: creates .memtomem/memories.local/ and registers it (run from the project root; requires .git or pyproject.toml)
+mm mem init --scope project_shared --confirm-project-shared   # same for the shared tier (memories written there land in git-tracked files)
 
 # Core (daily use)
 mm search "deployment"                 # hybrid search (keywords + meaning)

--- a/packages/memtomem/src/memtomem/cli/mem_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/mem_cmd.py
@@ -23,15 +23,16 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
-from typing import get_args
+from typing import cast, get_args
 
 import click
 
 from memtomem.cli._errors import raise_cli_error
 
 from memtomem import privacy
-from memtomem.cli.context_cmd import _find_project_root
-from memtomem.config import TargetScope
+from memtomem.cli.context_cmd import _append_gitignore_marker, _find_project_root
+from memtomem.config import TargetScope, register_project_memory_dir
+from memtomem.memory_scope import resolve_memory_scope_dir
 
 
 _MEMORY_SCOPE_CHOICES = list(get_args(TargetScope))
@@ -39,7 +40,7 @@ _MEMORY_SCOPE_CHOICES = list(get_args(TargetScope))
 
 @click.group("mem")
 def mem() -> None:
-    """Audit and inspect stored memories."""
+    """Audit, inspect, and set up stored memories."""
 
 
 def _resolve_source_filter(source: str) -> tuple[Path | None, Path | None]:
@@ -63,6 +64,126 @@ def _resolve_source_filter(source: str) -> tuple[Path | None, Path | None]:
         f"--source is not a file or directory: {resolved}",
         param_hint="--source",
     )
+
+
+@mem.command("init")
+@click.option(
+    "--scope",
+    type=click.Choice(["project_local", "project_shared"]),
+    default="project_local",
+    show_default=True,
+    help=(
+        "Memory tier to initialize. project_local writes to the gitignored "
+        "<project>/.memtomem/memories.local/; project_shared writes to "
+        "<project>/.memtomem/memories/ (files written there will be "
+        "git-tracked) and requires --confirm-project-shared."
+    ),
+)
+@click.option(
+    "--confirm-project-shared",
+    is_flag=True,
+    default=False,
+    help=(
+        "Confirm initializing the project_shared tier: memories written "
+        "there land in git-tracked files. Required (or answered "
+        "interactively) when --scope=project_shared."
+    ),
+)
+def init_cmd(scope: str, confirm_project_shared: bool) -> None:
+    """Create and register the project memory tier for the current project.
+
+    ADR-0011 project-tier writes (``mm add`` / MCP ``mem_add`` with
+    ``scope=project_local|project_shared``) require the tier directory to
+    be registered in ``IndexingConfig.project_memory_dirs`` — a deliberate
+    trust gate so unregistered project trees are never silently picked up
+    by the indexer. This command is the explicit opt-in: it creates
+    ``<project>/.memtomem/memories[.local]`` and appends it to
+    ``indexing.project_memory_dirs`` in ``~/.memtomem/config.json``
+    (locked, atomic, idempotent).
+
+    Registration is an explicit trust operation, so a real project root
+    (``.git`` or ``pyproject.toml`` marker) is required — run ``git init``
+    first in a scratch directory. For ``project_local`` the ``.gitignore``
+    guard block is established *before* registration; a failed
+    ``.gitignore`` write aborts so the local tier is never registered
+    unprotected. Deliberately CLI-only: exposing registration over MCP
+    would let the same principal the gate blocks self-authorize (#1700).
+    """
+    root = _find_project_root()
+    has_signal = (root / ".git").exists() or (root / "pyproject.toml").exists()
+    if not has_signal:
+        raise click.ClickException(
+            f"mm mem init requires a project root (with .git or pyproject.toml); "
+            f"none found at or above {root}. Run `git init` first."
+        )
+
+    # Gate B — same disclosure as ``mm context init --scope=project_shared``
+    # (ADR-0011 §5). Registration only creates an empty directory, but it
+    # authorizes future git-tracked writes, so confirm up front.
+    if scope == "project_shared" and not confirm_project_shared:
+        prompt = (
+            f"\n--scope=project_shared: memories written under "
+            f"{root}/.memtomem/memories/ will be git-tracked. Continue?"
+        )
+        if not click.confirm(prompt, default=False):
+            raise click.Abort()
+
+    tier_dir = resolve_memory_scope_dir(cast(TargetScope, scope), root)
+
+    # project_local: git protection FIRST, registration last — if the
+    # ``.gitignore`` write fails we must not leave the local tier
+    # registered (and writable) without the guard block.
+    if scope == "project_local":
+        try:
+            wrote, msg = _append_gitignore_marker(root)
+        except OSError as exc:
+            raise click.ClickException(
+                f"could not append the .gitignore guard block at {root}/.gitignore: "
+                f"{exc}. Aborting before registration so the project_local tier "
+                "is never registered without git protection."
+            ) from exc
+        if wrote:
+            click.secho(
+                "  Appended .gitignore marker (.memtomem/*.local/, .memtomem/.staging/)",
+                fg="green",
+            )
+        elif msg == "no_git_repo_pyproject_only":
+            click.secho(
+                "  warning: project root resolved via pyproject.toml but `.git` "
+                "is missing — the project_local tier is NOT git-protected here. "
+                "Run `git init` to make the .gitignore guard meaningful.",
+                fg="yellow",
+            )
+
+    created = not tier_dir.exists()
+    tier_dir.mkdir(parents=True, exist_ok=True)
+    if created:
+        click.secho(f"  Created {tier_dir}", fg="green")
+
+    try:
+        newly_registered = register_project_memory_dir(tier_dir)
+    except TimeoutError as exc:
+        raise click.ClickException(
+            "another process holds the config lock (~/.memtomem/config.json); retry in a moment."
+        ) from exc
+    except (ValueError, OSError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if newly_registered:
+        click.secho(
+            "  Registered in indexing.project_memory_dirs (~/.memtomem/config.json)",
+            fg="green",
+        )
+        click.echo(
+            f'  You can now run `mm add "..." --scope {scope}` from inside '
+            f"{root}.\n"
+            "  note: a running MCP server / mm web picks up the new tier "
+            "after restart."
+        )
+    elif not created:
+        click.echo(f"Already initialized: {tier_dir} exists and is registered. Nothing to do.")
+    else:
+        click.echo(f"  {tier_dir} was already registered; directory recreated.")
 
 
 @mem.command("rescan")

--- a/packages/memtomem/src/memtomem/cli/mem_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/mem_cmd.py
@@ -130,12 +130,22 @@ def init_cmd(scope: str, confirm_project_shared: bool) -> None:
 
     tier_dir = resolve_memory_scope_dir(cast(TargetScope, scope), root)
 
-    # project_local: git protection FIRST, registration last — if the
-    # ``.gitignore`` write fails we must not leave the local tier
-    # registered (and writable) without the guard block.
+    # project_local: git protection FIRST, registration last. A
+    # ``.gitignore`` is only meaningful inside a git working tree, so
+    # requiring ``.git`` here is a hard gate — registering the draft tier in
+    # a pyproject-only project would leave it exposed the moment the user
+    # runs ``git init`` (the guard block was skipped, so the local memories
+    # would be tracked). Refuse instead of warning-and-registering.
     if scope == "project_local":
+        if not (root / ".git").exists():
+            raise click.ClickException(
+                f"--scope=project_local needs a git repository at {root} so the "
+                "draft tier stays gitignored; without one a later `git init` "
+                "would start tracking it. Run `git init` first, then re-run "
+                "(or use --scope=project_shared for a git-tracked tier)."
+            )
         try:
-            wrote, msg = _append_gitignore_marker(root)
+            wrote, _msg = _append_gitignore_marker(root)
         except OSError as exc:
             raise click.ClickException(
                 f"could not append the .gitignore guard block at {root}/.gitignore: "
@@ -146,13 +156,6 @@ def init_cmd(scope: str, confirm_project_shared: bool) -> None:
             click.secho(
                 "  Appended .gitignore marker (.memtomem/*.local/, .memtomem/.staging/)",
                 fg="green",
-            )
-        elif msg == "no_git_repo_pyproject_only":
-            click.secho(
-                "  warning: project root resolved via pyproject.toml but `.git` "
-                "is missing — the project_local tier is NOT git-protected here. "
-                "Run `git init` to make the .gitignore guard meaningful.",
-                fg="yellow",
             )
 
     created = not tier_dir.exists()

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -220,9 +220,10 @@ class IndexingConfig(ConfigModel):
     # Project-tier index roots (ADR-0011). Each entry MUST resolve under a
     # ``<X>/.memtomem/memories`` or ``<X>/.memtomem/memories.local`` directory
     # so the path classifier can derive the scope without a side table. Empty
-    # by default; users opt in via the future ``mm context`` surface (PR-D /
-    # PR-E) or by editing the config directly. Sibling of ``memory_dirs`` so
-    # the wizard / Sources tab / auto-discover migration stay scope-unaware.
+    # by default; users opt in via ``mm mem init`` (#1700 — writes through
+    # ``register_project_memory_dir``) or by editing the config directly.
+    # Sibling of ``memory_dirs`` so the wizard / Sources tab / auto-discover
+    # migration stay scope-unaware.
     project_memory_dirs: Annotated[list[Path], APPEND] = Field(default_factory=list)
     supported_extensions: frozenset[str] = frozenset(
         {
@@ -2045,7 +2046,10 @@ _CONFIG_PATH_SCALAR_FIELDS: tuple[tuple[str, str], ...] = (
     ("storage", "sqlite_path"),
     ("session_trace", "jsonl_path"),
 )
-_CONFIG_PATH_LIST_FIELDS: tuple[tuple[str, str], ...] = (("indexing", "memory_dirs"),)
+_CONFIG_PATH_LIST_FIELDS: tuple[tuple[str, str], ...] = (
+    ("indexing", "memory_dirs"),
+    ("indexing", "project_memory_dirs"),
+)
 
 
 def _relativize_config_paths_in_place(data: dict) -> None:
@@ -2283,3 +2287,80 @@ def save_config_overrides(
 
         _relativize_config_paths_in_place(existing)
         _atomic_write_json(path, existing)
+
+
+def register_project_memory_dir(target_dir: Path, config_path: Path | None = None) -> bool:
+    """Append *target_dir* to ``indexing.project_memory_dirs`` in config.json.
+
+    The dedicated registration write for ``mm mem init`` (ADR-0011 project
+    tier opt-in). The whole read→append→write sequence runs inside
+    ``_config_write_lock`` so two concurrent registrations cannot each read
+    the pre-change file and clobber the other's entry.
+
+    ``project_memory_dirs`` is deliberately **not** in
+    ``_EXTRA_MUTATION_FIELDS``: ``save_config_overrides`` compares the live
+    (possibly stale — a long-running ``mm web`` loaded config at startup)
+    value against the comparand, and membership would let an unrelated
+    settings save silently drop a registration made after that process
+    started. Keeping the field out of every generic save path means those
+    writers never touch the key; this helper and manual editing are the only
+    writers.
+
+    Because ``config.json`` is a REPLACE-on-load layer (unlike ``config.d``
+    fragments, which APPEND), the helper persists the full merged list —
+    fragment-contributed entries included — not just the new entry;
+    otherwise the write would mask fragment registrations on the next load.
+
+    Returns ``True`` when newly registered, ``False`` when *target_dir* is
+    already registered (config.json or a fragment). Raises ``ValueError``
+    when *target_dir* is not a canonical ``.memtomem/memories[.local]``
+    tier directory, ``TimeoutError`` when another writer holds the config
+    lock, and ``OSError`` when the write itself fails.
+    """
+    import json as _json
+
+    resolved = target_dir.expanduser().resolve()
+    if resolved.name not in ("memories", "memories.local") or resolved.parent.name != ".memtomem":
+        raise ValueError(
+            f"not a project memory tier directory: {resolved} "
+            "(expected <project>/.memtomem/memories or <project>/.memtomem/memories.local)"
+        )
+
+    # Slow read-only rebuild — outside the lock, mirroring
+    # ``save_config_overrides``. Fragments are needed for the merged view;
+    # the lock only serializes config.json writers.
+    comparand = build_comparand(quiet=True)
+    path = config_path if config_path is not None else _override_path()
+
+    with _config_write_lock(path):
+        existing: dict = {}
+        if path.exists():
+            existing = _json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(existing, dict):
+            raise ValueError(f"config file is not a JSON object: {path}")
+
+        indexing = existing.get("indexing")
+        if not isinstance(indexing, dict):
+            indexing = {}
+            existing["indexing"] = indexing
+
+        # Effective list mirrors load semantics: config.json REPLACES the
+        # fragment-appended value when the key is present.
+        raw = indexing.get("project_memory_dirs")
+        if isinstance(raw, list):
+            effective: list[object] = list(raw)
+        else:
+            effective = list(comparand.indexing.project_memory_dirs)
+
+        registered = {
+            Path(str(d)).expanduser().resolve() for d in effective if isinstance(d, (str, Path))
+        }
+        if resolved in registered:
+            return False
+
+        effective.append(resolved)
+        indexing["project_memory_dirs"] = effective
+
+        _relativize_config_paths_in_place(existing)
+        _atomic_write_json(path, existing)
+        return True

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -2320,7 +2320,20 @@ def register_project_memory_dir(target_dir: Path, config_path: Path | None = Non
     import json as _json
 
     resolved = target_dir.expanduser().resolve()
-    if resolved.name not in ("memories", "memories.local") or resolved.parent.name != ".memtomem":
+    # Must be ``<project_root>/.memtomem/memories[.local]`` with a NON-EMPTY
+    # project root above ``.memtomem`` — the scope classifier only matches
+    # ``/.memtomem/...`` at a positive offset (something before the marker),
+    # so a root-level ``/.memtomem/memories`` would register but never
+    # classify as a project tier. ``project_root == project_root.parent`` is
+    # true only at the filesystem root.
+    memtomem_dir = resolved.parent
+    project_root = memtomem_dir.parent
+    if (
+        resolved.name not in ("memories", "memories.local")
+        or memtomem_dir.name != ".memtomem"
+        or not project_root.name
+        or project_root == project_root.parent
+    ):
         raise ValueError(
             f"not a project memory tier directory: {resolved} "
             "(expected <project>/.memtomem/memories or <project>/.memtomem/memories.local)"

--- a/packages/memtomem/src/memtomem/memory_scope.py
+++ b/packages/memtomem/src/memtomem/memory_scope.py
@@ -92,8 +92,10 @@ def project_tier_registration_error(target_dir: Path, scope: TargetScope) -> str
         "IndexingConfig.project_memory_dirs. Writing without registration "
         "would persist a row with the requested scope but the read "
         "surface and indexing watcher would not see it.\n"
-        f"Edit ~/.memtomem/config.json and add {target_dir} to "
-        f'indexing.project_memory_dirs, then retry with scope="{scope}".'
+        f"Run `mm mem init --scope={scope}` in a terminal from the project "
+        f'root, then retry with scope="{scope}". (Registration is CLI-only '
+        "by design; alternatively edit ~/.memtomem/config.json and add "
+        f"{target_dir} to indexing.project_memory_dirs.)"
     )
 
 

--- a/packages/memtomem/tests/test_context_memory_migrate.py
+++ b/packages/memtomem/tests/test_context_memory_migrate.py
@@ -743,9 +743,11 @@ def test_memory_migrate_unregistered_target_tier_refused(monkeypatch, fake_proje
     # that command shape doesn't exist — ``mm config set`` rejects
     # ``project_memory_dirs`` because it's outside MUTABLE_FIELDS, and
     # the bracketed assignment isn't supported syntax). The hint must
-    # point at the only path that actually works: editing
-    # ``~/.memtomem/config.json`` directly.
+    # point at the paths that actually work: ``mm mem init`` (#1700)
+    # first, with editing ``~/.memtomem/config.json`` as the manual
+    # fallback.
     assert "mm config set" not in out
+    assert "mm mem init" in out
     assert "config.json" in out
     # Refusal must happen before any FS / DB mutation, including the
     # cheap ``count_chunks_by_source`` probe.

--- a/packages/memtomem/tests/test_mem_init.py
+++ b/packages/memtomem/tests/test_mem_init.py
@@ -150,16 +150,31 @@ def test_init_gitignore_failure_aborts_before_registration(home: Path, project: 
     assert _loaded_config().indexing.project_memory_dirs == []
 
 
-def test_init_pyproject_only_discloses_unprotected(home: Path, tmp_path, monkeypatch) -> None:
+def test_init_project_local_pyproject_only_refused(home: Path, tmp_path, monkeypatch) -> None:
+    """project_local needs a git repo: a pyproject-only project cannot
+    gitignore the draft tier, so a later ``git init`` would track it.
+    Refuse rather than register-and-warn (Codex review of #1700)."""
     root = tmp_path / "pyproj"
     root.mkdir()
     (root / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
     monkeypatch.chdir(root)
     result = _invoke(["init"])
+    assert result.exit_code != 0
+    assert "git init" in result.output
+    assert not (root / ".memtomem").exists()
+    assert _loaded_config().indexing.project_memory_dirs == []
+
+
+def test_init_project_shared_pyproject_only_allowed(home: Path, tmp_path, monkeypatch) -> None:
+    """project_shared has no gitignore dependency (its tier is meant to be
+    tracked), so a pyproject-only project may still initialize it."""
+    root = tmp_path / "pyproj_shared"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    monkeypatch.chdir(root)
+    result = _invoke(["init", "--scope", "project_shared", "--confirm-project-shared"])
     assert result.exit_code == 0, result.output
-    assert "NOT git-protected" in result.output
-    # Still registers — disclosure, not refusal.
-    tier = root / ".memtomem" / "memories.local"
+    tier = root / ".memtomem" / "memories"
     assert is_project_tier_registered(tier, _loaded_config().indexing.project_memory_dirs)
 
 
@@ -187,6 +202,15 @@ def test_register_rejects_non_tier_paths(home: Path, tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="not a project memory tier"):
         # Right leaf name, wrong parent.
         register_project_memory_dir(tmp_path / "memories")
+
+
+def test_register_rejects_root_level_memtomem(home: Path) -> None:
+    """A root-level ``/.memtomem/memories`` has the right leaf + parent
+    names but no project component above ``.memtomem`` — the scope
+    classifier (positive offset before ``/.memtomem``) would never match
+    it, so registration must reject it (Codex review of #1700)."""
+    with pytest.raises(ValueError, match="not a project memory tier"):
+        register_project_memory_dir(Path("/.memtomem/memories"))
 
 
 def test_register_returns_false_when_already_present(home: Path, tmp_path: Path) -> None:

--- a/packages/memtomem/tests/test_mem_init.py
+++ b/packages/memtomem/tests/test_mem_init.py
@@ -1,0 +1,296 @@
+"""``mm mem init`` — project memory tier init/register verb (#1700).
+
+Pins the ADR-0011 opt-in contract:
+
+1. The verb creates ``<project>/.memtomem/memories[.local]`` and registers
+   it in ``indexing.project_memory_dirs`` via a locked, atomic
+   read-modify-write on ``config.json``.
+2. Registration is an explicit trust operation: a project marker
+   (``.git`` / ``pyproject.toml``) is hard-required, ``project_shared``
+   passes Gate B, and for ``project_local`` the ``.gitignore`` guard is
+   established *before* registration (a failed write aborts, leaving
+   nothing registered).
+3. ``register_project_memory_dir`` survives concurrent registrations
+   (cross-process lock) and preserves fragment-contributed entries
+   (config.json is REPLACE-on-load, so the aggregate list is pinned).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem import config as _cfg
+from memtomem.config import (
+    Mem2MemConfig,
+    load_config_d,
+    load_config_overrides,
+    register_project_memory_dir,
+)
+from memtomem.memory_scope import is_project_tier_registered
+
+from .helpers import set_home
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolated HOME + ``_override_path`` pointing into it."""
+    home = tmp_path / "home"
+    home.mkdir()
+    set_home(monkeypatch, home)
+    override = home / ".memtomem" / "config.json"
+    monkeypatch.setattr(_cfg, "_override_path", lambda: override)
+    return home
+
+
+@pytest.fixture
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A marker-bearing project root, with cwd inside it."""
+    root = tmp_path / "proj"
+    (root / ".git").mkdir(parents=True)
+    monkeypatch.chdir(root)
+    return root
+
+
+def _invoke(args: list[str], **kwargs):
+    from memtomem.cli.mem_cmd import mem
+
+    return CliRunner().invoke(mem, args, **kwargs)
+
+
+def _loaded_config() -> Mem2MemConfig:
+    cfg = Mem2MemConfig()
+    load_config_d(cfg, quiet=True)
+    load_config_overrides(cfg, migrate=False)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# CLI contract
+# ---------------------------------------------------------------------------
+
+
+def test_init_project_local_creates_registers_and_gitignores(home: Path, project: Path) -> None:
+    result = _invoke(["init"])
+    assert result.exit_code == 0, result.output
+
+    tier = project / ".memtomem" / "memories.local"
+    assert tier.is_dir()
+
+    # Registered — round-trip through the real loader, and the exact
+    # membership check every write surface uses.
+    cfg = _loaded_config()
+    assert is_project_tier_registered(tier, cfg.indexing.project_memory_dirs)
+
+    # .gitignore guard block landed (before registration — see ordering test).
+    gitignore = (project / ".gitignore").read_text(encoding="utf-8")
+    assert ".memtomem/*.local/" in gitignore
+
+    # Under HOME the persisted entry is tilde-relativized (portable-paths
+    # parity with ``memory_dirs``) — but this project lives OUTSIDE the
+    # isolated HOME, so the raw entry stays absolute here; parity is pinned
+    # separately in test_register_relativizes_under_home.
+    assert "restart" in result.output
+
+
+def test_init_is_idempotent(home: Path, project: Path) -> None:
+    assert _invoke(["init"]).exit_code == 0
+    rerun = _invoke(["init"])
+    assert rerun.exit_code == 0
+    assert "Already initialized" in rerun.output
+
+    cfg = _loaded_config()
+    entries = [str(d) for d in cfg.indexing.project_memory_dirs]
+    assert len(entries) == len(set(entries)) == 1
+
+
+def test_init_requires_project_marker(home: Path, tmp_path: Path, monkeypatch) -> None:
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    monkeypatch.chdir(bare)
+    result = _invoke(["init"])
+    assert result.exit_code != 0
+    assert "git init" in result.output
+    assert not (bare / ".memtomem").exists()
+    assert _loaded_config().indexing.project_memory_dirs == []
+
+
+def test_init_project_shared_gate_b(home: Path, project: Path) -> None:
+    # Declined interactive confirm → abort, nothing created or registered.
+    refused = _invoke(["init", "--scope", "project_shared"], input="n\n")
+    assert refused.exit_code != 0
+    assert not (project / ".memtomem" / "memories").exists()
+    assert _loaded_config().indexing.project_memory_dirs == []
+
+    # Explicit flag → proceeds.
+    ok = _invoke(["init", "--scope", "project_shared", "--confirm-project-shared"])
+    assert ok.exit_code == 0, ok.output
+    tier = project / ".memtomem" / "memories"
+    assert tier.is_dir()
+    assert is_project_tier_registered(tier, _loaded_config().indexing.project_memory_dirs)
+
+
+def test_init_gitignore_failure_aborts_before_registration(home: Path, project: Path) -> None:
+    """Codex design-gate Major: git protection FIRST, registration last.
+
+    ``.gitignore`` as a directory makes the append raise ``OSError``
+    deterministically (no chmod, works under root CI). The verb must
+    abort with the local tier neither created nor registered.
+    """
+    (project / ".gitignore").mkdir()
+    result = _invoke(["init"])
+    assert result.exit_code != 0
+    assert "Aborting before registration" in result.output
+    assert not (project / ".memtomem" / "memories.local").exists()
+    assert _loaded_config().indexing.project_memory_dirs == []
+
+
+def test_init_pyproject_only_discloses_unprotected(home: Path, tmp_path, monkeypatch) -> None:
+    root = tmp_path / "pyproj"
+    root.mkdir()
+    (root / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    monkeypatch.chdir(root)
+    result = _invoke(["init"])
+    assert result.exit_code == 0, result.output
+    assert "NOT git-protected" in result.output
+    # Still registers — disclosure, not refusal.
+    tier = root / ".memtomem" / "memories.local"
+    assert is_project_tier_registered(tier, _loaded_config().indexing.project_memory_dirs)
+
+
+def test_init_resolves_write_surface_project_context(home: Path, project: Path) -> None:
+    """The exact seam ``mem_add`` uses: after init, the cwd resolves to the
+    project root via the registered dirs (no server restart needed for
+    fresh-process CLI writes)."""
+    from memtomem.server.tools.search import _resolve_project_context_from_dirs
+
+    assert _invoke(["init"]).exit_code == 0
+    cfg = _loaded_config()
+    resolved = _resolve_project_context_from_dirs(cfg.indexing.project_memory_dirs)
+    assert resolved is not None
+    assert resolved == project.resolve()
+
+
+# ---------------------------------------------------------------------------
+# register_project_memory_dir — unit + persistence contracts
+# ---------------------------------------------------------------------------
+
+
+def test_register_rejects_non_tier_paths(home: Path, tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="not a project memory tier"):
+        register_project_memory_dir(tmp_path / "random_dir")
+    with pytest.raises(ValueError, match="not a project memory tier"):
+        # Right leaf name, wrong parent.
+        register_project_memory_dir(tmp_path / "memories")
+
+
+def test_register_returns_false_when_already_present(home: Path, tmp_path: Path) -> None:
+    tier = tmp_path / "p" / ".memtomem" / "memories"
+    assert register_project_memory_dir(tier) is True
+    assert register_project_memory_dir(tier) is False
+    raw = json.loads(_cfg._override_path().read_text(encoding="utf-8"))
+    assert len(raw["indexing"]["project_memory_dirs"]) == 1
+
+
+def test_register_relativizes_under_home(home: Path) -> None:
+    tier = home / "work" / "proj" / ".memtomem" / "memories.local"
+    assert register_project_memory_dir(tier) is True
+    raw = json.loads(_cfg._override_path().read_text(encoding="utf-8"))
+    assert raw["indexing"]["project_memory_dirs"] == ["~/work/proj/.memtomem/memories.local"]
+
+
+def test_register_preserves_fragment_entries(home: Path, tmp_path: Path) -> None:
+    """config.json REPLACES the fragment-appended list on load, so the
+    helper must persist the aggregate — otherwise the write would mask
+    fragment registrations on the next load (Codex design-gate item)."""
+    frag_tier = tmp_path / "frag_proj" / ".memtomem" / "memories"
+    config_d = home / ".memtomem" / "config.d"
+    config_d.mkdir(parents=True)
+    (config_d / "10-frag.json").write_text(
+        json.dumps({"indexing": {"project_memory_dirs": [str(frag_tier)]}}),
+        encoding="utf-8",
+    )
+
+    # Registering the fragment's own entry is a no-op: already effective.
+    assert register_project_memory_dir(frag_tier) is False
+    assert not _cfg._override_path().exists()
+
+    # Registering a NEW entry pins the aggregate (fragment + new).
+    new_tier = tmp_path / "new_proj" / ".memtomem" / "memories.local"
+    assert register_project_memory_dir(new_tier) is True
+    cfg = _loaded_config()
+    resolved = {Path(d).expanduser().resolve() for d in cfg.indexing.project_memory_dirs}
+    assert frag_tier.resolve() in resolved
+    assert new_tier.resolve() in resolved
+
+
+def test_register_preserves_unrelated_config_keys(home: Path, tmp_path: Path) -> None:
+    override = _cfg._override_path()
+    override.parent.mkdir(parents=True)
+    override.write_text(
+        json.dumps({"indexing": {"memory_dirs": ["~/memories"]}, "decay": {"enabled": False}}),
+        encoding="utf-8",
+    )
+    register_project_memory_dir(tmp_path / "p" / ".memtomem" / "memories")
+    raw = json.loads(override.read_text(encoding="utf-8"))
+    assert raw["indexing"]["memory_dirs"] == ["~/memories"]
+    assert raw["decay"] == {"enabled": False}
+
+
+def test_register_concurrent_processes_lose_nothing(home: Path, tmp_path: Path) -> None:
+    """Codex design-gate Major: the whole read→append→write runs inside
+    the config write lock, so N concurrent registrations (distinct
+    projects, separate processes — the lock is cross-process) must all
+    survive. A naive read-outside-lock implementation loses entries."""
+    n = 4
+    override = _cfg._override_path()
+    script = (
+        "import sys\n"
+        "from pathlib import Path\n"
+        "from memtomem.config import register_project_memory_dir\n"
+        "register_project_memory_dir(Path(sys.argv[1]), config_path=Path(sys.argv[2]))\n"
+    )
+    tiers = [tmp_path / f"proj{i}" / ".memtomem" / "memories" for i in range(n)]
+    procs = [
+        subprocess.Popen(
+            [sys.executable, "-c", script, str(t), str(override)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        for t in tiers
+    ]
+    for p in procs:
+        _, err = p.communicate(timeout=120)
+        assert p.returncode == 0, err.decode()
+
+    raw = json.loads(override.read_text(encoding="utf-8"))
+    persisted = {Path(d).expanduser().resolve() for d in raw["indexing"]["project_memory_dirs"]}
+    assert persisted == {t.resolve() for t in tiers}
+
+
+def test_save_config_overrides_does_not_clobber_registration(home: Path, tmp_path: Path) -> None:
+    """``project_memory_dirs`` stays OUT of ``_EXTRA_MUTATION_FIELDS``: a
+    long-running process (``mm web``) that loaded config *before* a
+    registration would otherwise pop the key on its next unrelated save
+    (stale live == comparand). Generic saves must leave the key alone."""
+    from memtomem.config import save_config_overrides
+
+    # A process loads its config BEFORE the registration happens.
+    stale_cfg = _loaded_config()
+    assert stale_cfg.indexing.project_memory_dirs == []
+
+    tier = tmp_path / "p" / ".memtomem" / "memories"
+    register_project_memory_dir(tier)
+
+    # The stale process saves an unrelated override.
+    stale_cfg.search.default_top_k = 99
+    save_config_overrides(stale_cfg)
+
+    raw = json.loads(_cfg._override_path().read_text(encoding="utf-8"))
+    assert raw["indexing"]["project_memory_dirs"], "registration was clobbered by a generic save"
+    assert raw["search"] == {"default_top_k": 99}


### PR DESCRIPTION
Closes #1700

## Summary

Adds **`mm mem init`** — the missing explicit opt-in that creates a project memory tier directory and registers it in `indexing.project_memory_dirs`. Until now the ADR-0011 registration trust gate could only be satisfied by hand-editing `~/.memtomem/config.json` (the field had zero writers in the tree), which is exactly what every refusal message told users to do.

```
$ cd <project>            # .git or pyproject.toml required
$ mm mem init             # default --scope project_local
  Appended .gitignore marker (.memtomem/*.local/, .memtomem/.staging/)
  Created <project>/.memtomem/memories.local
  Registered in indexing.project_memory_dirs (~/.memtomem/config.json)

$ mm mem init --scope project_shared --confirm-project-shared
```

## Design decisions (pre-implementation review)

- **CLI-only, no MCP twin.** Exposing registration over MCP would let the same principal the gate blocks self-authorize (register its own tree, retry the write). Refusals from MCP/web now point at the CLI command; the human stays the trust anchor.
- **Registration append runs entirely inside the config write lock.** A bare read → append → save sequence can lose a concurrent registration; `register_project_memory_dir()` re-reads config.json inside `_config_write_lock` and appends atomically. Pinned by a cross-process concurrency test (4 parallel registrations, all survive).
- **`project_memory_dirs` stays OUT of `_EXTRA_MUTATION_FIELDS`** (deviation from the initial design, found during implementation): `save_config_overrides` is delta-vs-comparand over the persisted-field set, so membership would let a long-running process (`mm web` loaded config before the registration) pop the key on its next unrelated save (stale live == comparand → drop). Keeping the field out of every generic save path means only the dedicated helper and manual editing ever write it. Pinned by `test_save_config_overrides_does_not_clobber_registration`. Consequence: `mm config unset indexing.project_memory_dirs` remains rejected — deregistration is manual editing until a follow-up `unregister` verb.
- **Fragment preservation.** `config.json` is REPLACE-on-load while `config.d/` fragments APPEND, so the helper persists the fragment-merged aggregate; writing only the new entry would mask fragment registrations on the next load. Registering an entry that a fragment already provides is a no-op (does not pin the fragment).
- **Git protection before registration** (`project_local`): the `.gitignore` guard block is written first and a failed write aborts, so the local tier is never left registered without protection. pyproject-only roots get an explicit "NOT git-protected" disclosure and proceed.
- **Hard project-marker guard** (`.git`/`pyproject.toml`): registration is an explicit trust operation; scratch folders must `git init` first. `project_local` specifically requires a **git repo** — a pyproject-only project is refused, because the `.gitignore` guard can't protect the draft tier there and a later `git init` would start tracking it (`project_shared`, whose tier is meant to be tracked, still accepts a pyproject-only marker).
- **Gate B at init** for `project_shared` (`--confirm-project-shared` or interactive), mirroring `mm context init`; wording avoids calling the (empty) directory itself git-tracked.
- **Watcher contract**: a running MCP server / `mm web` schedules index roots at startup; the command prints a restart hint instead of mutating live processes.

## Changes

- `config.py` — `register_project_memory_dir()` (locked read-modify-write, path-shape validation, canonical dedup); `project_memory_dirs` added to `_CONFIG_PATH_LIST_FIELDS` (`~`-relativization parity with `memory_dirs`); field comment updated (the "future `mm context` surface" is now this verb).
- `cli/mem_cmd.py` — `mm mem init`; `mem` group help broadened to "Audit, inspect, and set up stored memories".
- `memory_scope.py` — `project_tier_registration_error` now suggests `mm mem init --scope=...` first, manual config editing as fallback (single chokepoint → propagates to MCP `mem_add`/`mem_batch_add`, web 422s, CLI `mm add`, `mm context memory-migrate`).
- Tests — new `test_mem_init.py` (16 tests: CLI contract incl. Gate B / marker guard / gitignore-first-fatal ordering / idempotence, `_resolve_project_context_from_dirs` integration seam, unit + persistence contracts incl. cross-process concurrency, fragment round-trip, stale-save non-clobber); pinned error-text test in `test_context_memory_migrate.py` updated (keeps the "must NOT suggest `mm config set`" assertion, adds `mm mem init`).
- Docs — `data-config-cli.md` CLI reference, `getting-started.md` troubleshooting, `configuration.md` env-var row (restart contract + manual deregistration), `CHANGELOG.md`.

## Testing

- `uv run pytest -m "not ollama"` — full suite green (incl. new `test_mem_init.py`).
- `uv run ruff check` + `ruff format --check` — clean. `mypy` on touched files — clean.
- Manual smoke in an isolated HOME: init → idempotent rerun → `mm add "…" --scope project_local` lands the file under `.memtomem/memories.local/` and indexes it; Gate B abort and no-marker refusal verified.
- Design + implementation both reviewed adversarially (design gate, then post-commit); the project_local-git requirement and root-level path rejection above are the two review findings, fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
