### PR TITLE
feat(cli): add --help usage examples (epilog) to mm search and mm add

### DIFF
--- a/packages/memtomem/src/memtomem/cli/memory.py
+++ b/packages/memtomem/src/memtomem/cli/memory.py
@@ -67,7 +67,15 @@ def _render_validity_window(valid_from_unix: int | None, valid_to_unix: int | No
     return f"[{_fmt(valid_from_unix)} → {_fmt(valid_to_unix)}]"
 
 
-@click.command()
+ADD_EPILOG = """\
+Examples:
+  mm add "Canary deploy froze at 14:02Z; rolled back." --tags incident,postmortem
+  mm add "Decision: standardize on uv for installs." --scope project_shared --confirm-project-shared
+  mm add "Quick note to self" --json
+"""
+
+
+@click.command(epilog=ADD_EPILOG)
 @click.argument("content")
 @click.option("--title", "-t", default=None, help="Entry title")
 @click.option("--tags", default=None, help="Comma-separated tags")

--- a/packages/memtomem/src/memtomem/cli/search.py
+++ b/packages/memtomem/src/memtomem/cli/search.py
@@ -21,8 +21,15 @@ from memtomem.server.tools.search import (
     _resolve_project_context_root as _resolve_project_context_root_from_cwd,
 )
 
+SEARCH_EPILOG = """\
+Examples:
+  mm search "payment timeout"
+  mm search "onboarding flow" --tag-filter onboarding --top-k 5
+  mm search "incident" --scope project_shared --format context
+"""
 
-@click.command()
+
+@click.command(epilog=SEARCH_EPILOG)
 @click.argument("query")
 @click.option("--top-k", "-k", default=10, help="Number of results")
 @click.option("--source-filter", "-s", default=None, help="Source file filter")

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -1102,3 +1102,19 @@ class TestSubcommandHelp:
         result = runner.invoke(cli, ["shell", "--help"])
         assert result.exit_code == 0
         assert "Interactive" in result.output
+
+
+class TestHelpEpilog:
+    """#1667: ``mm search`` / ``mm add`` --help should surface usage examples."""
+
+    def test_search_help_shows_examples(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["search", "--help"])
+        assert result.exit_code == 0
+        assert "Examples:" in result.output
+        assert 'mm search "payment timeout"' in result.output
+
+    def test_add_help_shows_examples(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["add", "--help"])
+        assert result.exit_code == 0
+        assert "Examples:" in result.output
+        assert 'mm add "Canary deploy froze' in result.output


### PR DESCRIPTION
## Summary
Closes #1667.

Adds a `--help` epilog with concrete usage examples to the `mm search` and `mm add` commands:
- `packages/memtomem/src/memtomem/cli/search.py`: `@click.command(epilog=SEARCH_EPILOG)`
- `packages/memtomem/src/memtomem/cli/memory.py`: `@click.command(epilog=ADD_EPILOG)` (the decorator directly above `def add`, not the later `recall` one)
- Added `TestHelpEpilog` to `packages/memtomem/tests/test_cli.py` asserting the examples appear in each command's `--help` output.

## Verification
- `uvx ruff check` and `uvx ruff format --check` pass on all three changed files.
- `python -m py_compile` clean; epilog strings present and decorators updated.
- Confirmed with `click` (CliRunner) that the epilog renders under `--help` for both commands using the exact example strings.

Note: a full local `uv sync` + `pytest` is slow in this sandbox (Python 3.14 forces source builds of several transitive deps, e.g. via `mcp[cli]`); CI on the supported Python versions will run the suite.