### PR TITLE
fix(web): stabilize mobile primary workflows

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -5345,7 +5345,7 @@ function _renderMemorySourceItem(s, maxChunks) {
     STATE.pendingActivateChunkSourcePath = '';
     document.querySelectorAll('.source-item').forEach(el => el.classList.remove('active'));
     item.classList.add('active');
-    browseSource(s.path);
+    browseSource(s.path, 100, true);
   });
   item.addEventListener('keydown', e => {
     // Only treat Enter/Space as a row-open when the row itself has focus.
@@ -5358,7 +5358,7 @@ function _renderMemorySourceItem(s, maxChunks) {
   return item;
 }
 
-async function browseSource(path, limit = 100) {
+async function browseSource(path, limit = 100, enterMobileDetail = false) {
   const browser = qs('chunks-browser');
   panelLoading(browser);
   try {
@@ -5385,7 +5385,7 @@ async function browseSource(path, limit = 100) {
         ? t('chunks.load_all') : 'Load All';
       loadAllBtn.textContent = loadAllLabel;
       loadAllBtn.setAttribute('data-i18n', 'chunks.load_all');
-      loadAllBtn.addEventListener('click', () => browseSource(path, 500));
+      loadAllBtn.addEventListener('click', () => browseSource(path, 500, enterMobileDetail));
       header.appendChild(loadAllBtn);
     }
     // View mode toggle: Chunks | Document
@@ -5539,7 +5539,9 @@ async function browseSource(path, limit = 100) {
       });
     }
     browser.appendChild(content);
-    _setSourcesMobileDetail(true);
+    if (enterMobileDetail) {
+      _setSourcesMobileDetail(true);
+    }
 
     // Consume ``pendingActivateChunkId`` (set by ``_navigateToSource``
     // when the caller — e.g. Timeline — knows the specific chunk).

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -827,7 +827,9 @@
               <label class="checkbox-warn" data-i18n-title="index.force_unsafe_title" title="Index files even if they contain secrets (API keys, tokens). Audit-logged. Git-tracked project_shared files are still blocked."><input type="checkbox" id="index-force-unsafe" /> <span data-i18n="index.force_unsafe">Index without privacy gate</span></label>
             </div>
           </details>
-          <button id="index-btn" class="btn-primary" data-i18n="index.index_btn">Index</button>
+          <div class="mobile-sticky-actions index-primary-actions">
+            <button id="index-btn" class="btn-primary" data-i18n="index.index_btn">Index</button>
+          </div>
           <div id="index-msg" class="status-msg" hidden></div>
           <div id="index-progress" class="index-progress" hidden>
             <div class="progress-bar-wrap">
@@ -866,7 +868,9 @@
             <input id="upload-input" type="file" multiple accept=".md,.txt,.json,.yaml,.yml,.toml" hidden />
           </div>
           <div id="upload-file-list" class="upload-file-list" hidden></div>
-          <button id="upload-btn" class="btn-primary mt-10" disabled data-i18n="index.upload_btn">Upload &amp; Index</button>
+          <div class="mobile-sticky-actions index-primary-actions">
+            <button id="upload-btn" class="btn-primary" disabled data-i18n="index.upload_btn">Upload &amp; Index</button>
+          </div>
           <div id="upload-msg" class="status-msg" hidden></div>
           <div id="upload-result" class="upload-result" hidden></div>
           <p id="upload-usage" aria-live="polite" hidden>
@@ -890,7 +894,9 @@
           <label class="field-label" for="add-content" data-i18n="index.add_content_label">Content</label>
           <textarea id="add-content" spellcheck="false" data-i18n-placeholder="index.add_content_placeholder" placeholder="Write your memory here…"></textarea>
           <p class="panel-help-text" data-i18n="index.add_privacy_hint">Privacy guard scans for tokens, API keys, and private keys — not email or phone numbers.</p>
-          <button id="add-btn" class="btn-primary mt-10" data-i18n="index.add_btn">Add</button>
+          <div class="mobile-sticky-actions index-primary-actions">
+            <button id="add-btn" class="btn-primary" data-i18n="index.add_btn">Add</button>
+          </div>
           <div id="add-msg" class="status-msg" hidden></div>
         </div>
       </div>
@@ -1767,7 +1773,7 @@
   <script src="/app.js?v=148"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=14"></script>
-  <script src="/sources-memory-dirs.js?v=13"></script>
+  <script src="/sources-memory-dirs.js?v=14"></script>
   <script src="/settings-maintenance.js?v=5"></script>
   <script src="/settings-namespaces.js?v=12"></script>
   <script src="/settings-harness.js?v=5"></script>

--- a/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
+++ b/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
@@ -283,7 +283,7 @@ function _buildMemoryDirsPanel(initialDirs) {
         // Single Sources panel: just open the source in the shared
         // chunks-browser pane.
         if (typeof browseSource === 'function') {
-          browseSource(s.path);
+          browseSource(s.path, 100, true);
         }
       };
       li.addEventListener('click', activate);

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -2857,7 +2857,8 @@ body.show-retrieval-debug .score-detail-row[data-tooltip-debug]:hover::after {
 }
 
 /* ── Sprint 4: Home Tab ── */
-.home-layout { display: flex; flex-direction: column; gap: 16px; padding: 20px; overflow-y: auto; }
+.home-layout { display: flex; flex-direction: column; gap: 16px; padding: 20px; overflow-y: auto; min-width: 0; }
+.home-layout > * { min-width: 0; max-width: 100%; }
 
 /* S2.3 — first-run orientation block (collapsible getting-started card). */
 .home-orientation {
@@ -3092,6 +3093,16 @@ body.dev-mode .home-stats-row { grid-template-columns: repeat(6, 1fr); }
 .home-source-row2 {
   font-size: 0.68rem; color: var(--muted); font-family: var(--mono); padding-left: 14px;
 }
+.home-source-row1,
+.home-source-row2 { min-width: 0; overflow: hidden; }
+.home-source-row1 .source-ns-badge {
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: min(32vw, 220px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.home-source-row1 > .badge-blue { flex-shrink: 0; }
 
 /* F. Quick Actions + Pinned bottom row */
 .home-bottom-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
@@ -5008,6 +5019,64 @@ button.ctx-runtime-chip--greyed:focus-visible {
      diff stays readable on narrow screens during the destructive
      Reload-vs-Force choice (was two ~225px columns side by side). */
   #ctx-conflict-preview-row { flex-direction: column; }
+
+  /* P0 mobile work areas: each Sources pane owns the full available height;
+     explicit row activation swaps panes and Back restores the active row. */
+  #tab-sources.active { overflow: hidden; }
+  #tab-search.active,
+  #tab-index.active { overflow: hidden; }
+  #tab-search .results-layout,
+  #tab-search #detail-panel {
+    min-height: 0;
+    height: 100%;
+  }
+  #tab-index .index-layout { flex: 1; min-height: 0; }
+  .sources-layout {
+    flex: 1;
+    min-height: 0;
+    height: 100%;
+    overflow: hidden;
+  }
+  .sources-layout .sources-sidebar {
+    display: flex;
+    width: 100% !important;
+    height: 100%;
+    max-height: none;
+    min-height: 0;
+    border-bottom: 0;
+  }
+  .sources-layout .chunks-browser { display: none; }
+  .sources-layout.mobile-detail .sources-sidebar { display: none; }
+  .sources-layout.mobile-detail .chunks-browser {
+    display: block;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+  }
+  .sources-mobile-back-btn { margin-bottom: 12px; }
+
+  /* Keep destructive/primary work actions reachable while their panel scrolls.
+     The panel padding reserves the same footprint so the final content is not
+     obscured by the sticky surface. */
+  #detail-view,
+  .index-panel { padding-bottom: 72px; }
+  .detail-actions,
+  .mobile-sticky-actions {
+    position: fixed;
+    left: 12px;
+    right: 12px;
+    bottom: 0;
+    z-index: 20;
+    margin: 0;
+    padding: 10px 12px max(10px, env(safe-area-inset-bottom));
+    background: color-mix(in srgb, var(--bg) 94%, transparent);
+    border-top: 1px solid var(--border);
+    box-shadow: 0 -8px 18px rgba(0, 0, 0, 0.12);
+    backdrop-filter: blur(8px);
+  }
+  .mobile-sticky-actions { display: flex; }
+  .mobile-sticky-actions > .btn-primary { width: 100%; }
+  .index-panels { margin: 0 12px; }
 }
 
 /* ── Wiki browser (ADR-0008 PR-E, ctx-wiki) ─────────────────────────────── */

--- a/packages/memtomem/tests/web/test_ui_smoke_matrix.py
+++ b/packages/memtomem/tests/web/test_ui_smoke_matrix.py
@@ -310,6 +310,12 @@ def test_ui_smoke_matrix(page, mode: str, viewport: tuple[int, int]) -> None:
             assert page.evaluate(
                 "() => document.documentElement.scrollWidth <= window.innerWidth + 1"
             )
+            assert page.locator(".home-layout").evaluate("el => el.scrollWidth === el.clientWidth")
+            page.locator("#lang-toggle").click()
+            page.wait_for_function("() => document.documentElement.lang === 'ko'")
+            assert page.locator(".home-layout").evaluate("el => el.scrollWidth === el.clientWidth")
+            page.locator("#lang-toggle").click()
+            page.wait_for_function("() => document.documentElement.lang === 'en'")
 
         page.locator('.tab-btn[data-tab="search"]').focus()
         before_history = page.evaluate("() => history.length")
@@ -339,37 +345,54 @@ def test_ui_smoke_matrix(page, mode: str, viewport: tuple[int, int]) -> None:
             page.locator("#results-list .results-debug-details summary").inner_text()
             == "Advanced details"
         )
+        if viewport[0] <= 390:
+            detail_actions = page.locator("#detail-panel .detail-actions")
+            assert detail_actions.is_visible()
+            assert detail_actions.evaluate(
+                "el => { const r = el.getBoundingClientRect(); "
+                "return r.top >= 0 && r.bottom <= window.innerHeight + 1; }"
+            )
 
         page.locator('.tab-btn[data-tab="sources"]').click()
         assert page.locator(".sources-vendor-tab").count() >= 1
-        if viewport[0] <= 390:
-            assert not page.locator(".sources-layout").evaluate(
-                "el => el.classList.contains('mobile-detail')"
-            )
-            # Exercise the row's production Enter handler as part of the
-            # keyboard-only acceptance path. This also avoids racing the
-            # source tree's async status repaint with a stale pointer point.
-            source_row = page.locator("#sources-list .source-item").first
-            source_row.focus()
-            page.keyboard.press("Enter")
         page.wait_for_function(
-            "() => document.querySelector('#chunks-browser .chunks-browser-header .file-path')?.textContent.includes('notes.md')",
+            "() => document.querySelectorAll('#sources-list .source-item').length > 0",
             timeout=5_000,
         )
-        if viewport[0] <= 390:
-            assert page.locator(".sources-layout").evaluate(
-                "el => el.classList.contains('mobile-detail')"
-            )
-            assert page.locator(".sources-mobile-back").is_visible()
-            page.locator(".sources-mobile-back").click()
-            assert not page.locator(".sources-layout").evaluate(
-                "el => el.classList.contains('mobile-detail')"
+        if viewport[0] > 390:
+            page.wait_for_function(
+                "() => document.querySelector('#chunks-browser .chunks-browser-header .file-path')?.textContent.includes('notes.md')",
+                timeout=5_000,
             )
         for vendor in ("user", "claude", "openai"):
             tab = page.locator(f'.sources-vendor-tab[data-vendor="{vendor}"]')
             if tab.count():
                 tab.click()
                 assert tab.get_attribute("aria-selected") == "true"
+        if viewport[0] <= 390:
+            # Return to the populated vendor, then reacquire the row after the
+            # asynchronous tree refresh. Pointer click must drive drilldown;
+            # forcing keyboard focus would mask hit-testing/layout regressions.
+            page.locator('.sources-vendor-tab[data-vendor="user"]').click()
+            page.wait_for_function(
+                "() => document.querySelectorAll('#sources-list .source-item').length > 0",
+                timeout=5_000,
+            )
+            source_row = page.locator("#sources-list .source-item").first
+            source_row.click()
+            page.wait_for_function(
+                "() => document.querySelector('.sources-layout')?.classList.contains('mobile-detail')",
+                timeout=5_000,
+            )
+            page.locator(".sources-mobile-back").click()
+            page.wait_for_function(
+                "() => !document.querySelector('.sources-layout')?.classList.contains('mobile-detail')"
+            )
+            page.wait_for_function(
+                "() => document.activeElement === "
+                "document.querySelector('#sources-list .source-item.active')",
+                timeout=2_000,
+            )
 
         page.locator('.tab-btn[data-tab="context-gateway"]').click()
         # ADR-0026 D-F flip: Simple is the production default and hides the gateway
@@ -442,6 +465,18 @@ def test_ui_smoke_matrix(page, mode: str, viewport: tuple[int, int]) -> None:
                 )
                 assert checkbox_metrics["inputHeight"] <= 24
                 assert checkbox_metrics["labelHeight"] >= 44
+            if viewport[0] <= 390:
+                action = page.locator(
+                    {
+                        "folder": "#index-btn",
+                        "upload": "#upload-btn",
+                        "compose": "#add-btn",
+                    }[index_mode]
+                )
+                assert action.evaluate(
+                    "el => { const r = el.getBoundingClientRect(); "
+                    "return r.top >= 0 && r.bottom <= window.innerHeight + 1; }"
+                )
 
         page.locator('.tab-btn[data-tab="tags"]').click()
         assert page.locator("#tags-search").is_visible()


### PR DESCRIPTION
## Summary

- keep the Sources list usable at 390px and enter detail only after an explicit row activation
- restore focus to the selected source after Back and cover the path with a real pointer click
- constrain Home recent-source metadata to eliminate horizontal overflow
- keep Search save/delete and all Index primary actions visible in the mobile viewport
- bump affected static asset cache keys

## Compatibility

No API, schema, URL hash, DOM ID, shortcut, Simple/Advanced, or Context Gateway semantic changes.

## Verification

- `uv run pytest packages/memtomem/tests/web/test_ui_smoke_matrix.py -q`
- `npm test` (63 files, 439 tests passed)
- `uv run ruff check packages/memtomem/src packages/memtomem/tests tools`
- `uv run ruff format --check packages/memtomem/src packages/memtomem/tests tools`
- `git diff --check`