### PR TITLE
feat(web): typed Pydantic response models for the Context Gateway wire (#1692 PR 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **Typed response models on the Context Gateway wire** (#1692) — the
+  Overview, Projects, Runtimes, Status All, Sync All (single + cross-project
+  batch), and Import (all seven artifact-import routes) responses are now
+  validated against Pydantic models (`Context*` components in
+  `/openapi.json`) instead of returned as unchecked dicts. The wire shapes
+  are unchanged — golden wire fixtures pin key sets, key order, and value
+  types before/after, now including the two POST report endpoints — but
+  shape drift in a handler now fails loudly (HTTP 500) instead of silently
+  changing the wire. One key-order normalization ships along: the batch
+  sync's crash-path `error` envelope now orders `error_kind, http_status,
+  message` like its timeout sibling and the per-phase envelope (same keys,
+  same values).
+
 - **Runtime probe availability is now explicit** (#1692) — a failed
   provider-client probe was previously wire-identical to "no runtimes".
   `GET /api/context/runtimes` gains additive `runtimes_status`

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -53,6 +53,7 @@ from memtomem.web.routes.context_projects import (
     resolve_scope_root_cascade_gated,
     resolve_writable_scope_root,
 )
+from memtomem.web.schemas.context import ContextImportNeedsConfirmation, ContextImportReport
 
 # Flat list of project-relative runtime scan paths reported on list / import
 # responses so the web UI's empty-state hint can name the exact directories
@@ -329,7 +330,12 @@ async def sync_agents(
 # ── Import ───────────────────────────────────────────────────────────────
 
 
-@router.post("/context/agents/import")
+@router.post(
+    "/context/agents/import",
+    response_model=ContextImportReport | ContextImportNeedsConfirmation,
+    # exclude_unset: dry_run is omitted (not null) when the builder gets None.
+    response_model_exclude_unset=True,
+)
 async def import_agents(
     body: ImportRequest | None = None,
     project_root: Path = Depends(resolve_scope_root),
@@ -353,7 +359,11 @@ async def import_agents(
     return await _atomic_kind.import_artifacts(_SPEC, body, project_root, target_scope, dry_run)
 
 
-@router.post("/context/agents/{name}/import")
+@router.post(
+    "/context/agents/{name}/import",
+    response_model=ContextImportReport | ContextImportNeedsConfirmation,
+    response_model_exclude_unset=True,
+)
 async def import_agent(
     name: str,
     body: ImportRequest | None = None,

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -52,6 +52,7 @@ from memtomem.web.routes.context_projects import (
     resolve_scope_root_cascade_gated,
     resolve_writable_scope_root,
 )
+from memtomem.web.schemas.context import ContextImportNeedsConfirmation, ContextImportReport
 
 # Flat list of project-relative runtime scan paths reported on list / import
 # responses so the web UI's empty-state hint can name the exact directories
@@ -327,7 +328,12 @@ async def sync_commands(
 # ── Import ───────────────────────────────────────────────────────────────
 
 
-@router.post("/context/commands/import")
+@router.post(
+    "/context/commands/import",
+    response_model=ContextImportReport | ContextImportNeedsConfirmation,
+    # exclude_unset: dry_run is omitted (not null) when the builder gets None.
+    response_model_exclude_unset=True,
+)
 async def import_commands(
     body: ImportRequest | None = None,
     project_root: Path = Depends(resolve_scope_root),
@@ -351,7 +357,11 @@ async def import_commands(
     return await _atomic_kind.import_artifacts(_SPEC, body, project_root, target_scope, dry_run)
 
 
-@router.post("/context/commands/{name}/import")
+@router.post(
+    "/context/commands/{name}/import",
+    response_model=ContextImportReport | ContextImportNeedsConfirmation,
+    response_model_exclude_unset=True,
+)
 async def import_command(
     name: str,
     body: ImportRequest | None = None,

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -25,6 +25,11 @@ from memtomem.context.status import (
 from memtomem.wiki.store import WikiStore
 from memtomem.web.routes._errors import _classify_exception, _error, _redact_message
 from memtomem.web.routes.context_projects import _discover_for, resolve_scope_root
+from memtomem.web.schemas.context import (
+    ContextOverviewResponse,
+    ContextRuntimesResponse,
+    ContextStatusAllResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -305,7 +310,13 @@ def _error_payload(exc: BaseException, *, shape: str = "total") -> dict:
     return {"total": 0, "error": True, "error_kind": kind, "error_message": message}
 
 
-@router.get("/context/overview")
+@router.get(
+    "/context/overview",
+    response_model=ContextOverviewResponse,
+    # exclude_unset: detected_runtimes entries conditionally OMIT
+    # installed/memtomem_registered (runtime_coverage.py) — absent ≠ null.
+    response_model_exclude_unset=True,
+)
 async def context_overview(
     project_root: Path = Depends(resolve_scope_root),
     target_scope: TargetScope = Query(
@@ -457,7 +468,7 @@ async def context_overview(
     return await asyncio.to_thread(_collect)
 
 
-@router.get("/context/runtimes")
+@router.get("/context/runtimes", response_model=ContextRuntimesResponse)
 async def context_runtimes(
     project_root: Path = Depends(resolve_scope_root),
 ) -> dict:
@@ -592,7 +603,7 @@ def _status_all_entry(
     }
 
 
-@router.get("/context/status-all")
+@router.get("/context/status-all", response_model=ContextStatusAllResponse)
 async def context_status_all(
     request: Request,
     target_scope: TargetScope = Query(

--- a/packages/memtomem/src/memtomem/web/routes/context_projects.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_projects.py
@@ -49,6 +49,7 @@ from memtomem.context.skills import diff_skills, list_canonical_skills
 from memtomem.config import TargetScope
 from memtomem.web.deps import get_project_root
 from memtomem.web.routes._errors import _error, _redact_message
+from memtomem.web.schemas.context import ContextProjectsResponse
 
 logger = logging.getLogger(__name__)
 
@@ -472,7 +473,13 @@ def _scope_to_dict(
     }
 
 
-@router.get("/context/projects")
+@router.get(
+    "/context/projects",
+    response_model=ContextProjectsResponse,
+    # exclude_unset: runtime_coverage entries conditionally OMIT
+    # installed/memtomem_registered (runtime_coverage.py) — absent ≠ null.
+    response_model_exclude_unset=True,
+)
 async def list_projects(
     request: Request,
     scope_id: str | None = Query(

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -53,6 +53,7 @@ from memtomem.web.routes.context_projects import (
     resolve_scope_root_cascade_gated,
     resolve_writable_scope_root,
 )
+from memtomem.web.schemas.context import ContextImportNeedsConfirmation, ContextImportReport
 
 # Flat list of project-relative runtime scan paths reported on list / import
 # responses so the web UI's empty-state hint can name the exact directories
@@ -747,7 +748,12 @@ def _import_payload(
     return payload
 
 
-@router.post("/context/skills/import")
+@router.post(
+    "/context/skills/import",
+    response_model=ContextImportReport | ContextImportNeedsConfirmation,
+    # exclude_unset: dry_run is omitted (not null) when the builder gets None.
+    response_model_exclude_unset=True,
+)
 async def import_skills(
     body: ImportRequest | None = None,
     project_root: Path = Depends(resolve_scope_root),
@@ -823,7 +829,11 @@ async def import_skills(
     return _import_payload(result, project_root, target_scope, dry_run=dry_run)
 
 
-@router.post("/context/skills/{name}/import")
+@router.post(
+    "/context/skills/{name}/import",
+    response_model=ContextImportReport | ContextImportNeedsConfirmation,
+    response_model_exclude_unset=True,
+)
 async def import_skill(
     name: str,
     body: ImportRequest | None = None,
@@ -894,7 +904,11 @@ async def import_skill(
     return _import_payload(result, project_root, target_scope, dry_run=None)
 
 
-@router.post("/context/skills/{name}/import-to-user")
+@router.post(
+    "/context/skills/{name}/import-to-user",
+    response_model=ContextImportReport | ContextImportNeedsConfirmation,
+    response_model_exclude_unset=True,
+)
 async def import_skill_to_user(
     name: str,
     body: ImportRequest | None = None,

--- a/packages/memtomem/src/memtomem/web/routes/context_sync_all.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_sync_all.py
@@ -97,6 +97,7 @@ from memtomem.web.routes.context_mcp_servers import _sync_mcp_servers_core
 from memtomem.web.routes.context_projects import _discover_for, resolve_writable_scope_root
 from memtomem.web.routes.context_skills import _sync_skills_core
 from memtomem.web.routes.settings_sync import _sync_settings_core
+from memtomem.web.schemas.context import ContextSyncAllProjectsReport, ContextSyncAllReport
 
 logger = logging.getLogger(__name__)
 
@@ -289,7 +290,7 @@ def _reject_ineligible_tier(target_scope: TargetScope) -> None:
         )
 
 
-@router.post("/context/sync-all")
+@router.post("/context/sync-all", response_model=ContextSyncAllReport)
 async def sync_all_context(
     project_root: Path = Depends(resolve_writable_scope_root),
     target_scope: TargetScope = Query(
@@ -401,7 +402,7 @@ def _summarize_projects(entries: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-@router.post("/context/sync-all-projects")
+@router.post("/context/sync-all-projects", response_model=ContextSyncAllProjectsReport)
 async def sync_all_projects_context(
     request: Request,
     target_scope: TargetScope = Query(
@@ -486,10 +487,14 @@ async def sync_all_projects_context(
                     **base,
                     "status": "failed",
                     "phases": phases,
+                    # Key order matches the timeout envelope above and
+                    # ``_phase_error_envelope`` (error_kind, http_status,
+                    # message) — one order for every batch failure envelope
+                    # so the typed model serializes all of them verbatim.
                     "error": {
                         "error_kind": _classify_exception(exc),
-                        "message": _redact_message(str(exc)),
                         "http_status": 500,
+                        "message": _redact_message(str(exc)),
                     },
                 }
             )

--- a/packages/memtomem/src/memtomem/web/schemas/__init__.py
+++ b/packages/memtomem/src/memtomem/web/schemas/__init__.py
@@ -5,6 +5,7 @@ from memtomem.web.schemas.search import *  # noqa: F403
 from memtomem.web.schemas.sources import *  # noqa: F403
 from memtomem.web.schemas.memory import *  # noqa: F403
 from memtomem.web.schemas.config import *  # noqa: F403
+from memtomem.web.schemas.context import *  # noqa: F403
 from memtomem.web.schemas.tags import *  # noqa: F403
 from memtomem.web.schemas.dedup import *  # noqa: F403
 from memtomem.web.schemas.decay import *  # noqa: F403

--- a/packages/memtomem/src/memtomem/web/schemas/context.py
+++ b/packages/memtomem/src/memtomem/web/schemas/context.py
@@ -1,0 +1,467 @@
+"""Typed response models for the Context Gateway wire (#1692 PR 7).
+
+These models formalize the shapes the gateway routes have emitted as plain
+dicts since the campaign stabilized them (PRs 0–6). Attaching them via
+``response_model=`` makes shape drift a loud 500 instead of a silent wire
+change; the golden wire fixtures (``tests/test_web_wire_fixtures*.py``)
+remain the byte-level pin.
+
+Ground rules for editing this module:
+
+- **Field order is wire order.** The goldens compare rendered JSON text, so
+  a model's field declaration order must transcribe its builder's dict
+  insertion order exactly. Additive fields go LAST, matching the handlers'
+  append-only discipline.
+- **Exactly one field in this module has a default** —
+  ``ContextImportReport.dry_run``. Every other field is required (nullable
+  where the builder emits ``None``), so a handler that stops emitting a key
+  fails validation instead of silently null-filling the wire. The routes
+  that need omitted-key semantics (overview, projects, imports) pair their
+  model with ``response_model_exclude_unset=True``; any future defaulted
+  field on those models must be unconditionally set by the handler or it
+  will vanish from the wire.
+- **``extra="allow"`` only for verbatim-embedded bodies.** Sync-all phase
+  entries carry the per-type engine reports untouched (module contract in
+  ``routes/context_sync_all.py``); their shapes are pinned by the goldens,
+  not by these models.
+- **Open vocabularies stay ``str`` / ``dict[str, int]``** (row states,
+  reason codes, per-status diff counts with conditional and hyphenated
+  keys); ``Literal`` is reserved for values the route itself constructs
+  from a closed set.
+- Unions are non-discriminated on purpose: the natural ``status``
+  discriminators collide across variants (``"error"``, ``"failed"``), and
+  every union below has disjoint *required* fields, so smart-union
+  validation resolves exactly one member.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+__all__ = [
+    "ContextErrorEnvelope",
+    "ContextImportNeedsConfirmation",
+    "ContextImportReport",
+    "ContextImportSkippedRow",
+    "ContextImportedArtifact",
+    "ContextKindCountError",
+    "ContextOverviewResponse",
+    "ContextProjectScope",
+    "ContextProjectsResponse",
+    "ContextRegistryWarning",
+    "ContextRuntimeCoverageEntry",
+    "ContextRuntimeRegistration",
+    "ContextRuntimesResponse",
+    "ContextSettingsError",
+    "ContextSettingsSummary",
+    "ContextStatusAllCrashed",
+    "ContextStatusAllProject",
+    "ContextStatusAllResponse",
+    "ContextStatusAllSkipped",
+    "ContextStatusAllSummary",
+    "ContextStatusRow",
+    "ContextStatusWarning",
+    "ContextSyncAllProjectsReport",
+    "ContextSyncAllProjectsSummary",
+    "ContextSyncAllReport",
+    "ContextSyncAllSummary",
+    "ContextSyncPhase",
+    "ContextSyncPhaseError",
+    "ContextSyncProjectExecuted",
+    "ContextSyncProjectFailed",
+    "ContextSyncProjectSkipped",
+    "ContextWikiInstalls",
+]
+
+
+# ── Shared leaves ─────────────────────────────────────────────────────────
+
+
+class ContextKindCountError(BaseModel):
+    """Count-shaped per-kind error envelope (``_error_payload(shape="total")``)."""
+
+    total: int
+    error: bool
+    error_kind: str
+    error_message: str
+
+
+class ContextSettingsSummary(BaseModel):
+    """``summarize_settings_statuses`` roll-up — ``error`` is a COUNT here,
+    ``status`` the roll-up string (``in_sync``/``out_of_sync``/``error``)."""
+
+    total: int
+    in_sync: int
+    out_of_sync: int
+    missing_target: int
+    error: int
+    status: str
+
+
+class ContextSettingsError(BaseModel):
+    """Status-shaped settings error envelope (``_error_payload(shape="status")``)."""
+
+    status: Literal["error"]
+    error_kind: str
+    error_message: str
+
+
+#: Per-kind diff summary: an open count vocabulary (``summarize_diff_with_canonical``
+#: emits one snake_cased key per engine status, conditionally) or the count-shaped
+#: error envelope when the diff scan raised. Typed models first so smart-union
+#: strict validation resolves them before the open dict.
+ContextKindCounts = ContextKindCountError | dict[str, int]
+
+
+class ContextRuntimeCoverageEntry(BaseModel):
+    """``compute_runtime_coverage`` entry.
+
+    ``installed`` / ``memtomem_registered`` are conditionally OMITTED (not
+    null) when the registry probe had no row for the runtime — the consuming
+    routes pass ``response_model_exclude_unset=True`` to preserve that.
+    """
+
+    name: str
+    available: bool
+    installed: bool | None = None
+    memtomem_registered: bool | None = None
+
+
+class ContextErrorEnvelope(BaseModel):
+    """Status-all collector-crash envelope (``error_kind, message, http_status``
+    order — the sync-all surfaces order theirs differently, see
+    :class:`ContextSyncPhaseError`)."""
+
+    error_kind: str
+    message: str
+    http_status: int
+
+
+# ── GET /context/overview ─────────────────────────────────────────────────
+
+
+class ContextWikiInstalls(BaseModel):
+    total: int
+    behind: int
+
+
+class ContextOverviewResponse(BaseModel):
+    target_scope: str
+    project_root: str
+    detected_runtimes: list[ContextRuntimeCoverageEntry]
+    last_synced_at: str | None
+    wiki_installs: ContextWikiInstalls | None
+    skills: ContextKindCounts
+    commands: ContextKindCounts
+    agents: ContextKindCounts
+    mcp_servers: ContextKindCounts
+    settings: ContextSettingsSummary | ContextSettingsError
+    # Appended last: the wire goldens pin key positions, so additive fields
+    # never displace existing keys (#1692 PR 5 precedent).
+    detected_runtimes_unavailable: bool
+
+
+# ── GET /context/runtimes ─────────────────────────────────────────────────
+
+
+class ContextRuntimeRegistration(BaseModel):
+    """``RuntimeStatus.to_dict()`` — per-client probe failures ride in
+    ``error_kind``; the response-level ``runtimes_status`` is disjoint."""
+
+    name: str
+    installed: bool
+    memtomem_registered: bool
+    mms_registered: bool
+    registered_locations: list[str]
+    config_paths: list[str]
+    error_kind: str | None
+
+
+class ContextStatusWarning(BaseModel):
+    """Runtimes-route availability warning — the registry warning minus
+    ``skipped_rows`` (no row concept there), by design."""
+
+    reason_code: str
+    error_kind: str
+    message: str
+    retryable: bool
+
+
+class ContextRuntimesResponse(BaseModel):
+    project_root: str
+    runtimes: list[ContextRuntimeRegistration]
+    runtimes_status: Literal["ok", "unavailable"]
+    warnings: list[ContextStatusWarning]
+
+
+# ── GET /context/projects ─────────────────────────────────────────────────
+
+
+class ContextRegistryWarning(BaseModel):
+    """``known_projects.json`` load-report warning (#1699). ``skipped_rows``
+    is non-null only for row-level degradation."""
+
+    reason_code: str
+    error_kind: str
+    message: str
+    retryable: bool
+    skipped_rows: int | None
+
+
+class ContextProjectScope(BaseModel):
+    """One ``_scope_to_dict`` row. ``counts`` / ``runtime_coverage`` and their
+    ``*_unavailable`` sidecars are ``None`` when their ``?include=`` section
+    wasn't requested — null means "not computed", distinct from empty."""
+
+    project_scope_id: str
+    scope_id: str
+    label: str
+    root: str | None
+    tier: str
+    sources: list[str]
+    missing: bool
+    stale: bool
+    experimental: bool
+    enabled: bool
+    sync_eligible: bool
+    counts: dict[str, int] | None
+    runtime_coverage: list[ContextRuntimeCoverageEntry] | None
+    counts_unavailable: list[str] | None
+    runtime_coverage_unavailable: bool | None
+
+
+class ContextProjectsResponse(BaseModel):
+    target_scope: str
+    scopes: list[ContextProjectScope]
+    registry_status: Literal["ok", "unavailable"]
+    warnings: list[ContextRegistryWarning]
+
+
+# ── GET /context/status-all ───────────────────────────────────────────────
+
+
+class ContextStatusAllSkipped(BaseModel):
+    """Ineligible-scope entry (shared ``sync_skip_reason`` codes)."""
+
+    project_scope_id: str
+    label: str
+    root: str | None
+    status: Literal["skipped"]
+    reason_code: str
+    message: str
+
+
+class ContextStatusAllCrashed(BaseModel):
+    """Total collector-crash entry — the entry-level ``error`` object is
+    reserved for this; per-kind probe failures stay inside ``diff_counts``."""
+
+    project_scope_id: str
+    label: str
+    root: str
+    status: Literal["error"]
+    error: ContextErrorEnvelope
+
+
+class ContextStatusRow(BaseModel):
+    """Serialized ``StatusRow``. ``pin_commit`` / ``installed_at`` are empty
+    strings (not null) for draft rows; ``state`` stays open for future
+    ``StatusState`` values (new states must not 500 the fleet view)."""
+
+    asset_type: str
+    name: str
+    pin_commit: str
+    installed_at: str
+    state: str
+    dirty_file_count: int
+    reason: str | None
+    tier: str
+
+
+class ContextStatusAllProject(BaseModel):
+    """Executed-project entry (``_status_all_entry``). ``status: "error"``
+    here means a corrupt lockfile or a per-kind diff probe that raised —
+    distinct from :class:`ContextStatusAllCrashed` (disjoint required
+    fields resolve the union, not the colliding ``status`` values)."""
+
+    project_scope_id: str
+    label: str
+    root: str
+    status: Literal["ok", "drift", "error"]
+    wiki_head: str | None
+    lockfile_error: str | None
+    state_counts: dict[str, int]
+    diff_counts: dict[str, ContextSettingsSummary | ContextSettingsError | ContextKindCounts]
+    rows: list[ContextStatusRow]
+
+
+class ContextStatusAllSummary(BaseModel):
+    """Counts only — deliberately no roll-up status string; fleet health is
+    ``drifted + errors == 0``, derivable."""
+
+    projects_total: int
+    executed: int
+    drifted: int
+    clean: int
+    errors: int
+    skipped: int
+
+
+class ContextStatusAllResponse(BaseModel):
+    target_scope: str
+    projects: list[ContextStatusAllSkipped | ContextStatusAllCrashed | ContextStatusAllProject]
+    summary: ContextStatusAllSummary
+
+
+# ── POST /context/sync-all (+ /context/sync-all-projects) ────────────────
+
+
+class ContextSyncPhase(BaseModel):
+    """One phase entry: ``{type, status, **native}``.
+
+    The per-type engine reports (and a failed phase's ``error`` envelope,
+    which can carry extra detail keys like strict-drop's ``generated``) ride
+    as extras BY CONTRACT — phase entries embed the native bodies verbatim
+    (ADR-0024; ``routes/context_sync_all.py`` module docstring). Their
+    shapes are pinned by the wire goldens, not this model. One permissive
+    model for all variants on purpose: the settings phase can be ``failed``
+    with native ``results`` and no ``error`` key, so an ok/failed model
+    split would either strip keys or null-inject.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: str
+    status: Literal["ok", "failed", "needs_confirmation"]
+
+
+class ContextSyncAllSummary(BaseModel):
+    """Run-level roll-up (``_summarize``) — totals are counts, not
+    classifications; skip severity stays with per-row ``reason_code``."""
+
+    status: Literal["ok", "failed", "partial"]
+    changed: bool
+    outcome: Literal["changed", "noop"]
+    ok: int
+    failed: int
+    needs_confirmation: int
+    generated_total: int
+    skipped_total: int
+
+
+class ContextSyncAllReport(BaseModel):
+    phases: list[ContextSyncPhase]
+    summary: ContextSyncAllSummary
+
+
+class ContextSyncPhaseError(BaseModel):
+    """Batch project-level failure envelope (``error_kind, http_status,
+    message`` order — matches ``_phase_error_envelope``, differs from the
+    status-all :class:`ContextErrorEnvelope`). ``extra="allow"``: dict
+    details keep their extra keys so partial fan-out stays visible."""
+
+    model_config = ConfigDict(extra="allow")
+
+    error_kind: str
+    http_status: int
+    message: str
+
+
+class ContextSyncProjectSkipped(BaseModel):
+    project_scope_id: str
+    label: str
+    root: str | None
+    status: Literal["skipped"]
+    reason_code: str
+    message: str
+
+
+class ContextSyncProjectFailed(BaseModel):
+    """Engine error or lock timeout for one project — completed ``phases``
+    are kept (their writes are real); no ``summary`` (the loop didn't
+    finish), which is what disambiguates this from
+    :class:`ContextSyncProjectExecuted` at ``status: "failed"``."""
+
+    project_scope_id: str
+    label: str
+    root: str
+    status: Literal["failed"]
+    phases: list[ContextSyncPhase]
+    error: ContextSyncPhaseError
+
+
+class ContextSyncProjectExecuted(BaseModel):
+    """Completed project entry — ``status`` mirrors its own ``summary.status``."""
+
+    project_scope_id: str
+    label: str
+    root: str
+    status: Literal["ok", "failed", "partial"]
+    phases: list[ContextSyncPhase]
+    summary: ContextSyncAllSummary
+
+
+class ContextSyncAllProjectsSummary(BaseModel):
+    """Batch roll-up (``_summarize_projects``)."""
+
+    status: Literal["ok", "failed", "partial"]
+    projects_total: int
+    executed: int
+    ok: int
+    partial: int
+    failed: int
+    skipped: int
+    generated_total: int
+    skipped_rows_total: int
+
+
+class ContextSyncAllProjectsReport(BaseModel):
+    projects: list[
+        ContextSyncProjectSkipped | ContextSyncProjectFailed | ContextSyncProjectExecuted
+    ]
+    summary: ContextSyncAllProjectsSummary
+
+
+# ── POST /context/<kind>/import family ────────────────────────────────────
+
+
+class ContextImportedArtifact(BaseModel):
+    name: str
+    canonical_path: str
+    source_runtime: str | None
+    duplicate_candidates: list[str]
+
+
+class ContextImportSkippedRow(BaseModel):
+    name: str
+    reason: str
+    reason_code: str
+
+
+class ContextImportReport(BaseModel):
+    """``_import_payload`` shape, shared by every import route and the
+    host-write gate's nested ``plan``.
+
+    ``dry_run`` is the ONLY defaulted field in this module: the bulk routes
+    always emit it, the single-item routes never do, and the import routes
+    pair this model with ``response_model_exclude_unset=True`` so an
+    omitted key stays omitted (absent ≠ ``null`` on this wire).
+    """
+
+    imported: list[ContextImportedArtifact]
+    skipped: list[ContextImportSkippedRow]
+    project_root: str
+    scanned_dirs: list[str]
+    dry_run: bool | None = None
+
+
+class ContextImportNeedsConfirmation(BaseModel):
+    """Unconfirmed user-tier import: the ``host_write_gate`` disclosure
+    envelope with the dry-run preview nested under ``plan`` (#1263)."""
+
+    status: Literal["needs_confirmation"]
+    confirm: str
+    reason: str
+    host_targets: list[str]
+    plan: ContextImportReport

--- a/packages/memtomem/tests/data/wire/import_agent_single.json
+++ b/packages/memtomem/tests/data/wire/import_agent_single.json
@@ -1,0 +1,20 @@
+{
+  "imported": [
+    {
+      "name": "str",
+      "canonical_path": "str",
+      "source_runtime": "str",
+      "duplicate_candidates": [
+        "str"
+      ]
+    }
+  ],
+  "skipped": [],
+  "project_root": "str",
+  "scanned_dirs": [
+    "str",
+    "str",
+    "str",
+    "str"
+  ]
+}

--- a/packages/memtomem/tests/data/wire/import_agents.json
+++ b/packages/memtomem/tests/data/wire/import_agents.json
@@ -1,0 +1,27 @@
+{
+  "imported": [
+    {
+      "name": "str",
+      "canonical_path": "str",
+      "source_runtime": "str",
+      "duplicate_candidates": [
+        "str"
+      ]
+    }
+  ],
+  "skipped": [
+    {
+      "name": "str",
+      "reason": "str",
+      "reason_code": "str"
+    }
+  ],
+  "project_root": "str",
+  "scanned_dirs": [
+    "str",
+    "str",
+    "str",
+    "str"
+  ],
+  "dry_run": "bool"
+}

--- a/packages/memtomem/tests/data/wire/import_needs_confirmation.json
+++ b/packages/memtomem/tests/data/wire/import_needs_confirmation.json
@@ -1,0 +1,29 @@
+{
+  "status": "str",
+  "confirm": "str",
+  "reason": "str",
+  "host_targets": [
+    "str"
+  ],
+  "plan": {
+    "imported": [
+      {
+        "name": "str",
+        "canonical_path": "str",
+        "source_runtime": "str",
+        "duplicate_candidates": [
+          "str"
+        ]
+      }
+    ],
+    "skipped": [],
+    "project_root": "str",
+    "scanned_dirs": [
+      "str",
+      "str",
+      "str",
+      "str"
+    ],
+    "dry_run": "bool"
+  }
+}

--- a/packages/memtomem/tests/data/wire/sync_all.json
+++ b/packages/memtomem/tests/data/wire/sync_all.json
@@ -1,0 +1,129 @@
+{
+  "phases": [
+    {
+      "type": "str",
+      "status": "str",
+      "generated": [],
+      "skipped": [
+        {
+          "runtime": "str",
+          "reason": "str",
+          "reason_code": "str"
+        }
+      ],
+      "canonical_root": "str"
+    },
+    {
+      "type": "str",
+      "status": "str",
+      "generated": [],
+      "dropped": [],
+      "skipped": [
+        {
+          "runtime": "str",
+          "reason": "str",
+          "reason_code": "str"
+        }
+      ],
+      "canonical_root": "str"
+    },
+    {
+      "type": "str",
+      "status": "str",
+      "generated": [
+        {
+          "runtime": "str",
+          "path": "str"
+        },
+        {
+          "runtime": "str",
+          "path": "str"
+        },
+        {
+          "runtime": "str",
+          "path": "str"
+        },
+        {
+          "runtime": "str",
+          "path": "str"
+        }
+      ],
+      "dropped": [
+        {
+          "runtime": "str",
+          "name": "str",
+          "fields": [
+            "str"
+          ]
+        },
+        {
+          "runtime": "str",
+          "name": "str",
+          "fields": [
+            "str"
+          ]
+        }
+      ],
+      "skipped": [],
+      "canonical_root": "str"
+    },
+    {
+      "type": "str",
+      "status": "str",
+      "generated": [],
+      "skipped": [
+        {
+          "runtime": "str",
+          "reason": "str",
+          "reason_code": "str"
+        }
+      ],
+      "canonical_root": "str"
+    },
+    {
+      "type": "str",
+      "status": "str",
+      "results": [
+        {
+          "name": "str",
+          "status": "str",
+          "reason": "str",
+          "warnings": [],
+          "target": "null"
+        },
+        {
+          "name": "str",
+          "status": "str",
+          "reason": "str",
+          "warnings": [],
+          "target": "null"
+        },
+        {
+          "name": "str",
+          "status": "str",
+          "reason": "str",
+          "warnings": [],
+          "target": "null"
+        },
+        {
+          "name": "str",
+          "status": "str",
+          "reason": "str",
+          "warnings": [],
+          "target": "null"
+        }
+      ],
+      "duplicate_tier_warnings": []
+    }
+  ],
+  "summary": {
+    "status": "str",
+    "changed": "bool",
+    "outcome": "str",
+    "ok": "int",
+    "failed": "int",
+    "needs_confirmation": "int",
+    "generated_total": "int",
+    "skipped_total": "int"
+  }
+}

--- a/packages/memtomem/tests/data/wire/sync_all_projects.json
+++ b/packages/memtomem/tests/data/wire/sync_all_projects.json
@@ -1,0 +1,255 @@
+{
+  "projects": [
+    {
+      "project_scope_id": "str",
+      "label": "str",
+      "root": "str",
+      "status": "str",
+      "phases": [
+        {
+          "type": "str",
+          "status": "str",
+          "generated": [],
+          "skipped": [
+            {
+              "runtime": "str",
+              "reason": "str",
+              "reason_code": "str"
+            }
+          ],
+          "canonical_root": "str"
+        },
+        {
+          "type": "str",
+          "status": "str",
+          "generated": [],
+          "dropped": [],
+          "skipped": [
+            {
+              "runtime": "str",
+              "reason": "str",
+              "reason_code": "str"
+            }
+          ],
+          "canonical_root": "str"
+        },
+        {
+          "type": "str",
+          "status": "str",
+          "generated": [
+            {
+              "runtime": "str",
+              "path": "str"
+            },
+            {
+              "runtime": "str",
+              "path": "str"
+            },
+            {
+              "runtime": "str",
+              "path": "str"
+            },
+            {
+              "runtime": "str",
+              "path": "str"
+            }
+          ],
+          "dropped": [
+            {
+              "runtime": "str",
+              "name": "str",
+              "fields": [
+                "str"
+              ]
+            },
+            {
+              "runtime": "str",
+              "name": "str",
+              "fields": [
+                "str"
+              ]
+            }
+          ],
+          "skipped": [],
+          "canonical_root": "str"
+        },
+        {
+          "type": "str",
+          "status": "str",
+          "generated": [],
+          "skipped": [
+            {
+              "runtime": "str",
+              "reason": "str",
+              "reason_code": "str"
+            }
+          ],
+          "canonical_root": "str"
+        },
+        {
+          "type": "str",
+          "status": "str",
+          "results": [
+            {
+              "name": "str",
+              "status": "str",
+              "reason": "str",
+              "warnings": [],
+              "target": "null"
+            },
+            {
+              "name": "str",
+              "status": "str",
+              "reason": "str",
+              "warnings": [],
+              "target": "null"
+            },
+            {
+              "name": "str",
+              "status": "str",
+              "reason": "str",
+              "warnings": [],
+              "target": "null"
+            },
+            {
+              "name": "str",
+              "status": "str",
+              "reason": "str",
+              "warnings": [],
+              "target": "null"
+            }
+          ],
+          "duplicate_tier_warnings": []
+        }
+      ],
+      "summary": {
+        "status": "str",
+        "changed": "bool",
+        "outcome": "str",
+        "ok": "int",
+        "failed": "int",
+        "needs_confirmation": "int",
+        "generated_total": "int",
+        "skipped_total": "int"
+      }
+    },
+    {
+      "project_scope_id": "str",
+      "label": "str",
+      "root": "str",
+      "status": "str",
+      "phases": [
+        {
+          "type": "str",
+          "status": "str",
+          "generated": [],
+          "skipped": [
+            {
+              "runtime": "str",
+              "reason": "str",
+              "reason_code": "str"
+            }
+          ],
+          "canonical_root": "str"
+        },
+        {
+          "type": "str",
+          "status": "str",
+          "generated": [],
+          "dropped": [],
+          "skipped": [
+            {
+              "runtime": "str",
+              "reason": "str",
+              "reason_code": "str"
+            }
+          ],
+          "canonical_root": "str"
+        },
+        {
+          "type": "str",
+          "status": "str",
+          "generated": [],
+          "dropped": [],
+          "skipped": [
+            {
+              "runtime": "str",
+              "reason": "str",
+              "reason_code": "str"
+            }
+          ],
+          "canonical_root": "str"
+        },
+        {
+          "type": "str",
+          "status": "str",
+          "generated": [],
+          "skipped": [
+            {
+              "runtime": "str",
+              "reason": "str",
+              "reason_code": "str"
+            }
+          ],
+          "canonical_root": "str"
+        },
+        {
+          "type": "str",
+          "status": "str",
+          "results": [
+            {
+              "name": "str",
+              "status": "str",
+              "reason": "str",
+              "warnings": [],
+              "target": "null"
+            },
+            {
+              "name": "str",
+              "status": "str",
+              "reason": "str",
+              "warnings": [],
+              "target": "null"
+            },
+            {
+              "name": "str",
+              "status": "str",
+              "reason": "str",
+              "warnings": [],
+              "target": "null"
+            },
+            {
+              "name": "str",
+              "status": "str",
+              "reason": "str",
+              "warnings": [],
+              "target": "null"
+            }
+          ],
+          "duplicate_tier_warnings": []
+        }
+      ],
+      "summary": {
+        "status": "str",
+        "changed": "bool",
+        "outcome": "str",
+        "ok": "int",
+        "failed": "int",
+        "needs_confirmation": "int",
+        "generated_total": "int",
+        "skipped_total": "int"
+      }
+    }
+  ],
+  "summary": {
+    "status": "str",
+    "projects_total": "int",
+    "executed": "int",
+    "ok": "int",
+    "partial": "int",
+    "failed": "int",
+    "skipped": "int",
+    "generated_total": "int",
+    "skipped_rows_total": "int"
+  }
+}

--- a/packages/memtomem/tests/test_web_wire_fixtures.py
+++ b/packages/memtomem/tests/test_web_wire_fixtures.py
@@ -20,9 +20,9 @@ Regenerate after an intentional wire change with::
 
 and review the golden diff like any other contract change.
 
-The two POST report endpoints (Sync All, Import) are pinned separately when
-they gain typed models — their goldens need seeded-mutation setups this
-read-only file deliberately avoids.
+The POST report endpoints (Sync All, Import) are pinned in the sibling
+``test_web_wire_fixtures_reports.py`` — their goldens need seeded-mutation
+setups this read-only file deliberately avoids.
 """
 
 from __future__ import annotations

--- a/packages/memtomem/tests/test_web_wire_fixtures_reports.py
+++ b/packages/memtomem/tests/test_web_wire_fixtures_reports.py
@@ -1,0 +1,205 @@
+"""Golden wire-shape fixtures for the Context Gateway POST report endpoints (#1692 PR 7).
+
+Sibling of ``test_web_wire_fixtures.py`` (which pins the read endpoints and
+owns the golden machinery — ``_shape`` / ``_assert_matches_golden`` are
+imported from there). These endpoints mutate the seeded tmp project, so they
+get their own file: the read-only suite deliberately avoids seeded-mutation
+setups.
+
+Pinned shape variants (one golden per variant, not per kind — the three
+artifact kinds share the ``_import_payload`` builders byte-for-byte):
+
+- ``sync_all``            — single-project five-phase report
+- ``sync_all_projects``   — cross-project batch report (ADR-0025)
+- ``import_agents``       — bulk import: populated ``imported`` + ``skipped``
+                            and the always-present bulk ``dry_run`` key
+- ``import_agent_single`` — single-item import: ``dry_run`` OMITTED
+                            (``response_model_exclude_unset`` contract)
+- ``import_needs_confirmation`` — unconfirmed user-tier import: the
+                            ``host_write_gate`` envelope with nested ``plan``
+
+Regenerate after an intentional wire change with::
+
+    MEMTOMEM_UPDATE_WIRE_GOLDENS=1 uv run pytest \
+        packages/memtomem/tests/test_web_wire_fixtures_reports.py
+
+and review the golden diff like any other contract change.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from memtomem.config import ContextGatewayConfig, Mem2MemConfig
+from memtomem.web.app import create_app
+
+from .helpers import set_home
+from .test_web_wire_fixtures import _assert_matches_golden
+
+_AGENT_BODY = b"""---
+name: reviewer
+description: Code review agent
+tools: [Read, Grep]
+---
+You are a code review agent.
+"""
+
+_RUNTIME_AGENT_BODY = b"""---
+name: newagent
+description: Freshly authored runtime agent
+tools: [Read]
+---
+You are a new runtime agent.
+"""
+
+
+# ── Fixtures (mirror test_web_wire_fixtures.py) ───────────────────────────
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    set_home(monkeypatch, home)
+    monkeypatch.delenv("MEMTOMEM_WIKI_PATH", raising=False)
+    # Kimi's locations honor these env vars (runtime_registry) — a developer
+    # machine that sets either would leak a real config into the runtime
+    # probes and change the golden shapes.
+    monkeypatch.delenv("KIMI_SHARE_DIR", raising=False)
+    monkeypatch.delenv("KIMI_CODE_HOME", raising=False)
+    return home
+
+
+@pytest.fixture
+def cwd_root(tmp_path: Path, fake_home: Path) -> Path:
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    (cwd / ".claude").mkdir()
+    (cwd / ".memtomem").mkdir()
+    # One canonical agent so the sync agents phase has fan-out work to report.
+    agents = cwd / ".memtomem" / "agents"
+    agents.mkdir(parents=True)
+    (agents / "reviewer.md").write_bytes(_AGENT_BODY)
+    return cwd
+
+
+@pytest.fixture
+def known_projects_path(tmp_path: Path) -> Path:
+    return tmp_path / "kp.json"
+
+
+@pytest.fixture
+def app(cwd_root: Path, known_projects_path: Path):
+    application = create_app(lifespan=None, mode="dev")
+    application.state.project_root = cwd_root
+    application.state.storage = AsyncMock()
+    config = Mem2MemConfig()
+    config.context_gateway = ContextGatewayConfig(
+        known_projects_path=known_projects_path,
+        experimental_claude_projects_scan=False,
+    )
+    application.state.config = config
+    application.state.search_pipeline = None
+    application.state.index_engine = None
+    application.state.embedder = None
+    application.state.dedup_scanner = None
+    application.state.last_reload_error = None
+    return application
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def _register_second_project(client, tmp_path: Path) -> None:
+    """A second (registered) scope so the batch report pins >1 project entry."""
+    other = tmp_path / "other"
+    other.mkdir()
+    (other / ".claude").mkdir()
+    (other / ".memtomem").mkdir()
+    resp = await client.post("/api/context/known-projects", json={"root": str(other)})
+    assert resp.status_code == 200, resp.text
+
+
+def _seed_runtime_agents(cwd_root: Path) -> None:
+    """One importable runtime agent + one runtime copy of the existing
+    canonical, so the import report pins BOTH arrays populated."""
+    runtime_agents = cwd_root / ".claude" / "agents"
+    runtime_agents.mkdir(parents=True, exist_ok=True)
+    (runtime_agents / "newagent.md").write_bytes(_RUNTIME_AGENT_BODY)
+    (runtime_agents / "reviewer.md").write_bytes(_AGENT_BODY)
+
+
+# ── Sync All pins ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sync_all_wire_shape(client) -> None:
+    resp = await client.post("/api/context/sync-all")
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    # The agents phase fans out the seeded canonical — a report of pure
+    # empty phases would pin a weaker shape than production emits.
+    agents_phase = next(p for p in payload["phases"] if p["type"] == "agents")
+    assert agents_phase["generated"], agents_phase
+    _assert_matches_golden("sync_all", payload)
+
+
+@pytest.mark.asyncio
+async def test_sync_all_projects_wire_shape(client, tmp_path: Path) -> None:
+    await _register_second_project(client, tmp_path)
+    resp = await client.post("/api/context/sync-all-projects")
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["summary"]["executed"] == 2, payload["summary"]
+    _assert_matches_golden("sync_all_projects", payload)
+
+
+# ── Import pins ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_import_bulk_wire_shape(client, cwd_root: Path) -> None:
+    _seed_runtime_agents(cwd_root)
+    resp = await client.post("/api/context/agents/import")
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    # Bulk responses always carry dry_run; both arrays are populated so the
+    # golden pins the row shapes, not just empty lists.
+    assert payload["imported"] and payload["skipped"], payload
+    assert payload["dry_run"] is False
+    _assert_matches_golden("import_agents", payload)
+
+
+@pytest.mark.asyncio
+async def test_import_single_wire_shape(client, cwd_root: Path) -> None:
+    _seed_runtime_agents(cwd_root)
+    resp = await client.post("/api/context/agents/newagent/import")
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    # The single-item response never carried dry_run — absent, not null
+    # (the response_model_exclude_unset contract this golden pins).
+    assert "dry_run" not in payload
+    _assert_matches_golden("import_agent_single", payload)
+
+
+@pytest.mark.asyncio
+async def test_import_needs_confirmation_wire_shape(client, fake_home: Path) -> None:
+    # A user-tier import reads the HOME runtime roots; an unconfirmed request
+    # with pending writes returns the host_write_gate disclosure envelope
+    # (200 + status, not an error) with the dry-run preview nested as plan.
+    home_agents = fake_home / ".claude" / "agents"
+    home_agents.mkdir(parents=True)
+    (home_agents / "homeagent.md").write_bytes(_RUNTIME_AGENT_BODY)
+    resp = await client.post("/api/context/agents/import?target_scope=user")
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["status"] == "needs_confirmation", payload
+    _assert_matches_golden("import_needs_confirmation", payload)


### PR DESCRIPTION
## Summary

PR 7 (last) of #1692 — typed Pydantic response models for the Context Gateway
wire, with golden fixtures pinning shape compatibility.

The gateway's read and report endpoints returned hand-built dicts, so a handler
edit could change the wire silently. This PR formalizes the now-stable shapes
(PRs 0–6) as Pydantic models attached via `response_model=`; shape drift now
fails loudly (HTTP 500 + a golden diff) instead of riding along.

**Routes covered** (12 decorators, kwargs only — no body/signature changes):

| Surface | Route(s) | Model |
|---|---|---|
| Overview | `GET /api/context/overview` | `ContextOverviewResponse` |
| Projects | `GET /api/context/projects` | `ContextProjectsResponse` |
| Runtimes | `GET /api/context/runtimes` | `ContextRuntimesResponse` |
| Status All | `GET /api/context/status-all` | `ContextStatusAllResponse` |
| Sync All | `POST /api/context/sync-all`, `POST /api/context/sync-all-projects` | `ContextSyncAllReport`, `ContextSyncAllProjectsReport` |
| Import | all 7 artifact-import routes (skills ×3 incl. import-to-user, agents ×2, commands ×2) | `ContextImportReport \| ContextImportNeedsConfirmation` |

## Design

- **Field order is wire order** — model declaration order transcribes each
  builder's dict insertion order; the goldens compare rendered JSON text, so
  key order is part of the contract.
- **One defaulted field in the whole module** (`ContextImportReport.dry_run`);
  everything else is required (nullable where builders emit `None`), so a
  handler that stops emitting a key fails validation instead of silently
  null-filling the wire.
- **`response_model_exclude_unset=True`** on overview / projects / imports
  preserves the conditionally-omitted keys (runtime coverage entries'
  `installed`/`memtomem_registered`; the single-import responses' absent
  `dry_run`). Absent ≠ null on this wire.
- **`extra="allow"` only for verbatim-embedded bodies** — sync-all phase
  entries carry the per-type engine reports untouched; their shapes are pinned
  by the goldens, not the models.
- **Non-discriminated unions with disjoint required fields** — the natural
  `status` discriminators collide across variants (`"error"`, `"failed"`).
- Attached on the thin decorated route functions (never `_atomic_kind.py`
  shared bodies), preserving the #1514 thin-handler split, the AST invariant
  registry, and operationIds. All OpenAPI components are `Context*`-prefixed.

One deliberate normalization rides along: the batch sync's crash-path `error`
envelope now orders `error_kind, http_status, message` like its timeout
sibling and `_phase_error_envelope` (same keys, same values), so one model
serializes every batch failure envelope verbatim.

## Goldens

- The five existing read-endpoint goldens pass **unregenerated** — byte-level
  proof that attaching the models changed nothing on the read wire.
- New sibling suite `test_web_wire_fixtures_reports.py` pins the POST report
  endpoints PR 0 deferred, one golden per shape variant: `sync_all`,
  `sync_all_projects`, `import_agents` (bulk, `dry_run` present),
  `import_agent_single` (`dry_run` omitted), `import_needs_confirmation`
  (host-write gate envelope with nested `plan`).

## Verification

- `pytest packages/memtomem/tests/test_web_wire_fixtures.py` — 5 passed with
  no regeneration; both wire suites (10) green.
- Full suite `pytest -m "not ollama"` — 8277 passed, 11 skipped.
- `ruff check` + `ruff format --check` clean; mypy adds no new errors
  (13 pre-existing advisory findings elsewhere).
- OpenAPI sanity: all `Context*` components registered; routes reference them.
- Mutation check: swapping two model fields makes the golden test fail —
  the order pin is live.

Refs #1692

🤖 Generated with [Claude Code](https://claude.com/claude-code)
