### PR TITLE
fix(release): identify repository for SBOM upload

### DIFF
--- a/.github/workflows/release-sbom.yml
+++ b/.github/workflows/release-sbom.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Create release if needed and upload missing assets
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           VERSION: ${{ steps.contract.outputs.version }}
         run: |

--- a/packages/memtomem/tests/test_release_sbom.py
+++ b/packages/memtomem/tests/test_release_sbom.py
@@ -138,3 +138,8 @@ def test_manual_backfill_workflow_is_restricted_to_main() -> None:
     workflow = (_ROOT / ".github/workflows/release-sbom.yml").read_text(encoding="utf-8")
     assert '"$GITHUB_EVENT_NAME" == "workflow_dispatch"' in workflow
     assert '"$GITHUB_REF" != "refs/heads/main"' in workflow
+
+
+def test_release_upload_names_repository_without_root_checkout() -> None:
+    workflow = (_ROOT / ".github/workflows/release-sbom.yml").read_text(encoding="utf-8")
+    assert "GH_REPO: ${{ github.repository }}" in workflow


### PR DESCRIPTION
## Summary
- set `GH_REPO` explicitly for release asset operations in the multi-checkout SBOM job
- add a regression assertion for the repository context

## Verification
- 19 focused tests passed
- Ruff passed
- actionlint passed

Fixes the v0.3.6 SBOM backfill failure in run 29181825311.