### PR TITLE
release: plugin 0.2.2 pins core 0.3.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
         "path": "packages/memtomem-claude-plugin"
       },
       "description": "Semantic memory with hybrid BM25 + dense search",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "author": { "name": "memtomem" },
       "repository": "https://github.com/memtomem/memtomem",
       "license": "Apache-2.0",

--- a/packages/memtomem-claude-plugin/.claude-plugin/plugin.json
+++ b/packages/memtomem-claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memtomem",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Markdown-first semantic memory for AI agents — hybrid BM25 + dense search across your markdown files",
   "author": {
     "name": "memtomem",

--- a/packages/memtomem-claude-plugin/.mcp.json
+++ b/packages/memtomem-claude-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "memtomem": {
       "command": "uvx",
-      "args": ["--from", "memtomem==0.3.5", "memtomem-server"]
+      "args": ["--from", "memtomem==0.3.6", "memtomem-server"]
     }
   }
 }

--- a/packages/memtomem/tests/test_supply_chain_contracts.py
+++ b/packages/memtomem/tests/test_supply_chain_contracts.py
@@ -14,7 +14,7 @@ _ROOT = Path(__file__).resolve().parents[3]
 _ACTION_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_./-]+)?@[0-9a-f]{40}$")
 _DOCKER_RE = re.compile(r"^docker://[^\s@]+@sha256:[0-9a-f]{64}$")
 _USES_LINE_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)")
-_PLUGIN_CORE_MAP = {"0.2.1": "0.3.5"}
+_PLUGIN_CORE_MAP = {"0.2.2": "0.3.6"}
 
 
 def _assert_pinned_ref(reference: str) -> None:


### PR DESCRIPTION
## Summary
- bump the Claude plugin manifest and marketplace entry from 0.2.1 to 0.2.2
- pin the plugin MCP server to the independently verified memtomem==0.3.6 release
- update the reviewed plugin-to-core mapping guard

The marketplace top-level metadata version remains 1.0.0.

## Stack
Depends on #1719, which depends on #1718. Retarget to main after the dependencies merge.

## Validation
- 34 plugin mapping and docs guard tests passed
- all three JSON documents parse successfully