### PR TITLE
release: map plugin 0.2.3 to core 0.3.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
         "path": "packages/memtomem-claude-plugin"
       },
       "description": "Semantic memory with hybrid BM25 + dense search",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "author": { "name": "memtomem" },
       "repository": "https://github.com/memtomem/memtomem",
       "license": "Apache-2.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- Claude plugin 0.2.3 now maps to the verified core 0.3.7 release (#1727).
+
 ## [0.3.7] — 2026-07-12
 
 ### Security

--- a/packages/memtomem-claude-plugin/.claude-plugin/plugin.json
+++ b/packages/memtomem-claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memtomem",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Markdown-first semantic memory for AI agents — hybrid BM25 + dense search across your markdown files",
   "author": {
     "name": "memtomem",

--- a/packages/memtomem-claude-plugin/.mcp.json
+++ b/packages/memtomem-claude-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "memtomem": {
       "command": "uvx",
-      "args": ["--from", "memtomem==0.3.6", "memtomem-server"]
+      "args": ["--from", "memtomem==0.3.7", "memtomem-server"]
     }
   }
 }

--- a/packages/memtomem/tests/test_supply_chain_contracts.py
+++ b/packages/memtomem/tests/test_supply_chain_contracts.py
@@ -14,7 +14,7 @@ _ROOT = Path(__file__).resolve().parents[3]
 _ACTION_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_./-]+)?@[0-9a-f]{40}$")
 _DOCKER_RE = re.compile(r"^docker://[^\s@]+@sha256:[0-9a-f]{64}$")
 _USES_LINE_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)")
-_PLUGIN_CORE_MAP = {"0.2.2": "0.3.6"}
+_PLUGIN_CORE_MAP = {"0.2.3": "0.3.7"}
 
 
 def _assert_pinned_ref(reference: str) -> None:


### PR DESCRIPTION
## Summary

- bump the Claude plugin manifest and marketplace entry from `0.2.2` to `0.2.3`
- pin the bundled MCP server to the independently verified PyPI release `memtomem==0.3.7`
- update the reviewed plugin-to-core mapping guard to `0.2.3 -> 0.3.7`

Core 0.3.7 production provenance was verified before this follow-up: the exact `v0.3.7` merge commit passed release preflight and isolated installs, published wheel/sdist to PyPI, and attached both core and all-extras CycloneDX SBOMs.

## Verification

- `jq empty .claude-plugin/marketplace.json packages/memtomem-claude-plugin/.claude-plugin/plugin.json packages/memtomem-claude-plugin/.mcp.json`
- `uv run pytest packages/memtomem/tests/test_supply_chain_contracts.py -q` (13 passed)
- `uv run ruff check packages/memtomem/tests/test_supply_chain_contracts.py`
- `uv run ruff format --check packages/memtomem/tests/test_supply_chain_contracts.py`
- `git diff --check`