### PR TITLE
fix(storage): delete namespace_metadata row even when namespace has no chunks

### DIFF
--- a/packages/memtomem/src/memtomem/storage/sqlite_namespace.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_namespace.py
@@ -106,22 +106,26 @@ class NamespaceOps:
             (namespace,),
         ).fetchall()
 
-        if not rows:
-            return 0
-
+        # The metadata delete runs unconditionally, even when the namespace has
+        # no chunks: a metadata-only namespace (registered via
+        # set_namespace_meta but never written to) is still listed by
+        # list_namespace_meta, so an early return here would leave it
+        # undeletable through this API. Return value stays the chunk count, so
+        # deleting a wholly nonexistent namespace remains a 0 no-op.
         ids = [row[0] for row in rows]
         rowids = [row[1] for row in rows]
 
         try:
-            db.execute(f"DELETE FROM chunks WHERE id IN ({placeholders(len(ids))})", ids)
-            db.execute(
-                f"DELETE FROM chunks_fts WHERE rowid IN ({placeholders(len(rowids))})", rowids
-            )
-            if self._has_vec_table():
+            if rows:
+                db.execute(f"DELETE FROM chunks WHERE id IN ({placeholders(len(ids))})", ids)
                 db.execute(
-                    f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders(len(rowids))})",
-                    rowids,
+                    f"DELETE FROM chunks_fts WHERE rowid IN ({placeholders(len(rowids))})", rowids
                 )
+                if self._has_vec_table():
+                    db.execute(
+                        f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders(len(rowids))})",
+                        rowids,
+                    )
             db.execute("DELETE FROM namespace_metadata WHERE namespace=?", (namespace,))
             db.commit()
         except Exception as exc:

--- a/packages/memtomem/tests/test_storage_extended.py
+++ b/packages/memtomem/tests/test_storage_extended.py
@@ -1098,3 +1098,48 @@ class TestSetNamespaceMetaAtomicity:
         meta = await storage.get_namespace_meta("shared")
         assert meta["description"] == "keep me"
         assert meta["color"] == "red"
+
+
+class TestDeleteByNamespaceMetadata:
+    """``delete_by_namespace`` must remove the ``namespace_metadata`` row even
+    when the namespace holds no chunks, otherwise a metadata-only namespace
+    (registered via ``set_namespace_meta`` but never written to) stays listed
+    by ``list_namespace_meta`` and is undeletable through this API — an
+    undeletable tombstone for scratch-namespace GC callers (#1705)."""
+
+    def _listed(self, metas):
+        return {m["namespace"] for m in metas}
+
+    @pytest.mark.asyncio
+    async def test_deletes_metadata_only_namespace(self, components):
+        """A namespace that exists only as metadata (zero chunks) is removed
+        and returns 0 (the chunk count), not left behind."""
+        storage = components.storage
+        await storage.set_namespace_meta("board-run:abc", description="scratch")
+        assert "board-run:abc" in self._listed(await storage.list_namespace_meta())
+
+        deleted = await storage.delete_by_namespace("board-run:abc")
+
+        assert deleted == 0
+        assert "board-run:abc" not in self._listed(await storage.list_namespace_meta())
+        assert await storage.get_namespace_meta("board-run:abc") is None
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_namespace_is_noop(self, components):
+        """Deleting a wholly unknown namespace stays a 0 no-op."""
+        storage = components.storage
+        assert await storage.delete_by_namespace("board-run:never") == 0
+
+    @pytest.mark.asyncio
+    async def test_deletes_chunks_and_metadata(self, components):
+        """The chunks+metadata path is unchanged: chunks are gone, the
+        metadata row is gone, and the return value is the chunk count."""
+        storage = components.storage
+        await storage.set_namespace_meta("work", description="real")
+        await storage.upsert_chunks([make_chunk(content="c1", namespace="work", source="a.md")])
+
+        deleted = await storage.delete_by_namespace("work")
+
+        assert deleted == 1
+        assert "work" not in self._listed(await storage.list_namespace_meta())
+        assert await storage.get_namespace_meta("work") is None


### PR DESCRIPTION
## Problem

`delete_by_namespace` early-returned before the `namespace_metadata` delete when the namespace held **no chunks** (`sqlite_namespace.py` — `if not rows: return 0`). Since `list_namespace_meta()` unions `namespace_metadata` with `chunks`, a metadata-only namespace (registered via `set_namespace_meta` but never written to) kept being listed after "deletion" — undeletable through this API, surprising for an API named delete-**by-namespace**.

Real-world impact: scratch-namespace GC callers (syncmill's `board-run:{run_id}` sweep) enumerate namespaces via `list_namespace_meta()` and purge dead ones via `delete_by_namespace()`. A run that registers its scratch namespace up front but writes zero chunks leaves a metadata-only tombstone that is re-enumerated and re-purged on every sweep, surviving each time.

## Fix

Run the `namespace_metadata` delete unconditionally inside the same transaction; keep the return value as the chunk count. All three call sites use the return only as a display count, never as an existence check, so caller semantics are unchanged:

- `web/routes/namespaces.py` → `DeleteResponse(deleted=deleted)`
- `server/tools/memory_crud.py` → `f"Removed {deleted} chunks …"`
- `server/tools/namespace.py` → `f"Deleted {deleted} chunks …"`

Behavior after: deleting a metadata-only namespace returns 0 and actually removes it; deleting a wholly nonexistent namespace stays a 0 no-op; the chunks+metadata path is unchanged (chunk-count return, atomic rollback on error).

## Tests

New `TestDeleteByNamespaceMetadata` (3 cases): metadata-only deletion, nonexistent no-op, chunks+metadata deletion. Confirmed the metadata-only test fails against the pre-fix code and passes with the fix. Storage suite green; ruff check + format clean.

Closes #1705

🤖 Generated with [Claude Code](https://claude.com/claude-code)
