### PR TITLE
security(web): add disk-backed upload quarantine

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -21,7 +21,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from memtomem.config import (
@@ -1474,15 +1474,34 @@ async def preview_namespace(
 
 
 _ALLOWED_UPLOAD_EXTS = {".md", ".txt", ".json", ".yaml", ".yml", ".toml"}
-_MAX_UPLOAD_FILES = 32
-_MAX_UPLOAD_BYTES = 100 * 1024 * 1024
-_MAX_UPLOAD_AGGREGATE_BYTES = 200 * 1024 * 1024
-_UPLOAD_CHUNK_BYTES = 1024 * 1024
 
 
-@router.post("/upload", response_model=UploadResponse, dependencies=[Depends(require_configured)])
+@router.post(
+    "/upload",
+    response_model=UploadResponse,
+    dependencies=[Depends(require_configured)],
+    openapi_extra={
+        "requestBody": {
+            "required": True,
+            "content": {
+                "multipart/form-data": {
+                    "schema": {
+                        "type": "object",
+                        "required": ["files"],
+                        "properties": {
+                            "files": {
+                                "type": "array",
+                                "items": {"type": "string", "format": "binary"},
+                            }
+                        },
+                    }
+                }
+            },
+        }
+    },
+)
 async def upload_files(
-    files: list[UploadFile] = File(...),
+    request: Request,
     force_unsafe: bool = False,
     index_engine=Depends(get_index_engine),
 ) -> UploadResponse:
@@ -1494,98 +1513,91 @@ async def upload_files(
     (query param) bypasses for the whole batch with audit logging.
     """
     from memtomem import privacy
-    from memtomem.context._atomic import atomic_write_bytes
-
-    if len(files) > _MAX_UPLOAD_FILES:
-        raise HTTPException(status_code=413, detail="Too many upload files")
+    from memtomem.web.upload_quarantine import (
+        UploadQuarantineError,
+        QuarantinedUpload,
+        promote_no_overwrite,
+        quarantine_uploads,
+    )
 
     upload_dir = Path("~/.memtomem/uploads").expanduser()
-    upload_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-    os.chmod(upload_dir, 0o700)
 
-    buffered: list[tuple[UploadFile, bytes]] = []
-    aggregate = 0
-    for file in files:
-        chunks: list[bytes] = []
-        size = 0
-        while chunk := await file.read(_UPLOAD_CHUNK_BYTES):
-            size += len(chunk)
-            aggregate += len(chunk)
-            if size > _MAX_UPLOAD_BYTES or aggregate > _MAX_UPLOAD_AGGREGATE_BYTES:
-                raise HTTPException(status_code=413, detail="Upload size limit exceeded")
-            chunks.append(chunk)
-        buffered.append((file, b"".join(chunks)))
+    try:
+        async with quarantine_uploads(request, upload_dir) as quarantined:
+            decisions: list[tuple[QuarantinedUpload, str, bool, str | None]] = []
+            for item in quarantined:
+                fname = item.filename
+                suffix = Path(fname).suffix.lower()
+                if suffix not in _ALLOWED_UPLOAD_EXTS:
+                    decisions.append((item, fname, False, f"Unsupported type: {suffix}"))
+                    continue
+                try:
+                    content = await _asyncio.to_thread(item.path.read_bytes)
+                    text = content.decode("utf-8")
+                except UnicodeDecodeError as exc:
+                    decisions.append((item, fname, False, f"Decode failed: {exc}"))
+                    continue
+                except Exception:
+                    logger.exception("Upload adjudication failed for %s", fname)
+                    decisions.append((item, fname, False, "Upload processing failed"))
+                    continue
 
-    results: list[UploadFileResult] = []
-    for file, content in buffered:
-        fname = Path(file.filename or "upload").name
-        if Path(fname).suffix.lower() not in _ALLOWED_UPLOAD_EXTS:
-            results.append(
-                UploadFileResult(
-                    filename=fname,
-                    indexed_chunks=0,
-                    error=f"Unsupported type: {Path(fname).suffix}",
-                )
-            )
-            continue
-        dest = upload_dir / fname
-        if dest.exists():
-            stem, suffix = dest.stem, dest.suffix
-            dest = upload_dir / f"{stem}_{dest.stat().st_mtime_ns}{suffix}"
-        try:
-            # Decode text content for redaction scanning. The allowlist
-            # above limits this branch to UTF-8 markdown / config files;
-            # a decode failure here is a malformed file rather than a
-            # privacy bypass, so we surface it as a per-file error.
-            try:
-                text = content.decode("utf-8")
-            except UnicodeDecodeError as exc:
-                results.append(
-                    UploadFileResult(
-                        filename=fname,
-                        indexed_chunks=0,
-                        error=f"Decode failed: {exc}",
+                try:
+                    guard = privacy.enforce_write_guard(
+                        text,
+                        surface="web_api_upload",
+                        force_unsafe=force_unsafe,
+                        audit_context={"filename": fname},
                     )
-                )
-                continue
-
-            guard = privacy.enforce_write_guard(
-                text,
-                surface="web_api_upload",
-                force_unsafe=force_unsafe,
-                audit_context={"filename": fname},
-            )
-            if guard.decision == "blocked":
-                results.append(
-                    UploadFileResult(
-                        filename=fname,
-                        indexed_chunks=0,
-                        error=f"redaction_blocked (hits={len(guard.hits)})",
+                except Exception:
+                    logger.exception("Upload privacy check failed for %s", fname)
+                    decisions.append((item, fname, False, "Upload processing failed"))
+                    continue
+                if guard.decision == "blocked":
+                    decisions.append(
+                        (item, fname, False, f"redaction_blocked (hits={len(guard.hits)})")
                     )
-                )
-                continue
+                else:
+                    decisions.append((item, fname, True, None))
 
-            atomic_write_bytes(dest, content, mode=0o600)
-            # Route-layer guard above already adjudicated this content
-            # (``enforce_write_guard``); skip the engine gate (ADR-0006 PR-A).
-            stats = await index_engine.index_file(dest, already_scanned=True)
-            results.append(
-                UploadFileResult(
-                    filename=fname,
-                    indexed_chunks=stats.indexed_chunks,
-                    path=str(dest),
-                )
-            )
-        except Exception:
-            logger.exception("Upload processing failed for %s", fname)
-            results.append(
-                UploadFileResult(filename=fname, indexed_chunks=0, error="Upload processing failed")
-            )
+            results: list[UploadFileResult] = []
+            for item, fname, accepted, error in decisions:
+                if not accepted:
+                    results.append(UploadFileResult(filename=fname, indexed_chunks=0, error=error))
+                    continue
+                dest: Path | None = None
+                try:
+                    dest = promote_no_overwrite(item.path, upload_dir, fname)
+                    stats = await index_engine.index_file(dest, already_scanned=True)
+                    results.append(
+                        UploadFileResult(
+                            filename=fname,
+                            indexed_chunks=stats.indexed_chunks,
+                            path=str(dest),
+                        )
+                    )
+                except Exception:
+                    logger.exception("Upload processing failed for %s", fname)
+                    results.append(
+                        UploadFileResult(
+                            filename=fname,
+                            indexed_chunks=0,
+                            path=str(dest) if dest is not None and dest.exists() else None,
+                            error="Upload processing failed",
+                        )
+                    )
 
-    return UploadResponse(
-        files=results,
-        total_indexed=sum(r.indexed_chunks for r in results),
-    )
+            return UploadResponse(
+                files=results,
+                total_indexed=sum(r.indexed_chunks for r in results),
+            )
+    except UploadQuarantineError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    except BaseException as exc:
+        if isinstance(exc, _asyncio.CancelledError):
+            raise
+        logger.exception("Upload batch processing failed")
+        raise HTTPException(status_code=500, detail="Upload processing failed") from exc
 
 
 @router.get("/uploads/usage", response_model=UploadUsageResponse)

--- a/packages/memtomem/src/memtomem/web/upload_quarantine.py
+++ b/packages/memtomem/src/memtomem/web/upload_quarantine.py
@@ -1,0 +1,175 @@
+"""Disk-backed multipart quarantine for the web upload boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import errno
+import os
+import secrets
+import shutil
+import tempfile
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import AsyncIterator
+
+from starlette.datastructures import FormData, UploadFile
+from starlette.formparsers import MultiPartException, MultiPartParser
+from starlette.requests import Request
+
+MAX_UPLOAD_FILES = 32
+MAX_UPLOAD_BYTES = 100 * 1024 * 1024
+MAX_UPLOAD_AGGREGATE_BYTES = 200 * 1024 * 1024
+UPLOAD_CHUNK_BYTES = 1024 * 1024
+
+
+class UploadQuarantineError(Exception):
+    """A safe, classified upload error suitable for HTTP translation."""
+
+    def __init__(self, detail: str, *, status_code: int) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+@dataclass(frozen=True, slots=True)
+class QuarantinedUpload:
+    filename: str
+    path: Path
+    size: int
+
+
+class _ClosingMultiPartParser(MultiPartParser):
+    """Close parser-owned spools for cancellation and unexpected failures too."""
+
+    async def parse(self) -> FormData:
+        try:
+            return await super().parse()
+        except BaseException:
+            for spool in self._files_to_close_on_error:
+                spool.close()
+            raise
+
+
+def prepare_upload_dir(upload_dir: Path) -> None:
+    upload_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(upload_dir, 0o700)
+
+
+def _write_chunk(fd: int, chunk: bytes) -> None:
+    view = memoryview(chunk)
+    while view:
+        written = os.write(fd, view)
+        view = view[written:]
+
+
+def _close_form(form: FormData) -> None:
+    """Synchronously close spools so cancellation cannot interrupt cleanup."""
+    for _, value in form.multi_items():
+        if isinstance(value, UploadFile):
+            value.file.close()
+
+
+async def _copy_to_quarantine(source: UploadFile, destination: Path) -> int:
+    fd = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    size = 0
+    try:
+        while chunk := await source.read(UPLOAD_CHUNK_BYTES):
+            size += len(chunk)
+            if size > MAX_UPLOAD_BYTES:
+                raise UploadQuarantineError("Upload size limit exceeded", status_code=413)
+            await asyncio.to_thread(_write_chunk, fd, chunk)
+        await asyncio.to_thread(os.fsync, fd)
+    finally:
+        os.close(fd)
+    return size
+
+
+@asynccontextmanager
+async def quarantine_uploads(
+    request: Request,
+    upload_dir: Path,
+) -> AsyncIterator[list[QuarantinedUpload]]:
+    """Parse multipart and yield a fully copied, automatically cleaned batch."""
+    parser = _ClosingMultiPartParser(
+        headers=request.headers,
+        stream=request.stream(),
+        max_files=MAX_UPLOAD_FILES,
+        max_fields=0,
+    )
+    form: FormData | None = None
+    quarantine_dir: Path | None = None
+    try:
+        try:
+            form = await parser.parse()
+        except MultiPartException as exc:
+            detail = "Too many upload files" if "Too many files" in str(exc) else "Malformed upload"
+            status = 413 if detail == "Too many upload files" else 400
+            raise UploadQuarantineError(detail, status_code=status) from exc
+        except (KeyError, ValueError) as exc:
+            raise UploadQuarantineError("Malformed upload", status_code=400) from exc
+
+        raw_entries = form.multi_items()
+        if not raw_entries:
+            raise UploadQuarantineError("No upload files provided", status_code=422)
+        entries: list[UploadFile] = []
+        for key, value in raw_entries:
+            if key != "files" or not isinstance(value, UploadFile):
+                raise UploadQuarantineError("Malformed upload", status_code=400)
+            entries.append(value)
+
+        prepare_upload_dir(upload_dir)
+        quarantine_dir = Path(tempfile.mkdtemp(prefix=".quarantine-", dir=upload_dir))
+        os.chmod(quarantine_dir, 0o700)
+
+        aggregate = 0
+        quarantined: list[QuarantinedUpload] = []
+        for index, upload in enumerate(entries):
+            destination = quarantine_dir / f"{index:04d}.part"
+            size = await _copy_to_quarantine(upload, destination)
+            aggregate += size
+            if aggregate > MAX_UPLOAD_AGGREGATE_BYTES:
+                raise UploadQuarantineError("Upload size limit exceeded", status_code=413)
+            quarantined.append(
+                QuarantinedUpload(
+                    filename=Path(upload.filename or "upload").name,
+                    path=destination,
+                    size=size,
+                )
+            )
+
+        _close_form(form)
+        form = None
+        yield quarantined
+    finally:
+        if form is not None:
+            _close_form(form)
+        if quarantine_dir is not None:
+            shutil.rmtree(quarantine_dir, ignore_errors=True)
+
+
+def promote_no_overwrite(source: Path, upload_dir: Path, filename: str) -> Path:
+    """Atomically promote by hard-linking; never replace an existing path."""
+    prepare_upload_dir(upload_dir)
+    original = Path(filename or "upload").name
+    stem, suffix = Path(original).stem, Path(original).suffix
+    candidates = [original]
+    candidates.extend(f"{stem}_{secrets.token_hex(6)}{suffix}" for _ in range(16))
+    for candidate in candidates:
+        destination = upload_dir / candidate
+        try:
+            os.link(source, destination)
+        except FileExistsError:
+            continue
+        except OSError as exc:
+            if exc.errno in {errno.EXDEV, errno.EPERM, errno.ENOTSUP}:
+                raise RuntimeError("Atomic upload promotion is unavailable") from exc
+            raise
+        try:
+            os.chmod(destination, 0o600)
+            source.unlink()
+        except BaseException:
+            destination.unlink(missing_ok=True)
+            raise
+        return destination
+    raise RuntimeError("Unable to allocate a unique upload filename")

--- a/packages/memtomem/src/memtomem/web/upload_quarantine.py
+++ b/packages/memtomem/src/memtomem/web/upload_quarantine.py
@@ -46,6 +46,9 @@ class _ClosingMultiPartParser(MultiPartParser):
         try:
             return await super().parse()
         except BaseException:
+            # Starlette keeps incomplete parser-owned spools in this private
+            # list. Keep this access explicit so an upstream rename fails
+            # loudly in the cleanup-path tests instead of leaking temp files.
             for spool in self._files_to_close_on_error:
                 spool.close()
             raise

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -27,6 +27,12 @@ from memtomem.models import Chunk, ChunkMetadata, IndexingStats, SearchResult
 from memtomem.search.pipeline import RetrievalStats
 from memtomem.web.app import create_app
 from .helpers import set_home
+from .web.test_upload_quarantine import (
+    TestUploadQuarantineBoundaries,  # noqa: F401
+    TestUploadQuarantineLifecycle,  # noqa: F401
+    test_body_limit_without_content_length_exact_and_plus_one,  # noqa: F401
+    test_upload_openapi_keeps_multipart_file_array_contract,  # noqa: F401
+)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/memtomem/tests/web/test_upload_quarantine.py
+++ b/packages/memtomem/tests/web/test_upload_quarantine.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from memtomem.web.middleware import body_limit
+
+# These cases are imported by ``test_web_routes.py`` so they share its large
+# application fixtures without duplicating those fixtures across modules.
+__test__ = False
+
+
+def _set_home(monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
+    monkeypatch.setenv("HOME", str(home))
+
+
+def _assert_no_quarantine(home: Path) -> None:
+    upload_dir = home / ".memtomem" / "uploads"
+    if upload_dir.exists():
+        assert not list(upload_dir.glob(".quarantine-*"))
+
+
+class TestUploadQuarantineBoundaries:
+    async def test_file_size_exact_limit_passes_and_plus_one_fails_without_final_writes(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from memtomem.web import upload_quarantine
+
+        _set_home(monkeypatch, tmp_path)
+        monkeypatch.setattr(upload_quarantine, "MAX_UPLOAD_BYTES", 4)
+        monkeypatch.setattr(upload_quarantine, "MAX_UPLOAD_AGGREGATE_BYTES", 20)
+
+        ok = await client.post("/api/upload", files={"files": ("ok.md", b"1234")})
+        assert ok.status_code == 200, ok.text
+
+        failed = await client.post("/api/upload", files={"files": ("large.md", b"12345")})
+        assert failed.status_code == 413
+        assert not (tmp_path / ".memtomem" / "uploads" / "large.md").exists()
+        _assert_no_quarantine(tmp_path)
+
+    async def test_aggregate_exact_limit_passes_and_plus_one_has_no_final_writes(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from memtomem.web import upload_quarantine
+
+        _set_home(monkeypatch, tmp_path)
+        monkeypatch.setattr(upload_quarantine, "MAX_UPLOAD_BYTES", 10)
+        monkeypatch.setattr(upload_quarantine, "MAX_UPLOAD_AGGREGATE_BYTES", 6)
+        exact = [("files", ("a.md", b"123")), ("files", ("b.md", b"456"))]
+        assert (await client.post("/api/upload", files=exact)).status_code == 200
+
+        overflow = [("files", ("c.md", b"123")), ("files", ("d.md", b"4567"))]
+        response = await client.post("/api/upload", files=overflow)
+        assert response.status_code == 413
+        upload_dir = tmp_path / ".memtomem" / "uploads"
+        assert not (upload_dir / "c.md").exists()
+        assert not (upload_dir / "d.md").exists()
+        _assert_no_quarantine(tmp_path)
+
+    async def test_exact_file_count_passes_and_plus_one_is_rejected_before_upload_dir(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_home(monkeypatch, tmp_path)
+        exact = [("files", (f"{i}.md", b"x")) for i in range(32)]
+        assert (await client.post("/api/upload", files=exact)).status_code == 200
+
+        second_home = tmp_path / "overflow"
+        second_home.mkdir()
+        _set_home(monkeypatch, second_home)
+        overflow = [("files", (f"{i}.md", b"x")) for i in range(33)]
+        response = await client.post("/api/upload", files=overflow)
+        assert response.status_code == 413
+        assert not (second_home / ".memtomem" / "uploads").exists()
+
+    async def test_text_field_and_empty_multipart_are_generic_client_errors(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_home(monkeypatch, tmp_path)
+        text = await client.post("/api/upload", data={"note": "x"}, files={"files": ("a.md", b"x")})
+        assert text.status_code == 400
+        assert text.json() == {"detail": "Malformed upload"}
+
+        empty = await client.post(
+            "/api/upload",
+            content=b"--empty--\r\n",
+            headers={"content-type": "multipart/form-data; boundary=empty"},
+        )
+        assert empty.status_code == 422
+        assert empty.json() == {"detail": "No upload files provided"}
+
+
+class TestUploadQuarantineLifecycle:
+    async def test_decode_failure_cleans_quarantine_and_writes_no_final(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_home(monkeypatch, tmp_path)
+        response = await client.post("/api/upload", files={"files": ("bad.md", b"\xff")})
+        assert response.status_code == 200
+        assert response.json()["files"][0]["error"].startswith("Decode failed:")
+        assert not (tmp_path / ".memtomem" / "uploads" / "bad.md").exists()
+        _assert_no_quarantine(tmp_path)
+
+    async def test_blocked_file_cleans_quarantine(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_home(monkeypatch, tmp_path)
+        secret = b"token=sk-" + b"a" * 30
+        response = await client.post("/api/upload", files={"files": ("secret.md", secret)})
+        assert response.status_code == 200
+        assert response.json()["files"][0]["error"].startswith("redaction_blocked")
+        assert not (tmp_path / ".memtomem" / "uploads" / "secret.md").exists()
+        _assert_no_quarantine(tmp_path)
+
+    async def test_copy_cancellation_propagates_and_cleans_quarantine(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from memtomem.web import upload_quarantine
+
+        _set_home(monkeypatch, tmp_path)
+
+        async def cancel(*args, **kwargs):
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(upload_quarantine, "_copy_to_quarantine", cancel)
+        # Starlette's BaseHTTPMiddleware converts a cancelled downstream
+        # response into this transport-level failure; the cleanup contract is
+        # the assertion that matters here.
+        with pytest.raises(RuntimeError, match="No response returned"):
+            await client.post("/api/upload", files={"files": ("safe.md", b"safe")})
+        _assert_no_quarantine(tmp_path)
+
+    async def test_unexpected_copy_failure_is_generic_and_cleans_quarantine(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from memtomem.web import upload_quarantine
+
+        _set_home(monkeypatch, tmp_path)
+
+        async def fail(*args, **kwargs):
+            raise RuntimeError("sensitive server detail")
+
+        monkeypatch.setattr(upload_quarantine, "_copy_to_quarantine", fail)
+        response = await client.post("/api/upload", files={"files": ("safe.md", b"safe")})
+        assert response.status_code == 500
+        assert response.json() == {"detail": "Upload processing failed"}
+        _assert_no_quarantine(tmp_path)
+
+    async def test_index_failure_keeps_promoted_file_and_cleans_quarantine(
+        self, app, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_home(monkeypatch, tmp_path)
+        app.state.index_engine.index_file = AsyncMock(side_effect=RuntimeError("internal detail"))
+        response = await client.post("/api/upload", files={"files": ("kept.md", b"safe")})
+        assert response.status_code == 200
+        result = response.json()["files"][0]
+        assert result["error"] == "Upload processing failed"
+        assert Path(result["path"]).read_bytes() == b"safe"
+        _assert_no_quarantine(tmp_path)
+
+    async def test_same_name_never_overwrites(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_home(monkeypatch, tmp_path)
+
+        async def upload(content: bytes):
+            return await client.post("/api/upload", files={"files": ("same.md", content)})
+
+        first, second = await asyncio.gather(upload(b"first"), upload(b"second"))
+        assert first.status_code == second.status_code == 200
+        paths = {first.json()["files"][0]["path"], second.json()["files"][0]["path"]}
+        assert len(paths) == 2
+        assert {Path(path).read_bytes() for path in paths} == {b"first", b"second"}
+        _assert_no_quarantine(tmp_path)
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode contract")
+    async def test_quarantine_and_final_modes_are_owner_only(
+        self, client: AsyncClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_home(monkeypatch, tmp_path)
+        response = await client.post("/api/upload", files={"files": ("safe.md", b"safe")})
+        path = Path(response.json()["files"][0]["path"])
+        assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+async def test_body_limit_without_content_length_exact_and_plus_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(body_limit, "UPLOAD_REQUEST_LIMIT", 4)
+
+    async def consume(scope, receive, send):
+        while (await receive()).get("more_body", False):
+            pass
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    transport = ASGITransport(app=body_limit.UploadBodyLimitMiddleware(consume))
+
+    async def stream(data: bytes):
+        yield data
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        exact = await client.post("/api/upload", content=stream(b"1234"))
+        overflow = await client.post("/api/upload", content=stream(b"12345"))
+    assert exact.status_code == 204
+    assert overflow.status_code == 413
+    assert overflow.json() == {"detail": "Upload request too large"}
+
+
+async def test_upload_openapi_keeps_multipart_file_array_contract(app) -> None:
+    schema = app.openapi()["paths"]["/api/upload"]["post"]["requestBody"]
+    multipart = schema["content"]["multipart/form-data"]["schema"]
+    assert multipart["required"] == ["files"]
+    assert multipart["properties"]["files"] == {
+        "type": "array",
+        "items": {"type": "string", "format": "binary"},
+    }


### PR DESCRIPTION
## Summary

- parse multipart uploads explicitly with a 32-file / zero-field boundary
- copy parsed files into an owner-only disk-backed quarantine before privacy adjudication
- enforce per-file and aggregate limits during quarantine copying
- atomically promote accepted files without overwriting concurrent same-name uploads
- clean parser spools and quarantine artifacts on limit, decode, privacy, indexing, cancellation, and unexpected failures
- preserve generic client errors and server-side diagnostic logging

Index failures intentionally keep an already promoted file and report a generic per-file error, matching the reviewed persistence semantics. ADR-0029 remains unchanged.

## Verification

- `uv run ruff check packages/memtomem/src/memtomem/web/upload_quarantine.py packages/memtomem/src/memtomem/web/routes/system.py packages/memtomem/tests/web/test_upload_quarantine.py packages/memtomem/tests/test_web_routes.py`
- `uv run ruff format --check packages/memtomem/src/memtomem/web/upload_quarantine.py packages/memtomem/src/memtomem/web/routes/system.py packages/memtomem/tests/web/test_upload_quarantine.py packages/memtomem/tests/test_web_routes.py`
- `uv run mypy packages/memtomem/src/memtomem/web/upload_quarantine.py`
- `uv run pytest packages/memtomem/tests/web/test_upload_quarantine.py packages/memtomem/tests/test_web_routes.py -q` (223 passed)
- `git diff --check`

Closes #1722