### PR TITLE
ci: gate releases and publish reproducible SBOMs

### DIFF
--- a/.github/workflows/release-sbom.yml
+++ b/.github/workflows/release-sbom.yml
@@ -52,6 +52,10 @@ jobs:
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "manual SBOM backfills must run from the protected main branch" >&2
+            exit 1
+          fi
           if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "SBOM backfill requires an exact production tag, got: $RELEASE_TAG" >&2
             exit 1

--- a/.github/workflows/release-sbom.yml
+++ b/.github/workflows/release-sbom.yml
@@ -56,7 +56,7 @@ jobs:
             echo "SBOM backfill requires an exact production tag, got: $RELEASE_TAG" >&2
             exit 1
           fi
-          python3 tooling/tools/release_preflight.py contract \
+          uv run --no-project --python 3.12 python tooling/tools/release_preflight.py contract \
             --tag "$RELEASE_TAG" \
             --repo-root release \
             --github-output "$GITHUB_OUTPUT"
@@ -77,7 +77,7 @@ jobs:
           VERSION: ${{ steps.contract.outputs.version }}
         run: |
           set -euo pipefail
-          python3 tooling/tools/release_sbom.py \
+          uv run --no-project --python 3.12 python tooling/tools/release_sbom.py \
             --core-raw "$RUNNER_TEMP/memtomem-core.raw.json" \
             --all-raw "$RUNNER_TEMP/memtomem-all.raw.json" \
             --core-out "$RUNNER_TEMP/memtomem-${VERSION}-core.cdx.json" \

--- a/.github/workflows/release-sbom.yml
+++ b/.github/workflows/release-sbom.yml
@@ -1,0 +1,118 @@
+name: Release SBOM
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: Immutable production tag to describe
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing production tag to backfill
+        required: true
+        type: string
+
+permissions: {}
+
+env:
+  UV_VERSION: "0.11.16"
+
+jobs:
+  sbom:
+    name: Build and attach CycloneDX SBOMs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      # The tooling checkout is the caller commit for future tags and main for
+      # workflow_dispatch backfills. The release checkout always remains the
+      # immutable tag whose lock graph the SBOM describes.
+      - name: Check out trusted SBOM tooling
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.sha }}
+          path: tooling
+          persist-credentials: false
+      - name: Check out immutable release tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ inputs.release_tag }}
+          path: release
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: ${{ env.UV_VERSION }}
+      - name: Validate production tag contract
+        id: contract
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "SBOM backfill requires an exact production tag, got: $RELEASE_TAG" >&2
+            exit 1
+          fi
+          python3 tooling/tools/release_preflight.py contract \
+            --tag "$RELEASE_TAG" \
+            --repo-root release \
+            --github-output "$GITHUB_OUTPUT"
+          echo "release_sha=$(git -C release rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Export locked core and all-extras graphs
+        env:
+          CORE_RAW: ${{ runner.temp }}/memtomem-core.raw.json
+          ALL_RAW: ${{ runner.temp }}/memtomem-all.raw.json
+        working-directory: release
+        run: |
+          set -euo pipefail
+          uv export --quiet --frozen --preview-features sbom-export \
+            --format cyclonedx1.5 --package memtomem --no-dev -o "$CORE_RAW"
+          uv export --quiet --frozen --preview-features sbom-export \
+            --format cyclonedx1.5 --package memtomem --no-dev --all-extras -o "$ALL_RAW"
+      - name: Normalize and validate SBOM contract
+        env:
+          VERSION: ${{ steps.contract.outputs.version }}
+        run: |
+          set -euo pipefail
+          python3 tooling/tools/release_sbom.py \
+            --core-raw "$RUNNER_TEMP/memtomem-core.raw.json" \
+            --all-raw "$RUNNER_TEMP/memtomem-all.raw.json" \
+            --core-out "$RUNNER_TEMP/memtomem-${VERSION}-core.cdx.json" \
+            --all-out "$RUNNER_TEMP/memtomem-${VERSION}-all.cdx.json" \
+            --version "$VERSION"
+      - name: Create release if needed and upload missing assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          VERSION: ${{ steps.contract.outputs.version }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" --verify-tag --title "$RELEASE_TAG" --generate-notes
+          fi
+          for name in \
+            "memtomem-${VERSION}-core.cdx.json" \
+            "memtomem-${VERSION}-all.cdx.json"
+          do
+            generated="$RUNNER_TEMP/$name"
+            if gh release view "$RELEASE_TAG" --json assets \
+              --jq '.assets[].name' | grep -Fxq "$name"
+            then
+              existing_dir="$RUNNER_TEMP/existing-$name"
+              mkdir -p "$existing_dir"
+              gh release download "$RELEASE_TAG" --pattern "$name" --dir "$existing_dir"
+              if ! cmp -s "$generated" "$existing_dir/$name"; then
+                echo "refusing to overwrite differing release asset: $name" >&2
+                exit 1
+              fi
+              echo "$name already exists with identical bytes"
+            else
+              gh release upload "$RELEASE_TAG" "$generated"
+            fi
+            sha256sum "$generated" | tee -a "$GITHUB_STEP_SUMMARY"
+          done
+          echo "Release tag: $RELEASE_TAG" >> "$GITHUB_STEP_SUMMARY"
+          echo "Release commit: ${{ steps.contract.outputs.release_sha }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,10 @@ name: Publish
 # Both paths share the same `pypi` GitHub environment, gated to tag
 # pushes matching `v*` and `test-v*` only.
 #
-# Build and publish run in a single job — actions/upload-artifact@v4
-# scopes artifacts per run-attempt, so a partial rerun cannot reuse the
-# previous attempt's build artifact. Keeping everything in one job means
-# every (re)run rebuilds locally and avoids the cross-attempt artifact
-# lookup entirely.
+# The OIDC publish job builds and publishes in one job — no distribution
+# artifact crosses jobs or run-attempts. A read-only preflight independently
+# verifies the exact main CI run, package contract, and isolated installs;
+# the production-only SBOM job independently describes the immutable tag.
 #
 # `uv build` is given an explicit source path AND --out-dir so the
 # resulting dist/ lands at the workspace root regardless of monorepo
@@ -33,9 +32,73 @@ env:
   UV_VERSION: "0.11.16"
 
 jobs:
+  preflight:
+    name: Release preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: ${{ env.UV_VERSION }}
+      - name: Validate tag, package, lock, and changelog versions
+        id: contract
+        run: >-
+          python3 tools/release_preflight.py contract
+          --tag "$GITHUB_REF_NAME"
+          --repo-root .
+          --github-output "$GITHUB_OUTPUT"
+      - name: Require the tag commit to be on main
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+      - name: Require the exact main-push CI run to succeed
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          python3 tools/release_preflight.py wait-ci
+          --repository "$GITHUB_REPOSITORY"
+          --sha "$GITHUB_SHA"
+          --timeout-seconds 2400
+          --interval-seconds 15
+      - run: uv lock --check
+      - name: Build preflight distributions
+        run: uv build packages/memtomem --out-dir preflight-dist
+      - name: Validate wheel and sdist metadata
+        run: >-
+          python3 tools/release_preflight.py artifacts
+          --dist preflight-dist
+          --version "${{ steps.contract.outputs.version }}"
+      - name: Verify isolated base, all-extras, and sdist installs
+        run: |
+          set -euo pipefail
+          wheel=$(find preflight-dist -maxdepth 1 -name '*.whl' -print -quit)
+          sdist=$(find preflight-dist -maxdepth 1 -name '*.tar.gz' -print -quit)
+          uv venv --python 3.12 "$RUNNER_TEMP/release-base"
+          uv pip install --python "$RUNNER_TEMP/release-base/bin/python" "$wheel"
+          uv pip check --python "$RUNNER_TEMP/release-base/bin/python"
+          "$RUNNER_TEMP/release-base/bin/mm" --version
+          uv venv --python 3.12 "$RUNNER_TEMP/release-all"
+          uv pip install --python "$RUNNER_TEMP/release-all/bin/python" "${wheel}[all]"
+          uv pip check --python "$RUNNER_TEMP/release-all/bin/python"
+          "$RUNNER_TEMP/release-all/bin/python" -c \
+            'import fastapi, fastembed, kiwipiepy, langfuse, ollama, openai, tree_sitter, urllib3'
+          uv venv --python 3.12 "$RUNNER_TEMP/release-sdist"
+          uv pip install --python "$RUNNER_TEMP/release-sdist/bin/python" "$sdist"
+          uv pip check --python "$RUNNER_TEMP/release-sdist/bin/python"
+
   publish:
     name: Build and publish to ${{ startsWith(github.ref_name, 'test-') && 'TestPyPI' || 'PyPI' }}
+    needs: preflight
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: pypi
       url: ${{ startsWith(github.ref_name, 'test-') && 'https://test.pypi.org/p/memtomem' || 'https://pypi.org/p/memtomem' }}
@@ -48,6 +111,11 @@ jobs:
           version: ${{ env.UV_VERSION }}
       - name: Build distribution
         run: uv build packages/memtomem --out-dir dist
+      - name: Revalidate publish artifacts
+        run: |
+          set -euo pipefail
+          version=$(python3 tools/release_preflight.py contract --tag "$GITHUB_REF_NAME" --repo-root .)
+          python3 tools/release_preflight.py artifacts --dist dist --version "$version"
       - name: Publish to PyPI
         if: ${{ !startsWith(github.ref_name, 'test-') }}
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
@@ -61,3 +129,13 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: dist
           skip-existing: true
+
+  sbom:
+    name: Publish production SBOMs
+    needs: publish
+    if: ${{ !startsWith(github.ref_name, 'test-') }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release-sbom.yml
+    with:
+      release_tag: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Validate tag, package, lock, and changelog versions
         id: contract
         run: >-
-          python3 tools/release_preflight.py contract
+          uv run --no-project --python 3.12 python tools/release_preflight.py contract
           --tag "$GITHUB_REF_NAME"
           --repo-root .
           --github-output "$GITHUB_OUTPUT"
@@ -63,7 +63,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: >-
-          python3 tools/release_preflight.py wait-ci
+          uv run --no-project --python 3.12 python tools/release_preflight.py wait-ci
           --repository "$GITHUB_REPOSITORY"
           --sha "$GITHUB_SHA"
           --timeout-seconds 2400
@@ -73,7 +73,7 @@ jobs:
         run: uv build packages/memtomem --out-dir preflight-dist
       - name: Validate wheel and sdist metadata
         run: >-
-          python3 tools/release_preflight.py artifacts
+          uv run --no-project --python 3.12 python tools/release_preflight.py artifacts
           --dist preflight-dist
           --version "${{ steps.contract.outputs.version }}"
       - name: Verify isolated base, all-extras, and sdist installs
@@ -114,8 +114,10 @@ jobs:
       - name: Revalidate publish artifacts
         run: |
           set -euo pipefail
-          version=$(python3 tools/release_preflight.py contract --tag "$GITHUB_REF_NAME" --repo-root .)
-          python3 tools/release_preflight.py artifacts --dist dist --version "$version"
+          version=$(uv run --no-project --python 3.12 python tools/release_preflight.py \
+            contract --tag "$GITHUB_REF_NAME" --repo-root .)
+          uv run --no-project --python 3.12 python tools/release_preflight.py \
+            artifacts --dist dist --version "$version"
       - name: Publish to PyPI
         if: ${{ !startsWith(github.ref_name, 'test-') }}
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
           uv run --no-project --python 3.12 python tools/release_preflight.py artifacts
           --dist preflight-dist
           --version "${{ steps.contract.outputs.version }}"
+          --repo-root .
       - name: Verify isolated base, all-extras, and sdist installs
         run: |
           set -euo pipefail
@@ -117,7 +118,7 @@ jobs:
           version=$(uv run --no-project --python 3.12 python tools/release_preflight.py \
             contract --tag "$GITHUB_REF_NAME" --repo-root .)
           uv run --no-project --python 3.12 python tools/release_preflight.py \
-            artifacts --dist dist --version "$version"
+            artifacts --dist dist --version "$version" --repo-root .
       - name: Publish to PyPI
         if: ${{ !startsWith(github.ref_name, 'test-') }}
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/packages/memtomem/tests/test_release_preflight.py
+++ b/packages/memtomem/tests/test_release_preflight.py
@@ -27,11 +27,30 @@ def _load_tool() -> ModuleType:
 rp = _load_tool()
 
 
-def _repo(tmp_path: Path, *, version: str = "0.3.6", lock_version: str | None = None) -> Path:
+def _repo(
+    tmp_path: Path,
+    *,
+    version: str = "0.3.6",
+    lock_version: str | None = None,
+    cryptography: str = ">=48.0.1",
+    urllib3: str = ">=2.7.0",
+) -> Path:
     package = tmp_path / "packages" / "memtomem"
     package.mkdir(parents=True)
     (package / "pyproject.toml").write_text(
-        f'[project]\nname = "memtomem"\nversion = "{version}"\n', encoding="utf-8"
+        f'[project]\nname = "memtomem"\nversion = "{version}"\n'
+        "dependencies = [\n"
+        f'  "cryptography{cryptography}",\n'
+        '  "starlette>=1.3.1",\n'
+        '  "idna>=3.15",\n'
+        '  "pyjwt>=2.13.0",\n'
+        '  "python-multipart>=0.0.27",\n'
+        "]\n\n"
+        "[project.optional-dependencies]\n"
+        f'onnx = ["fastembed>=0.8,<0.9", "urllib3{urllib3}"]\n'
+        f'langfuse = ["langfuse>=4.0", "urllib3{urllib3}"]\n'
+        'all = ["memtomem[onnx,langfuse]"]\n',
+        encoding="utf-8",
     )
     (tmp_path / "uv.lock").write_text(
         "version = 1\n\n"
@@ -45,16 +64,21 @@ def _repo(tmp_path: Path, *, version: str = "0.3.6", lock_version: str | None = 
     return tmp_path
 
 
-def _metadata(version: str = "0.3.6") -> bytes:
+def _metadata(
+    version: str = "0.3.6",
+    *,
+    cryptography: str = ">=48.0.1",
+    urllib3: str = ">=2.7.0",
+) -> bytes:
     requirements = [
-        "cryptography>=48.0.1",
+        f"cryptography{cryptography}",
         "starlette>=1.3.1",
         "idna>=3.15",
         "pyjwt>=2.13.0",
         "python-multipart>=0.0.27",
-        'urllib3>=2.7.0; extra == "all"',
-        'urllib3>=2.7.0; extra == "onnx"',
-        'urllib3>=2.7.0; extra == "langfuse"',
+        f'urllib3{urllib3}; extra == "all"',
+        f'urllib3{urllib3}; extra == "onnx"',
+        f'urllib3{urllib3}; extra == "langfuse"',
     ]
     lines = ["Metadata-Version: 2.4", "Name: memtomem", f"Version: {version}"]
     lines.extend(f"Requires-Dist: {requirement}" for requirement in requirements)
@@ -107,21 +131,30 @@ def test_contract_rejects_missing_changelog_heading(tmp_path: Path) -> None:
 
 
 def test_artifacts_accept_wheel_and_sdist_contract(tmp_path: Path) -> None:
-    wheel, sdist = rp.validate_artifacts(_dist(tmp_path), "0.3.6")
+    repo = _repo(tmp_path)
+    wheel, sdist = rp.validate_artifacts(_dist(tmp_path), "0.3.6", repo)
     assert wheel.suffix == ".whl"
     assert sdist.name.endswith(".tar.gz")
 
 
 def test_artifacts_reject_missing_floor(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
     body = _metadata().replace(b"Requires-Dist: starlette>=1.3.1\n", b"")
     with pytest.raises(rp.ReleaseCheckError, match="direct floors"):
-        rp.validate_artifacts(_dist(tmp_path, metadata=body), "0.3.6")
+        rp.validate_artifacts(_dist(tmp_path, metadata=body), "0.3.6", repo)
 
 
 def test_artifacts_reject_missing_extra_marker(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
     body = _metadata().replace(b'Requires-Dist: urllib3>=2.7.0; extra == "onnx"\n', b"")
     with pytest.raises(rp.ReleaseCheckError, match="urllib3"):
-        rp.validate_artifacts(_dist(tmp_path, metadata=body), "0.3.6")
+        rp.validate_artifacts(_dist(tmp_path, metadata=body), "0.3.6", repo)
+
+
+def test_artifacts_accept_raised_project_floors(tmp_path: Path) -> None:
+    repo = _repo(tmp_path, cryptography=">=48.0.2", urllib3=">=2.8.0")
+    body = _metadata(cryptography=">=48.0.2", urllib3=">=2.8.0")
+    rp.validate_artifacts(_dist(tmp_path, metadata=body), "0.3.6", repo)
 
 
 class _Clock:

--- a/packages/memtomem/tests/test_release_preflight.py
+++ b/packages/memtomem/tests/test_release_preflight.py
@@ -1,0 +1,217 @@
+"""Tests for the fail-closed release preflight helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_tool() -> ModuleType:
+    path = _ROOT / "tools" / "release_preflight.py"
+    spec = importlib.util.spec_from_file_location("release_preflight", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+rp = _load_tool()
+
+
+def _repo(tmp_path: Path, *, version: str = "0.3.6", lock_version: str | None = None) -> Path:
+    package = tmp_path / "packages" / "memtomem"
+    package.mkdir(parents=True)
+    (package / "pyproject.toml").write_text(
+        f'[project]\nname = "memtomem"\nversion = "{version}"\n', encoding="utf-8"
+    )
+    (tmp_path / "uv.lock").write_text(
+        "version = 1\n\n"
+        "[[package]]\n"
+        'name = "memtomem"\n'
+        f'version = "{lock_version or version}"\n'
+        'source = { editable = "packages/memtomem" }\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "CHANGELOG.md").write_text(f"## [{version}] — 2026-07-12\n", encoding="utf-8")
+    return tmp_path
+
+
+def _metadata(version: str = "0.3.6") -> bytes:
+    requirements = [
+        "cryptography>=48.0.1",
+        "starlette>=1.3.1",
+        "idna>=3.15",
+        "pyjwt>=2.13.0",
+        "python-multipart>=0.0.27",
+        'urllib3>=2.7.0; extra == "all"',
+        'urllib3>=2.7.0; extra == "onnx"',
+        'urllib3>=2.7.0; extra == "langfuse"',
+    ]
+    lines = ["Metadata-Version: 2.4", "Name: memtomem", f"Version: {version}"]
+    lines.extend(f"Requires-Dist: {requirement}" for requirement in requirements)
+    return ("\n".join(lines) + "\n\n").encode()
+
+
+def _dist(tmp_path: Path, *, version: str = "0.3.6", metadata: bytes | None = None) -> Path:
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    body = metadata or _metadata(version)
+    wheel = dist / f"memtomem-{version}-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr(f"memtomem-{version}.dist-info/METADATA", body)
+    sdist = dist / f"memtomem-{version}.tar.gz"
+    with tarfile.open(sdist, "w:gz") as archive:
+        info = tarfile.TarInfo(f"memtomem-{version}/PKG-INFO")
+        info.size = len(body)
+        archive.addfile(info, io.BytesIO(body))
+    return dist
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [("v0.3.6", "0.3.6"), ("test-v0.3.6a1", "0.3.6"), ("test-v1.2.3a99", "1.2.3")],
+)
+def test_version_from_tag(tag: str, expected: str) -> None:
+    assert rp.version_from_tag(tag) == expected
+
+
+@pytest.mark.parametrize("tag", ["0.3.6", "v0.3.6a1", "test-v0.3.6", "test-v0.3.6rc1"])
+def test_version_from_tag_rejects_unsupported_shapes(tag: str) -> None:
+    with pytest.raises(rp.ReleaseCheckError):
+        rp.version_from_tag(tag)
+
+
+def test_contract_accepts_matching_project_lock_and_changelog(tmp_path: Path) -> None:
+    assert rp.validate_contract("v0.3.6", _repo(tmp_path)) == "0.3.6"
+
+
+def test_contract_rejects_lock_drift(tmp_path: Path) -> None:
+    with pytest.raises(rp.ReleaseCheckError, match="lock version"):
+        rp.validate_contract("v0.3.6", _repo(tmp_path, lock_version="0.3.5"))
+
+
+def test_contract_rejects_missing_changelog_heading(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    (repo / "CHANGELOG.md").write_text("## [Unreleased]\n", encoding="utf-8")
+    with pytest.raises(rp.ReleaseCheckError, match="CHANGELOG"):
+        rp.validate_contract("v0.3.6", repo)
+
+
+def test_artifacts_accept_wheel_and_sdist_contract(tmp_path: Path) -> None:
+    wheel, sdist = rp.validate_artifacts(_dist(tmp_path), "0.3.6")
+    assert wheel.suffix == ".whl"
+    assert sdist.name.endswith(".tar.gz")
+
+
+def test_artifacts_reject_missing_floor(tmp_path: Path) -> None:
+    body = _metadata().replace(b"Requires-Dist: starlette>=1.3.1\n", b"")
+    with pytest.raises(rp.ReleaseCheckError, match="direct floors"):
+        rp.validate_artifacts(_dist(tmp_path, metadata=body), "0.3.6")
+
+
+def test_artifacts_reject_missing_extra_marker(tmp_path: Path) -> None:
+    body = _metadata().replace(b'Requires-Dist: urllib3>=2.7.0; extra == "onnx"\n', b"")
+    with pytest.raises(rp.ReleaseCheckError, match="urllib3"):
+        rp.validate_artifacts(_dist(tmp_path, metadata=body), "0.3.6")
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _run(*, status: str, conclusion: str | None, sha: str = "abc", branch: str = "main"):
+    return {
+        "id": 123,
+        "html_url": "https://example.test/run/123",
+        "head_sha": sha,
+        "head_branch": branch,
+        "event": "push",
+        "status": status,
+        "conclusion": conclusion,
+    }
+
+
+def test_wait_ci_ignores_wrong_sha_then_accepts_success() -> None:
+    clock = _Clock()
+    responses = iter(
+        [
+            [_run(status="completed", conclusion="success", sha="other")],
+            [_run(status="completed", conclusion="success")],
+        ]
+    )
+    result = rp.wait_for_exact_main_ci(
+        repository="memtomem/memtomem",
+        sha="abc",
+        token="token",
+        timeout_seconds=10,
+        interval_seconds=1,
+        fetch_runs=lambda *_: next(responses),
+        monotonic=clock.monotonic,
+        sleep=clock.sleep,
+    )
+    assert result["id"] == 123
+
+
+def test_wait_ci_fails_immediately_on_exact_failed_run() -> None:
+    clock = _Clock()
+    with pytest.raises(rp.ReleaseCheckError, match="failure"):
+        rp.wait_for_exact_main_ci(
+            repository="memtomem/memtomem",
+            sha="abc",
+            token="token",
+            timeout_seconds=10,
+            interval_seconds=1,
+            fetch_runs=lambda *_: [_run(status="completed", conclusion="failure")],
+            monotonic=clock.monotonic,
+            sleep=clock.sleep,
+        )
+
+
+def test_wait_ci_fails_closed_after_three_api_errors() -> None:
+    clock = _Clock()
+
+    def fail(*_args):
+        raise OSError("offline")
+
+    with pytest.raises(rp.ReleaseCheckError, match="3 consecutive"):
+        rp.wait_for_exact_main_ci(
+            repository="memtomem/memtomem",
+            sha="abc",
+            token="token",
+            timeout_seconds=10,
+            interval_seconds=1,
+            fetch_runs=fail,
+            monotonic=clock.monotonic,
+            sleep=clock.sleep,
+        )
+
+
+def test_wait_ci_times_out_when_no_exact_run_appears() -> None:
+    clock = _Clock()
+    with pytest.raises(rp.ReleaseCheckError, match="timed out"):
+        rp.wait_for_exact_main_ci(
+            repository="memtomem/memtomem",
+            sha="abc",
+            token="token",
+            timeout_seconds=2,
+            interval_seconds=1,
+            fetch_runs=lambda *_: [],
+            monotonic=clock.monotonic,
+            sleep=clock.sleep,
+        )

--- a/packages/memtomem/tests/test_release_sbom.py
+++ b/packages/memtomem/tests/test_release_sbom.py
@@ -1,0 +1,134 @@
+"""Tests for release SBOM normalization and structural validation."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+_ROOT = Path(__file__).resolve().parents[3]
+_CORE = {"cryptography", "idna", "pyjwt", "python-multipart", "starlette"}
+_EXTRAS = {
+    "fastapi",
+    "fastembed",
+    "kiwipiepy",
+    "langfuse",
+    "ollama",
+    "openai",
+    "tree-sitter",
+    "urllib3",
+}
+
+
+def _load_tool() -> ModuleType:
+    path = _ROOT / "tools" / "release_sbom.py"
+    spec = importlib.util.spec_from_file_location("release_sbom", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+rs = _load_tool()
+
+
+def _payload(names: set[str], *, version: str = "0.3.6", serial: str = "one") -> dict:
+    root_ref = f"memtomem@{version}"
+    return {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "serialNumber": f"urn:uuid:{serial}",
+        "metadata": {
+            "timestamp": "2026-07-12T00:00:00Z",
+            "component": {
+                "type": "library",
+                "bom-ref": root_ref,
+                "name": "memtomem",
+                "version": version,
+            },
+        },
+        "components": [
+            {
+                "type": "library",
+                "bom-ref": f"{name}@1",
+                "name": name,
+                "version": "1",
+                "purl": f"pkg:pypi/{name}@1",
+            }
+            for name in sorted(names)
+        ],
+        "dependencies": [{"ref": root_ref, "dependsOn": [f"{name}@1" for name in sorted(names)]}],
+    }
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_normalize_removes_only_optional_nondeterminism() -> None:
+    payload = _payload(_CORE)
+    normalized = rs.normalize(payload)
+    assert "serialNumber" not in normalized
+    assert "timestamp" not in normalized["metadata"]
+    assert normalized["components"] == payload["components"]
+
+
+def test_pair_is_validated_and_written_reproducibly(tmp_path: Path) -> None:
+    core_a, all_a = tmp_path / "core-a.json", tmp_path / "all-a.json"
+    core_b, all_b = tmp_path / "core-b.json", tmp_path / "all-b.json"
+    _write(core_a, _payload(_CORE, serial="one"))
+    _write(all_a, _payload(_CORE | _EXTRAS, serial="two"))
+    _write(core_b, _payload(_CORE, serial="three"))
+    _write(all_b, _payload(_CORE | _EXTRAS, serial="four"))
+    first_core, first_all = tmp_path / "first-core.json", tmp_path / "first-all.json"
+    second_core, second_all = tmp_path / "second-core.json", tmp_path / "second-all.json"
+
+    rs.normalize_validate_pair(
+        core_raw=core_a,
+        all_raw=all_a,
+        core_out=first_core,
+        all_out=first_all,
+        version="0.3.6",
+    )
+    rs.normalize_validate_pair(
+        core_raw=core_b,
+        all_raw=all_b,
+        core_out=second_core,
+        all_out=second_all,
+        version="0.3.6",
+    )
+
+    assert first_core.read_bytes() == second_core.read_bytes()
+    assert first_all.read_bytes() == second_all.read_bytes()
+
+
+def test_pair_rejects_all_graph_that_is_not_core_superset(tmp_path: Path) -> None:
+    core, all_raw = tmp_path / "core.json", tmp_path / "all.json"
+    _write(core, _payload(_CORE))
+    _write(all_raw, _payload((_CORE - {"starlette"}) | _EXTRAS))
+    with pytest.raises(rs.SbomError, match="not a superset"):
+        rs.normalize_validate_pair(
+            core_raw=core,
+            all_raw=all_raw,
+            core_out=tmp_path / "out-core.json",
+            all_out=tmp_path / "out-all.json",
+            version="0.3.6",
+        )
+
+
+def test_pair_rejects_wrong_root_version(tmp_path: Path) -> None:
+    core, all_raw = tmp_path / "core.json", tmp_path / "all.json"
+    _write(core, _payload(_CORE, version="0.3.5"))
+    _write(all_raw, _payload(_CORE | _EXTRAS))
+    with pytest.raises(rs.SbomError, match="root component"):
+        rs.normalize_validate_pair(
+            core_raw=core,
+            all_raw=all_raw,
+            core_out=tmp_path / "out-core.json",
+            all_out=tmp_path / "out-all.json",
+            version="0.3.6",
+        )

--- a/packages/memtomem/tests/test_release_sbom.py
+++ b/packages/memtomem/tests/test_release_sbom.py
@@ -132,3 +132,9 @@ def test_pair_rejects_wrong_root_version(tmp_path: Path) -> None:
             all_out=tmp_path / "out-all.json",
             version="0.3.6",
         )
+
+
+def test_manual_backfill_workflow_is_restricted_to_main() -> None:
+    workflow = (_ROOT / ".github/workflows/release-sbom.yml").read_text(encoding="utf-8")
+    assert '"$GITHUB_EVENT_NAME" == "workflow_dispatch"' in workflow
+    assert '"$GITHUB_REF" != "refs/heads/main"' in workflow

--- a/tools/release_preflight.py
+++ b/tools/release_preflight.py
@@ -22,12 +22,12 @@ from typing import Any, Callable
 
 _PROD_TAG_RE = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
 _TEST_TAG_RE = re.compile(r"^test-v(?P<version>\d+\.\d+\.\d+)a\d+$")
-_REQUIRED_DIRECT = {
-    "cryptography>=48.0.1",
-    "starlette>=1.3.1",
-    "idna>=3.15",
-    "pyjwt>=2.13.0",
-    "python-multipart>=0.0.27",
+_SECURITY_DIRECT_NAMES = {
+    "cryptography",
+    "starlette",
+    "idna",
+    "pyjwt",
+    "python-multipart",
 }
 _REQUIRED_URLLIB3_EXTRAS = {"all", "langfuse", "onnx"}
 _TERMINAL_FAILURES = {"action_required", "cancelled", "failure", "stale", "timed_out"}
@@ -121,7 +121,58 @@ def _normalized_requirement(value: str) -> str:
     return re.sub(r"\s+", "", value).lower()
 
 
-def _validate_metadata(message: email.message.Message, expected: str, label: str) -> None:
+def _requirement_name(value: str) -> str:
+    match = re.match(r"^[a-z0-9]+(?:[._-][a-z0-9]+)*", value, re.IGNORECASE)
+    if match is None:
+        raise ReleaseCheckError(f"cannot determine requirement name from {value!r}")
+    return match.group(0).lower().replace("_", "-").replace(".", "-")
+
+
+def security_metadata_contract(repo_root: Path) -> tuple[set[str], dict[str, str]]:
+    """Derive security-sensitive artifact requirements from project metadata."""
+    pyproject = repo_root / "packages" / "memtomem" / "pyproject.toml"
+    project = _load_toml(pyproject).get("project", {})
+    dependencies = project.get("dependencies", [])
+    if not isinstance(dependencies, list) or not all(
+        isinstance(item, str) for item in dependencies
+    ):
+        raise ReleaseCheckError(f"project.dependencies in {pyproject} must be a list of strings")
+    by_name = {_requirement_name(item): _normalized_requirement(item) for item in dependencies}
+    missing_direct = _SECURITY_DIRECT_NAMES - by_name.keys()
+    if missing_direct:
+        raise ReleaseCheckError(
+            f"{pyproject} misses security-sensitive direct dependencies: {sorted(missing_direct)}"
+        )
+
+    optional = project.get("optional-dependencies", {})
+    if not isinstance(optional, dict):
+        raise ReleaseCheckError(f"project.optional-dependencies in {pyproject} must be a table")
+    urllib3_by_extra: dict[str, str] = {}
+    for extra in {"onnx", "langfuse"}:
+        values = optional.get(extra, [])
+        if not isinstance(values, list) or not all(isinstance(item, str) for item in values):
+            raise ReleaseCheckError(f"optional dependency {extra!r} in {pyproject} must be a list")
+        matches = [item for item in values if _requirement_name(item) == "urllib3"]
+        if len(matches) != 1:
+            raise ReleaseCheckError(
+                f"optional dependency {extra!r} in {pyproject} must declare urllib3 exactly once"
+            )
+        urllib3_by_extra[extra] = _normalized_requirement(matches[0])
+    if len(set(urllib3_by_extra.values())) != 1:
+        raise ReleaseCheckError(f"urllib3 requirements for onnx and langfuse differ in {pyproject}")
+    urllib3_by_extra["all"] = urllib3_by_extra["onnx"]
+    return {
+        _normalized_requirement(by_name[name]) for name in _SECURITY_DIRECT_NAMES
+    }, urllib3_by_extra
+
+
+def _validate_metadata(
+    message: email.message.Message,
+    expected: str,
+    label: str,
+    direct_contract: set[str],
+    urllib3_contract: dict[str, str],
+) -> None:
     if message.get("Name", "").lower() != "memtomem":
         raise ReleaseCheckError(f"{label} metadata has unexpected Name: {message.get('Name')!r}")
     if message.get("Version") != expected:
@@ -131,26 +182,29 @@ def _validate_metadata(message: email.message.Message, expected: str, label: str
     requirements = {
         _normalized_requirement(value) for value in message.get_all("Requires-Dist", [])
     }
-    missing_direct = {
-        requirement for requirement in _REQUIRED_DIRECT if requirement.lower() not in requirements
-    }
+    missing_direct = direct_contract - requirements
     if missing_direct:
         raise ReleaseCheckError(f"{label} metadata misses direct floors: {sorted(missing_direct)}")
-    urllib3_extras: set[str] = set()
+    urllib3_extras: dict[str, str] = {}
     for requirement in requirements:
-        if not requirement.startswith("urllib3>=2.7.0;"):
+        requirement_value, separator, marker = requirement.partition(";")
+        if _requirement_name(requirement_value) != "urllib3" or not separator:
             continue
-        match = re.search(r"extra==[\'\"]([^\'\"]+)[\'\"]", requirement)
+        match = re.search(r"extra==[\'\"]([^\'\"]+)[\'\"]", marker)
         if match:
-            urllib3_extras.add(match.group(1))
-    missing_extras = _REQUIRED_URLLIB3_EXTRAS - urllib3_extras
+            urllib3_extras[match.group(1)] = requirement_value
+    missing_extras = {
+        extra
+        for extra in _REQUIRED_URLLIB3_EXTRAS
+        if urllib3_extras.get(extra) != urllib3_contract[extra]
+    }
     if missing_extras:
         raise ReleaseCheckError(
-            f"{label} metadata misses urllib3>=2.7.0 extras: {sorted(missing_extras)}"
+            f"{label} metadata misses expected urllib3 extras: {sorted(missing_extras)}"
         )
 
 
-def validate_artifacts(dist: Path, expected: str) -> tuple[Path, Path]:
+def validate_artifacts(dist: Path, expected: str, repo_root: Path) -> tuple[Path, Path]:
     """Validate exactly one wheel and sdist plus their published metadata contract."""
     wheels = sorted(dist.glob("memtomem-*.whl"))
     sdists = sorted(dist.glob("memtomem-*.tar.gz"))
@@ -158,8 +212,13 @@ def validate_artifacts(dist: Path, expected: str) -> tuple[Path, Path]:
         raise ReleaseCheckError(
             f"expected one wheel and one sdist in {dist}; found {len(wheels)} and {len(sdists)}"
         )
-    _validate_metadata(_metadata_from_wheel(wheels[0]), expected, "wheel")
-    _validate_metadata(_metadata_from_sdist(sdists[0]), expected, "sdist")
+    direct_contract, urllib3_contract = security_metadata_contract(repo_root)
+    _validate_metadata(
+        _metadata_from_wheel(wheels[0]), expected, "wheel", direct_contract, urllib3_contract
+    )
+    _validate_metadata(
+        _metadata_from_sdist(sdists[0]), expected, "sdist", direct_contract, urllib3_contract
+    )
     return wheels[0], sdists[0]
 
 
@@ -261,6 +320,7 @@ def _build_parser() -> argparse.ArgumentParser:
     artifacts = subparsers.add_parser("artifacts")
     artifacts.add_argument("--dist", type=Path, required=True)
     artifacts.add_argument("--version", required=True)
+    artifacts.add_argument("--repo-root", type=Path, default=Path.cwd())
 
     wait_ci = subparsers.add_parser("wait-ci")
     wait_ci.add_argument("--repository", required=True)
@@ -278,7 +338,9 @@ def main(argv: list[str] | None = None) -> int:
             _write_github_output(args.github_output, "version", version)
             print(version)
         elif args.command == "artifacts":
-            wheel, sdist = validate_artifacts(args.dist.resolve(), args.version)
+            wheel, sdist = validate_artifacts(
+                args.dist.resolve(), args.version, args.repo_root.resolve()
+            )
             print(f"validated {wheel.name} and {sdist.name}")
         else:
             token = os.environ.get("GITHUB_TOKEN", "")

--- a/tools/release_preflight.py
+++ b/tools/release_preflight.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Fail-closed release tag, CI, and distribution contract checks."""
+
+from __future__ import annotations
+
+import argparse
+import email
+import json
+import os
+import re
+import sys
+import tarfile
+import time
+import tomllib
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Any, Callable
+
+
+_PROD_TAG_RE = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
+_TEST_TAG_RE = re.compile(r"^test-v(?P<version>\d+\.\d+\.\d+)a\d+$")
+_REQUIRED_DIRECT = {
+    "cryptography>=48.0.1",
+    "starlette>=1.3.1",
+    "idna>=3.15",
+    "pyjwt>=2.13.0",
+    "python-multipart>=0.0.27",
+}
+_REQUIRED_URLLIB3_EXTRAS = {"all", "langfuse", "onnx"}
+_TERMINAL_FAILURES = {"action_required", "cancelled", "failure", "stale", "timed_out"}
+
+
+class ReleaseCheckError(RuntimeError):
+    """A release invariant was not met."""
+
+
+def version_from_tag(tag: str) -> str:
+    """Return the distribution version encoded by a supported release tag."""
+    for pattern in (_PROD_TAG_RE, _TEST_TAG_RE):
+        match = pattern.fullmatch(tag)
+        if match:
+            return match.group("version")
+    raise ReleaseCheckError(f"unsupported release tag {tag!r}; expected vX.Y.Z or test-vX.Y.ZaN")
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    try:
+        return tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, tomllib.TOMLDecodeError) as exc:
+        raise ReleaseCheckError(f"cannot read valid TOML from {path}: {exc}") from exc
+
+
+def project_version(repo_root: Path) -> str:
+    pyproject = repo_root / "packages" / "memtomem" / "pyproject.toml"
+    value = _load_toml(pyproject).get("project", {}).get("version")
+    if not isinstance(value, str) or not value:
+        raise ReleaseCheckError(f"missing project.version in {pyproject}")
+    return value
+
+
+def lock_version(repo_root: Path) -> str:
+    lock_path = repo_root / "uv.lock"
+    packages = _load_toml(lock_path).get("package", [])
+    matches = [
+        row
+        for row in packages
+        if isinstance(row, dict)
+        and row.get("name") == "memtomem"
+        and row.get("source") == {"editable": "packages/memtomem"}
+    ]
+    if len(matches) != 1:
+        raise ReleaseCheckError(
+            f"expected one editable memtomem package in {lock_path}, found {len(matches)}"
+        )
+    value = matches[0].get("version")
+    if not isinstance(value, str) or not value:
+        raise ReleaseCheckError(f"missing memtomem version in {lock_path}")
+    return value
+
+
+def validate_contract(tag: str, repo_root: Path) -> str:
+    """Validate tag, member metadata, lock metadata, and changelog parity."""
+    expected = version_from_tag(tag)
+    actual_project = project_version(repo_root)
+    actual_lock = lock_version(repo_root)
+    if actual_project != expected:
+        raise ReleaseCheckError(
+            f"tag version {expected} does not match package version {actual_project}"
+        )
+    if actual_lock != expected:
+        raise ReleaseCheckError(f"tag version {expected} does not match lock version {actual_lock}")
+    changelog = (repo_root / "CHANGELOG.md").read_text(encoding="utf-8")
+    if not re.search(rf"^## \[{re.escape(expected)}\](?:\s|$)", changelog, re.MULTILINE):
+        raise ReleaseCheckError(f"CHANGELOG.md has no release heading for {expected}")
+    return expected
+
+
+def _metadata_from_wheel(path: Path) -> email.message.Message:
+    with zipfile.ZipFile(path) as archive:
+        names = [name for name in archive.namelist() if name.endswith(".dist-info/METADATA")]
+        if len(names) != 1:
+            raise ReleaseCheckError(f"expected one METADATA in {path}, found {len(names)}")
+        return email.message_from_bytes(archive.read(names[0]))
+
+
+def _metadata_from_sdist(path: Path) -> email.message.Message:
+    with tarfile.open(path, mode="r:gz") as archive:
+        members = [member for member in archive.getmembers() if member.name.endswith("/PKG-INFO")]
+        if len(members) != 1:
+            raise ReleaseCheckError(f"expected one PKG-INFO in {path}, found {len(members)}")
+        extracted = archive.extractfile(members[0])
+        if extracted is None:
+            raise ReleaseCheckError(f"cannot read PKG-INFO from {path}")
+        return email.message_from_bytes(extracted.read())
+
+
+def _normalized_requirement(value: str) -> str:
+    return re.sub(r"\s+", "", value).lower()
+
+
+def _validate_metadata(message: email.message.Message, expected: str, label: str) -> None:
+    if message.get("Name", "").lower() != "memtomem":
+        raise ReleaseCheckError(f"{label} metadata has unexpected Name: {message.get('Name')!r}")
+    if message.get("Version") != expected:
+        raise ReleaseCheckError(
+            f"{label} metadata version {message.get('Version')!r} does not match {expected}"
+        )
+    requirements = {
+        _normalized_requirement(value) for value in message.get_all("Requires-Dist", [])
+    }
+    missing_direct = {
+        requirement for requirement in _REQUIRED_DIRECT if requirement.lower() not in requirements
+    }
+    if missing_direct:
+        raise ReleaseCheckError(f"{label} metadata misses direct floors: {sorted(missing_direct)}")
+    urllib3_extras: set[str] = set()
+    for requirement in requirements:
+        if not requirement.startswith("urllib3>=2.7.0;"):
+            continue
+        match = re.search(r"extra==[\'\"]([^\'\"]+)[\'\"]", requirement)
+        if match:
+            urllib3_extras.add(match.group(1))
+    missing_extras = _REQUIRED_URLLIB3_EXTRAS - urllib3_extras
+    if missing_extras:
+        raise ReleaseCheckError(
+            f"{label} metadata misses urllib3>=2.7.0 extras: {sorted(missing_extras)}"
+        )
+
+
+def validate_artifacts(dist: Path, expected: str) -> tuple[Path, Path]:
+    """Validate exactly one wheel and sdist plus their published metadata contract."""
+    wheels = sorted(dist.glob("memtomem-*.whl"))
+    sdists = sorted(dist.glob("memtomem-*.tar.gz"))
+    if len(wheels) != 1 or len(sdists) != 1:
+        raise ReleaseCheckError(
+            f"expected one wheel and one sdist in {dist}; found {len(wheels)} and {len(sdists)}"
+        )
+    _validate_metadata(_metadata_from_wheel(wheels[0]), expected, "wheel")
+    _validate_metadata(_metadata_from_sdist(sdists[0]), expected, "sdist")
+    return wheels[0], sdists[0]
+
+
+def _request_runs(repository: str, sha: str, token: str) -> list[dict[str, Any]]:
+    encoded_sha = urllib.parse.quote(sha, safe="")
+    url = (
+        f"https://api.github.com/repos/{repository}/actions/workflows/ci.yml/runs"
+        f"?event=push&head_sha={encoded_sha}&per_page=20"
+    )
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "memtomem-release-preflight",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=20) as response:  # noqa: S310
+        payload = json.load(response)
+    runs = payload.get("workflow_runs")
+    if not isinstance(runs, list):
+        raise ReleaseCheckError("GitHub workflow-runs response has no workflow_runs list")
+    return [row for row in runs if isinstance(row, dict)]
+
+
+def wait_for_exact_main_ci(
+    *,
+    repository: str,
+    sha: str,
+    token: str,
+    timeout_seconds: float,
+    interval_seconds: float,
+    fetch_runs: Callable[[str, str, str], list[dict[str, Any]]] = _request_runs,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    """Wait for the exact main-push CI run, failing closed on errors or failures."""
+    deadline = monotonic() + timeout_seconds
+    consecutive_errors = 0
+    while monotonic() < deadline:
+        try:
+            rows = fetch_runs(repository, sha, token)
+            consecutive_errors = 0
+        except (OSError, urllib.error.URLError, json.JSONDecodeError, ReleaseCheckError) as exc:
+            consecutive_errors += 1
+            if consecutive_errors >= 3:
+                raise ReleaseCheckError(
+                    f"GitHub Actions API failed {consecutive_errors} consecutive times: {exc}"
+                ) from exc
+            sleep(interval_seconds)
+            continue
+
+        exact = [
+            row
+            for row in rows
+            if row.get("head_sha") == sha
+            and row.get("head_branch") == "main"
+            and row.get("event") == "push"
+        ]
+        successes = [
+            row
+            for row in exact
+            if row.get("status") == "completed" and row.get("conclusion") == "success"
+        ]
+        if successes:
+            return successes[0]
+        failures = [
+            row
+            for row in exact
+            if row.get("status") == "completed" and row.get("conclusion") in _TERMINAL_FAILURES
+        ]
+        if failures:
+            run = failures[0]
+            raise ReleaseCheckError(
+                f"exact main CI run {run.get('id')} completed as {run.get('conclusion')}"
+            )
+        sleep(interval_seconds)
+    raise ReleaseCheckError(
+        f"timed out after {timeout_seconds:g}s waiting for successful main CI at {sha}"
+    )
+
+
+def _write_github_output(path: str | None, key: str, value: str) -> None:
+    if path:
+        with Path(path).open("a", encoding="utf-8") as handle:
+            handle.write(f"{key}={value}\n")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    contract = subparsers.add_parser("contract")
+    contract.add_argument("--tag", required=True)
+    contract.add_argument("--repo-root", type=Path, default=Path.cwd())
+    contract.add_argument("--github-output")
+
+    artifacts = subparsers.add_parser("artifacts")
+    artifacts.add_argument("--dist", type=Path, required=True)
+    artifacts.add_argument("--version", required=True)
+
+    wait_ci = subparsers.add_parser("wait-ci")
+    wait_ci.add_argument("--repository", required=True)
+    wait_ci.add_argument("--sha", required=True)
+    wait_ci.add_argument("--timeout-seconds", type=float, default=2400)
+    wait_ci.add_argument("--interval-seconds", type=float, default=15)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "contract":
+            version = validate_contract(args.tag, args.repo_root.resolve())
+            _write_github_output(args.github_output, "version", version)
+            print(version)
+        elif args.command == "artifacts":
+            wheel, sdist = validate_artifacts(args.dist.resolve(), args.version)
+            print(f"validated {wheel.name} and {sdist.name}")
+        else:
+            token = os.environ.get("GITHUB_TOKEN", "")
+            if not token:
+                raise ReleaseCheckError("GITHUB_TOKEN is required for wait-ci")
+            run = wait_for_exact_main_ci(
+                repository=args.repository,
+                sha=args.sha,
+                token=token,
+                timeout_seconds=args.timeout_seconds,
+                interval_seconds=args.interval_seconds,
+            )
+            print(f"exact main CI succeeded: {run.get('html_url') or run.get('id')}")
+    except (OSError, UnicodeError, ReleaseCheckError) as exc:
+        print(f"release preflight failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release_sbom.py
+++ b/tools/release_sbom.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Normalize and validate memtomem's core and all-extras CycloneDX SBOMs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+_CORE_ANCHORS = {"cryptography", "idna", "pyjwt", "python-multipart", "starlette"}
+_ALL_ANCHORS = {
+    "fastapi",
+    "fastembed",
+    "kiwipiepy",
+    "langfuse",
+    "ollama",
+    "openai",
+    "tree-sitter",
+    "urllib3",
+}
+
+
+class SbomError(RuntimeError):
+    """An SBOM contract was not met."""
+
+
+def _load(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise SbomError(f"cannot read valid JSON from {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SbomError(f"SBOM root in {path} must be an object")
+    return payload
+
+
+def normalize(payload: dict[str, Any]) -> dict[str, Any]:
+    """Remove optional time/random fields while preserving the dependency graph."""
+    normalized = json.loads(json.dumps(payload))
+    normalized.pop("serialNumber", None)
+    metadata = normalized.get("metadata")
+    if isinstance(metadata, dict):
+        metadata.pop("timestamp", None)
+    return normalized
+
+
+def _components(payload: dict[str, Any], label: str) -> set[tuple[str, str, str]]:
+    rows = payload.get("components")
+    if not isinstance(rows, list):
+        raise SbomError(f"{label} SBOM components must be a list")
+    result: set[tuple[str, str, str]] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            raise SbomError(f"{label} SBOM contains a non-object component")
+        name, version, purl = row.get("name"), row.get("version"), row.get("purl", "")
+        if not isinstance(name, str) or not isinstance(version, str) or not isinstance(purl, str):
+            raise SbomError(f"{label} SBOM component misses name/version/purl")
+        result.add((name, version, purl))
+    return result
+
+
+def _validate_one(
+    payload: dict[str, Any], *, label: str, version: str
+) -> set[tuple[str, str, str]]:
+    if payload.get("bomFormat") != "CycloneDX" or payload.get("specVersion") != "1.5":
+        raise SbomError(f"{label} SBOM must be CycloneDX 1.5")
+    metadata = payload.get("metadata")
+    component = metadata.get("component") if isinstance(metadata, dict) else None
+    expected_root = {"name": "memtomem", "version": version, "type": "library"}
+    if not isinstance(component, dict) or any(
+        component.get(k) != v for k, v in expected_root.items()
+    ):
+        raise SbomError(f"{label} SBOM root component must be memtomem {version} library")
+    dependencies = payload.get("dependencies")
+    if not isinstance(dependencies, list):
+        raise SbomError(f"{label} SBOM dependencies must be a list")
+    root_ref = component.get("bom-ref")
+    if not isinstance(root_ref, str) or not any(
+        isinstance(row, dict) and row.get("ref") == root_ref for row in dependencies
+    ):
+        raise SbomError(f"{label} SBOM has no dependency row for its root component")
+    return _components(payload, label)
+
+
+def normalize_validate_pair(
+    *, core_raw: Path, all_raw: Path, core_out: Path, all_out: Path, version: str
+) -> None:
+    core = normalize(_load(core_raw))
+    all_extras = normalize(_load(all_raw))
+    core_components = _validate_one(core, label="core", version=version)
+    all_components = _validate_one(all_extras, label="all", version=version)
+    if not core_components <= all_components:
+        missing = sorted(core_components - all_components)
+        raise SbomError(f"all SBOM is not a superset of core: {missing[:5]}")
+    core_names = {name for name, _, _ in core_components}
+    all_names = {name for name, _, _ in all_components}
+    if missing := _CORE_ANCHORS - core_names:
+        raise SbomError(f"core SBOM misses required components: {sorted(missing)}")
+    if missing := _ALL_ANCHORS - all_names:
+        raise SbomError(f"all SBOM misses extras components: {sorted(missing)}")
+    for path, payload in ((core_out, core), (all_out, all_extras)):
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--core-raw", type=Path, required=True)
+    parser.add_argument("--all-raw", type=Path, required=True)
+    parser.add_argument("--core-out", type=Path, required=True)
+    parser.add_argument("--all-out", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args(argv)
+    try:
+        normalize_validate_pair(
+            core_raw=args.core_raw,
+            all_raw=args.all_raw,
+            core_out=args.core_out,
+            all_out=args.all_out,
+            version=args.version,
+        )
+    except (OSError, UnicodeError, SbomError) as exc:
+        print(f"SBOM validation failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- gate TestPyPI/PyPI publication on exact successful main CI plus tag/package/lock/changelog parity
- validate built wheel/sdist metadata and isolated base, all-extras, and sdist installs before OIDC publication
- add production-only CycloneDX 1.5 core/all SBOM workflow with manual v0.3.6 backfill and no-overwrite asset semantics

## Security properties
- publish job retains only id-token: write
- preflight uses actions: read and contents: read
- SBOM job uses contents: write and no id-token
- existing release assets are never clobbered

## Validation
- 42 focused tests passed
- Ruff check and format check passed
- actionlint passed
- real v0.3.6 wheel/sdist metadata validation passed
- real v0.3.6 core/all CycloneDX export and validation passed