### PR TITLE
feat(context): add `--force-head` escape hatch to follow a deliberate wiki rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **`mm context update --force-head` — follow a deliberate wiki rollback**
+  (#1689) — the forward-only guard (#1685) refuses to move a project's pin
+  backward after a wiki reset / force-pull, and `--force` deliberately does
+  not bypass it. `--force-head` is the explicit escape hatch: it records the
+  current wiki HEAD even when it does not descend from the recorded pin,
+  warning on stderr **before** anything is written (single asset and `--all`;
+  the `--all` preview table tags affected rows `[moves pin BACKWARD]`).
+  Orthogonal to `--force` (wiki-side history vs project-side edits — a
+  backward move onto locally edited files needs both), and it never bypasses
+  the wiki-dirty gate or a lockfile entry with no recorded pin. The web
+  update route gains the matching `force_head` request field plus an additive
+  `pin_moved_backward` response field (a client cannot derive direction from
+  the two commit SHAs).
+
 - **Typed response models on the Context Gateway wire** (#1692) — the
   Overview, Projects, Runtimes, Status All, Sync All (single + cross-project
   batch), and Import (all seven artifact-import routes) responses are now
@@ -50,6 +64,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   picks up the new tier after restart.
 
 ### Changed
+
+- **Missing-pin update refusals now report `pin_missing`, not
+  `pin_not_ancestor`** (#1689) — a lockfile entry with no usable `wiki_commit`
+  pin used to surface as the forward-only guard's 409 `pin_not_ancestor`,
+  whose fixed message claims the wiki history "diverged" and the pin "would
+  move backward" — neither is true when no pin exists. The engine now raises
+  `PinMissingError` (a `PinNotAncestorError` subclass, so existing Python
+  catch sites are unaffected) and the web route returns
+  `409 reason_code="pin_missing"` with an accurate message (re-install or
+  adopt; `force_head` cannot bypass). HTTP status and envelope shape are
+  unchanged; clients branching on `pin_not_ancestor` for this rare case will
+  observe the corrected discriminator. Both reason codes are pinned by route
+  tests.
 
 - **A failed status probe is now an error, not drift** (#1692) — in the
   Context Gateway fleet view (`GET /api/context/status-all`) and

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -53,6 +53,8 @@ from memtomem.context.install import (
     _classify_for_all_update,
     _classify_for_install_all,
     _commit_hint,
+    _has_recorded_pin,
+    _pin_backward_reason,
     adopt_agent,
     adopt_command,
     adopt_skill,
@@ -93,7 +95,7 @@ from memtomem.context.projects import (
     resolve_project_selector,
     sync_skip_reason,
 )
-from memtomem.context.lockfile import LockfileError
+from memtomem.context.lockfile import Lockfile, LockfileError
 from memtomem.context.status import (
     DRIFT_STATES,
     ProjectStatus,
@@ -2038,6 +2040,17 @@ def _dirty_asset_refusal_text(
     help="Overwrite local edits; each dirty file is preserved as <file>.bak.",
 )
 @click.option(
+    "--force-head",
+    "force_head",
+    is_flag=True,
+    help=(
+        "Follow a deliberate wiki rollback: record the current wiki HEAD even "
+        "when it does NOT descend from the recorded pin (moves the pin "
+        "BACKWARD). Orthogonal to --force, which only overrides project-side "
+        "edits — a backward move onto locally edited files needs both."
+    ),
+)
+@click.option(
     "--dry-run",
     is_flag=True,
     help=(
@@ -2053,6 +2066,7 @@ def update_cmd(
     all_projects: bool,
     yes: bool,
     force: bool,
+    force_head: bool,
     dry_run: bool,
 ) -> None:
     """Refresh an installed wiki asset from the wiki HEAD.
@@ -2064,6 +2078,15 @@ def update_cmd(
     in the wiki never blocks. A no-op (pin already at HEAD) still
     succeeds and prints an asset-scoped note when the asset has
     uncommitted wiki edits.
+
+    Update is forward-only (#1685): when the wiki was reset / force-pulled
+    so HEAD no longer descends from the recorded pin, it refuses rather
+    than silently downgrading — and ``--force`` does not bypass that
+    either. ``--force-head`` (#1689) is the deliberate escape hatch: it
+    follows the rollback and moves the pin BACKWARD, warning on stderr
+    before anything is written. It never bypasses the wiki-dirty gate,
+    the project-side dirty gate (still ``--force``), or a lockfile entry
+    with no recorded pin (remedy: ``mm context adopt`` or re-install).
 
     Without ``--all``: refresh in the current project only. No-op when
     the wiki commit pinned in ``.memtomem/lock.json`` already matches
@@ -2101,12 +2124,50 @@ def update_cmd(
         raise click.ClickException(str(exc)) from exc
 
     if all_projects:
-        _run_update_all(asset_type, name, root, wiki=wiki, yes=yes, force=force, dry_run=dry_run)
+        _run_update_all(
+            asset_type,
+            name,
+            root,
+            wiki=wiki,
+            yes=yes,
+            force=force,
+            force_head=force_head,
+            dry_run=dry_run,
+        )
         return
 
     if dry_run:
-        _run_update_dry_run_single(asset_type, name, root, wiki=wiki)
+        _run_update_dry_run_single(asset_type, name, root, wiki=wiki, force_head=force_head)
         return
+
+    # --force-head pre-write WARNING (#1689): resolve the target commit HERE
+    # and thread it into the engine as pinned_commit, so the commit this
+    # warning is computed against and the commit the engine gates on and
+    # records are the same string — a HEAD move between the two reads can't
+    # produce an unwarned backward write. Preflight read errors are ignored:
+    # the engine raises the canonical error moments later (pinned_commit
+    # stays None, so it resolves HEAD itself).
+    pinned_commit: str | None = None
+    if force_head:
+        try:
+            pinned_commit = wiki.current_commit()
+            entry = Lockfile.at(root).read_entry(f"{asset_type}s", name) or {}
+            pin = entry.get("wiki_commit")
+            if _has_recorded_pin(pin) and _pin_backward_reason(wiki, pin, pinned_commit):
+                click.secho(
+                    f"WARNING: --force-head will move the {asset_type}s/{name} pin "
+                    f"BACKWARD ({str(pin)[:12]} → {pinned_commit[:12]}) to follow the "
+                    f"wiki rollback.",
+                    fg="red",
+                    err=True,
+                )
+        except (WikiNotFoundError, WikiUnbornHeadError, LockfileError, OSError):
+            # Preflight is advisory: any read failure (incl. a wiki that
+            # vanished after the require_exists() above — TOCTOU) defers to the
+            # engine call below, which re-raises the canonical error through
+            # _translate_to_click. pinned_commit stays None → engine resolves
+            # HEAD itself and surfaces the same error a non-force-head run would.
+            pinned_commit = None
 
     # PrivacyScanError here is a Gate A refusal (ADR-0011 §5, #1247).
     with _translate_to_click(
@@ -2122,11 +2183,32 @@ def update_cmd(
         PrivacyScanError,
     ):
         if asset_type == "skill":
-            result = update_skill(root, name, wiki=wiki, force=force)
+            result = update_skill(
+                root,
+                name,
+                wiki=wiki,
+                force=force,
+                force_head=force_head,
+                pinned_commit=pinned_commit,
+            )
         elif asset_type == "agent":
-            result = update_agent(root, name, wiki=wiki, force=force)
+            result = update_agent(
+                root,
+                name,
+                wiki=wiki,
+                force=force,
+                force_head=force_head,
+                pinned_commit=pinned_commit,
+            )
         elif asset_type == "command":
-            result = update_command(root, name, wiki=wiki, force=force)
+            result = update_command(
+                root,
+                name,
+                wiki=wiki,
+                force=force,
+                force_head=force_head,
+                pinned_commit=pinned_commit,
+            )
         else:  # pragma: no cover — guarded by click.Choice
             raise click.ClickException(f"unknown asset type: {asset_type}")
 
@@ -2138,9 +2220,10 @@ def update_cmd(
         _maybe_hint_dirty_noop(wiki, result.asset_type, result.name)
         return
 
+    backward_note = " (pin moved BACKWARD)" if result.pin_moved_backward else ""
     click.secho(
         f"Updated {result.asset_type}/{result.name} "
-        f"({result.old_wiki_commit[:12]} → {result.new_wiki_commit[:12]})",
+        f"({result.old_wiki_commit[:12]} → {result.new_wiki_commit[:12]}){backward_note}",
         fg="green",
     )
     rel_dest = result.dest.relative_to(root) if result.dest.is_relative_to(root) else result.dest
@@ -2164,6 +2247,7 @@ def _run_update_dry_run_single(
     root: Path,
     *,
     wiki: WikiStore,
+    force_head: bool = False,
 ) -> None:
     """Read-only preview for the single-project ``update --dry-run`` path.
 
@@ -2185,6 +2269,7 @@ def _run_update_dry_run_single(
             name,
             wiki=wiki,
             projects=[root],
+            force_head=force_head,
         )
 
     if not classifications:
@@ -2205,8 +2290,9 @@ def _run_update_dry_run_single(
     # Forward-only gate (#1685): a stale pin (HEAD does not descend from it)
     # exits non-zero like the real run's PinNotAncestorError. Checked BEFORE
     # the wiki-dirty gate to mirror _update_asset's order (ancestry precedes
-    # the dirty gate). Non-force-able — the reason names the wiki-history fix,
-    # not --force.
+    # the dirty gate). Not bypassed by --force; under --force-head only the
+    # missing-pin case still classifies stale-pin (PinMissingError parity) —
+    # the reason names the wiki-history fix.
     if row.state == "stale-pin":
         raise click.ClickException(f"{asset_type_plural}/{name}: {row.reason}")
 
@@ -2223,7 +2309,11 @@ def _run_update_dry_run_single(
     if row.state == "update":
         old = (row.lock_entry or {}).get("wiki_commit", "")
         old_abbr = old[:12] if isinstance(old, str) and old else "(unpinned)"
-        click.echo(f"\nDry run — nothing written; would update {old_abbr} → {new_commit[:12]}.")
+        backward_note = " — moving the pin BACKWARD (--force-head)" if row.pin_backward else ""
+        click.echo(
+            f"\nDry run — nothing written; would update "
+            f"{old_abbr} → {new_commit[:12]}{backward_note}."
+        )
     elif row.state == "unchanged":
         click.echo("\nDry run — nothing written; already up to date.")
         _maybe_hint_dirty_noop(wiki, asset_type_plural, name)
@@ -2244,6 +2334,7 @@ def _run_update_all(
     wiki: WikiStore,
     yes: bool,
     force: bool,
+    force_head: bool = False,
     dry_run: bool = False,
 ) -> None:
     """Orchestrate ``mm context update <type> <name> --all``.
@@ -2308,6 +2399,7 @@ def _run_update_all(
             name,
             wiki=wiki,
             projects=project_roots,
+            force_head=force_head,
         )
 
     if not classifications:
@@ -2323,6 +2415,7 @@ def _run_update_all(
     needs_force = [c for c in classifications if c.state == "refuse"]
     stale_pins = [c for c in classifications if c.state == "stale-pin"]
     has_errors = [c for c in classifications if c.state == "error"]
+    backward_rows = [c for c in classifications if c.pin_backward]
 
     if not needs_update and not needs_force and not stale_pins and not has_errors:
         click.echo("\nAll projects are up to date.")
@@ -2360,6 +2453,8 @@ def _run_update_all(
         # even with refuse/error rows (the table already shows them; the
         # refusal exit belongs to the run that actually intends to write).
         parts = [f"{len(needs_update)} would update"]
+        if backward_rows:
+            parts.append(f"{len(backward_rows)} would move the pin BACKWARD (--force-head)")
         if needs_force:
             parts.append(f"{len(needs_force)} would refuse without --force")
         if stale_pins:
@@ -2388,6 +2483,18 @@ def _run_update_all(
             err=True,
         )
 
+    # --force-head pre-write WARNING (#1689): fires only when a row will
+    # ACTUALLY move its pin backward (an all-forward batch with the flag is
+    # a silent no-op), and regardless of --yes — it must inform the confirm
+    # prompt and the automation log alike, before anything is written.
+    if backward_rows:
+        click.secho(
+            f"WARNING: --force-head will move {len(backward_rows)} project pin(s) "
+            f"BACKWARD to follow the wiki rollback.",
+            fg="red",
+            err=True,
+        )
+
     if not yes:
         click.confirm("\nContinue?", abort=True)
 
@@ -2404,9 +2511,10 @@ def _run_update_all(
         if c.state == "stale-pin":
             # Forward-only gate (#1685): HEAD does not descend from this
             # project's pin — advancing would downgrade it. Per-project skip
-            # (never force-able), counted as a failure so the batch exits
-            # non-zero: the user asked to update and this one could not be
-            # safely advanced. Siblings that ARE forward keep updating.
+            # (not bypassed by --force; under --force-head only missing-pin
+            # rows still land here, #1689), counted as a failure so the batch
+            # exits non-zero: the user asked to update and this one could not
+            # be safely advanced. Siblings that ARE forward keep updating.
             click.secho(f"  ⚠ {c.project_root}: {c.reason}", fg="red")
             failures += 1
             continue
@@ -2428,6 +2536,7 @@ def _run_update_all(
                 wiki_commit=new_commit,
                 lock_entry=c.lock_entry,
                 force=force,
+                pin_moved_backward=c.pin_backward,
                 surface="cli_context_update_all",
             )
         except StaleInstallError as exc:
@@ -2453,7 +2562,8 @@ def _run_update_all(
             removed_note = (
                 f" ({len(upd.files_removed)} file(s) removed)" if upd.files_removed else ""
             )
-            click.secho(f"  ✓ {c.project_root}: updated{removed_note}", fg="green")
+            backward_note = " (pin moved BACKWARD)" if upd.pin_moved_backward else ""
+            click.secho(f"  ✓ {c.project_root}: updated{removed_note}{backward_note}", fg="green")
             successes += 1
 
     click.echo(
@@ -2478,6 +2588,9 @@ def _print_classification_table(
 
     Columns: state · project root (relative when possible) · reason
     (only shown for ``refuse`` and ``error`` rows where it carries info).
+    A row made actionable by ``--force-head`` (#1689) is forced red and
+    tagged ``[moves pin BACKWARD]`` — the downgrade must be visible in the
+    table the user confirms against, not only in the stderr WARNING.
     """
     click.echo(
         f"\n{asset_type_plural}/{name} — wiki HEAD {new_commit[:12]} — "
@@ -2491,10 +2604,12 @@ def _print_classification_table(
         "error": "red",
     }
     for c in classifications:
-        color = state_color[c.state]
+        color = "red" if c.pin_backward else state_color[c.state]
         line = f"  {c.state:10s}  {c.project_root}"
         if c.reason:
             line += f"  ({c.reason})"
+        if c.pin_backward:
+            line += "  [moves pin BACKWARD]"
         click.secho(line, fg=color)
 
 

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -76,6 +76,7 @@ __all__ = [
     "CommitNotFoundError",
     "InstallResult",
     "NotInstalledError",
+    "PinMissingError",
     "PinNotAncestorError",
     "ProjectInstallClassification",
     "StaleInstallError",
@@ -176,8 +177,26 @@ class PinNotAncestorError(RuntimeError):
     Deliberately NOT bypassed by ``--force`` — that flag overrides project-side
     dest edits, never wiki-side history (the same asymmetry the wiki-dirty gate
     keeps). The remedy is to investigate the wiki: advance HEAD past the pin, or
-    re-install at the intended commit. A degraded ``--force-head`` escape hatch
-    is deferred, mirroring the ``install --all`` orphan handling.
+    re-install at the intended commit — or, for a *deliberate* wiki rollback,
+    pass ``--force-head`` (#1689), which follows HEAD backward for a recorded
+    pin (see :func:`_has_recorded_pin`; a missing pin raises
+    :class:`PinMissingError` instead and is never force-able). The analogous
+    degraded fallback for ``install --all`` orphans remains deferred.
+    """
+
+
+class PinMissingError(PinNotAncestorError):
+    """Raised when the lockfile entry has no usable ``wiki_commit`` pin (#1689).
+
+    The forward-only guard (#1685) needs a recorded pin to prove an update is
+    forward; a missing/non-string/empty ``wiki_commit`` (hand-edited or legacy
+    lockfile) proves nothing — there is no pin to move backward, so the
+    "diverged history" narrative of :class:`PinNotAncestorError` would be
+    false. Neither ``--force`` nor ``--force-head`` bypasses this: the remedy
+    is ``mm context adopt`` (#1684) or a re-install, which records a real pin.
+    Subclasses :class:`PinNotAncestorError` so every existing catch site keeps
+    working; the web route catches this first to return the accurate
+    ``pin_missing`` reason code instead of ``pin_not_ancestor``.
     """
 
 
@@ -243,6 +262,10 @@ class UpdateResult:
       #1247) — ``installed_at`` was re-captured after the copy, and any
       dirty files were preserved at the listed ``.bak`` paths (only
       populated when ``--force`` was used against a dirty asset).
+    - ``pin_moved_backward=True`` only when ``--force-head`` recorded a
+      commit that does not descend from the old pin (#1689) — the
+      deliberate-rollback escape hatch; always ``False`` on forward
+      updates and no-ops.
     """
 
     asset_type: Literal["skills", "agents", "commands"]
@@ -255,6 +278,7 @@ class UpdateResult:
     dest: Path
     files_written: int
     files_removed: tuple[Path, ...] = ()
+    pin_moved_backward: bool = False
 
 
 @dataclass(frozen=True)
@@ -281,10 +305,15 @@ class ProjectClassification:
     - ``"stale-pin"`` — wiki HEAD ≠ lockfile pin AND HEAD does not
       descend from the pin (wiki reset / force-pull past the pin, #1685).
       Advancing would move the pin BACKWARD, so this row is skipped
-      per-project (never force-able — the write-path counterpart of the
-      ``mm context status`` ``stale-pin`` state, see
+      per-project (not bypassed by ``--force``; the write-path
+      counterpart of the ``mm context status`` ``stale-pin`` state, see
       :func:`_pin_backward_reason`); ``dirty_report`` stays ``None``
-      because the dirty walk is short-circuited before it runs.
+      because the dirty walk is short-circuited before it runs. Under
+      ``--force-head`` (#1689) the recorded-pin sub-cases (unreachable /
+      divergent) reclassify through the normal dirty walk to
+      ``"update"``/``"refuse"`` with ``pin_backward=True``; a missing
+      pin stays ``"stale-pin"`` (there is no pin to move backward — see
+      :class:`PinMissingError`).
     - ``"error"`` — the project's lockfile is corrupt or unreadable;
       ``reason`` carries the detail. Propagates as a row-level failure
       in the execute summary.
@@ -292,7 +321,9 @@ class ProjectClassification:
     ``lock_entry`` is the live lockfile entry (carries ``installed_at``
     and ``wiki_commit``). ``dirty_report`` is populated only for
     ``"update"`` and ``"refuse"`` states — the two cases where the
-    dirty walk actually ran.
+    dirty walk actually ran. ``pin_backward=True`` marks a row whose
+    write would move the pin backward and was made actionable by
+    ``force_head`` — the preview table and the batch WARNING key off it.
     """
 
     project_root: Path
@@ -300,6 +331,7 @@ class ProjectClassification:
     reason: str | None
     lock_entry: dict[str, Any] | None
     dirty_report: DirtyReport | None
+    pin_backward: bool = False
 
 
 def install_skill(
@@ -1068,6 +1100,8 @@ def update_skill(
     *,
     wiki: WikiStore | None = None,
     force: bool = False,
+    force_head: bool = False,
+    pinned_commit: str | None = None,
     lock_timeout: float | None = None,
     surface: str = "cli_context_update",
 ) -> UpdateResult:
@@ -1085,6 +1119,13 @@ def update_skill(
     (#1246/#1248 real-ingress rule): the CLI keeps the default, the web
     route passes ``"web_context_update"`` so a browser-triggered block is
     not misattributed to a CLI event.
+
+    ``force_head`` (#1689) follows a deliberate wiki rollback: the recorded
+    pin advances (backward) to the target commit even when that commit does
+    not descend from it. ``pinned_commit`` pins the target commit explicitly
+    instead of resolving HEAD here — the CLI passes the commit its
+    pre-write WARNING was computed against, so the warned-about commit and
+    the recorded commit are the same by construction.
     """
     return _update_asset(
         project_root,
@@ -1092,6 +1133,8 @@ def update_skill(
         name,
         wiki=wiki,
         force=force,
+        force_head=force_head,
+        pinned_commit=pinned_commit,
         lock_timeout=lock_timeout,
         surface=surface,
     )
@@ -1103,6 +1146,8 @@ def update_agent(
     *,
     wiki: WikiStore | None = None,
     force: bool = False,
+    force_head: bool = False,
+    pinned_commit: str | None = None,
     lock_timeout: float | None = None,
     surface: str = "cli_context_update",
 ) -> UpdateResult:
@@ -1113,6 +1158,8 @@ def update_agent(
         name,
         wiki=wiki,
         force=force,
+        force_head=force_head,
+        pinned_commit=pinned_commit,
         lock_timeout=lock_timeout,
         surface=surface,
     )
@@ -1124,6 +1171,8 @@ def update_command(
     *,
     wiki: WikiStore | None = None,
     force: bool = False,
+    force_head: bool = False,
+    pinned_commit: str | None = None,
     lock_timeout: float | None = None,
     surface: str = "cli_context_update",
 ) -> UpdateResult:
@@ -1134,6 +1183,8 @@ def update_command(
         name,
         wiki=wiki,
         force=force,
+        force_head=force_head,
+        pinned_commit=pinned_commit,
         lock_timeout=lock_timeout,
         surface=surface,
     )
@@ -1184,6 +1235,20 @@ def _pin_backward_reason(wiki: WikiStore, pin: object, new_commit: str) -> str |
     )
 
 
+def _has_recorded_pin(pin: object) -> bool:
+    """True when the lockfile entry actually records a ``wiki_commit`` pin (#1689).
+
+    Gates which :func:`_pin_backward_reason` refusals ``--force-head`` may
+    override: the flag follows wiki history that moved out from under a
+    *recorded* pin (unreachable / divergent — including a malformed pin
+    string, which classifies as unreachable and has the same remedy: record
+    the current commit). A missing/non-string/empty pin proves nothing and
+    has nothing to move backward — that case raises
+    :class:`PinMissingError` regardless of the flag.
+    """
+    return isinstance(pin, str) and bool(pin)
+
+
 def _update_asset(
     project_root: Path | str,
     asset_type: str,
@@ -1191,6 +1256,8 @@ def _update_asset(
     *,
     wiki: WikiStore | None,
     force: bool = False,
+    force_head: bool = False,
+    pinned_commit: str | None = None,
     lock_timeout: float | None = None,
     surface: str = "cli_context_update",
 ) -> UpdateResult:
@@ -1201,7 +1268,11 @@ def _update_asset(
     1. Validate ``name`` and project root.
     2. Read the existing lockfile entry — ``NotInstalledError`` if absent.
     3. Pin wiki HEAD as ``new_commit`` once (concurrent ``git pull`` in the
-       wiki cannot make the recorded commit drift mid-update).
+       wiki cannot make the recorded commit drift mid-update). When the
+       caller supplies ``pinned_commit`` (#1689: the CLI ``--force-head``
+       preflight), that commit IS the snapshot — no second HEAD read —
+       so the commit a pre-write WARNING was computed against and the
+       commit every gate checks and records are the same string.
     4. **True no-op short-circuit**: when ``new_commit`` matches the lockfile
        pin, return early *without touching the lockfile*. ``installed_at``
        is echoed from the existing entry; ``was_no_op=True``. The no-op
@@ -1249,7 +1320,7 @@ def _update_asset(
             f"run `mm context install {asset_type_singular} {validated}` first"
         )
 
-    new_commit = wiki.current_commit()
+    new_commit = pinned_commit if pinned_commit is not None else wiki.current_commit()
     dest = project_root / ".memtomem" / asset_type / validated
 
     if lock_entry.get("wiki_commit") == new_commit:
@@ -1290,11 +1361,18 @@ def _update_asset(
     # downgrade. Runs BEFORE the dirty gate (the pin is stale regardless of
     # worktree state) and AFTER HEAD-presence (so it mirrors
     # `_classify_for_all_update`, whose HEAD-presence gate fires batch-global up
-    # front). NOT force-able — same wiki-side/project-side asymmetry the dirty
-    # gate keeps; the remedy is to fix the wiki, not to clobber the pin.
-    backward = _pin_backward_reason(wiki, lock_entry.get("wiki_commit"), new_commit)
+    # front). NOT bypassed by ``force`` — same wiki-side/project-side asymmetry
+    # the dirty gate keeps. ``force_head`` (#1689) deliberately overrides the
+    # recorded-pin sub-cases (unreachable/divergent — a wiki rollback the user
+    # chose to follow); a missing pin raises PinMissingError regardless (there
+    # is no pin to move backward — the remedy is adopt/re-install, #1684).
+    pin = lock_entry.get("wiki_commit")
+    backward = _pin_backward_reason(wiki, pin, new_commit)
     if backward is not None:
-        raise PinNotAncestorError(f"{asset_type}/{validated}: {backward}")
+        if not _has_recorded_pin(pin):
+            raise PinMissingError(f"{asset_type}/{validated}: {backward}")
+        if not force_head:
+            raise PinNotAncestorError(f"{asset_type}/{validated}: {backward}")
 
     # Same-asset dirty gate (#1652): worktree state must equal HEAD for THIS
     # asset — otherwise the user-visible wiki bytes and the refreshed bytes
@@ -1320,6 +1398,7 @@ def _update_asset(
         wiki_commit=new_commit,
         lock_entry=lock_entry,
         force=force,
+        pin_moved_backward=backward is not None,
         surface=surface,
         lock_timeout=lock_timeout,
     )
@@ -1335,6 +1414,7 @@ def _apply_update(
     wiki_commit: str,
     lock_entry: dict[str, Any],
     force: bool,
+    pin_moved_backward: bool = False,
     surface: str = "cli_context_update",
     lock_timeout: float | None = None,
 ) -> UpdateResult:
@@ -1344,6 +1424,11 @@ def _apply_update(
     (:meth:`WikiStore.copy_asset_at_commit`), never from the wiki working
     tree, so the lockfile's ``wiki_commit``/``digests`` claims below are
     literally true — pin==bytes holds by construction.
+
+    ``pin_moved_backward`` is caller-derived display state (#1689): the
+    guard that proved ``wiki_commit`` does not descend from the old pin
+    lives in the callers (``_update_asset`` / the ``--all`` classifier),
+    so they pass the verdict down to be echoed on the result.
 
     Pre-conditions enforced by callers (``_update_asset`` for the single-
     asset path, ``mm context update --all`` orchestration for the batch
@@ -1558,6 +1643,7 @@ def _apply_update(
         dest=dest,
         files_written=len(digest_map),
         files_removed=files_removed,
+        pin_moved_backward=pin_moved_backward,
     )
 
 
@@ -1567,6 +1653,7 @@ def _classify_for_all_update(
     *,
     wiki: WikiStore,
     projects: list[Path],
+    force_head: bool = False,
 ) -> tuple[str, list[ProjectClassification]]:
     """Classify ``asset_type/name`` across many project roots in one pass.
 
@@ -1575,6 +1662,15 @@ def _classify_for_all_update(
     caller is expected to thread ``new_commit`` into each subsequent
     :func:`_apply_update` invocation so the execute phase writes against
     the same snapshot the user confirmed.
+
+    ``force_head`` (#1689) reclassifies a would-be ``stale-pin`` row whose
+    pin IS recorded (unreachable / divergent — a wiki rollback the user
+    chose to follow) through the normal dirty walk: it becomes ``update``
+    or ``refuse`` like any other stale row, carrying ``pin_backward=True``
+    so the preview table and the batch WARNING can mark it. Missing-pin
+    rows stay ``stale-pin`` regardless (see :class:`PinMissingError`), and
+    dest-side orthogonality is preserved for free — a backward move onto a
+    dirty dest still classifies ``refuse`` and demands ``--force``.
 
     Used by ``mm context update --all``. The wiki state is read **once**
     up front: ``wiki.current_commit()`` and the HEAD-presence gate
@@ -1689,21 +1785,29 @@ def _classify_for_all_update(
         # silent downgrade. Mirrors the single-asset _update_asset guard so the
         # --all preview agrees with what the wet run would refuse. Checked
         # BEFORE the dirty walk (the pin is stale regardless of dest state);
-        # a non-force-able per-project skip, not a batch-blocking refuse.
-        backward = _pin_backward_reason(wiki, lock_entry.get("wiki_commit"), new_commit)
+        # a per-project skip not bypassed by --force. Under force_head (#1689)
+        # a recorded-pin row falls through to the dirty walk below instead —
+        # the write becomes actionable, but dest dirt still gates it.
+        pin = lock_entry.get("wiki_commit")
+        backward = _pin_backward_reason(wiki, pin, new_commit)
+        pin_backward = False
         if backward is not None:
-            out.append(
-                ProjectClassification(
-                    project_root=project_root,
-                    state="stale-pin",
-                    reason=backward,
-                    lock_entry=lock_entry,
-                    dirty_report=None,
+            if force_head and _has_recorded_pin(pin):
+                pin_backward = True
+            else:
+                out.append(
+                    ProjectClassification(
+                        project_root=project_root,
+                        state="stale-pin",
+                        reason=backward,
+                        lock_entry=lock_entry,
+                        dirty_report=None,
+                    )
                 )
-            )
-            continue
+                continue
 
-        # Wiki advanced — classify dirty/clean for this project.
+        # Wiki advanced (or force_head follows it backward) — classify
+        # dirty/clean for this project.
         report = is_asset_dirty(project_root, asset_type, name, lock_entry=lock_entry)
         dest = project_root / ".memtomem" / asset_type / name
         flat_path, flat_dirty = (
@@ -1742,6 +1846,7 @@ def _classify_for_all_update(
                 reason=reason,
                 lock_entry=lock_entry,
                 dirty_report=report,
+                pin_backward=pin_backward,
             )
         )
 

--- a/packages/memtomem/src/memtomem/web/routes/context_mutations.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_mutations.py
@@ -32,6 +32,7 @@ from memtomem.context.install import (
     AssetNotFoundError,
     InstallResult,
     NotInstalledError,
+    PinMissingError,
     PinNotAncestorError,
     ProjectRootMissingError,
     StaleInstallError,
@@ -82,9 +83,15 @@ class UpdateAssetRequest(BaseModel):
     ``force`` mirrors the CLI ``--force``: overwrite a dirty dest, preserving
     each locally edited file as a ``.bak`` sibling first. Install takes no body
     (a fresh install can never clobber — it refuses if the dest already exists).
+
+    ``force_head`` mirrors the CLI ``--force-head`` (#1689): follow a deliberate
+    wiki rollback, recording a HEAD that does not descend from the recorded pin
+    (moves the pin BACKWARD). Orthogonal to ``force``, which only overrides
+    project-side edits — a backward move onto a dirty dest needs both.
     """
 
     force: bool = False
+    force_head: bool = False
 
 
 def _safe_rel(p: Path, project_root: Path) -> str:
@@ -233,9 +240,15 @@ async def update_asset(
     local edits would be clobbered; the client re-POSTs
     ``{"force": true}`` to overwrite (each dirty file kept as a ``.bak``
     sibling). An asset with no lockfile entry → 404 ``not_installed``.
+    Forward-only (#1685): a wiki rollback refuses with 409
+    ``pin_not_ancestor``; the client re-POSTs ``{"force_head": true}`` to
+    deliberately follow it backward (#1689) — the success payload then
+    reports ``pin_moved_backward: true``. A lockfile entry with no usable
+    pin refuses with 409 ``pin_missing`` regardless of ``force_head``.
     """
     _validate_name_or_error(asset_type, name)
     force = body.force if body is not None else False
+    force_head = body.force_head if body is not None else False
     updater = _UPDATERS[asset_type]
 
     def _run() -> UpdateResult:
@@ -246,6 +259,7 @@ async def update_asset(
             name,
             wiki=WikiStore.at_default(),
             force=force,
+            force_head=force_head,
             lock_timeout=_INSTALL_LOCK_BUDGET_S,
             surface="web_context_update",
         )
@@ -292,18 +306,34 @@ async def update_asset(
             f"`mm wiki <type> commit <name> --canonical` — and retry",
             reason_code="wiki_uncommitted",
         ) from exc
+    except PinMissingError as exc:
+        # Ordered BEFORE its parent PinNotAncestorError (#1689): a lockfile
+        # entry with no usable wiki_commit pin proves nothing about direction,
+        # so the "diverged history / would move backward" narrative below
+        # would be false remediation guidance. Not bypassed by force_head —
+        # there is no pin to move backward; the remedy records a real pin.
+        raise _error(
+            409,
+            "conflict",
+            f"{asset_type}/{name}: no usable wiki_commit pin is recorded for this "
+            f"asset, so the update cannot be proven forward; re-install or adopt "
+            f"it to record a pin (force_head cannot bypass this)",
+            reason_code="pin_missing",
+        ) from exc
     except PinNotAncestorError as exc:
         # Forward-only gate (#1685): wiki HEAD does not descend from this
         # project's pin (wiki reset / force-pull), so update would move the pin
         # backward. Fixed message (the engine text names the pinned SHA only,
         # not a host path, but keep the envelope contract uniform); NOT
-        # force-able — the remedy is to fix the wiki, not to re-run with force.
+        # bypassed by force — for a deliberate rollback the client re-POSTs
+        # with force_head: true (#1689) to follow the wiki backward.
         raise _error(
             409,
             "conflict",
             f"{asset_type}/{name}: the wiki history diverged from this project's "
             f"pin (reset or force-pull past it); update would move the pin "
-            f"backward. Investigate the wiki before retrying",
+            f"backward. Retry with force_head: true to deliberately follow the "
+            f"rollback, or fix the wiki",
             reason_code="pin_not_ancestor",
         ) from exc
     except PrivacyScanError as exc:
@@ -339,4 +369,5 @@ async def update_asset(
         "files_removed": [_safe_rel(p, project_root) for p in result.files_removed],
         "bak_file_count": len(result.bak_files_written),
         "bak_files": [_safe_rel(p, project_root) for p in result.bak_files_written],
+        "pin_moved_backward": result.pin_moved_backward,
     }

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -29,6 +29,7 @@ from memtomem.context.install import (
     AlreadyInstalledError,
     AssetNotFoundError,
     NotInstalledError,
+    PinMissingError,
     PinNotAncestorError,
     StaleInstallError,
     UncommittedAssetError,
@@ -221,6 +222,271 @@ def test_pin_backward_reason_allows_forward_and_noop(wiki_root: Path, tmp_path: 
     assert _pin_backward_reason(wiki, "0" * 40, commit2) is not None  # unreachable
     assert _pin_backward_reason(wiki, "", commit2) is not None  # missing pin
     assert _pin_backward_reason(wiki, None, commit2) is not None  # non-str pin
+
+
+# ── --force-head escape hatch (#1689) ───────────────────────────────────
+
+
+def test_update_force_head_follows_wiki_rollback(wiki_root: Path, tmp_path: Path) -> None:
+    """``force_head=True`` follows a deliberate rollback: the pin moves BACKWARD.
+
+    The flipped mirror of ``test_update_refuses_when_wiki_reset_behind_pin`` —
+    same setup, but the escape hatch records the rolled-back HEAD, restores the
+    older bytes, and reports ``pin_moved_backward=True`` (#1689).
+    """
+    _initialized_wiki(wiki_root)
+    commit1 = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+    install_skill(project, "foo")
+
+    commit2 = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    update_skill(project, "foo")  # pin forward to commit2
+    _reset_wiki_hard(wiki_root, commit1)  # HEAD now behind the pin
+
+    result = update_skill(project, "foo", force_head=True)
+
+    assert result.was_no_op is False
+    assert result.old_wiki_commit == commit2
+    assert result.new_wiki_commit == commit1
+    assert result.pin_moved_backward is True
+    assert (project / ".memtomem" / "skills" / "foo" / "SKILL.md").read_bytes() == b"v1\n"
+    lock_doc = json.loads((project / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == commit1
+
+
+def test_update_force_head_follows_unreachable_pin(wiki_root: Path, tmp_path: Path) -> None:
+    """A recorded-but-unreachable pin (history rewrite) is also force_head-able."""
+    from memtomem.context.lockfile import Lockfile
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+    install_skill(project, "foo")
+    Lockfile.at(project).upsert_entry(
+        "skills", "foo", wiki_commit="0" * 40, installed_at="2030-01-01T00:00:00.000000Z"
+    )
+    new_commit = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    result = update_skill(project, "foo", force_head=True)
+
+    assert result.pin_moved_backward is True
+    lock_doc = json.loads((project / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == new_commit
+
+
+def test_update_force_head_follows_malformed_pin(wiki_root: Path, tmp_path: Path) -> None:
+    """A non-empty malformed pin string classifies unreachable → force_head-able.
+
+    Distinct from the valid-but-unreachable SHA case above (Codex R2): a
+    garbage recorded pin is still a *recorded* pin — the remedy (record the
+    current commit) is identical, so the flag covers it.
+    """
+    from memtomem.context.lockfile import Lockfile
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+    install_skill(project, "foo")
+    Lockfile.at(project).upsert_entry(
+        "skills", "foo", wiki_commit="not-a-sha", installed_at="2030-01-01T00:00:00.000000Z"
+    )
+    new_commit = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    with pytest.raises(PinNotAncestorError):
+        update_skill(project, "foo")  # without the flag: refuse
+
+    result = update_skill(project, "foo", force_head=True)
+    assert result.pin_moved_backward is True
+    lock_doc = json.loads((project / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == new_commit
+
+
+def test_update_missing_pin_raises_pin_missing_error(wiki_root: Path, tmp_path: Path) -> None:
+    """A lockfile entry with no usable pin raises PinMissingError even unflagged (#1689).
+
+    The split is observable independently of ``force_head`` — the old
+    ``PinNotAncestorError`` "diverged history" narrative was false for this
+    case. The subclass keeps every existing ``except PinNotAncestorError``
+    working.
+    """
+    from memtomem.context.lockfile import Lockfile
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+    install_skill(project, "foo")
+    Lockfile.at(project).upsert_entry(
+        "skills", "foo", wiki_commit="", installed_at="2030-01-01T00:00:00.000000Z"
+    )
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    with pytest.raises(PinMissingError) as exc:
+        update_skill(project, "foo")
+    assert isinstance(exc.value, PinNotAncestorError)  # catch-site compatibility
+    assert "no wiki_commit pin" in str(exc.value)
+
+
+def test_update_force_head_missing_pin_still_refuses(wiki_root: Path, tmp_path: Path) -> None:
+    """``force_head`` never bypasses a missing pin — there is nothing to move backward."""
+    from memtomem.context.lockfile import Lockfile
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+    install_skill(project, "foo")
+    Lockfile.at(project).upsert_entry(
+        "skills", "foo", wiki_commit="", installed_at="2030-01-01T00:00:00.000000Z"
+    )
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    with pytest.raises(PinMissingError):
+        update_skill(project, "foo", force_head=True)
+    lock_doc = json.loads((project / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == ""
+
+
+def test_update_pinned_commit_recorded_despite_head_advance(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """``pinned_commit`` anchors gate AND record to the caller's snapshot (#1689).
+
+    The CLI --force-head preflight computes its pre-write WARNING against a
+    commit and threads that commit here; a HEAD move in between must not make
+    the engine gate/record a different commit (Codex R2 race: preflight sees
+    forward, engine snapshot sees backward → unwarned backward write).
+    """
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+    install_skill(project, "foo")
+
+    commit2 = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    # HEAD advances AFTER the caller captured commit2 (the race window).
+    commit3 = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v3\n"})
+    assert commit2 != commit3
+
+    result = update_skill(project, "foo", pinned_commit=commit2)
+
+    # Ancestry was checked against and the record made at the CAPTURED commit.
+    assert result.new_wiki_commit == commit2
+    assert result.pin_moved_backward is False
+    assert (project / ".memtomem" / "skills" / "foo" / "SKILL.md").read_bytes() == b"v2\n"
+    lock_doc = json.loads((project / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == commit2
+
+
+def test_update_force_head_forward_update_not_marked_backward(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """The flag on a normal forward update is a no-op: nothing marked backward."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+    install_skill(project, "foo")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    result = update_skill(project, "foo", force_head=True)
+
+    assert result.pin_moved_backward is False
+
+
+def test_update_force_head_dirty_dest_still_needs_force(wiki_root: Path, tmp_path: Path) -> None:
+    """Orthogonality (#1689): force_head is wiki-side only — dest dirt still needs force."""
+    _initialized_wiki(wiki_root)
+    commit1 = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+    install_skill(project, "foo")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    update_skill(project, "foo")
+    _reset_wiki_hard(wiki_root, commit1)
+
+    edited = project / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    edited.write_bytes(b"local edit\n")
+    _bump_mtime(edited)
+
+    with pytest.raises(StaleInstallError):
+        update_skill(project, "foo", force_head=True)
+
+    result = update_skill(project, "foo", force=True, force_head=True)
+    assert result.pin_moved_backward is True
+    bak = edited.with_suffix(edited.suffix + ".bak")
+    assert bak.read_bytes() == b"local edit\n"
+    assert edited.read_bytes() == b"v1\n"
+
+
+def test_update_force_head_does_not_bypass_uncommitted_gate(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """force_head overrides pin ancestry only — wiki worktree dirt still refuses."""
+    _initialized_wiki(wiki_root)
+    commit1 = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+    install_skill(project, "foo")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    update_skill(project, "foo")
+    _reset_wiki_hard(wiki_root, commit1)
+
+    # Uncommitted wiki edit on the SAME asset — the commit-true gate (#1652)
+    # fires after the (overridden) forward-only gate.
+    (wiki_root / "skills" / "foo" / "SKILL.md").write_bytes(b"uncommitted\n")
+
+    with pytest.raises(UncommittedAssetError):
+        update_skill(project, "foo", force_head=True)
+
+
+def test_classify_for_all_update_force_head_reclassifies_stale_pin(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """Under force_head a recorded-pin stale row runs the dirty walk (#1689).
+
+    Recorded-but-unreachable pin → ``update`` with ``pin_backward=True`` and a
+    populated ``dirty_report``; a missing-pin row stays ``stale-pin``.
+    """
+    from memtomem.context.lockfile import Lockfile
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    wiki = WikiStore.at_default()
+
+    proj_forward = tmp_path / "forward"
+    proj_forward.mkdir()
+    install_skill(proj_forward, "foo")
+
+    proj_stale = tmp_path / "stale"
+    proj_stale.mkdir()
+    install_skill(proj_stale, "foo")
+    Lockfile.at(proj_stale).upsert_entry(
+        "skills", "foo", wiki_commit="0" * 40, installed_at="2030-01-01T00:00:00.000000Z"
+    )
+
+    proj_unpinned = tmp_path / "unpinned"
+    proj_unpinned.mkdir()
+    install_skill(proj_unpinned, "foo")
+    Lockfile.at(proj_unpinned).upsert_entry(
+        "skills", "foo", wiki_commit="", installed_at="2030-01-01T00:00:00.000000Z"
+    )
+
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    _, rows = _classify_for_all_update(
+        "skills",
+        "foo",
+        wiki=wiki,
+        projects=[proj_forward, proj_stale, proj_unpinned],
+        force_head=True,
+    )
+    by_root = {r.project_root: r for r in rows}
+
+    fwd = by_root[proj_forward]
+    assert (fwd.state, fwd.pin_backward) == ("update", False)
+
+    stale = by_root[proj_stale]
+    assert (stale.state, stale.pin_backward) == ("update", True)
+    assert stale.dirty_report is not None  # the dirty walk ran — orthogonality intact
+
+    unpinned = by_root[proj_unpinned]
+    assert (unpinned.state, unpinned.pin_backward) == ("stale-pin", False)
+    assert unpinned.dirty_report is None
 
 
 def test_dirty_refuse_without_force(wiki_root: Path, tmp_path: Path) -> None:
@@ -449,7 +715,15 @@ def test_cli_update_dispatches_to_correct_wrapper(
     calls: list[tuple[str, str]] = []
 
     def _fake(asset_type: str):
-        def _impl(root: Path, name: str, *, wiki: object = None, force: bool = False) -> object:
+        def _impl(
+            root: Path,
+            name: str,
+            *,
+            wiki: object = None,
+            force: bool = False,
+            force_head: bool = False,
+            pinned_commit: str | None = None,
+        ) -> object:
             calls.append((asset_type, name))
             # Return a sentinel UpdateResult — minimal fields the CLI prints.
             from memtomem.context.install import UpdateResult
@@ -548,6 +822,124 @@ def test_cli_update_dry_run_stale_pin_exits_nonzero(
     assert "backward" in result.output
 
 
+# ── CLI: --force-head (#1689) ───────────────────────────────────────────
+
+
+def test_cli_update_force_head_follows_rollback_with_warning(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    """``--force-head`` follows the rollback; the WARNING precedes the write.
+
+    Ordering pin (Codex R1/R2): the red stderr WARNING must appear BEFORE the
+    "Updated" success line — a post-write warning cannot inform the downgrade
+    it warns about. The success line carries the backward note from the
+    authoritative ``pin_moved_backward``.
+    """
+    _initialized_wiki(wiki_root)
+    commit1 = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project_cwd, "foo")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    update_skill(project_cwd, "foo")  # pin forward to commit2
+    _reset_wiki_hard(wiki_root, commit1)  # HEAD now behind the pin
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--force-head"])
+
+    assert result.exit_code == 0, result.output
+    assert "WARNING" in result.output
+    assert "BACKWARD" in result.output
+    assert result.output.index("WARNING") < result.output.index("Updated")
+    assert "(pin moved BACKWARD)" in result.output
+    lock_doc = json.loads((project_cwd / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == commit1
+    assert (project_cwd / ".memtomem" / "skills" / "foo" / "SKILL.md").read_bytes() == b"v1\n"
+
+
+def test_cli_update_force_head_missing_pin_still_refuses(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    """CLI ``--force-head`` cannot bypass a missing pin (PinMissingError, #1689)."""
+    from memtomem.context.lockfile import Lockfile
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project_cwd, "foo")
+    Lockfile.at(project_cwd).upsert_entry(
+        "skills", "foo", wiki_commit="", installed_at="2030-01-01T00:00:00.000000Z"
+    )
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--force-head"])
+
+    assert result.exit_code != 0
+    assert "no wiki_commit pin" in result.output
+    lock_doc = json.loads((project_cwd / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == ""
+
+
+def test_cli_update_force_head_preflight_wiki_vanish_defers_to_engine(
+    wiki_root: Path,
+    project_cwd: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A wiki that vanishes during the --force-head preflight defers to the engine.
+
+    The preflight is advisory (#1689): if the wiki disappears in the TOCTOU
+    window after ``require_exists()``, its read failure must NOT escape raw —
+    it defers to the engine call, which re-raises the canonical error through
+    ``_translate_to_click`` (a clean Click error + non-zero exit, no traceback).
+    """
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project_cwd, "foo")
+
+    from memtomem.wiki.store import WikiNotFoundError
+
+    def _vanish(self: WikiStore) -> str:
+        raise WikiNotFoundError("wiki vanished mid-run")
+
+    monkeypatch.setattr(WikiStore, "current_commit", _vanish)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--force-head"])
+
+    # The preflight swallows the read failure and defers to the engine, whose
+    # own current_commit re-raises → _translate_to_click surfaces a clean Click
+    # error. Without the WikiNotFoundError catch, the preflight would let the
+    # raw exception escape (CliRunner would capture it as result.exception).
+    assert result.exit_code != 0
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+def test_cli_update_dry_run_force_head_previews_backward(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    """``--dry-run --force-head`` previews the backward move and writes nothing."""
+    _initialized_wiki(wiki_root)
+    commit1 = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project_cwd, "foo")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+    update_skill(project_cwd, "foo")
+    lock_doc = json.loads((project_cwd / ".memtomem" / "lock.json").read_text())
+    pinned = lock_doc["skills"]["foo"]["wiki_commit"]
+    _reset_wiki_hard(wiki_root, commit1)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--dry-run", "--force-head"])
+
+    assert result.exit_code == 0, result.output
+    assert "[moves pin BACKWARD]" in result.output  # table marker
+    assert "moving the pin BACKWARD (--force-head)" in result.output  # summary note
+    # Nothing written — pin and bytes untouched.
+    lock_doc = json.loads((project_cwd / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == pinned
+    assert (project_cwd / ".memtomem" / "skills" / "foo" / "SKILL.md").read_bytes() == b"v2\n"
+
+
 # ── coverage: silence unused-import warnings on agent/command wrappers ──
 
 
@@ -558,6 +950,8 @@ def test_update_agent_command_wrappers_dispatch(monkeypatch: pytest.MonkeyPatch)
     seen: list[str] = []
     timeouts: list[float | None] = []
     surfaces: list[str] = []
+    force_heads: list[object] = []
+    pinned_commits: list[object] = []
 
     def _fake_update_asset(
         project_root: object,
@@ -567,14 +961,18 @@ def test_update_agent_command_wrappers_dispatch(monkeypatch: pytest.MonkeyPatch)
         wiki: object,
         force: bool,
         lock_timeout: float | None = None,
-        # Sentinel default (NOT "cli_context_update") so a wrapper that stops
-        # forwarding surface= fails the assertions below instead of the fake's
-        # own default masking the dropped kwarg (mutation-style pin).
+        # Sentinel defaults (NOT the wrappers' real defaults) so a wrapper
+        # that stops forwarding a kwarg fails the assertions below instead of
+        # the fake's own default masking the dropped kwarg (mutation-style pin).
+        force_head: object = "<force-head-not-forwarded>",
+        pinned_commit: object = "<pinned-commit-not-forwarded>",
         surface: str = "<surface-not-forwarded>",
     ) -> object:
         seen.append(asset_type)
         timeouts.append(lock_timeout)
         surfaces.append(surface)
+        force_heads.append(force_head)
+        pinned_commits.append(pinned_commit)
         from memtomem.context.install import UpdateResult
 
         return UpdateResult(
@@ -595,11 +993,12 @@ def test_update_agent_command_wrappers_dispatch(monkeypatch: pytest.MonkeyPatch)
     update_command(Path("/tmp/p"), "c")
     update_skill(Path("/tmp/p"), "s")
     update_skill(Path("/tmp/p"), "s", surface="web_context_update")
+    update_skill(Path("/tmp/p"), "s", force_head=True, pinned_commit="a" * 40)
 
-    assert seen == ["agents", "commands", "skills", "skills"]
+    assert seen == ["agents", "commands", "skills", "skills", "skills"]
     # The wrappers forward lock_timeout verbatim; callers that omit it (the
     # CLI / direct Python use) get the unbounded default (None).
-    assert timeouts == [None, None, None, None]
+    assert timeouts == [None, None, None, None, None]
     # surface= forwards verbatim: the CLI default when omitted, the caller's
     # audit surface (e.g. the web route's) when given.
     assert surfaces == [
@@ -607,7 +1006,12 @@ def test_update_agent_command_wrappers_dispatch(monkeypatch: pytest.MonkeyPatch)
         "cli_context_update",
         "cli_context_update",
         "web_context_update",
+        "cli_context_update",
     ]
+    # force_head / pinned_commit (#1689) forward verbatim: the real defaults
+    # when omitted, the caller's values when given.
+    assert force_heads == [False, False, False, False, True]
+    assert pinned_commits == [None, None, None, None, "a" * 40]
 
 
 # ════════════════════════════════════════════════════════════════════════
@@ -1069,6 +1473,184 @@ def test_cli_update_all_dry_run_reports_stale_pin(
     assert "stale pin" in result.output  # summary line
     stale_lock = json.loads((proj_stale / ".memtomem" / "lock.json").read_text())
     assert stale_lock["skills"]["foo"]["wiki_commit"] == "0" * 40
+
+
+# ── CLI --all: --force-head (#1689) ─────────────────────────────────────
+
+
+def test_cli_update_all_force_head_updates_stale_row_and_marks_table(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--all --force-head`` makes the stale row actionable, marked in the table.
+
+    The flipped mirror of the stale-pin skip test: the recorded-but-unreachable
+    row updates (pin moves to the batch snapshot), the table tags it
+    ``[moves pin BACKWARD]``, the WARNING fires before execution, and the batch
+    exits 0 — no failure rows left.
+    """
+    from memtomem.context.lockfile import Lockfile
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+
+    proj_forward = tmp_path / "forward"
+    proj_forward.mkdir()
+    install_skill(proj_forward, "foo")
+
+    proj_stale = tmp_path / "stale"
+    proj_stale.mkdir()
+    install_skill(proj_stale, "foo")
+    Lockfile.at(proj_stale).upsert_entry(
+        "skills", "foo", wiki_commit="0" * 40, installed_at="2030-01-01T00:00:00.000000Z"
+    )
+
+    new_commit = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj_forward, proj_stale])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        context_group, ["update", "skill", "foo", "--all", "--yes", "--force-head"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "[moves pin BACKWARD]" in result.output  # preview table marker
+    assert "WARNING: --force-head" in result.output
+    assert "(pin moved BACKWARD)" in result.output  # per-row success note
+    # Both rows updated to the batch snapshot.
+    for proj in (proj_forward, proj_stale):
+        lock_doc = json.loads((proj / ".memtomem" / "lock.json").read_text())
+        assert lock_doc["skills"]["foo"]["wiki_commit"] == new_commit
+        assert (proj / ".memtomem" / "skills" / "foo" / "SKILL.md").read_bytes() == b"v2\n"
+
+
+def test_cli_update_all_dry_run_force_head_counts_backward(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--all --dry-run --force-head`` counts the backward bucket, writes nothing."""
+    from memtomem.context.lockfile import Lockfile
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    proj_stale = tmp_path / "stale"
+    proj_stale.mkdir()
+    install_skill(proj_stale, "foo")
+    Lockfile.at(proj_stale).upsert_entry(
+        "skills", "foo", wiki_commit="0" * 40, installed_at="2030-01-01T00:00:00.000000Z"
+    )
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj_stale])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        context_group, ["update", "skill", "foo", "--all", "--dry-run", "--force-head"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "would move the pin BACKWARD (--force-head)" in result.output
+    assert "[moves pin BACKWARD]" in result.output
+    stale_lock = json.loads((proj_stale / ".memtomem" / "lock.json").read_text())
+    assert stale_lock["skills"]["foo"]["wiki_commit"] == "0" * 40
+
+
+def test_cli_update_all_yes_force_head_warns_without_prompt(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--yes --force-head`` three-way invariant: WARNING + no prompt + executed."""
+    from memtomem.context.lockfile import Lockfile
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    proj_stale = tmp_path / "stale"
+    proj_stale.mkdir()
+    install_skill(proj_stale, "foo")
+    Lockfile.at(proj_stale).upsert_entry(
+        "skills", "foo", wiki_commit="0" * 40, installed_at="2030-01-01T00:00:00.000000Z"
+    )
+    new_commit = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj_stale])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        context_group, ["update", "skill", "foo", "--all", "--yes", "--force-head"]
+    )
+
+    assert result.exit_code == 0, result.output
+    # 1. WARNING printed (regardless of --yes — the automation log needs it).
+    assert "WARNING: --force-head" in result.output
+    # 2. Prompt skipped.
+    assert "Continue?" not in result.output
+    # 3. Batch executed — the pin moved.
+    stale_lock = json.loads((proj_stale / ".memtomem" / "lock.json").read_text())
+    assert stale_lock["skills"]["foo"]["wiki_commit"] == new_commit
+
+
+def test_cli_update_all_force_head_backward_dirty_row_still_needs_force(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Orthogonality in the batch: a backward row with dest dirt still needs --force."""
+    from memtomem.context.lockfile import Lockfile
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    proj = tmp_path / "stale_dirty"
+    proj.mkdir()
+    install_skill(proj, "foo")
+    # PAST installed_at (unlike the other stale-pin fixtures' 2030 sentinel):
+    # the mtime-based dirty walk must see the local edit as newer.
+    Lockfile.at(proj).upsert_entry(
+        "skills", "foo", wiki_commit="0" * 40, installed_at="2020-01-01T00:00:00.000000Z"
+    )
+    edited = proj / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    edited.write_bytes(b"local\n")
+    _bump_mtime(edited)
+    new_commit = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        context_group, ["update", "skill", "foo", "--all", "--yes", "--force-head"]
+    )
+
+    # --force-head alone: the row classifies refuse → batch refuses, no write.
+    assert result.exit_code != 0, result.output
+    assert "--force" in result.output
+    lock_doc = json.loads((proj / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == "0" * 40
+
+    forced = runner.invoke(
+        context_group,
+        ["update", "skill", "foo", "--all", "--yes", "--force", "--force-head"],
+    )
+    assert forced.exit_code == 0, forced.output
+    bak = edited.with_suffix(edited.suffix + ".bak")
+    assert bak.read_bytes() == b"local\n"
+    assert edited.read_bytes() == b"v2\n"
+    lock_doc = json.loads((proj / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == new_commit
 
 
 # ── CLI --all: --yes invariants (no WARN unless --force) ────────────────

--- a/packages/memtomem/tests/test_web_routes_context_mutations.py
+++ b/packages/memtomem/tests/test_web_routes_context_mutations.py
@@ -389,6 +389,97 @@ async def test_update_stale_pin_is_409(client, seeded_wiki: Path, project_root: 
 
 
 @pytest.mark.asyncio
+async def test_update_force_head_follows_rollback(
+    client, seeded_wiki: Path, project_root: Path
+) -> None:
+    """``force_head: true`` (#1689) follows the rollback: 200 + backward pin.
+
+    The 2-step web flow is the pre-write warning channel: the first attempt's
+    409 names the rollback, the explicit re-POST opts in. The success payload
+    reports ``pin_moved_backward: true`` (a client cannot derive direction
+    from two SHAs); a plain forward update reports ``false``.
+    """
+    assert (await client.post("/api/context/skills/alpha/install")).status_code == 200
+    base = WikiStore.at_default().current_commit()
+    _advance_wiki(seeded_wiki)
+    forward = await client.post("/api/context/skills/alpha/update")
+    assert forward.status_code == 200
+    assert forward.json()["pin_moved_backward"] is False  # forward baseline
+    subprocess.run(
+        ["git", "-C", str(seeded_wiki), "reset", "--hard", base], check=True, capture_output=True
+    )
+
+    resp = await client.post("/api/context/skills/alpha/update", json={"force_head": True})
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["was_no_op"] is False
+    assert data["pin_moved_backward"] is True
+    assert data["new_wiki_commit"] == base
+    assert _lock_entry(project_root, "skills", "alpha")["wiki_commit"] == base
+    # The rolled-back bytes landed.
+    landed = project_root / ".memtomem" / "skills" / "alpha" / "SKILL.md"
+    assert "Upstream change." not in landed.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_update_missing_pin_is_409_pin_missing(
+    client, seeded_wiki: Path, project_root: Path
+) -> None:
+    """A missing pin returns 409 ``pin_missing`` — flag or no flag (#1689).
+
+    Split from ``pin_not_ancestor`` (whose fixed "diverged history / would
+    move backward" message is false here); the accurate envelope points at
+    re-install/adopt and says ``force_head`` cannot bypass.
+    """
+    assert (await client.post("/api/context/skills/alpha/install")).status_code == 200
+    Lockfile.at(project_root).upsert_entry(
+        "skills", "alpha", wiki_commit="", installed_at="2030-01-01T00:00:00.000000Z"
+    )
+    _advance_wiki(seeded_wiki)
+
+    for body in (None, {"force_head": True}):
+        resp = await client.post("/api/context/skills/alpha/update", json=body)
+        assert resp.status_code == 409, resp.text
+        detail = resp.json()["detail"]
+        assert detail["reason_code"] == "pin_missing"
+        assert "diverged" not in detail["message"]
+        assert "backward" not in detail["message"]
+        assert str(seeded_wiki) not in resp.text  # no host-path leak
+    assert _lock_entry(project_root, "skills", "alpha")["wiki_commit"] == ""
+
+
+@pytest.mark.asyncio
+async def test_update_force_head_and_force_are_orthogonal(
+    client, seeded_wiki: Path, project_root: Path
+) -> None:
+    """``force_head`` is wiki-side only: a dirty dest still needs ``force`` (#1689)."""
+    assert (await client.post("/api/context/skills/alpha/install")).status_code == 200
+    base = WikiStore.at_default().current_commit()
+    _advance_wiki(seeded_wiki)
+    assert (await client.post("/api/context/skills/alpha/update")).status_code == 200
+    subprocess.run(
+        ["git", "-C", str(seeded_wiki), "reset", "--hard", base], check=True, capture_output=True
+    )
+    landed = project_root / ".memtomem" / "skills" / "alpha" / "SKILL.md"
+    landed.write_text(_SKILL_BODY + "\nLocal edit.\n", encoding="utf-8")
+
+    resp = await client.post("/api/context/skills/alpha/update", json={"force_head": True})
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["reason_code"] == "stale_install"
+
+    both = await client.post(
+        "/api/context/skills/alpha/update", json={"force": True, "force_head": True}
+    )
+    assert both.status_code == 200, both.text
+    data = both.json()
+    assert data["pin_moved_backward"] is True
+    assert data["bak_file_count"] >= 1
+    assert _lock_entry(project_root, "skills", "alpha")["wiki_commit"] == base
+    bak = landed.with_suffix(".md.bak")
+    assert "Local edit." in bak.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
 async def test_update_never_installed_is_404(client, seeded_wiki) -> None:
     resp = await client.post("/api/context/skills/alpha/update")
     assert resp.status_code == 404


### PR DESCRIPTION
## What

Adds a distinct `--force-head` flag to `mm context update` (single + `--all`) and a matching `force_head` request field on the web update route, letting a user who has **deliberately** rolled the wiki back to older/divergent history make projects follow to the current wiki HEAD — overriding the forward-only refusal from #1685 (PR #1688).

## Why

`mm context update` is forward-only: it advances a project's pin to wiki HEAD only when the recorded pin is an ancestor of HEAD. After a wiki `reset` / force-pull, HEAD no longer descends from the pin, so update refuses rather than silently moving the pin **backward** — and `--force` deliberately does **not** bypass this (`--force` overrides project-side dest edits, never wiki-side history). But an intentional backward roll (revert a bad wiki commit, have every project follow) is a legitimate workflow with no first-class verb. This adds the deliberate escape hatch.

## Design

- **Distinct flag, not folded into `--force`** — preserves the wiki-side/project-side asymmetry. A backward move onto a locally-edited dest still needs `--force` too (orthogonal).
- **Loud, pre-write UX** — the single path resolves the target commit in a preflight, warns on stderr **before** the write when the move is actually backward, and threads that commit into the engine as `pinned_commit` so the warned-about commit and the recorded commit are the same string (no HEAD-move race can produce an unwarned backward write). `--all` warns before the confirm prompt (regardless of `--yes`) and tags affected preview rows `[moves pin BACKWARD]`.
- **Missing-pin split** — a lockfile entry with no usable `wiki_commit` pin now raises `PinMissingError` (a `PinNotAncestorError` subclass, so existing catch sites are unaffected); the web route returns `409 pin_missing` with an accurate message (re-install or adopt; `force_head` cannot bypass), instead of the `pin_not_ancestor` "diverged history" message that was factually wrong for this case.
- **Additive web envelope** — the success payload gains `pin_moved_backward` (a client cannot derive direction from two commit SHAs).

## Scope

`mm context update` (single + `--all`) + the web update route only. The analogous `install --all` orphan degraded-fallback stays deferred (the flag name/semantics are chosen so it can reuse them later).

## Testing

- New engine / CLI / web tests: rollback follow (pin moves backward, `pin_moved_backward` true), unreachable + malformed pins are force-head-able, missing pin still refuses (`PinMissingError` / `409 pin_missing`), warning-before-write ordering, dry-run preview markers, `--all` reclassification + backward bucket + `--yes` no-prompt invariant, `force`/`force_head` orthogonality, a HEAD-advance race pin (recorded commit == the captured `pinned_commit`), and a preflight-`WikiNotFoundError`-defers-to-engine regression.
- Full suite: **8298 passed, 11 skipped** (`-m "not ollama"`); `ruff check` + `ruff format --check` clean; `mypy` clean on the changed files.
- Manual e2e in an isolated wiki+project: forward update → `git reset --hard` rollback → plain/`--force` refuse → `--dry-run --force-head` preview → `--force-head` succeeds with the WARNING before the Updated line and `lock.json` pin at the rolled-back HEAD.

Closes #1689

🤖 Generated with [Claude Code](https://claude.com/claude-code)
