### PR TITLE
test(web): fix reindex browser probes for CSRF-POST SSE transport

### DIFF
--- a/packages/memtomem/tests/web/test_memory_dirs_chunk_progress.py
+++ b/packages/memtomem/tests/web/test_memory_dirs_chunk_progress.py
@@ -86,7 +86,7 @@ def _goto_after_i18n_ready(page, mm_web_url: str) -> None:
 
 
 def _driver(event_script_body: str) -> str:
-    """Build a ``page.evaluate`` script that sets up a fake EventSource,
+    """Build a ``page.evaluate`` script that fakes the index-stream transport,
     drives ``mdReindexOne`` against a synthetic ``.source-group`` row,
     and runs the per-test event injection ``event_script_body``.
 
@@ -99,18 +99,20 @@ def _driver(event_script_body: str) -> str:
     return (
         """
   async () => {
-    let esInstance = null;
-    class FakeEventSource {
-      constructor(url) {
-        this.url = String(url);
-        this.onmessage = null;
-        this.onerror = null;
-        this.closed = false;
-        esInstance = this;
-      }
-      close() { this.closed = true; }
-    }
-    window.EventSource = FakeEventSource;
+    // Fake the CSRF-protected POST SSE transport (``app.js:fetchIndexStream``).
+    // The consumer no longer opens an ``EventSource``; ``mdReindexOne`` calls
+    // the global ``fetchIndexStream`` and receives already-parsed event objects
+    // through ``onEvent``. We capture that callback and drive events by hand;
+    // ``streamResolve`` ends the awaited transport once a terminal event lands.
+    let capturedOnEvent = null;
+    let streamClosed = false;
+    let streamResolve = () => {};
+    window.fetchIndexStream = (body, opts = {}) => {
+      capturedOnEvent = (opts && opts.onEvent) || null;
+      return new Promise((resolve) => {
+        streamResolve = () => { streamClosed = true; resolve(); };
+      });
+    };
 
     const group = document.createElement('details');
     group.className = 'source-group';
@@ -123,13 +125,17 @@ def _driver(event_script_body: str) -> str:
     group.appendChild(btn);
     document.body.appendChild(group);
 
-    // Kick the reindex but do NOT await — it only resolves on stream
-    // close. Yield once so the SSE wiring is up.
+    // Kick the reindex but do NOT await — it only resolves once the stream
+    // ends. Poll until the transport hook is installed: ``mdReindexOne`` runs
+    // an async ``STATE.indexing`` preflight before it calls the transport.
     const reindexPromise = mdReindexOne('/tmp/memories', btn);
-    await new Promise((r) => setTimeout(r, 0));
+    for (let i = 0; i < 100 && capturedOnEvent === null; i++) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
 
     const emit = (event) => {
-      esInstance.onmessage({ data: JSON.stringify(event) });
+      capturedOnEvent(event);
+      if (event.type === 'complete' || event.type === 'error') streamResolve();
     };
 
     const observed = {};
@@ -143,7 +149,7 @@ def _driver(event_script_body: str) -> str:
       finalBtn: btn.textContent,
       btnDisabled: btn.disabled,
       stateIndexing: STATE.indexing,
-      sseClosed: esInstance.closed,
+      sseClosed: streamClosed,
     };
   }
 """

--- a/packages/memtomem/tests/web/test_memory_dirs_chunk_progress_i18n.py
+++ b/packages/memtomem/tests/web/test_memory_dirs_chunk_progress_i18n.py
@@ -107,18 +107,16 @@ def test_locale_toggle_mid_stream_flips_chunk_progress_template(page, mm_web_url
           // is populated before we proceed.
           await I18N.setLang('ko');
 
-          let esInstance = null;
-          class FakeEventSource {
-            constructor(url) {
-              this.url = String(url);
-              this.onmessage = null;
-              this.onerror = null;
-              this.closed = false;
-              esInstance = this;
-            }
-            close() { this.closed = true; }
-          }
-          window.EventSource = FakeEventSource;
+          // Fake the CSRF-protected POST SSE transport
+          // (``app.js:fetchIndexStream``). ``mdReindexOne`` no longer opens an
+          // ``EventSource``; it calls the global ``fetchIndexStream`` and gets
+          // already-parsed event objects via ``onEvent``, which we drive here.
+          let capturedOnEvent = null;
+          let streamResolve = () => {};
+          window.fetchIndexStream = (body, opts = {}) => {
+            capturedOnEvent = (opts && opts.onEvent) || null;
+            return new Promise((resolve) => { streamResolve = resolve; });
+          };
 
           const group = document.createElement('details');
           group.className = 'source-group';
@@ -132,10 +130,13 @@ def test_locale_toggle_mid_stream_flips_chunk_progress_template(page, mm_web_url
           document.body.appendChild(group);
 
           const reindexPromise = mdReindexOne('/tmp/memories', btn);
-          await new Promise((r) => setTimeout(r, 0));
+          for (let i = 0; i < 100 && capturedOnEvent === null; i++) {
+            await new Promise((r) => setTimeout(r, 5));
+          }
 
           const emit = (event) => {
-            esInstance.onmessage({ data: JSON.stringify(event) });
+            capturedOnEvent(event);
+            if (event.type === 'complete' || event.type === 'error') streamResolve();
           };
 
           // Final-tick (chunks_done >= chunks_total) bypasses the 100ms

--- a/packages/memtomem/tests/web/test_sources_reindex_retry.py
+++ b/packages/memtomem/tests/web/test_sources_reindex_retry.py
@@ -59,16 +59,18 @@ def test_sources_reindex_retries_when_local_indexing_flag_is_stale(page, mm_web_
 
     constructed = page.evaluate(
         """async () => {
-          let eventSourceUrl = '';
-          class FakeEventSource {
-            constructor(url) {
-              eventSourceUrl = String(url);
-              this.onmessage = null;
-              this.onerror = null;
-            }
-            close() {}
-          }
-          window.EventSource = FakeEventSource;
+          // Fake the CSRF-protected POST SSE transport
+          // (``app.js:fetchIndexStream``). ``mdReindexOne`` no longer opens an
+          // ``EventSource`` with the path in the query string — it POSTs
+          // ``fetchIndexStream({ path, ... })``. Capture the request body and
+          // keep the stream in-flight (the returned promise never resolves) so
+          // the post-preflight indexing / disabled-button state stays
+          // observable instead of being torn down by cleanup.
+          let streamBody = null;
+          window.fetchIndexStream = (body, opts = {}) => {
+            streamBody = body;
+            return new Promise(() => {});
+          };
           STATE.indexing = true;
 
           const group = document.createElement('details');
@@ -82,16 +84,21 @@ def test_sources_reindex_retries_when_local_indexing_flag_is_stale(page, mm_web_
           group.appendChild(btn);
           document.body.appendChild(group);
 
-          await mdReindexOne('/tmp/memories', btn);
+          // Do NOT await — the transport promise never resolves. Poll until the
+          // stale ``STATE.indexing`` preflight clears and the POST is issued.
+          mdReindexOne('/tmp/memories', btn);
+          for (let i = 0; i < 100 && streamBody === null; i++) {
+            await new Promise((r) => setTimeout(r, 5));
+          }
+
           return {
-            eventSourceUrl,
+            streamPath: streamBody ? streamBody.path : null,
             stateIndexing: STATE.indexing,
             buttonDisabled: btn.disabled,
           };
         }"""
     )
 
-    assert constructed["eventSourceUrl"].startswith("/api/index/stream?")
-    assert "path=%2Ftmp%2Fmemories" in constructed["eventSourceUrl"]
+    assert constructed["streamPath"] == "/tmp/memories"
     assert constructed["stateIndexing"] is True
     assert constructed["buttonDisabled"] is True


### PR DESCRIPTION
## Problem

The web hardening in `6ca69599` ("security: harden web and managed ingress boundaries") replaced the index-stream transport in `app.js` — from `new EventSource(...)` + `es.onmessage` to a CSRF-protected POST + fetch reader (`fetchIndexStream`, POST `/api/index/stream`). Three Memory Dirs reindex **browser** probes were still written against the old transport:

- They faked `window.EventSource` and drove `esInstance.onmessage(...)`. With no `EventSource` constructed, `esInstance` stayed `null`, so every probe crashed with `TypeError: Cannot read properties of null (reading 'onmessage')`.
- `test_sources_reindex_retry` additionally asserted the path in the `EventSource` **URL query string**; the path now travels in the POST **body**.

This is a base-branch breakage: the `browser (Playwright + Chromium)` gate is red on `main` and on every open PR. `fa146fa4` cleared the `lint`/`bandit` failures but not this one.

## Fix (test-only)

Re-point all three probes at the new transport seam:

- **Fake the global `fetchIndexStream`** instead of `EventSource`. `mdReindexOne` calls it as a bare global (classic script), so the override is picked up exactly as the old `window.EventSource` override was. `onEvent` receives already-parsed event objects, so `emit` passes the raw event (no `{ data: JSON.stringify(...) }` envelope) and resolves the awaited transport on a terminal (`complete`/`error`) event.
- **Poll for the transport hook** rather than yielding a single tick — `mdReindexOne` now runs an async `STATE.indexing` preflight (`GET /api/indexing/active`) before it opens the stream.
- **Assert the POST body's `path`** (was the query-string param) and keep the retry probe's stream in-flight so the post-preflight indexing / disabled-button state stays observable.

No shipping code changes — this only realigns the probes with the transport rewrite.

## Verification

```
uv run pytest -m browser packages/memtomem/tests/web/
# 266 passed, 63 deselected  (was: 4 failed, 262 passed)
```
`ruff check` + `ruff format --check` clean on the three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
