### PR TITLE
fix(observability): guard os.fchmod on Windows in session trace writer

### DIFF
--- a/packages/memtomem/src/memtomem/observability/session_tracing.py
+++ b/packages/memtomem/src/memtomem/observability/session_tracing.py
@@ -554,7 +554,15 @@ def _write_local_jsonl(
             flags |= os.O_NOFOLLOW
         fd = os.open(jsonl_path, flags, 0o600)
         try:
-            os.fchmod(fd, 0o600)
+            # ``os.open(..., 0o600)`` already sets the mode; the ``fchmod`` is
+            # belt-and-suspenders against a permissive umask. Windows Python
+            # < 3.13 lacks ``os.fchmod`` (POSIX-only), so guard it the same way
+            # ``provenance.py`` and ``context/_atomic.py`` do — otherwise the
+            # trace write raises ``AttributeError`` and every trace silently
+            # fails on Windows. NTFS ignores POSIX modes beyond the read-only
+            # bit anyway, so skipping ``fchmod`` there loses nothing.
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, 0o600)
             with os.fdopen(fd, "a", encoding="utf-8") as f:
                 fd = -1
                 f.write(json.dumps(row, default=str) + "\n")


### PR DESCRIPTION
## Problem

The trace hardening in `bcc0357a` ("security: harden dependencies, CI, secrets, and traces") added an **unguarded** `os.fchmod(fd, 0o600)` to `_write_trace_jsonl` in `session_tracing.py`. `os.fchmod` is **POSIX-only** — Windows Python (< 3.13) does not define it, so the call raises `AttributeError`, the trace write is aborted, and the JSONL file is left empty.

`test_session_tracing.py` then fails four cases on `json.loads` of the empty file:

```
FAILED test_session_tracing.py::TestTraceSessionContext::test_local_jsonl_writing
FAILED test_session_tracing.py::TestCLIIntegration::test_session_start_traces_written
FAILED test_session_tracing.py::TestCLIIntegration::test_metadata_redacted_in_jsonl
FAILED test_session_tracing.py::TestCLIIntegration::test_metadata_verbatim_in_full_mode
  json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
  (root cause: module 'os' has no attribute 'fchmod')
```

This turns the required `test (windows-latest)` gate **red on `main`** and on every PR branched from it.

## Fix

`provenance.py:202` and `context/_atomic.py:310` already call `os.fchmod` behind a `hasattr(os, "fchmod")` guard for exactly this reason (the latter carries a "Windows Python < 3.13 lacks `os.fchmod`" comment). The trace writer just missed it. Apply the same guard.

`os.open(..., 0o600)` already sets the mode at creation, so `fchmod` is only belt-and-suspenders against a permissive umask — skipping it on Windows (where NTFS ignores POSIX modes beyond the read-only bit) loses nothing. POSIX behavior is unchanged (`hasattr(os, "fchmod")` is always true there).

After this, all three `os.fchmod` call sites in `src/` are guarded — no unguarded caller remains.

## Verification

```
uv run pytest packages/memtomem/tests/test_session_tracing.py   # 38 passed
uv run ruff check / format --check                              # clean
```
(Windows-specific `AttributeError` path can't be exercised on the POSIX dev box; the `hasattr` guard mirrors the already-proven pattern in `provenance.py` / `_atomic.py`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
