### PR TITLE
docs: restructure public docs around first success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 - Claude plugin 0.2.3 now maps to the verified core 0.3.7 release (#1727).
 
+### Documentation
+
+- **Public docs now lead with a deterministic first memory round trip.** The
+  GitHub and PyPI READMEs, Getting Started guide, and guide index share the
+  same `mm init` → `mm status` → `mm add` → `mm search` journey before
+  branching into editor setup, existing-note indexing, Context Gateway, and
+  operations. Configuration and MCP examples now reflect `config.json` / env
+  precedence, recent privacy and Wiki lifecycle commands are discoverable,
+  and docs tests pin public links, Quick Start parity, and the runnable smoke
+  path.
+
 ## [0.3.7] — 2026-07-12
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # memtomem
 
-> Markdown-first long-term memory for AI coding agents — your data, your quota, no hooks.
+> Markdown-first long-term memory for AI coding agents — your files stay yours, and core usage is hook-free by default.
 
 [![PyPI](https://img.shields.io/pypi/v/memtomem)](https://pypi.org/project/memtomem/)
 [![Downloads](https://img.shields.io/pypi/dm/memtomem)](https://pypi.org/project/memtomem/)
@@ -36,7 +36,7 @@ flowchart LR
 | Keyword search misses related content | Hybrid search: exact keywords + meaning-based similarity |
 | Notes scattered across tools | One searchable index for markdown, JSON, YAML, Python, JS/TS |
 | Vendor lock-in | Your `.md` files are the source of truth. The DB is a rebuildable cache |
-| Hook-based capture chains can recurse | Captures fire only on explicit MCP tool calls — no auto-fire on every prompt or session-end |
+| Hidden automation is hard to reason about | Core memory operations run only when you call them; optional client hooks are explicit, removable integrations |
 
 ---
 
@@ -63,6 +63,9 @@ mm init                               # preset picker, then memory_dir + MCP
 
 The interactive picker starts with three presets — **Minimal** (BM25, no downloads), **English (Recommended)** (ONNX `bge-small-en-v1.5` + English reranker + auto-discover providers), **Korean-optimized** (ONNX `bge-m3` + `kiwipiepy` tokenizer + multilingual reranker) — plus an **Advanced** entry that opens the full 10-step wizard. Preset paths only ask about the memory directory and MCP registration; everything else is set from the preset.
 
+Choose **Minimal** for the fastest no-download first proof; rerun `mm init`
+later when you are ready to add semantic search.
+
 > **Indexing vs. discovery (Claude Code):** provider memory folders that setup auto-discovers (e.g. `~/.claude/projects/*/memory/`) are added to the search *index*. That is separate from the Web UI's opt-in Context Gateway scan of `~/.claude/projects/`, which discovers project *roots* for Skills, Custom Commands, and Subagents — see [Configuration → Context Gateway](docs/guides/configuration.md#context-gateway) for the distinction and the lossy-slug caveats.
 
 For automation / CI:
@@ -75,18 +78,35 @@ mm init --advanced                          # force the full 10-step wizard
 
 See [Embeddings](docs/guides/embeddings.md) for the full model/provider matrix.
 
-### 3. Use
+<a id="3-use"></a>
+### 3. Verify a complete memory round trip
 
+The first success path does not require an existing notes directory or a connected editor:
+
+```bash
+mm status
+mm add "Deployment checklist uses blue-green rollout" --tags ops
+mm search "blue-green"
 ```
-"Call the mem_status tool"   →  confirms the server is connected
-"Index my notes folder"      →  mem_index(path="~/notes")
-"Search for deployment"      →  mem_search(query="deployment checklist")
-"Remember this insight"      →  mem_add(content="...", tags=["ops"])
+
+`mm add` writes to your configured user memory directory and indexes the entry immediately. The final command should return the sentence you just added.
+
+Then verify the editor connection:
+
+```text
+"Call the mem_status tool"
 ```
 
-> Prefer the terminal? `mm status` is a CLI mirror of `mem_status` — same output, no editor needed. Add `--json` (or `--format json`) for machine-readable output in scripts and CI.
+To bring existing notes into the same index, point `mm index` at a directory that already exists:
 
-### 4. Web UI (optional)
+```bash
+mm index /path/to/your/notes
+```
+
+`mm status --json` (or `--format json`) provides the same status as machine-readable output for scripts and CI.
+
+<a id="4-web-ui-optional"></a>
+### 4. Open the Web UI (optional)
 
 ```bash
 mm web                # polished dashboard on http://127.0.0.1:8080
@@ -134,9 +154,9 @@ See [MCP Client Setup](docs/guides/mcp-clients.md) for Cursor / Windsurf / Claud
 - **Namespaces** — organize memories into scoped groups with auto-derivation from folder names; review and label them (colour, description) from Settings → Namespaces in the Web UI
 - **Maintenance** — near-duplicate detection, time-based decay, TTL expiration, auto-tagging
 - **Web UI** — visual dashboard for search, sources, tags, timeline, dedup, and more (`mm web --dev` for the full maintainer surface)
-- **Context Gateway** — author canonical Skills, Commands, and Subagents once in a wiki-backed Store, then sync them to your AI tools (each artifact type's supported runtimes); a Projects portal in the Web UI tracks per-project drift. See [Context Gateway](docs/guides/context-gateway.md).
+- **Context Gateway** — keep canonical Skills, Commands, and Subagents in a project or user Store, optionally install reusable assets from a separate Wiki, then sync them to supported AI runtimes. See [Context Gateway](docs/guides/context-gateway.md).
 - **MCP tools** — `mem_do` meta-tool routes all non-core actions in `core` mode for minimal context usage
-- **Predictable surface** — memory operations fire only on explicit MCP tool calls (`mem_add`, `mem_index`, etc.), not from background hooks attached to every prompt or session-end. Less magic, fewer surprises.
+- **Predictable core** — memory operations run on explicit CLI/MCP calls (`mm add`, `mem_add`, `mem_index`, etc.). Optional client hooks are installed and removed separately rather than being a hidden runtime default.
 - **Scriptable CLI** — `--json` output on `mm status` and write commands (`mm add` / `mm reset` / `mm purge`); `mm warmup` pre-loads local models so the first query skips the cold-start cost
 - **Scheduled jobs** — `mm schedule add/list/run-now/delete` (or `mem_do(action="schedule_*")`) for cron-driven compaction, importance decay, dead-link cleanup, and dedup scans
 
@@ -157,15 +177,17 @@ Hosted at **[memtomem.com](https://memtomem.com)** — also available as Markdow
 
 | Guide | Description |
 |-------|-------------|
-| [Getting Started](docs/guides/getting-started.md) | Install, setup wizard, first use |
+| [Getting Started](docs/guides/getting-started.md) | Install, configure, save and find your first memory |
 | [Example notebooks](examples/notebooks/) | Runnable Python-API walkthrough (start with `01_hello_memory.ipynb`, local ONNX — no server) |
 | [MCP Client Setup](docs/guides/mcp-clients.md) | Editor-specific configuration |
-| [Configuration](docs/guides/configuration.md) | All `MEMTOMEM_*` environment variables |
+| [Core memory tools](docs/guides/reference/core-memory-tools.md) | Index existing notes, search, and manage memories |
+| [Configuration](docs/guides/configuration.md) | Supported config files, precedence, and `MEMTOMEM_*` variables |
 | [Embeddings](docs/guides/embeddings.md) | ONNX, Ollama, and OpenAI embedding providers |
 | [LLM Providers](docs/guides/llm-providers.md) | Ollama, OpenAI, Anthropic, and compatible endpoints |
 | [Context Gateway](docs/guides/context-gateway.md) | Share Skills, Commands, and Subagents across your AI tools from one Store |
 | [Multi-device sync](docs/guides/multi-device-sync.md) | Sync markdown memories across personal devices via a private git repo |
-| [Reference](docs/guides/reference.md) | Complete feature reference for all tools and patterns |
+| [Operations & troubleshooting](docs/guides/reference/operations.md) | Web UI, privacy audits, diagnostics, and recovery |
+| [Reference](docs/guides/reference.md) | Complete tool and workflow reference |
 | [Uninstalling memtomem](docs/guides/uninstall.md) | Clean removal steps |
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -129,6 +129,9 @@ docs, and the bind-time banner to keep the misconfiguration probability low.
 - **No unsafe deserialization**: No pickle, no unsafe YAML loading
 - **No command injection**: No subprocess/eval/exec with user input
 - **Path validation**: CLI uses `Path.relative_to()` for directory containment checks
+- **Pre-write privacy guard**: Managed memory, import, fetch, upload, session-summary, and Context Gateway write paths scan content before persistence. Git-tracked `project_shared` writes cannot bypass a finding.
+- **Restricted persistence**: Managed files use owner-only directories/files and atomic promotion. Web uploads are streamed into an owner-only disk quarantine, capped by file count and per-file/aggregate byte limits, and promoted only after the full batch passes multipart, filename/type, UTF-8, and privacy adjudication; accepted files are then indexed.
+- **Historical audits**: `mm mem rescan --scope <tier>`, `mm mem rescan-files`, and `mm context rescan --scope <tier>` are read-only checks that exit `1` on findings. See [Operations → Privacy audits](docs/guides/reference/operations.md#privacy-audits).
 
 ## Best Practices
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,42 +1,60 @@
 # memtomem guides
 
-Every guide stands on its own, but if you're picking up memtomem for the first
-time this is the suggested reading order — get set up, tune to taste, then reach
-for the reference as you need it.
+Start with one successful memory round trip, then pick the task you need. The
+guides are organized by outcome rather than by feature name.
 
-## Set up
+<a id="set-up"></a>
+## Start here
 
-1. **[Getting Started](getting-started.md)** — install, the setup wizard, and
-   your first memories. A working setup in under five minutes.
-2. **[MCP Client Setup](mcp-clients.md)** — connect any MCP editor — Claude Code,
-   Cursor, Codex CLI, Antigravity, Windsurf, Claude Desktop, Gemini / Kimi CLI.
-   New here? Claude Code is the one-command setup. Per-editor deep dives:
+1. **[Getting Started](getting-started.md)** — install memtomem, run setup,
+   save one memory, and find it again in under five minutes.
+2. **[MCP Client Setup](mcp-clients.md)** — connect Claude Code, Cursor,
+   Codex CLI, Antigravity, Windsurf, Claude Desktop, Gemini CLI, or Kimi CLI.
+   Client-specific deep dives:
    - [Claude Code](integrations/claude-code.md)
    - [Cursor](integrations/cursor.md)
    - [Claude Desktop](integrations/claude-desktop.md)
 
-## Tune
+## Work with memories
 
-3. **[Configuration](configuration.md)** — every `MEMTOMEM_*` setting and how the
-   config layers (`config.json`, `config.d/` fragments, environment variables)
-   merge.
-4. **[Embeddings](embeddings.md)** — embedding providers and the model matrix:
-   BM25-only (the default), ONNX, Ollama, and OpenAI.
-5. **[LLM Providers](llm-providers.md)** — enable the LLM-powered features (query
-   expansion, fact extraction): Ollama, OpenAI, Anthropic, and compatible
-   endpoints.
+- **Save and search** — [Core memory tools](reference/core-memory-tools.md)
+  covers `mm add`, `mm index`, `mm search`, `mem_add`, and `mem_search`.
+- **Bring in existing tool memory** — [Data, config & CLI](reference/data-config-cli.md)
+  covers `mm ingest` for Claude, Codex, Gemini/Antigravity, Obsidian, and
+  Notion sources.
+- **Organize and maintain** — [Organization & maintenance](reference/organization-maintenance.md)
+  covers namespaces, deduplication, decay, tagging, and memory health.
+- **Automate upkeep** — [Automation](reference/automation.md) covers policies
+  and scheduled jobs.
 
-## Power features
+<a id="tune"></a>
+## Improve search quality
 
-6. **[Context Gateway](context-gateway.md)** — keep one Store of Skills,
-   Commands, and Subagents and sync it to your AI tools (each artifact type's
-   supported runtimes).
-7. **[Multi-device sync](multi-device-sync.md)** — sync your markdown memories
-   across personal devices via a private git repo.
+- **[Embeddings](embeddings.md)** — choose BM25-only, ONNX, Ollama, or OpenAI
+  and switch models safely.
+- **[LLM Providers](llm-providers.md)** — enable optional query expansion,
+  extraction, auto-tagging, and summaries.
+- **[Configuration](configuration.md)** — understand config files,
+  precedence, environment variables, and advanced tuning.
 
-## Reference & lifecycle
+<a id="power-features"></a>
+## Share and sync
 
-8. **[Reference](reference.md)** — the complete reference for every action, tool,
-   and pattern. Reach for it once you're set up.
-9. **[Uninstalling memtomem](uninstall.md)** — clean removal, with `--keep-data`
-   to preserve your memories.
+- **[Context Gateway](context-gateway.md)** — keep one Store of Skills,
+  Commands, and Subagents and sync it to supported AI runtimes.
+- **[Multi-device sync](multi-device-sync.md)** — sync markdown memories
+  across your own machines with a private git repository.
+
+## Operate and recover
+
+- **[Operations & troubleshooting](reference/operations.md)** — run the Web
+  UI, diagnose indexing/search issues, audit historical content, and recover
+  safely.
+- **[Uninstalling memtomem](uninstall.md)** — remove the runtime while keeping
+  or deleting stored data explicitly.
+
+<a id="reference--lifecycle"></a>
+## Reference
+
+- **[Reference index](reference.md)** — concepts, tool modes, MCP tools, and
+  links to every topic reference.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -1,6 +1,11 @@
 # Configuration Reference
 
-memtomem reads configuration from environment variables. All variables use the `MEMTOMEM_` prefix, with nested sections separated by `__` (double underscore). Unprefixed names are never read, with one documented exception: the Langfuse SDK credentials described in [Session Trace](#session-trace).
+memtomem resolves supported user settings from built-in defaults,
+`config.d/` fragments, `config.json`, and environment variables. Environment
+variables use the `MEMTOMEM_` prefix with nested sections separated by `__`
+(double underscore). Unprefixed names are never read, with one documented
+exception: the Langfuse SDK credentials described in
+[Session Trace](#session-trace).
 
 ```bash
 # Example: switch from Ollama to OpenAI
@@ -50,10 +55,10 @@ of increasing priority:
 
 1. **Built-in defaults** — the values in `config.py`.
 2. **`~/.memtomem/config.d/*.json`** — drop-in fragments, applied in
-   lexicographic filename order. Intended for integration installers
-   (`mm init <client>` drops one fragment; removing the file reverses
-   the change). For `list[*]` fields, each fragment respects a per-field
-   merge strategy (see below).
+   lexicographic filename order. Intended for administrators and external
+   integration installers that need reversible layered settings. `mm init`
+   does not create client fragments; it writes `config.json`. For `list[*]`
+   fields, each fragment respects a per-field merge strategy (see below).
 3. **`~/.memtomem/config.json`** — the user-managed override layer that
    `mm init` writes to. Every key here replaces whatever earlier layers
    produced for that field (REPLACE semantics across the board).
@@ -474,6 +479,10 @@ True) that silently appended provider home directories on every startup.
 That flag is now **deprecated** and serves only as a one-shot migration
 trigger:
 
+The corresponding compatibility environment variable is
+`MEMTOMEM_INDEXING__AUTO_DISCOVER`. Do not add it to new configurations; use
+`mm init --include-provider ...` or explicit `memory_dirs` instead.
+
 - If your existing `~/.memtomem/config.json` carries `auto_discover: true`
   (or omits it, in which case it defaults True), the next CLI/server
   startup converts the canonical provider memory dirs that exist on your
@@ -596,6 +605,7 @@ The composite score (0–1) maps to a boost of `[1.0, max_boost]`. Runs as Stage
 |----------|---------|-------------|
 | `MEMTOMEM_NAMESPACE__DEFAULT_NAMESPACE` | `default` | Default namespace for new chunks |
 | `MEMTOMEM_NAMESPACE__ENABLE_AUTO_NS` | `false` | Auto-derive namespace from folder name |
+| `MEMTOMEM_NAMESPACE__RULES` | `[]` | Ordered path rules as a JSON array of objects, e.g. `[{"path_glob":"~/notes/**","namespace":"notes"}]` |
 
 `enable_auto_ns=true` uses the file's **immediate parent folder name** as
 the namespace, except for files sitting directly in a `memory_dirs` root

--- a/docs/guides/context-gateway.md
+++ b/docs/guides/context-gateway.md
@@ -20,6 +20,7 @@ environment variables; it does not re-document those here.
 **On this page**
 
 - [Prerequisites](#prerequisites)
+- [First success — put one skill under Store control](#first-success--put-one-skill-under-store-control)
 - [The model — Store, Runtimes, Sync, Import](#the-model--store-runtimes-sync-import)
 - [Where copies live — the "Stored in" tiers](#where-copies-live--the-stored-in-tiers)
 - [The wiki — a separate global library, not the Store](#the-wiki--a-separate-global-library-not-the-store)
@@ -42,6 +43,55 @@ uv tool install --reinstall 'memtomem[web]'   # or 'memtomem[all]'
 
 A search-only minimal install (without the `web` extra) has the CLI but no
 `mm web`. Either path operates on the same Store, so you can mix them.
+
+Run project-scoped commands from the project they should manage:
+
+```bash
+cd /path/to/your/project
+```
+
+The directory must have a project marker such as `.git/` or `pyproject.toml`.
+
+## First success — put one skill under Store control
+
+Choose the path that matches where the skill exists today.
+
+### Import a skill that already exists in an AI runtime
+
+For a skill named `reviewer` already present in Claude, Codex, Kimi, or another
+supported runtime:
+
+```bash
+mm context detect --include=skills
+mm context init --include=skills --only reviewer \
+  --scope project_shared --confirm-project-shared
+mm context diff --include=skills --scope project_shared
+mm context sync --include=skills --scope project_shared
+```
+
+`init --only` imports exactly one runtime artifact into the git-tracked
+project Store. Review and commit `.memtomem/skills/reviewer/` after the privacy
+gate passes. From then on, edit the Store copy and use `sync`; do not keep
+editing generated runtime copies.
+
+### Create a reusable skill from an empty state
+
+The CLI authoring path uses the optional global Wiki as an upstream library,
+then installs a committed snapshot into this project's Store:
+
+```bash
+mm wiki init
+mm wiki skill new reviewer --editor
+mm wiki skill lint reviewer
+mm wiki skill commit reviewer --canonical
+mm context install skill reviewer
+mm context diff --include=skills --scope project_shared
+mm context sync --include=skills --scope project_shared
+```
+
+Success means the final `diff` no longer reports missing or out-of-sync
+runtime copies. The Wiki is not a Store tier and never syncs directly to
+runtimes; `context install` is the explicit Wiki → project Store step.
 
 ## The model — Store, Runtimes, Sync, Import
 
@@ -122,9 +172,11 @@ wiki (~/.memtomem-wiki)  ──install──▶  project Store (<project>/.memto
   pin, update refuses rather than moving the pin **backward** (a silent
   downgrade) — the same drift `mm context status` reports as `stale-pin`;
   `--force` does not bypass this either (it overrides project-side edits, not
-  wiki history). Add `--dry-run` to print the would-update / unchanged /
-  refuse / stale-pin preview without writing anything (also works with
-  `--all`, where it prints the batch table and skips the confirm prompt; a
+  wiki history). Use `--force-head` only when you deliberately want to follow
+  the rollback; a backward move over project-side edits needs both
+  `--force-head` and `--force`. Add `--dry-run` to print the would-update /
+  unchanged / refuse / stale-pin preview without writing anything. This also
+  works with `--all`, where it prints the batch table and skips the confirm prompt; a
   stale-pin row there is skipped per-project while forward siblings still
   update).
 
@@ -154,6 +206,20 @@ file, then record it with `mm wiki <type> commit <name>` — while the asset has
 no vendor overrides, the commit defaults to the canonical, so no flags are
 needed; in scripts, keep the explicit `mm wiki <type> commit <name>
 --canonical` form.
+
+Three recovery/round-trip commands cover states that ordinary install/update
+deliberately refuse:
+
+- **Project Store → Wiki:** `mm wiki <type> promote <name>` imports an
+  untracked `project_shared` canonical into an absent Wiki asset, privacy
+  scans and lints it, and records one isolated Wiki commit. The project copy
+  remains unchanged.
+- **Existing Store bytes → lockfile:** `mm context adopt <type> <name>` records
+  provenance only when the untracked Store bytes exactly match the asset at
+  Wiki HEAD. It never modifies the destination and has no `--force` option.
+- **Deliberate Wiki rollback:** `mm context update <type> <name> --force-head`
+  follows an older or divergent Wiki HEAD after the normal forward-only check
+  refuses.
 
 In the Web UI the wiki panel is **read-only** (browse + Install); authoring
 canonical or vendor-override files is done with the `mm wiki …` CLI (or the

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,6 +1,8 @@
 # Getting Started
 
-This guide takes you from zero to a working memtomem setup. You'll be able to index your notes and search them from your AI editor in under 5 minutes.
+This guide takes a new installation from zero to one verified memory round
+trip. You do not need an existing notes directory, embedding server, API key,
+or connected AI editor for the first success.
 
 **On this page**
 
@@ -9,682 +11,333 @@ This guide takes you from zero to a working memtomem setup. You'll be able to in
 - [Prerequisites](#prerequisites)
 - [Install](#install)
 - [Setup wizard](#setup-wizard)
-- [Connect to your AI editor (manual)](#connect-to-your-ai-editor-manual)
 - [First use](#first-use)
-- [Optional: Sync memories across your own machines](#optional-sync-memories-across-your-own-machines)
-- [CLI reference](#cli-reference)
+- [Connect to your AI editor](#connect-to-your-ai-editor-manual)
+- [Sync memories across your own machines](#optional-sync-memories-across-your-own-machines)
 - [Troubleshooting](#troubleshooting)
-- [Optional: Share rules, skills, sub-agents, and commands across editors](#optional-share-rules-skills-sub-agents-and-commands-across-editors)
-- [Optional: STM Proxy — Proactive Memory Surfacing](#optional-stm-proxy--proactive-memory-surfacing)
-- [Optional: Web UI](#optional-web-ui)
-- [Optional: LLM Provider](#optional-llm-provider)
-- [Uninstall](#uninstall)
 - [Next steps](#next-steps)
 
 ## Quickstart
 
-The whole flow is four commands — each step is detailed below.
-
 ```bash
-uv tool install 'memtomem[all]'    # 1. install (includes the mm CLI)
-mm init                            # 2. configure (preset picker)
-mm index ~/notes                   # 3. index your notes
-mm search "deployment checklist"   # 4. search them
+uv tool install 'memtomem[all]'
+mm init
+mm status
+mm add "Deployment checklist uses blue-green rollout" --tags ops
+mm search "blue-green"
 ```
 
-Don't want the CLI? `uvx` runs the server on demand — see
-[Install → Option A](#option-a-from-pypi-recommended-for-most-users). New to
-the ideas behind it? Start with [What is memtomem?](#what-is-memtomem).
+The last command should return the sentence you just added. `mm add` creates a
+Markdown file under your configured user memory directory and indexes it
+immediately, so this flow does not depend on a pre-existing `~/notes` folder.
 
----
+If setup registered an MCP client, ask that client to `Call the mem_status
+tool` after the terminal round trip succeeds.
 
 ## What is memtomem?
 
-memtomem gives your AI coding agent (Claude Code, Cursor, etc.) **long-term memory**. You write notes as markdown files, memtomem indexes them, and your agent can search them by both keywords and meaning.
+memtomem gives AI coding agents long-term memory backed by files you control.
+It indexes Markdown, JSON, YAML, Python, and JavaScript/TypeScript content and
+can search by keywords, meaning, or both.
 
-**Key terms**:
-- **MCP** (Model Context Protocol) — a standard for connecting AI editors to external tools. memtomem uses MCP to talk to your editor.
-- **Embedding** — a numeric representation of text meaning. memtomem uses embeddings to find notes that are *related* to your query, not just keyword-matching.
-- **`memtomem-server`** — the MCP server that your editor connects to. This is what runs in the background.
-- **`mm`** — the CLI (command-line tool) for terminal use. Optional but convenient.
+Key terms:
 
----
+- **MCP** (Model Context Protocol) — how an AI client calls memtomem tools.
+- **Embedding** — a numeric representation used for meaning-based search.
+- **`memtomem-server`** — the MCP server your AI client starts.
+- **`mm`** — the terminal CLI for setup, memory work, and operations.
+
+Core memory operations are hook-free by default: they run only when you or an
+agent calls them. Optional client hooks are explicit integrations and can be
+installed or removed separately.
 
 ## Prerequisites
 
+<a id="pick-an-embedding-path-optional"></a>
+
 | Requirement | Install | Verify |
-|-------------|---------|--------|
-| **Python 3.12+** | [python.org](https://python.org) | `python3 --version` |
-| **An AI editor** | Claude Code, Cursor, Windsurf, etc. | Any one is enough |
+|---|---|---|
+| Python 3.12+ | [python.org](https://python.org) | `python3 --version` |
+| `uv` or `pipx` | [uv installation](https://docs.astral.sh/uv/getting-started/installation/) | `uv --version` |
+| An AI editor | Optional for the terminal first success | — |
 
-### Pick an embedding path (optional)
-
-memtomem ships with four embedding options. The setup wizard in the next
-section asks which one you want and writes the config for you — you
-don't have to decide now.
-
-| Option | Setup | When to pick it |
-|--------|-------|-----------------|
-| **Keyword-only (BM25)** | None | Default. Fast, no external deps. Great for short, exact-term notes. |
-| **ONNX (local, no server)** | `uv tool install 'memtomem[onnx]'` | Semantic search without running a server. ~90 MB–2.3 GB model on first use. |
-| **Ollama (local server)** | Install [Ollama](https://ollama.com), then `ollama pull nomic-embed-text` (English) or `ollama pull bge-m3` (multilingual, ~2.3 GB). | Semantic search with full local control; best Korean/JP/CN quality with `bge-m3`. |
-| **OpenAI (cloud)** | OpenAI API key, set via `mm init` or `MEMTOMEM_EMBEDDING__API_KEY`. | No local model to manage; pay-per-call. |
-
-**Not sure?** For English-only notes, **ONNX** is the best default — local
-semantic search, no server to run, no API cost. The setup wizard's *English*
-preset picks it for you, and you can switch later by re-running `mm init`.
-
-> **Multilingual tip**: if you work with Korean, Japanese, or Chinese,
-> pick Ollama with `bge-m3` or OpenAI `text-embedding-3-small` — both
-> significantly outperform English-only models for cross-language search.
-
----
+The Quickstart installs the `all` extra so every documented path is available.
+For the smallest BM25-only installation, omit `[all]`.
 
 ## Install
 
-Choose one path:
+Choose one installation path. The remainder of this guide uses a global tool
+install, where commands are invoked as `mm ...`.
 
 ### Option A: From PyPI (recommended for most users)
 
-No install needed for MCP usage — `uvx` downloads and runs memtomem on demand when your editor starts.
-
-If you also want the CLI (`mm` command):
 ```bash
-uv tool install 'memtomem[all]'    # or: pipx install 'memtomem[all]'
-mm --version                        # verify install
+uv tool install 'memtomem[all]'       # or: pipx install 'memtomem[all]'
+mm --version
 ```
 
-**`[all]` vs minimal**: `[all]` bundles ONNX dense embeddings, Korean tokenizer, Ollama / OpenAI SDKs, code chunker, and the Web UI (~250 MB total). For a BM25-only install without downloads (~40 MB), skip the extras:
+`[all]` includes ONNX embeddings, the Korean tokenizer, Ollama/OpenAI SDKs,
+code chunking, and the Web UI. For BM25-only search without optional downloads:
 
 ```bash
-uv tool install memtomem            # BM25 only — dense search, Web UI, Korean tokenizer unavailable
+uv tool install memtomem
 ```
 
-You can opt in to individual features later with `uv tool install --reinstall 'memtomem[onnx,web]'` or any combination from the extras table in [Option C](#option-c-from-source-for-development-or-testing).
+Add features later with a reinstall such as:
 
-*Hit a snag — `mm` not found, a stale `mm --version`, or upgrading later? See [Troubleshooting → Install and upgrade issues](#install-and-upgrade-issues).*
-
-Skip to [Connect to your AI editor](#connect-to-your-ai-editor-manual).
+```bash
+uv tool install --reinstall 'memtomem[onnx,web]'
+```
 
 ### Option B: Project dependency (per-project isolation)
 
-Add memtomem as a project dependency — version pinned in `pyproject.toml`:
-
 ```bash
-uv add 'memtomem[all]'          # or: uv add memtomem (BM25-only, skip extras)
+uv add 'memtomem[all]'
+uv run mm init
 ```
 
-All CLI commands need the `uv run` prefix:
-```bash
-uv run mm init                  # setup wizard
-uv run mm search "query"        # search
-uv run mm web                   # web UI
-```
-
-The wizard auto-detects project installs and registers the MCP server with `uv run` instead of `uvx`.
+Use the `uv run` prefix for every command in this installation mode.
 
 ### Option C: From source (for development or testing)
 
 ```bash
 git clone https://github.com/memtomem/memtomem.git
 cd memtomem
-uv venv --python 3.12 && source .venv/bin/activate
-uv pip install -e "packages/memtomem[all]"
+uv sync
+uv run mm --help
 ```
 
-`[all]` installs every optional dependency. You can also install only what you need:
-
-| Extra | What it adds |
-|-------|-------------|
-| `onnx` | Local embedding via ONNX (`fastembed`) — no server needed |
-| `ollama` | Local embedding via Ollama (`nomic-embed-text`) |
-| `openai` | Cloud embedding via OpenAI |
-| `korean` | Korean tokenizer (`kiwipiepy`) |
-| `code` | Code chunking (`tree-sitter` for Python/JS/TS) |
-| `web` | Web UI (`fastapi`, `uvicorn`) |
-| `langfuse` | LLM tracing / observability via Langfuse |
-| `all` | All of the above |
-
-```bash
-# Example: only Ollama embeddings + web UI
-uv pip install -e "packages/memtomem[ollama,web]"
-```
-
-Verify it works:
-```bash
-uv run mm -h               # CLI help
-uv run memtomem-server     # MCP server starts (Ctrl+C to stop)
-uv run pytest              # tests pass
-```
-
----
+Source checkouts also use the `uv run mm ...` form.
 
 ## Setup wizard
 
-The fastest way to configure everything:
+Run:
 
 ```bash
-mm init         # PyPI global install
-uv run mm init  # Project or source install
+mm init
 ```
 
-`mm init` starts with a preset picker — pick one of three bundled setups (**Minimal**, **English (Recommended)**, **Korean-optimized**) or choose **Advanced** for the full 10-step wizard. Preset paths only ask about the memory directory and MCP registration.
+The picker offers four paths:
 
-### Choose your setup
+<a id="choose-your-setup"></a>
 
-| Preset | What it bundles | When to pick |
+| Preset | Search stack | Choose it when |
 |---|---|---|
-| **Minimal** | BM25 keyword search, no downloads, unicode61 tokenizer, no reranker | Want the lightest possible install, or starting from scratch to explore |
-| **English (Recommended)** | ONNX `bge-small-en-v1.5` (384d, ~67 MB) + English reranker (`Xenova/ms-marco-MiniLM-L-6-v2`) + auto-discover provider memory folders | Most English-language setups — good default if you're unsure |
-| **Korean-optimized** | ONNX `bge-m3` (1024d, ~2.3 GB) + multilingual reranker (`jinaai/jina-reranker-v2-base-multilingual`) + `kiwipiepy` tokenizer + auto-discover | Korean content (or Korean/Chinese/Japanese mixed) |
-| **Advanced** | — (10-step wizard, full control) | Need to set every knob — custom model, separate DB path, decay, etc. |
+| **Minimal** | BM25 keyword search | You want no model download or external service |
+| **English (Recommended)** | Local ONNX English embedding + reranker | Most notes are English |
+| **Korean-optimized** | Local multilingual ONNX + Korean tokenizer + reranker | Notes include Korean, Chinese, or Japanese |
+| **Advanced** | Full ten-step wizard | You need to choose every provider and path |
 
-*A **reranker** is an optional second-pass model that re-orders the top search hits for higher precision — off in Minimal, on in the English and Korean presets.*
+For the most deterministic first proof, choose **Minimal**. It needs no model
+download or external service; you can rerun `mm init` after the round trip to
+switch to English, Korean-optimized, or Advanced settings.
 
-Type `b` to go back or `q` to quit at any prompt.
+Preset paths ask for the memory directory and optional MCP registration. The
+result is stored in `~/.memtomem/config.json`; generated MCP entries contain
+the server command, not duplicate environment overrides.
 
-#### Non-interactive mode (CI / automation)
-
-Skip prompting with `--non-interactive`. `mm init --non-interactive` alone applies the **Minimal** preset (same defaults as before this feature landed); pass `--preset` for the others:
-
-```bash
-mm init --non-interactive                                              # Minimal preset (BM25-only)
-mm init --preset english --non-interactive                             # English recommended
-mm init --preset korean --non-interactive                              # Korean-optimized
-mm init --advanced                                                     # Force the full 10-step wizard
-
-# Explicit flags override preset values:
-mm init --non-interactive --provider onnx --model all-MiniLM-L6-v2     # custom ONNX model
-mm init --non-interactive --provider ollama --model nomic-embed-text   # Ollama (requires `ollama serve`)
-mm init --non-interactive --provider openai --api-key sk-...           # OpenAI
-mm init --non-interactive --memory-dir ~/notes --mcp claude            # custom dir + Claude Code auto-setup
-
-# Pull in AI tool memory folders (repeat per category):
-mm init --non-interactive --include-provider claude-memory --include-provider codex
-```
-
-`-y` is a deprecated alias for `--non-interactive` on `mm init` and will stop implying it in v0.5.0 (it becomes an accepted no-op — `init` has no confirmation prompt to skip).
-
-`--preset` and `--advanced` are mutually exclusive. From a non-TTY (e.g., piped stdin), always pass `--non-interactive` — `--preset` and `--advanced` on their own still run wizard prompts, so scripted runs without `--non-interactive` either exit with an error or cancel without writing a config.
-
-<details>
-<summary><b>Advanced: the full 10-step wizard</b></summary>
-
-Selecting **Advanced** (from the picker or `--advanced`) runs all ten steps:
-
-1. **Embedding provider** — BM25-only (default, zero-dependency), Local ONNX (no server), Ollama (local server), or OpenAI (cloud)
-2. **Reranker (optional)** — off by default; opt-in to a local fastembed cross-encoder. Korean/Chinese/Japanese/mixed content should pick the multilingual model
-3. **Memory directory** — where your notes live (e.g., `~/notes`, `~/memories`)
-4. **Provider memory folders** — opt in (per category) to indexing Claude Code per-project memory (`~/.claude/projects/*/memory/`), Claude plans (`~/.claude/plans/`), and/or Codex memories (`~/.codex/memories/`). Skipped silently if none are present. Nothing is added without your confirmation
-5. **Storage** — SQLite database path (default: `~/.memtomem/memtomem.db`)
-6. **Namespace** — auto-assign namespace from folder name (e.g., `~/docs` → `docs`)
-7. **Search** — number of results per query (default: 10), time-decay toggle
-8. **Language** — tokenizer selection: Unicode (default) or Korean (kiwipiepy)
-9. **Claude Code hooks** — optional hook integration via settings.json
-10. **Editor connection** — Claude Code auto-setup, .mcp.json generation, or manual
-
-</details>
-
-After the wizard, your MCP server is ready. Skip to [First use](#first-use) if you ran the wizard.
-
----
-
-## Connect to your AI editor (manual)
-
-If you skipped the wizard's editor step, or want to configure manually:
-
-### Claude Code
+For automation:
 
 ```bash
-# PyPI (global)
-claude mcp add memtomem -s user -- uvx --from memtomem memtomem-server
-
-# Project dependency
-claude mcp add memtomem -s user -- uv run --directory /path/to/project memtomem-server
-
-# Source
-claude mcp add memtomem -s user -- uv run --directory /path/to/memtomem memtomem-server
+mm init --non-interactive --preset minimal --mcp skip
+mm init --non-interactive --preset english --mcp skip
+mm init --non-interactive --preset korean --mcp skip
+mm init --advanced
 ```
 
-Use `-s user` to make memtomem available in all projects. Use `-s project` for one project only.
+`-y` is a deprecated alias for `--non-interactive`; scripts should use the
+long option before v0.5.0 changes `-y` into an accepted no-op.
 
-### Cursor, Windsurf, Claude Desktop, Antigravity CLI, Gemini CLI
+## First use
 
-Add to your MCP config file:
+### 1. Check the empty store
 
-**PyPI:**
-```json
-{
-  "mcpServers": {
-    "memtomem": {
-      "command": "uvx",
-      "args": ["--from", "memtomem", "memtomem-server"],
-      "env": {
-        "MEMTOMEM_INDEXING__MEMORY_DIRS": "[\"~/notes\"]"
-      }
-    }
-  }
-}
-```
-
-**Source:**
-```json
-{
-  "mcpServers": {
-    "memtomem": {
-      "command": "uv",
-      "args": ["run", "--directory", "/path/to/memtomem", "memtomem-server"],
-      "env": {
-        "MEMTOMEM_INDEXING__MEMORY_DIRS": "[\"~/notes\"]"
-      }
-    }
-  }
-}
-```
-
-| Client | Config file |
-|--------|-------------|
-| Cursor | `~/.cursor/mcp.json` |
-| Windsurf | `~/.codeium/windsurf/mcp_config.json` |
-| Claude Desktop | `~/Library/Application Support/Claude/claude_desktop_config.json` |
-| Antigravity CLI (`agy`) | `~/.gemini/antigravity-cli/mcp_config.json` |
-| Gemini CLI (deprecated 2026-06-18) | `~/.gemini/settings.json` |
-
-> **Note**: Claude Code stores its MCP config in `~/.claude.json`, not a separate file.
->
-> **Gemini CLI → Antigravity CLI.** Google is replacing Gemini CLI with the
-> Antigravity CLI (`agy`); Gemini CLI stopped serving free/Pro/Ultra individual
-> tiers on 2026-06-18 (enterprise keeps it). Antigravity CLI uses its own
-> `mcp_config.json` above but still reads `~/.gemini/GEMINI.md`, so memory
-> indexed with `mm ingest gemini-memory` keeps working. In that file each
-> server object also carries `"type": "stdio"` — see the
-> [Antigravity section](mcp-clients.md#8-antigravity) of the MCP client guide
-> for the exact CLI shape.
-
-### Verify connection
-
-In your AI editor, ask:
-```
-Call the mem_status tool
-```
-
-You should see index statistics (0 chunks if nothing indexed yet).
-
-Or from a terminal — same output, no editor needed:
 ```bash
 mm status
 ```
 
----
+A new store reports zero chunks. This confirms that the config and database
+can be opened before you write anything.
 
-## First use
+### 2. Add one memory
 
-> Prefer Python to an editor? The same index → search → add flow is a runnable
-> notebook: [`examples/notebooks/01_hello_memory.ipynb`](../../examples/notebooks/01_hello_memory.ipynb)
-> (local ONNX embeddings, no server needed).
-
-Prefer clicking to typing? `mm web` gives you a visual version of everything
-below — see [Optional: Web UI](#optional-web-ui).
-
-### 1. Index your notes
-
-This one-shot command seeds the index with files already on disk. After
-this, the MCP server's file watcher (`memtomem-server`, launched by your
-editor) keeps your `memory_dirs` in sync with new edits automatically —
-you only need to run `mm index` again when you add a brand-new directory
-or want a forced rebuild (`--force`).
-
-In your editor:
-```
-"Index my notes folder"  →  mem_index(path="~/notes")
-```
-
-Or via CLI:
-```bash
-mm index ~/notes
-```
-
-This scans all supported files (`.md`, `.json`, `.yaml`, `.py`, `.js`, `.ts`, etc.), splits them into searchable chunks, and creates embeddings. The re-run is idempotent (content-hash dedup), so it's safe to repeat.
-
-### 2. Search
-
-```
-"Search for deployment checklist"  →  mem_search(query="deployment checklist")
-```
+<a id="3-add-a-memory"></a>
 
 ```bash
-mm search "deployment checklist"
+mm add "Deployment checklist uses blue-green rollout" --tags ops
 ```
 
-Results are ranked by a combination of keyword relevance and semantic similarity.
+The command writes the entry to the first configured user memory directory
+and indexes it immediately.
 
-### 3. Add a memory
+### 3. Find it again
 
-```
-"Remember that Redis LRU→LFU reduced cache misses by 40%"
-→  mem_add(content="Redis LRU→LFU migration reduced cache misses by 40%", tags=["redis", "performance"])
-```
+<a id="2-search"></a>
 
 ```bash
-mm add "Redis LRU→LFU reduced cache misses by 40%" --tags "redis,performance"
+mm search "blue-green"
 ```
 
-### 4. Recall recent memories
+The result should contain the same sentence. For scripts, use `mm status
+--json` and the documented JSON forms of write commands.
 
-```
-"What did I write this week?"  →  mem_recall(since="2026-04-01")
-```
+### 4. Index existing notes
+
+<a id="1-index-your-notes"></a>
+
+Once the controlled round trip works, point memtomem at a directory that
+already exists:
 
 ```bash
-mm recall --since 2026-04-01
+mm index /path/to/your/notes
+mm search "a phrase from those notes"
 ```
+
+See [Core memory tools](reference/core-memory-tools.md) for incremental
+indexing, filters, namespaces, redaction, and force-reindex behavior.
 
 ### 5. Organise memories with namespaces
 
-Each chunk lives in a **namespace**. Indexing creates them automatically (for
-example, ingesting `~/.claude/projects/...` produces `claude-memory:<slug>`
-namespaces), and you can pass `--namespace work-notes` to `mm index` to bucket
-on demand.
+Namespaces are optional labels such as `work`, `personal`, or a project name.
+Use the default while learning; see [Configuration → Namespace](configuration.md#namespace)
+when you need path-based rules or bulk organization.
 
-Want to colour-code them, add descriptions, or rename/delete a namespace? See
-[Configuration → Namespace](configuration.md#namespace).
+## Connect to your AI editor (manual)
 
----
+<a id="claude-code"></a>
+<a id="cursor-windsurf-claude-desktop-antigravity-cli-gemini-cli"></a>
+<a id="verify-connection"></a>
+
+If the setup wizard registered your client, restart or reconnect it and ask:
+
+```text
+Call the mem_status tool
+```
+
+If you skipped registration, use the client-specific instructions in
+[MCP Client Setup](mcp-clients.md). A normal manual registration starts the
+server and lets it read `~/.memtomem/config.json`; it should not repeat
+`MEMTOMEM_INDEXING__MEMORY_DIRS` in the MCP entry unless you intentionally
+want an environment override.
+
+Claude Code's minimal manual registration is:
+
+```bash
+claude mcp add memtomem -s user -- uvx --from memtomem memtomem-server
+```
+
+Claude Code users can instead install the [memtomem plugin](integrations/claude-code.md#mcp-server-setup),
+which bundles the MCP server plus optional commands, hooks, and a curator
+agent. Manual and plugin-managed server copies are not run simultaneously.
 
 ## Optional: Sync memories across your own machines
 
-For the first multi-device setup, keep the model simple:
-
-| What you want to share | Beginner path |
-|---|---|
-| Personal memories | Put `~/.memtomem/memories` in a private git repo |
-| Project memories | Commit `<project>/.memtomem/memories/` to that project repo |
-| Project rules, skills, agents, commands, hooks | Commit the project's `.memtomem/` files |
-| Local drafts / machine state | Do not sync |
-
-Use the copy/paste flow in
-[Multi-device sync → Easy mode](multi-device-sync.md#easy-mode--copypaste-setup)
-for the personal-memory repo. That guide also lists the files to keep out of
-git (`*.db`, `config.json`, caches, local tiers, and the Web UI's
-`known_projects.json`).
-
----
+The first-use flow indexes one local directory. To keep a private Markdown
+memory repository synchronized across your machines, follow
+[Multi-device sync](multi-device-sync.md). This is separate from database
+export/import and from Context Gateway artifact sync.
 
 ## CLI reference
 
-All commands support `-h` and `--help`. Interactive wizards support `b` (back) and `q` (quit).
+<a id="4-recall-recent-memories"></a>
+
+Daily commands are intentionally small:
 
 ```bash
-mm init                    # preset picker (or `--advanced` for the full 10-step wizard)
-mm search "query"          # hybrid search
-mm index ~/notes           # index files
-mm add "some note"         # add a memory
-mm recall --since 2026-04  # recall by date
-mm config show             # view settings
-mm config set key value    # change a setting
-mm config unset key        # drop a pinned override (e.g., mmr.enabled)
-mm status                  # show indexing stats + config (terminal mirror of mem_status; --json / --format json for scripts)
-mm embedding-reset         # check/resolve embedding model mismatch
-mm reset                   # delete all data and reinitialize the DB (--backup snapshots first)
-mm context detect          # find agent config files
-mm context init            # create .memtomem/context.md from existing files
-mm context generate        # generate CLAUDE.md, .cursorrules, GEMINI.md, etc.
-mm context diff            # show pending changes before syncing
-mm context sync            # update all editors after editing context.md
-mm context version --help  # manage version snapshots + label pointers (ADR-0022)
-mm context copy agents foo --to project_local   # copy a canonical artifact to another tier/project (dry-run; ADR-0023)
-mm context move agents foo --to project_shared  # move a canonical artifact, consuming the source (see reference.md for flags)
-mm session start           # start a tracked session
-mm session end             # end session with auto-summary
-mm session list            # list sessions
-mm session events <id>     # show events for a session
-mm activity log            # log agent activity event
-mm session wrap -- CMD     # wrap a command with session lifecycle
-mm watchdog status         # show latest health check results
-mm watchdog run            # run health checks immediately
-mm watchdog history        # view historical health check results
-mm ingest claude-memory --source PATH  # index Claude Code auto-memory
-mm ingest gemini-memory --source PATH  # index Gemini CLI / Antigravity CLI memory (GEMINI.md)
-mm ingest codex-memory --source PATH   # index Codex CLI memory
-mm shell                   # interactive REPL
-mm web                     # launch Web UI (http://127.0.0.1:8080)
+mm status
+mm add "note" --tags tag1,tag2
+mm index /path/to/notes
+mm search "query"
+mm recall --since 2026-01-01
 ```
 
----
+Use `mm --help` for the installed command tree and
+[Data, config & CLI](reference/data-config-cli.md#cli-reference) for the full
+reference.
 
 ## Troubleshooting
 
 ### Indexed, but search returns nothing
 
-1. Confirm something was actually indexed — `mm status` should show a non-zero
-   chunk count. If it's `0`, your `memory_dirs` had no supported files (see the
-   next entry).
-2. Re-index explicitly against the folder your notes really live in:
-   `mm index ~/notes`.
-3. Broaden the query and drop filters — try a single common word before
-   narrowing with `--source-filter` / `--tag-filter` / `--namespace`.
-4. If you recently switched embedding models, the old vectors no longer match:
-   `mm embedding-reset --mode apply-current` then `mm index ~/notes`.
+Run `mm status`, confirm `total_chunks` is nonzero, remove filters, and search
+for an exact phrase from a known file. Then see
+[Operations → No results found](reference/operations.md#no-results-found).
 
 ### "Nothing gets indexed" — path outside your index roots
 
-`mm index PATH` only indexes files **within a configured index root** — your
-user-tier `indexing.memory_dirs` (what `mm init` sets up) or a project-tier
-`indexing.project_memory_dirs`. A path outside every root is a silent no-op:
-it logs `Path … resolves outside configured memory_dirs, skipping` and indexes
-nothing.
-
-1. Check the configured roots: `mm config show` (look for
-   `indexing.memory_dirs` and `indexing.project_memory_dirs`).
-2. To index a new folder, register it first — re-run `mm init` and set it at
-   the *Memory directory* step (or add it to `indexing.memory_dirs` in
-   `~/.memtomem/config.json`) — then `mm index ~/that-folder`.
-   For a **project** tier, run `mm mem init` from the project root instead: it
-   creates `.memtomem/memories.local/` (or `.memtomem/memories/` with
-   `--scope project_shared --confirm-project-shared`) and registers it in
-   `indexing.project_memory_dirs`, which also unlocks
-   `mm add --scope project_local|project_shared` there. `project_local`
-   requires a git repo (`git init` first) so the draft tier is gitignored.
-3. Make sure the folder has at least one supported file. Only these extensions
-   are indexed (`.md`, `.json`, `.yaml`, `.py`, `.js`, `.ts`, …) — a folder of
-   only `.pdf` or `.docx` files indexes nothing.
+Use an existing path with `mm index /absolute/path`. If a managed write is
+outside the configured roots, add it through `mm init`, the Web UI, or the
+documented config surfaces before retrying.
 
 ### "Ollama not found" or "not running"
 
-```bash
-ollama serve               # start the Ollama server
-ollama list                # verify it's running
-```
+Run `ollama list`, pull the configured model, or switch to the Minimal/ONNX
+path. See [Embeddings](embeddings.md#ollama-local-server).
 
 ### "Embedding dimension mismatch"
 
-Your database was created with a different model than your current config.
-
-```bash
-mm embedding-reset                          # check status
-mm embedding-reset --mode apply-current     # reset DB to current model (re-index needed)
-mm index ~/notes                            # re-index
-```
+Stop other memtomem processes, run `mm embedding-reset`, choose the intended
+model, and re-index. See [Switching models](embeddings.md#switching-models-on-an-existing-index).
 
 ### "No such command" when running `mm`
 
-The CLI isn't installed. Install it:
 ```bash
-uv tool install 'memtomem[all]'     # PyPI
-# or
-uv pip install -e "packages/memtomem[all]"  # Source
+uv tool update-shell
+uv tool install 'memtomem[all]' --refresh
 ```
+
+Open a new shell after updating PATH. Project/source installs require
+`uv run mm` instead.
 
 ### Tools don't appear in my editor
 
-1. Restart your editor after configuring MCP
-2. Check that `memtomem-server` (not `memtomem`) is in your MCP config
-3. Verify the install is reachable: `mm --version` (or `uvx --from memtomem mm --version` for uvx-only setups) — side-effect-free, no state dir is touched
-4. From inside the editor, ask it to call the `mem_status` tool — a successful response confirms the MCP handshake reached the server
-
-> Running `uvx --from memtomem memtomem-server` directly in a terminal
-> now prints a setup hint and exits without provisioning `~/.memtomem/`.
-> That hint confirms the binary launches but is **not** a "does it
-> serve?" check — for that, configure your editor and call `mem_status`
-> from there. The network-transport flags (`--transport http|sse`) are
-> intended for remote deployments; see
-> [mcp-clients.md → Network transports](mcp-clients.md#11-network-transports-advanced).
+Confirm `mm status` works in a terminal, then restart the client and follow
+[MCP Client Setup → Verifying Your Connection](mcp-clients.md#9-verifying-your-connection).
 
 ### Install and upgrade issues
 
-**`mm: command not found` (installed but not on `$PATH`).** `uv tool install`
-writes the `mm` shim to `~/.local/bin` (the macOS/Linux default), which isn't on
-`$PATH` in a fresh shell profile. Run `uv tool update-shell` once, then open a
-new shell and re-run `mm --version`. (`uv` prints a one-line hint on the
-first-ever tool install, but it's easy to miss.)
-
-**`mm --version` shows an older release than expected.** `uv` caches PyPI
-metadata per package, so a fresh install can resolve to the cached entry for a
-short window after a new release. Re-run with `uv tool install 'memtomem[all]'
---refresh`, or clear the cache first: `uv cache clean memtomem`. Check the
-[latest release](https://github.com/memtomem/memtomem/releases) for the expected
-version.
-
-**Upgrading an installed memtomem.** Prefer `mm upgrade` over a bare `uv tool
-install --reinstall memtomem`. The latter only swaps the on-disk bytes, so any
-`memtomem-server` already running under your MCP client keeps executing the
-previous version until it exits. `mm upgrade` stops the server first (SIGTERM →
-SIGKILL after `--grace`), clears the stale pid lock, then runs the reinstall with
-`--refresh` so a freshly released version isn't masked by uv's cached resolver
-result. Pass `--version X.Y.Z` to pin or `--dry-run` to preview the plan.
-
----
+If `mm --version` is older than the latest release, re-run the install with
+`--refresh` or use `mm upgrade`. Detailed recovery commands live in
+[Operations](reference/operations.md).
 
 ## Optional: Share rules, skills, sub-agents, and commands across editors
 
-If you use multiple AI editors, keep their config files — and their agent **skills**, **sub-agents**, and **slash commands** — in sync from one source under `.memtomem/`:
-
-> For the full picture — the Store → Sync → Runtime model, the Web UI, and the tier choices — see the [Context Gateway](context-gateway.md) guide.
-
-```bash
-mm context init                         # create .memtomem/context.md from existing files
-mm context generate --agent all         # generate CLAUDE.md, .cursorrules, GEMINI.md, etc.
-mm context sync                         # update all after editing context.md
-
-# Also mirror .memtomem/skills/  → .claude/skills/, .gemini/skills/, .agents/skills/
-mm context sync --include=skills
-
-# Also fan out .memtomem/agents/  → .claude/agents/, .gemini/agents/, .codex/agents/
-# (reports dropped fields per runtime; add --strict to fail on any drop)
-mm context sync --include=agents
-
-# Also fan out .memtomem/commands/  → .claude/commands/*.md, .gemini/commands/*.toml
-# (Markdown ↔ TOML conversion with $ARGUMENTS ↔ {{args}} placeholder rewrite)
-mm context sync --include=commands
-
-# Everything in one shot
-mm context sync --include=skills,agents,commands
-
-# Versioning & promotion (agents & commands only)
-mm context version create agents my-agent --note "v1 release" # freeze current working canonical to v1
-mm context version promote agents my-agent --to production --version v1 # point 'production' label to v1
-mm context sync --include=agents,commands --label production # deploy the labeled version instead of the working canonical
-```
-
-Run `mm context --help` for the full fan-out matrix across editors (Claude Code, Cursor, Gemini CLI, OpenAI Codex, GitHub Copilot) and per-runtime field-drop details.
-
-> **Note:** writes targeting `project_shared` (sync, install/update, version
-> create, hook-rule promote) are privacy-scanned and refuse on detected
-> secrets — git history is forever, so there is no force bypass (ADR-0011 §5).
-
-For multi-device use, treat the project-shared `.memtomem/` tree as part of
-that project repo. Commit `.memtomem/context.md`, `.memtomem/agents/`,
-`.memtomem/skills/`, `.memtomem/commands/`, and `.memtomem/settings.json`
-when you want the context to follow the project checkout. Keep
-`.memtomem/*.local/` and `.claude/settings.local.json` out of git.
-
-> Cursor, OpenAI Codex, and GitHub Copilot generators concatenate the `Rules` and `Style` sections from `context.md` into a single block — `mm context generate` warns on stderr when both are populated. `context.md` remains the source of truth; edit there, not in the generated files.
-
-**Where do canonical files live? (3-tier model)** Canonical agents / skills /
-commands live at one of three **tiers**:
-
-| Tier (`--scope`) | Where it lives | Notes |
-|---|---|---|
-| `user` | `~/.memtomem/<artifact>/` | Available to every project on this machine |
-| `project_shared` | `<proj>/.memtomem/<artifact>/` | Git-tracked; the default for these artifacts |
-| `project_local` | `<proj>/.memtomem/<artifact>.local/` | Gitignored draft — never fans out to a runtime |
-
-Pick the tier per write with `--scope=<tier>` on `mm context init` / `sync` /
-`generate`. The tier (where the canonical lives) is distinct from the runtime
-**scope** it fans out to under `.claude/`. For moving canonicals between tiers
-and the full rationale, see the [Context Gateway](context-gateway.md) guide
-(ADR-0016 documents the split).
-
----
+The [Context Gateway](context-gateway.md) keeps canonical artifacts in a
+project or user Store and syncs them to supported runtimes. Its Wiki is a
+separate, optional upstream library—not the Store itself.
 
 ## Optional: STM Proxy — Proactive Memory Surfacing
 
-STM automatically surfaces relevant memories when your agent uses other MCP tools. It's optional — basic search/add works without it.
-
-STM is a separate package: **[memtomem-stm](https://github.com/memtomem/memtomem-stm)**. Install via PyPI:
-
-```bash
-pip install memtomem-stm
-```
-
-See the [memtomem-stm README](https://github.com/memtomem/memtomem-stm#readme) for proxy configuration, surfacing setup, and CLI usage.
-
----
+[memtomem-stm](https://github.com/memtomem/memtomem-stm) is a separate MCP
+proxy for automatic surfacing, compression, and caching. memtomem core remains
+the long-term-memory store and works without STM.
 
 ## Optional: Web UI
 
-For a visual dashboard:
-
 ```bash
-mm web                     # polished dashboard on http://127.0.0.1:8080
-mm web -b                  # run in the background
-mm web status              # show pid/port/start time
-mm web stop                # stop the tracked Web UI process
-mm web --dev               # adds opt-in maintainer pages
+mm web
 ```
 
-The Web UI opens in **Simple** mode by default, showing the Home, Search, Sources, Gateway, Index, and Settings tabs (the Settings tab holds Config, Namespaces, and Reset Database). Flip the header's **Advanced** toggle to add the Tags and Timeline tabs, plus the Dedup, Age-out, and Export/Import sections inside Settings. Pass `--dev` (or set `MEMTOMEM_WEB__MODE=dev` in your shell profile) to expose maintainer pages like Sessions, Working Memory, and Health Report — see [Configuration → Web UI Mode](configuration.md#web-ui-mode) for details.
-
----
+Open `http://127.0.0.1:8080`. Use `mm web --dev` only when you need maintainer
+pages. See [Operations → Web UI](reference/operations.md#web-ui) before any
+off-loopback exposure.
 
 ## Optional: LLM Provider
 
-memtomem can use an LLM for enhanced features like consolidation summaries, semantic auto-tagging, and query expansion. LLM is disabled by default — basic search, indexing, and tagging work without it.
-
-To enable:
-
-```bash
-export MEMTOMEM_LLM__ENABLED=true
-export MEMTOMEM_LLM__PROVIDER=ollama    # or: openai, anthropic
-```
-
-See [LLM Providers](llm-providers.md) for full setup including local servers (LM Studio, vLLM) and cloud APIs (OpenRouter).
-
----
+Basic indexing and search do not require an LLM. Configure one only for
+features such as query expansion, extraction, auto-tagging, and richer
+summaries. See [LLM Providers](llm-providers.md).
 
 ## Uninstall
 
-To completely remove memtomem, see the
-[Uninstalling memtomem](uninstall.md) guide. The short version:
-
-```bash
-# 1. Remove MCP server from your editor config (see table below)
-# 2. Uninstall the package
-uv tool uninstall memtomem    # or: pipx uninstall memtomem / uv remove memtomem
-# 3. Delete data
-rm -rf ~/.memtomem
-```
-
----
+Use `mm uninstall` for guided removal. The dedicated
+[Uninstalling memtomem](uninstall.md) guide explains how to preserve the
+database or remove client registrations and project artifacts.
 
 ## Next steps
 
-- [Reference](reference.md) — complete feature reference for all tools and patterns
-- Example notebooks — runnable Python-API walkthroughs (local ONNX, no server): [Hello memory](../../examples/notebooks/01_hello_memory.ipynb), [Indexing & filters](../../examples/notebooks/02_index_and_filter.ipynb), [Agent memory patterns](../../examples/notebooks/03_agent_memory_patterns.ipynb)
-- [Configuration](configuration.md) — all `MEMTOMEM_*` environment variables
-- [Embeddings](embeddings.md) — ONNX, Ollama, OpenAI providers
-- [LLM Providers](llm-providers.md) — Ollama, OpenAI, and compatible endpoints
-- [MCP Client Setup](mcp-clients.md) — editor-specific configuration
-- [Context Gateway](context-gateway.md) — share Skills, Commands, and Subagents across your AI tools from one Store
-- [Multi-device sync](multi-device-sync.md) — keep markdown memories in sync across personal devices via a private git repo
-- [Scheduled jobs](reference/automation.md#9-scheduled-jobs--mm-schedule-schedule_) — `mm schedule` for cron-driven compaction, importance decay, dead-link cleanup, and dedup scans
+- [MCP Client Setup](mcp-clients.md) — connect an editor.
+- [Core memory tools](reference/core-memory-tools.md) — index and search real data.
+- [Embeddings](embeddings.md) — improve semantic search quality.
+- [Context Gateway](context-gateway.md) — sync agent artifacts.
+- [Operations & troubleshooting](reference/operations.md) — diagnose and audit.

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -122,12 +122,7 @@ For a team-shared setup, commit a `.mcp.json` at the project root:
   "mcpServers": {
     "memtomem": {
       "command": "uvx",
-      "args": ["--from", "memtomem", "memtomem-server"],
-
-      "env": {
-        "MEMTOMEM_STORAGE__SQLITE_PATH": "~/.memtomem/memtomem.db",
-        "MEMTOMEM_INDEXING__MEMORY_DIRS": "[\"~/notes\"]"
-      }
+      "args": ["--from", "memtomem", "memtomem-server"]
     }
   }
 }
@@ -136,6 +131,10 @@ For a team-shared setup, commit a `.mcp.json` at the project root:
 Teammates see this server after approving the workspace-trust prompt on
 first use. To run against personal credentials without touching the
 shared file, add a `-s local` entry with the same name — local wins.
+
+The server reads `~/.memtomem/config.json`. Add a client `env` block only for
+an intentional highest-precedence override; see the
+[MCP client configuration guide](../mcp-clients.md#10-environment-variable-overrides).
 
 ---
 

--- a/docs/guides/integrations/claude-desktop.md
+++ b/docs/guides/integrations/claude-desktop.md
@@ -35,12 +35,7 @@ Edit the `~/Library/Application Support/Claude/claude_desktop_config.json` file:
   "mcpServers": {
     "memtomem": {
       "command": "uvx",
-      "args": ["--from", "memtomem", "memtomem-server"],
-      
-      "env": {
-        "MEMTOMEM_STORAGE__SQLITE_PATH": "~/.memtomem/memtomem.db",
-        "MEMTOMEM_INDEXING__MEMORY_DIRS": "[\"~/notes\"]"
-      }
+      "args": ["--from", "memtomem", "memtomem-server"]
     }
   }
 }
@@ -55,12 +50,7 @@ Edit the `%APPDATA%\Claude\claude_desktop_config.json` file:
   "mcpServers": {
     "memtomem": {
       "command": "uvx",
-      "args": ["--from", "memtomem", "memtomem-server"],
-      
-      "env": {
-        "MEMTOMEM_STORAGE__SQLITE_PATH": "%USERPROFILE%\\.memtomem\\memtomem.db",
-        "MEMTOMEM_INDEXING__MEMORY_DIRS": "[\"%USERPROFILE%\\\\notes\"]"
-      }
+      "args": ["--from", "memtomem", "memtomem-server"]
     }
   }
 }
@@ -69,6 +59,9 @@ Edit the `%APPDATA%\Claude\claude_desktop_config.json` file:
 Restart Claude Desktop after configuring.
 
 > **If you already have `mcpServers`**: Simply add the `"memtomem"` key to the existing object.
+>
+> The server reads `~/.memtomem/config.json`. Add an `env` block only when
+> this client should intentionally override saved settings.
 
 ---
 

--- a/docs/guides/integrations/cursor.md
+++ b/docs/guides/integrations/cursor.md
@@ -33,12 +33,7 @@ Create or edit the `~/.cursor/mcp.json` file:
   "mcpServers": {
     "memtomem": {
       "command": "uvx",
-      "args": ["--from", "memtomem", "memtomem-server"],
-      
-      "env": {
-        "MEMTOMEM_STORAGE__SQLITE_PATH": "~/.memtomem/memtomem.db",
-        "MEMTOMEM_INDEXING__MEMORY_DIRS": "[\"~/notes\"]"
-      }
+      "args": ["--from", "memtomem", "memtomem-server"]
     }
   }
 }
@@ -47,6 +42,10 @@ Create or edit the `~/.cursor/mcp.json` file:
 Restart Cursor after configuring.
 
 > **If you already have `mcpServers`**: Simply add the `"memtomem"` key to the existing object.
+>
+> The server reads `~/.memtomem/config.json`. Use an `env` block only for an
+> intentional client-specific override; environment variables take highest
+> precedence.
 
 ---
 

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -16,6 +16,11 @@
 
 > **Common mistake**: Using `memtomem` instead of `memtomem-server` in your MCP config will fail.
 
+Normal registrations contain only the server command. The server reads the
+configuration written by `mm init` from `~/.memtomem/config.json`. Add an
+`env` block only when you deliberately want that client to override the saved
+configuration; environment variables have the highest precedence.
+
 ---
 
 **Jump to your editor**
@@ -85,10 +90,7 @@ For a team-shared setup, create a `.mcp.json` at the project root:
   "mcpServers": {
     "memtomem": {
       "command": "uvx",
-      "args": ["--from", "memtomem", "memtomem-server"],
-      "env": {
-        "MEMTOMEM_INDEXING__MEMORY_DIRS": "[\"~/memories\"]"
-      }
+      "args": ["--from", "memtomem", "memtomem-server"]
     }
   }
 }
@@ -97,7 +99,8 @@ For a team-shared setup, create a `.mcp.json` at the project root:
 Teammates see this server after approving Claude Code's workspace-trust
 prompt on first use.
 
-### Verify Connection
+<a id="verify-connection"></a>
+### Verify Claude Code
 
 In Claude Code (or run `/memtomem:status` with the plugin):
 ```
@@ -115,17 +118,15 @@ Create or edit the `~/.cursor/mcp.json` file:
   "mcpServers": {
     "memtomem": {
       "command": "uvx",
-      "args": ["--from", "memtomem", "memtomem-server"],
-      "env": {
-        "MEMTOMEM_INDEXING__MEMORY_DIRS": "[\"~/memories\"]"
-      }
+      "args": ["--from", "memtomem", "memtomem-server"]
     }
   }
 }
 ```
 
 Restart Cursor after configuration.
-### Verify Connection
+<a id="verify-connection-1"></a>
+### Verify Cursor
 
 In Cursor's AI chat:
 ```
@@ -143,10 +144,7 @@ Create or edit the `~/.codeium/windsurf/mcp_config.json` file:
   "mcpServers": {
     "memtomem": {
       "command": "uvx",
-      "args": ["--from", "memtomem", "memtomem-server"],
-      "env": {
-        "MEMTOMEM_INDEXING__MEMORY_DIRS": "[\"~/memories\"]"
-      }
+      "args": ["--from", "memtomem", "memtomem-server"]
     }
   }
 }
@@ -165,10 +163,7 @@ Edit the `~/Library/Application Support/Claude/claude_desktop_config.json` (macO
   "mcpServers": {
     "memtomem": {
       "command": "uvx",
-      "args": ["--from", "memtomem", "memtomem-server"],
-      "env": {
-        "MEMTOMEM_INDEXING__MEMORY_DIRS": "[\"~/memories\"]"
-      }
+      "args": ["--from", "memtomem", "memtomem-server"]
     }
   }
 }
@@ -195,10 +190,7 @@ Create or edit the `~/.gemini/settings.json` file:
   "mcpServers": {
     "memtomem": {
       "command": "uvx",
-      "args": ["--from", "memtomem", "memtomem-server"],
-      "env": {
-        "MEMTOMEM_INDEXING__MEMORY_DIRS": "[\"~/memories\"]"
-      }
+      "args": ["--from", "memtomem", "memtomem-server"]
     }
   }
 }
@@ -244,9 +236,6 @@ memtomem:
 [mcp_servers.memtomem]
 command = "uvx"
 args = ["--from", "memtomem", "memtomem-server"]
-
-[mcp_servers.memtomem.env]
-MEMTOMEM_INDEXING__MEMORY_DIRS = '["~/memories"]'
 ```
 
 Restart Codex CLI after configuration.
@@ -259,7 +248,8 @@ Restart Codex CLI after configuration.
 > [Codex config reference](https://developers.openai.com/codex/config-reference)
 > for the full schema.
 
-### Verify Connection
+<a id="verify-connection-2"></a>
+### Verify Codex CLI
 
 In Codex CLI:
 
@@ -292,10 +282,7 @@ files — register memtomem in whichever you actually use:
   "mcpServers": {
     "memtomem": {
       "command": "uvx",
-      "args": ["--from", "memtomem", "memtomem-server"],
-      "env": {
-        "MEMTOMEM_INDEXING__MEMORY_DIRS": "[\"/path/to/notes\"]"
-      }
+      "args": ["--from", "memtomem", "memtomem-server"]
     }
   }
 }
@@ -329,10 +316,7 @@ Create or edit that file:
     "memtomem": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["--from", "memtomem", "memtomem-server"],
-      "env": {
-        "MEMTOMEM_INDEXING__MEMORY_DIRS": "[\"~/memories\"]"
-      }
+      "args": ["--from", "memtomem", "memtomem-server"]
     }
   }
 }
@@ -445,7 +429,10 @@ The STM proxy is distributed as a separate package: **[memtomem-stm](https://git
 
 ## 10. Environment Variable Overrides
 
-You can override settings by adding environment variables to the `env` block.
+You can override settings for one client by adding environment variables to
+the `env` block. This is an advanced, explicit override: these values win over
+`config.d/` and `config.json`. For ordinary setup, omit the block and manage
+settings with `mm init`, `mm config`, or the Web UI.
 
 > **List-typed settings must be JSON-encoded.** `MEMTOMEM_INDEXING__MEMORY_DIRS`
 > is a list, so pass it as a JSON array literal string: `"[\"~/memories\"]"`

--- a/docs/guides/reference/data-config-cli.md
+++ b/docs/guides/reference/data-config-cli.md
@@ -241,6 +241,8 @@ mm embedding-reset --mode revert-to-stored  # switch runtime to match DB
 mm init                                # preset picker; `--advanced` opens the full 10-step wizard (b: back, q: quit)
 mm mem init                            # opt this project into project-tier memory: creates .memtomem/memories.local/ and registers it (run from the project root; requires .git or pyproject.toml)
 mm mem init --scope project_shared --confirm-project-shared   # same for the shared tier (memories written there land in git-tracked files)
+mm mem rescan --scope user             # read-only privacy re-scan of stored user-scope chunks (exit 1 on findings)
+mm mem rescan-files                    # read-only scan of historical imported/fetched/session files
 
 # Core (daily use)
 mm search "deployment"                 # hybrid search (keywords + meaning)
@@ -293,6 +295,8 @@ cd <your project>                      # wiki is global; install/status are proj
 mm context install skill <name>        # snapshot the wiki asset (at HEAD; commit-true — refuses if the asset has uncommitted wiki changes)
 mm context update skill <name>         # re-snapshot at HEAD (commit-true — refuses if the asset has uncommitted wiki changes; --all, --force, --yes)
 mm context status                      # installed wiki assets + drift (reads the CURRENT project)
+mm wiki skill promote <name>           # project_shared Store → new Wiki asset + isolated commit (privacy-scanned)
+mm context adopt skill <name>          # lockfile-track Store bytes only when they match Wiki HEAD exactly
 
 # Add-on — seed a vendor override (only when a runtime needs a divergent render):
 mm wiki skill override <name> --vendor claude --editor  # writes overrides/claude.md (+ .bak under --force)
@@ -325,6 +329,7 @@ mm context init --include=skills --only my-skill   # import ONE named runtime ar
 mm context generate --agent all        # generate all agent files
 mm context generate --include=agents --label production # generate files using the 'production' labeled snapshot (agents/commands only)
 mm context diff                        # check sync status
+mm context rescan --scope project_shared  # read-only privacy scan of canonical artifacts in one explicit tier
 mm context status                      # installed wiki assets + their drift state (read-only)
 mm context status --all-projects       # aggregated drift across enrolled on-disk projects (read-only; same data as GET /api/context/status-all)
 mm context sync                        # sync context.md → agent files (project_shared default)
@@ -335,6 +340,7 @@ mm context sync --include=agents,commands --label production # sync using the 'p
 mm context sync --all-projects --yes   # batch over every enrolled on-disk project (project_shared only, ADR-0025)
 mm context generate --include=settings # merge hooks → ~/.claude/settings.json
 mm context diff --include=settings     # check hook sync status
+mm context update skill <name> --force-head  # deliberately follow older/divergent Wiki HEAD; use --force separately for local edits
 
 # Context Versioning (ADR-0022)
 mm context version create agents my-agent --note "stable"          # snapshot the current working canonical as a new immutable version

--- a/docs/guides/reference/operations.md
+++ b/docs/guides/reference/operations.md
@@ -1,12 +1,14 @@
 # Operations & troubleshooting
 
-Running the Web UI, fixing common problems, optional STM proactive surfacing, and uninstalling.
+Running the Web UI, auditing managed content, fixing common problems, optional
+STM proactive surfacing, and uninstalling.
 
 [← memtomem Reference](../reference.md)
 
 **On this page**
 
 - [Web UI](#web-ui)
+- [Privacy audits](#privacy-audits)
 - [Troubleshooting](#troubleshooting)
 - [STM: Proactive Memory Surfacing (Optional)](#stm-proactive-memory-surfacing-optional)
 - [Uninstalling memtomem](#uninstalling-memtomem)
@@ -58,6 +60,38 @@ mm web --host 0.0.0.0 --allow-remote-ui \
 Requests whose `Origin`/`Referer` or `Host` headers are not on the allow-list are rejected by the three-layer request guard — see [SECURITY.md](../../../SECURITY.md#csrf--origin--host-guard-rfc-787) for the full model and the `MEMTOMEM_WEB__CSRF_ENFORCE` rollback valve.
 
 **Anything beyond a trusted LAN needs an authenticating reverse proxy** — TLS plus auth in front, with memtomem still bound to loopback behind it. The [authenticated reverse proxy recipe](../mcp-clients.md#authenticated-reverse-proxy-required-for-public-exposure) (nginx, TLS + Basic auth) applies to the Web UI the same way it does to MCP network transports.
+
+---
+
+## Privacy audits
+
+memtomem applies its redaction guard before managed writes, but historical
+content may predate the current patterns. The audit commands below are
+read-only: they report findings without deleting, quarantining, rewriting, or
+re-embedding anything.
+
+```bash
+# Stored database chunks in one explicit memory tier
+mm mem rescan --scope user --json
+mm mem rescan --scope project_shared --json
+mm mem rescan --scope project_local --json
+
+# Historical files under managed _imported/, _fetched/, and sessions/ trees
+mm mem rescan-files --json
+
+# Canonical Context Gateway artifacts in one explicit tier
+mm context rescan --scope project_shared --json
+```
+
+Each command exits `0` when the scan is clean and `1` when it finds a
+violation. `mm mem rescan` accepts `--source` to narrow the database scan to
+one file or directory. `mm context rescan` requires a scope so CI and audit
+logs never rely on an implicit tier.
+
+Review every reported path or chunk before remediation. Move secrets out of
+git-tracked content, rotate exposed credentials, and then use the ordinary
+edit/delete/re-index workflow appropriate to that source. The audit commands
+intentionally have no automatic `--fix` mode.
 
 ---
 

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -2,7 +2,7 @@
 
 > 🚧 **Alpha** — APIs, defaults, and on-disk config surfaces may still change between `0.x` releases. Feedback and issue reports are especially welcome at [github.com/memtomem/memtomem/issues](https://github.com/memtomem/memtomem/issues).
 
-Markdown-first long-term memory infrastructure for AI agents. Hybrid keyword + semantic search across your notes, docs, and code via the Model Context Protocol.
+Markdown-first long-term memory infrastructure for AI agents. Core usage is hook-free by default: your files remain the source of truth, and memory changes happen only when you or your agent explicitly call memtomem. Optional client hooks are separate, visible integrations.
 
 **Core philosophy**: `.md` files are the source of truth and the vector database is a derived cache. Manage memories as plain text files — memtomem makes them instantly searchable.
 
@@ -14,81 +14,35 @@ Markdown-first long-term memory infrastructure for AI agents. Hybrid keyword + s
 ## Quick Start
 
 ```bash
-# 1. Install memtomem with all features (requires Python 3.12+)
+# 1. Install memtomem with all features (Python 3.12+)
 uv tool install 'memtomem[all]'  # or: pipx install 'memtomem[all]'
-mm --version                     # verify — if stale, re-run with --refresh
+mm --version
 
-# 2. Run the setup (preset picker → memory_dir + MCP)
-mm init    # on PATH after `uv tool install` — no `uv run` needed
+# 2. Configure storage, search, and optional MCP registration
+mm init
+
+# 3. Verify a complete memory round trip
+mm status
+mm add "Deployment checklist uses blue-green rollout" --tags ops
+mm search "blue-green"
 ```
 
-`[all]` pulls in ONNX dense embeddings, Korean tokenizer, Ollama / OpenAI SDKs, code chunker, and the Web UI. Skip it (`uv tool install memtomem` bare) for a BM25-only install (~40 MB); opt in later with `uv tool install --reinstall 'memtomem[onnx,web]'` or similar.
+The search should return the sentence you just added. `mm add` writes to your configured user memory directory and indexes the entry immediately, so this path works without an existing notes directory or a connected editor.
 
-> `uv` caches PyPI metadata. If `mm --version` doesn't match the [latest release](https://github.com/memtomem/memtomem/releases) right after install, re-run with `uv tool install 'memtomem[all]' --refresh` or clear the cache: `uv cache clean memtomem`.
+Choose **Minimal** in the setup picker for a no-model-download first proof;
+rerun `mm init` later to add semantic search.
 
-> **`mm: command not found`?** `uv` installs the shim to `~/.local/bin` — add it to `$PATH` with `uv tool update-shell`, then open a new shell.
-
-The picker offers three presets and an Advanced fallback:
-
-| Preset | Embedding | Reranker | Tokenizer |
-|---|---|---|---|
-| Minimal | BM25 only (no download) | — | unicode61 |
-| English (Recommended) | ONNX `bge-small-en-v1.5` (~67 MB, 384d) | English (`ms-marco-MiniLM-L-6-v2`) | unicode61 |
-| Korean-optimized | ONNX `bge-m3` (~2.3 GB, 1024d) | Multilingual (`jina-reranker-v2`) | `kiwipiepy` |
-| Advanced | — | — | — (full 10-step wizard, all options) |
-
-Pick a preset interactively, or use `mm init --non-interactive` (minimal), `mm init --preset korean --non-interactive`, or `mm init --advanced` for scripted runs. See [Embeddings](https://github.com/memtomem/memtomem/blob/main/docs/guides/embeddings.md) for the full model matrix.
-
-> **Claude Code — indexing vs. discovery:** the memory folders `mm init` indexes are added to the search *index*. That is separate from the Web UI's opt-in Context Gateway scan of `~/.claude/projects/`, which discovers project *roots* for Skills, Custom Commands, and Subagents — see [Configuration → Context Gateway](https://github.com/memtomem/memtomem/blob/main/docs/guides/configuration.md#context-gateway) for the opt-in behavior and lossy-slug caveats.
-
-Then in your AI editor, ask:
-
-```
-"Call the mem_status tool"   →  confirms the server is connected
-"Index my notes folder"      →  mem_index(path="~/notes")
-"Search for deployment"      →  mem_search(query="deployment checklist")
-"Remember this insight"      →  mem_add(content="...", tags=["ops"])
-```
-
-> Prefer the terminal? `mm status` is a CLI mirror of `mem_status` — same output, no editor needed. Add `--json` (or `--format json`) for machine-readable output in scripts and CI.
-
-That's it. Your agent now has a long-term memory built from plain markdown files.
-
-For full setup, OpenAI configuration, and troubleshooting, see the [Getting Started guide](https://github.com/memtomem/memtomem/blob/main/docs/guides/getting-started.md).
-
-<details>
-<summary><b>Prefer no install? (uvx direct, MCP only)</b></summary>
-
-If you'd rather skip the CLI install, `uvx` will download and run memtomem on demand. `~/.memtomem/memories` is always indexed; for AI tool memory folders (Claude Code per-project memory, Claude plans, Codex memories), run `mm init` once and pick the surfaces you want indexed — nothing is added silently. Set `MEMTOMEM_INDEXING__MEMORY_DIRS` to add custom paths.
+To index existing files next:
 
 ```bash
-claude mcp add memtomem -s user -- uvx --from memtomem memtomem-server
+mm index /path/to/your/notes
 ```
 
-Or add the following to your MCP client config file — the path depends on
-the editor: `~/.cursor/mcp.json` (Cursor),
-`~/.codeium/windsurf/mcp_config.json` (Windsurf),
-`~/Library/Application Support/Claude/claude_desktop_config.json`
-(Claude Desktop), `~/.gemini/antigravity-cli/mcp_config.json`
-(Antigravity CLI — entries also carry `"type": "stdio"`),
-`~/.gemini/settings.json` (Gemini CLI, deprecated 2026-06-18), or
-`~/.kimi/mcp.json` (Kimi CLI):
+If `mm init` registered an MCP client, ask it to `Call the mem_status tool`. See [Getting Started](https://github.com/memtomem/memtomem/blob/main/docs/guides/getting-started.md) for install alternatives and [MCP Client Setup](https://github.com/memtomem/memtomem/blob/main/docs/guides/mcp-clients.md) for manual registration.
 
-```json
-{
-  "mcpServers": {
-    "memtomem": {
-      "command": "uvx",
-      "args": ["--from", "memtomem", "memtomem-server"],
-      "env": {
-        "MEMTOMEM_INDEXING__MEMORY_DIRS": "[\"/path/to/your/notes\"]"
-      }
-    }
-  }
-}
-```
+`[all]` includes local ONNX embeddings, the Korean tokenizer, provider SDKs, code chunking, and the Web UI. Install bare `memtomem` for BM25-only usage. If `mm` is not on PATH, run `uv tool update-shell` and open a new shell. If an install appears stale, re-run it with `--refresh`.
 
-</details>
+> memtomem is the long-term-memory store. [memtomem-stm](https://github.com/memtomem/memtomem-stm) is a separate, optional MCP proxy for automatic surfacing, compression, and caching.
 
 ## Key Features
 
@@ -99,7 +53,7 @@ the editor: `~/.cursor/mcp.json` (Cursor),
 - **🧹 Maintenance** — near-duplicate detection with merge, time-based score decay, TTL expiration, auto-tagging
 - **🔄 Export / import** — JSON bundle backup and restore with re-embedding
 - **🌐 Web UI** — polished SPA dashboard for search, sources, indexing, tags, and timeline (`mm web --dev` unlocks the full maintainer surface including Sessions, Working Memory, and Health Report)
-- **🧭 Context Gateway** — author canonical Skills, Commands, and Subagents once in a wiki-backed Store (`mm wiki …`), then sync them to your AI tools (each artifact type's supported runtimes); a Projects portal in the Web UI tracks per-project drift
+- **🧭 Context Gateway** — keep canonical Skills, Commands, and Subagents in a project or user Store, optionally install reusable Wiki assets, then sync them to supported runtimes
 - **⚙️ Scriptable CLI** — `--json` output on `mm status` and write commands (`mm add` / `mm reset` / `mm purge`); `mm warmup` pre-loads local models so the first query skips cold-start
 - **🛠️ 87 MCP tools** — full feature surface as MCP tools, with `mem_do` meta-tool routing all registered actions in `core` mode (default) for minimal context usage
 
@@ -109,12 +63,14 @@ Full documentation lives in the [memtomem GitHub repo](https://github.com/memtom
 
 | Guide | Topic |
 |-------|-------|
-| [Getting Started](https://github.com/memtomem/memtomem/blob/main/docs/guides/getting-started.md) | **Start here** — install, setup wizard, first use |
-| [Reference](https://github.com/memtomem/memtomem/blob/main/docs/guides/reference.md) | Complete feature reference — all tools and patterns |
-| [Configuration](https://github.com/memtomem/memtomem/blob/main/docs/guides/configuration.md) | All `MEMTOMEM_*` environment variables |
+| [Getting Started](https://github.com/memtomem/memtomem/blob/main/docs/guides/getting-started.md) | **Start here** — install, configure, save and find your first memory |
+| [MCP Client Setup](https://github.com/memtomem/memtomem/blob/main/docs/guides/mcp-clients.md) | Connect Claude Code, Cursor, Codex, and other clients |
+| [Core memory tools](https://github.com/memtomem/memtomem/blob/main/docs/guides/reference/core-memory-tools.md) | Index existing notes, search, and manage memories |
+| [Configuration](https://github.com/memtomem/memtomem/blob/main/docs/guides/configuration.md) | Supported config files, precedence, and environment variables |
 | [Embeddings](https://github.com/memtomem/memtomem/blob/main/docs/guides/embeddings.md) | ONNX, Ollama, and OpenAI providers, model dimensions, switching models |
 | [Context Gateway](https://github.com/memtomem/memtomem/blob/main/docs/guides/context-gateway.md) | Author and sync canonical Skills, Commands, and Subagents to each type's supported AI tools |
-| [MCP Client Setup](https://github.com/memtomem/memtomem/blob/main/docs/guides/mcp-clients.md) | Editor-specific configuration |
+| [Operations & troubleshooting](https://github.com/memtomem/memtomem/blob/main/docs/guides/reference/operations.md) | Web UI, privacy audits, diagnostics, and recovery |
+| [Reference](https://github.com/memtomem/memtomem/blob/main/docs/guides/reference.md) | Complete feature reference — all tools and patterns |
 | [memtomem-stm](https://github.com/memtomem/memtomem-stm) | Optional STM proxy for proactive memory surfacing (separate package) |
 
 ## License

--- a/packages/memtomem/src/memtomem/cli/memory.py
+++ b/packages/memtomem/src/memtomem/cli/memory.py
@@ -72,7 +72,10 @@ def _render_validity_window(valid_from_unix: int | None, valid_to_unix: int | No
 @click.option("--title", "-t", default=None, help="Entry title")
 @click.option("--tags", default=None, help="Comma-separated tags")
 @click.option(
-    "--file", "file_name", default=None, help="Target file (relative to ~/.memtomem/memories/)"
+    "--file",
+    "file_name",
+    default=None,
+    help="Target file relative to the selected scope's memory directory.",
 )
 @click.option(
     "--force-unsafe",

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -1392,10 +1392,11 @@ def _dedup_key(item: object) -> object:
 def load_config_d(config: Mem2MemConfig, *, quiet: bool = False) -> None:
     """Apply fragments from ``~/.memtomem/config.d/*.json`` (if dir exists).
 
-    Intended for integration-installed fragments (``mm init <client>`` drops
-    one file, ``mm uninstall <client>`` removes it). Each fragment is a
-    partial ``Mem2MemConfig`` JSON. Fragments are applied in lexicographic
-    filename order. For each field:
+    Intended for administrator-managed or external integration fragments that
+    need a reversible layer. ``mm init`` itself writes ``config.json`` and
+    does not create client fragments. Each fragment is a partial
+    ``Mem2MemConfig`` JSON. Fragments are applied in lexicographic filename
+    order. For each field:
 
     - If ``MEMTOMEM_<SECTION>__<FIELD>`` env var is set → skip (env wins).
     - If scalar → last fragment wins.

--- a/packages/memtomem/src/memtomem/tools/consolidation_engine.py
+++ b/packages/memtomem/src/memtomem/tools/consolidation_engine.py
@@ -7,10 +7,10 @@ on the storage layer — no ``AppContext`` required.
 The summary is deterministic and chunk-type aware. Keyword-boosted regex
 (reused from ``entity_extraction``) picks decision/action lines over a plain
 first-sentence fallback, and checklist chunks are rendered as item counts
-rather than truncated prose. See ``docs/guides/user-guide.md`` "Consolidation"
-section and ``feedback_compression_priority.md`` for the rationale: nothing
-is lost, originals kept by default, source hash embedded for idempotent
-re-runs.
+rather than truncated prose. See
+``docs/guides/reference/automation.md`` (``auto_consolidate``) and
+``feedback_compression_priority.md`` for the rationale: nothing is lost,
+originals are kept by default, and a source hash makes re-runs idempotent.
 """
 
 from __future__ import annotations

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -1507,10 +1507,12 @@ async def upload_files(
 ) -> UploadResponse:
     """Upload one or more files, save to ~/.memtomem/uploads/, and index them.
 
-    Each file's text content passes through the trust-boundary redaction
-    guard before being written to disk. A flagged file is rejected
-    (``error="redaction_blocked"``) and **not** persisted; ``force_unsafe=True``
-    (query param) bypasses for the whole batch with audit logging.
+    Multipart parts first stream into an owner-only temporary disk quarantine.
+    Each file's text content then passes through the trust-boundary redaction
+    guard before durable promotion into ``uploads/``. A flagged file is
+    rejected (``error="redaction_blocked"``) and only the quarantine copy
+    exists until context cleanup; ``force_unsafe=True`` (query param) bypasses
+    for the whole batch with audit logging.
     """
     from memtomem import privacy
     from memtomem.web.upload_quarantine import (

--- a/packages/memtomem/tests/test_docs_guards.py
+++ b/packages/memtomem/tests/test_docs_guards.py
@@ -28,9 +28,12 @@ from __future__ import annotations
 
 import json
 import re
+import shlex
+import tomllib
 import types
 import typing
 from pathlib import Path
+from urllib.parse import unquote
 
 import click
 import pydantic
@@ -43,12 +46,29 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 _GUIDES = _REPO_ROOT / "docs" / "guides"
 _INTEGRATIONS = _GUIDES / "integrations"
 _README = _REPO_ROOT / "README.md"
+_PYPI_README = _REPO_ROOT / "packages" / "memtomem" / "README.md"
+_PLUGIN_README = _REPO_ROOT / "packages" / "memtomem-claude-plugin" / "README.md"
+_NOTEBOOKS_README = _REPO_ROOT / "examples" / "notebooks" / "README.md"
 _SRC = _REPO_ROOT / "packages" / "memtomem" / "src" / "memtomem"
 _PLUGIN_HOOKS_JSON = _REPO_ROOT / "packages" / "memtomem-claude-plugin" / "hooks" / "hooks.json"
 _HOOKS_SNIPPET_ANCHOR = "Add the following to `~/.claude/settings.json`:"
 
 _ASTERISK_TOOLS = ("mem_config", "mem_embedding_reset", "mem_reset")
 _FOOTNOTE_PREFIX = r"\* Requires `MEMTOMEM_TOOL_MODE=full`"
+
+
+def _public_markdown() -> list[Path]:
+    """Tracked public docs whose links and command examples are contractual."""
+    roots = [
+        _README,
+        _PYPI_README,
+        _PLUGIN_README,
+        _NOTEBOOKS_README,
+        _REPO_ROOT / "SECURITY.md",
+        _REPO_ROOT / "CONTRIBUTING.md",
+        _REPO_ROOT / "CLA.md",
+    ]
+    return sorted([*roots, *_GUIDES.rglob("*.md")])
 
 
 def _read(path: Path) -> str:
@@ -230,6 +250,18 @@ def _commands_by_event_matcher(hooks_doc: dict) -> dict[tuple[str, str], dict]:
     return out
 
 
+@pytest.fixture(scope="module")
+def plugin_commands() -> dict[tuple[str, str], dict]:
+    plugin_hooks = json.loads(_PLUGIN_HOOKS_JSON.read_text(encoding="utf-8"))
+    return _commands_by_event_matcher(plugin_hooks)
+
+
+@pytest.fixture(scope="module")
+def docs_commands(claude_code: str) -> dict[tuple[str, str], dict]:
+    snippet = _extract_hooks_snippet(claude_code)
+    return _commands_by_event_matcher(snippet)
+
+
 class TestPluginHooksDocsParity:
     """The hooks.json snippet in claude-code.md must declare byte-identical
     ``command`` strings to the plugin's shipped hooks.json for every
@@ -238,16 +270,6 @@ class TestPluginHooksDocsParity:
     copy-paste recipe tight), so we iterate over the docs entries and
     require each to match the plugin file — not the other way around.
     """
-
-    @pytest.fixture(scope="class")
-    def plugin_commands(self) -> dict[tuple[str, str], dict]:
-        plugin_hooks = json.loads(_PLUGIN_HOOKS_JSON.read_text(encoding="utf-8"))
-        return _commands_by_event_matcher(plugin_hooks)
-
-    @pytest.fixture(scope="class")
-    def docs_commands(self, claude_code: str) -> dict[tuple[str, str], dict]:
-        snippet = _extract_hooks_snippet(claude_code)
-        return _commands_by_event_matcher(snippet)
 
     def test_docs_snippet_is_subset_of_plugin(
         self,
@@ -388,6 +410,8 @@ def _doc_mm_paths(text: str) -> set[tuple[str, ...]]:
     """
     paths: set[tuple[str, ...]] = set()
     for line, in_fence in _iter_code_context(text):
+        if not in_fence and "no top-level" in line.lower():
+            continue
         segments: list[str] = []
         if in_fence:
             segments = re.findall(r"(?<![\w-])(?:uv run )?mm ([a-z][^\n`#]*)", line)
@@ -407,17 +431,7 @@ def _doc_mm_paths(text: str) -> set[tuple[str, ...]]:
     return paths
 
 
-_CLI_DOCS = (
-    _README,
-    _GUIDES / "getting-started.md",
-    _GUIDES / "reference.md",
-    _GUIDES / "reference" / "core-memory-tools.md",
-    _GUIDES / "reference" / "organization-maintenance.md",
-    _GUIDES / "reference" / "automation.md",
-    _GUIDES / "reference" / "data-config-cli.md",
-    _GUIDES / "reference" / "operations.md",
-    _GUIDES / "configuration.md",
-)
+_CLI_DOCS = tuple(_public_markdown())
 
 
 class TestDocumentedCliExists:
@@ -445,6 +459,45 @@ class TestDocumentedCliExists:
         assert not offenders, (
             "Docs reference CLI commands/subcommands that no longer exist in "
             "memtomem.cli (fix the doc or the command):\n  " + "\n  ".join(sorted(set(offenders)))
+        )
+
+    def test_documented_mm_flags_resolve(self) -> None:
+        """Flags shown on one-line or backslash-continued calls exist live."""
+        offenders: list[str] = []
+        for doc in _CLI_DOCS:
+            text = _read(doc).replace("\\\n", " ")
+            for line, in_fence in _iter_code_context(text):
+                segments: list[str] = []
+                if in_fence:
+                    segments = re.findall(r"(?<![\w-])(?:uv run )?mm ([^\n`#;|&]+)", line)
+                else:
+                    if "future" in line.lower():
+                        continue
+                    for span in re.findall(r"`([^`]+)`", line):
+                        segments.extend(re.findall(r"(?<![\w-])(?:uv run )?mm ([^;|&]+)", span))
+                for segment in segments:
+                    try:
+                        tokens = shlex.split(segment)
+                    except ValueError:
+                        continue
+                    node: click.Command = _CLI
+                    walked: list[str] = []
+                    for token in tokens:
+                        if token.startswith("-"):
+                            opt = token.split("=", 1)[0]
+                            if opt in {"--", "--help", "-h"}:
+                                continue
+                            live = {o for param in node.params for o in param.opts}
+                            if opt not in live:
+                                command = " ".join(["mm", *walked])
+                                offenders.append(f"{doc.name}: `{command} {opt}`")
+                            continue
+                        if isinstance(node, click.Group) and token in node.commands:
+                            node = node.commands[token]
+                            walked.append(token)
+        assert not offenders, (
+            "Docs reference flags that do not exist on the resolved live CLI command:\n  "
+            + "\n  ".join(sorted(set(offenders)))
         )
 
 
@@ -519,6 +572,16 @@ class TestDocumentedEnvVarsExist:
             f"(typo, removed, or missing from _ENV_ONLY_VARS?): {sorted(unknown)}"
         )
 
+    def test_every_settings_leaf_is_documented(self) -> None:
+        expected = _pydantic_env_vars(Mem2MemConfig)
+        used = set(re.findall(r"MEMTOMEM_[A-Z0-9_]+", _read(_GUIDES / "configuration.md")))
+        missing = expected - used
+        assert not missing, (
+            "configuration.md must name every pydantic settings leaf, including "
+            "deprecated compatibility fields (mark them deprecated rather than "
+            f"silently omitting them): {sorted(missing)}"
+        )
+
 
 def _slug(text: str) -> str:
     """GitHub-style heading anchor slug (no collapse of repeated separators)."""
@@ -545,13 +608,22 @@ def _anchors(md_text: str) -> set[str]:
 
 
 _LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+_GITHUB_BLOB_PREFIX = "https://github.com/memtomem/memtomem/blob/main/"
+_GITHUB_TREE_PREFIX = "https://github.com/memtomem/memtomem/tree/main/"
+
+
+def _same_repo_absolute_target(raw: str) -> str | None:
+    for prefix in (_GITHUB_BLOB_PREFIX, _GITHUB_TREE_PREFIX):
+        if raw.startswith(prefix):
+            return raw.removeprefix(prefix)
+    return None
 
 
 class TestInternalDocLinksResolve:
     """Internal markdown links and #anchors across the guides must resolve."""
 
     def test_links_and_anchors_resolve(self) -> None:
-        docs = sorted(_GUIDES.rglob("*.md")) + [_README]
+        docs = _public_markdown()
         anchor_cache: dict[Path, set[str]] = {}
         offenders: list[str] = []
         for doc in docs:
@@ -564,11 +636,23 @@ class TestInternalDocLinksResolve:
                 line = re.sub(r"`[^`]*`", "", line)
                 for raw in _LINK.findall(line):
                     target = raw.strip().strip("<>")
-                    if target.startswith(("http://", "https://", "mailto:", "tel:")):
+                    same_repo = _same_repo_absolute_target(target)
+                    if same_repo is not None:
+                        target = same_repo
+                    elif target.startswith(("http://", "https://", "mailto:", "tel:")):
                         continue
                     file_part, _, anchor = target.partition("#")
                     if file_part:
-                        tgt = (doc.parent / file_part).resolve()
+                        tgt = (
+                            (_REPO_ROOT / unquote(file_part)).resolve()
+                            if same_repo is not None
+                            else (doc.parent / unquote(file_part)).resolve()
+                        )
+                        try:
+                            tgt.relative_to(_REPO_ROOT)
+                        except ValueError:
+                            offenders.append(f"{doc.name}: target escapes repository -> {target}")
+                            continue
                         if not tgt.exists():
                             offenders.append(f"{doc.name}: missing target -> {target}")
                             continue
@@ -581,3 +665,132 @@ class TestInternalDocLinksResolve:
                         if anchor.lower() not in anchor_cache[anchor_src]:
                             offenders.append(f"{doc.name}: broken anchor -> {target}")
         assert not offenders, "Broken internal doc links/anchors:\n  " + "\n  ".join(offenders)
+
+    def test_no_duplicate_generated_heading_slugs(self) -> None:
+        offenders: list[str] = []
+        for doc in _public_markdown():
+            text = _read(doc)
+            seen: set[str] = set()
+            for line, in_fence in _iter_code_context(text):
+                if in_fence:
+                    continue
+                match = re.match(r"^#{1,6}\s+(.*?)\s*#*\s*$", line)
+                if not match:
+                    continue
+                slug = _slug(match.group(1))
+                if slug in seen:
+                    offenders.append(f"{doc.relative_to(_REPO_ROOT)}: {slug}")
+                seen.add(slug)
+        assert not offenders, (
+            "Duplicate public heading slugs make generated anchors ambiguous:\n  "
+            + "\n  ".join(offenders)
+        )
+
+    def test_restructured_entrypoints_keep_compatibility_anchors(self) -> None:
+        required = {
+            _README: {"3-use", "4-web-ui-optional"},
+            _GUIDES / "README.md": {
+                "set-up",
+                "tune",
+                "power-features",
+                "reference--lifecycle",
+            },
+            _GUIDES / "getting-started.md": {
+                "pick-an-embedding-path-optional",
+                "choose-your-setup",
+                "claude-code",
+                "cursor-windsurf-claude-desktop-antigravity-cli-gemini-cli",
+                "verify-connection",
+                "1-index-your-notes",
+                "2-search",
+                "3-add-a-memory",
+                "4-recall-recent-memories",
+            },
+            _GUIDES / "mcp-clients.md": {
+                "verify-connection",
+                "verify-connection-1",
+                "verify-connection-2",
+            },
+        }
+        for doc, expected in required.items():
+            missing = expected - _anchors(_read(doc))
+            assert not missing, f"{doc.name} lost compatibility anchors: {sorted(missing)}"
+
+
+def _quick_start(text: str) -> str:
+    match = re.search(r"^## Quick Start\s*$\n(.*?)(?=^##\s)", text, re.MULTILINE | re.DOTALL)
+    assert match is not None, "README lost its `## Quick Start` section"
+    return match.group(1)
+
+
+def _fenced_blocks(text: str, language: str) -> list[str]:
+    return re.findall(rf"```{language}\n(.*?)\n```", text, re.DOTALL)
+
+
+class TestPublicReadmeAndExamples:
+    _QUICK_START_COMMANDS = (
+        "mm init",
+        "mm status",
+        'mm add "Deployment checklist uses blue-green rollout" --tags ops',
+        'mm search "blue-green"',
+    )
+
+    @pytest.mark.parametrize("readme", [_README, _PYPI_README])
+    def test_readmes_share_quick_start_contract(self, readme: Path) -> None:
+        section = _quick_start(_read(readme))
+        positions = [section.find(command) for command in self._QUICK_START_COMMANDS]
+        assert all(position >= 0 for position in positions), (
+            f"{readme.name} must contain the shared deterministic Quick Start: "
+            f"{self._QUICK_START_COMMANDS}"
+        )
+        assert positions == sorted(positions), f"{readme.name} Quick Start command order drifted"
+
+    @pytest.mark.parametrize("readme", [_README, _PYPI_README])
+    def test_readmes_state_hook_and_stm_boundaries(self, readme: Path) -> None:
+        text = _read(readme).lower()
+        assert "hook-free by default" in text
+        assert "memtomem-stm" in text
+        assert "optional" in text
+
+    def test_pypi_readme_uses_absolute_markdown_links(self) -> None:
+        offenders = []
+        for raw in _LINK.findall(_read(_PYPI_README)):
+            target = raw.strip().strip("<>")
+            file_part = target.partition("#")[0]
+            if file_part.endswith(".md") and not target.startswith("https://"):
+                offenders.append(target)
+        assert not offenders, f"PyPI README has relative Markdown links: {offenders}"
+
+    def test_normal_mcp_examples_do_not_override_saved_memory_dirs(self) -> None:
+        mcp_clients = _read(_GUIDES / "mcp-clients.md")
+        ordinary, marker, overrides = mcp_clients.partition("## 10. Environment Variable Overrides")
+        assert marker
+        assert "MEMTOMEM_INDEXING__MEMORY_DIRS" not in ordinary
+        assert "MEMTOMEM_INDEXING__MEMORY_DIRS" in overrides
+        for name in ("claude-code.md", "cursor.md", "claude-desktop.md"):
+            assert "MEMTOMEM_INDEXING__MEMORY_DIRS" not in _read(_INTEGRATIONS / name)
+
+    def test_mcp_json_and_toml_examples_parse(self) -> None:
+        docs = [_GUIDES / "mcp-clients.md", *_INTEGRATIONS.glob("*.md")]
+        for doc in docs:
+            for index, block in enumerate(_fenced_blocks(_read(doc), "json"), start=1):
+                try:
+                    json.loads(block)
+                except json.JSONDecodeError as exc:
+                    pytest.fail(f"{doc.name} JSON block {index} is not copy-paste valid: {exc}")
+            for index, block in enumerate(_fenced_blocks(_read(doc), "toml"), start=1):
+                try:
+                    tomllib.loads(block)
+                except tomllib.TOMLDecodeError as exc:
+                    pytest.fail(f"{doc.name} TOML block {index} is not copy-paste valid: {exc}")
+
+    def test_hidden_qa_commands_stay_out_of_public_docs(self) -> None:
+        blob = "\n".join(_read(doc) for doc in _public_markdown())
+        assert "mm context seed-validation" not in blob
+        assert "mm agent debug-resolve" not in blob
+
+    def test_add_file_help_matches_scope_aware_path_resolution(self) -> None:
+        add = _CLI.commands["add"]
+        file_param = next(param for param in add.params if param.name == "file_name")
+        assert "selected scope's memory directory" in (file_param.help or "")
+        assert "~/.memtomem/memories" not in (file_param.help or "")

--- a/packages/memtomem/tests/test_docs_quickstart.py
+++ b/packages/memtomem/tests/test_docs_quickstart.py
@@ -1,0 +1,49 @@
+"""Runnable contract for the public documentation's first-success path."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+
+
+def test_documented_quickstart_round_trip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A fresh user can save and find one memory without existing notes."""
+    for name in tuple(os.environ):
+        if name.startswith("MEMTOMEM_"):
+            monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / ".local" / "share"))
+
+    runner = CliRunner()
+
+    init = runner.invoke(
+        cli,
+        ["init", "--non-interactive", "--preset", "minimal", "--mcp", "skip"],
+    )
+    assert init.exit_code == 0, init.output
+
+    empty_status = runner.invoke(cli, ["status", "--json"])
+    assert empty_status.exit_code == 0, empty_status.output
+    assert json.loads(empty_status.output)["index"]["total_chunks"] == 0
+
+    sentence = "Deployment checklist uses blue-green rollout"
+    add = runner.invoke(cli, ["add", sentence, "--tags", "ops", "--json"])
+    assert add.exit_code == 0, add.output
+    add_payload = json.loads(add.output)
+    assert add_payload["ok"] is True
+    assert add_payload["chunks"] == 1
+
+    search = runner.invoke(cli, ["search", "blue-green", "--format", "plain"])
+    assert search.exit_code == 0, search.output
+    assert sentence in search.output
+
+    populated_status = runner.invoke(cli, ["status", "--json"])
+    assert populated_status.exit_code == 0, populated_status.output
+    assert json.loads(populated_status.output)["index"]["total_chunks"] >= 1

--- a/packages/memtomem/tests/test_docs_quickstart.py
+++ b/packages/memtomem/tests/test_docs_quickstart.py
@@ -1,49 +1,108 @@
-"""Runnable contract for the public documentation's first-success path."""
+"""Runnable contract for the public documentation's first-success path.
+
+The Quickstart in the public READMEs and Getting Started guide promises a
+fresh user can ``mm init`` → ``mm status`` → ``mm add`` → ``mm search`` and
+find the memory back, with no existing notes directory or connected editor.
+
+This runs that exact journey through the installed ``mm`` entry point in a
+**subprocess**, not in-process via ``CliRunner``. Module-level constants
+like ``_bootstrap._CONFIG_PATH`` are bound at import time to the real
+``HOME``, so an in-process invocation reuses whatever ``HOME`` the test
+session imported under and cannot honor a per-test ``monkeypatch.setenv``
+— exactly the process-boundary gap ``test_context_cli_subprocess_e2e.py``
+documents (see #759). The subprocess re-resolves ``HOME`` / ``USERPROFILE``
+/ ``XDG_CONFIG_HOME`` on its own, so the round trip is genuinely isolated.
+"""
 
 from __future__ import annotations
 
 import json
 import os
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
-from click.testing import CliRunner
 
-from memtomem.cli import cli
+from .helpers import _MEMTOMEM_ENV_VARS
 
 
-def test_documented_quickstart_round_trip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_documented_quickstart_round_trip(tmp_path: Path) -> None:
     """A fresh user can save and find one memory without existing notes."""
-    for name in tuple(os.environ):
-        if name.startswith("MEMTOMEM_"):
-            monkeypatch.delenv(name, raising=False)
-    monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
-    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / ".local" / "share"))
+    # ``shutil.which`` adds the platform-correct suffix (``.exe`` on Windows
+    # via PATHEXT, none on POSIX), matching both ``.venv/bin/mm`` and
+    # ``.venv/Scripts/mm.exe``.
+    bin_dir = os.path.dirname(sys.executable)
+    mm_bin = shutil.which("mm", path=bin_dir)
+    # Fail loudly instead of pytest.skip — any valid test environment
+    # (``uv run pytest`` or ``uv pip install -e``) provides the ``mm`` entry
+    # point. A silent skip would turn this first-success guard into a CI
+    # false-green if the editable install is ever dropped.
+    if mm_bin is None:
+        pytest.fail(
+            f"mm binary not found in {bin_dir}. "
+            "Run `uv pip install -e packages/memtomem[all]` before testing."
+        )
 
-    runner = CliRunner()
+    home = tmp_path / "home"
+    home.mkdir()
 
-    init = runner.invoke(
-        cli,
-        ["init", "--non-interactive", "--preset", "minimal", "--mcp", "skip"],
-    )
-    assert init.exit_code == 0, init.output
+    env = os.environ.copy()
+    # ``HOME`` only isolates ``~/.memtomem/config.json`` reads; strip
+    # developer ``MEMTOMEM_*`` overrides so pydantic-settings does not
+    # re-point the subprocess at a real path (mirrors the subprocess e2e
+    # tests and ``helpers.isolate_memtomem_env``).
+    for var in _MEMTOMEM_ENV_VARS:
+        env.pop(var, None)
+    env["HOME"] = str(home)
+    env["USERPROFILE"] = str(home)  # Windows ``Path.home()`` priority
+    env["XDG_CONFIG_HOME"] = str(home / ".config")
+    env["XDG_DATA_HOME"] = str(home / ".local" / "share")
 
-    empty_status = runner.invoke(cli, ["status", "--json"])
-    assert empty_status.exit_code == 0, empty_status.output
-    assert json.loads(empty_status.output)["index"]["total_chunks"] == 0
+    def _run(*args: str) -> subprocess.CompletedProcess:
+        # ``encoding="utf-8"`` is required: ``text=True`` alone falls back to
+        # ``locale.getpreferredencoding(False)`` (``cp949`` on Korean
+        # Windows). The CLI emits UTF-8, so the reader would crash mid-decode
+        # and ``stdout`` come back ``None`` (#759).
+        return subprocess.run(
+            [mm_bin, *args],
+            env=env,
+            cwd=str(home),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=120,
+        )
+
+    def _status_json(result: subprocess.CompletedProcess) -> dict:
+        assert result.returncode == 0, (
+            f"status failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+        payload = json.loads(result.stdout)
+        # ``mm status --json`` emits ``{"error": ...}`` with exit code 0 on a
+        # ClickException (read-command JSON error shape), so returncode alone
+        # is too weak a guard — assert the report body is actually present.
+        assert "error" not in payload, f"status returned an error shape: {payload}"
+        return payload
+
+    init = _run("init", "--non-interactive", "--preset", "minimal", "--mcp", "skip")
+    assert init.returncode == 0, f"init failed:\nstdout={init.stdout}\nstderr={init.stderr}"
+
+    empty = _status_json(_run("status", "--json"))
+    assert empty["index"]["total_chunks"] == 0
 
     sentence = "Deployment checklist uses blue-green rollout"
-    add = runner.invoke(cli, ["add", sentence, "--tags", "ops", "--json"])
-    assert add.exit_code == 0, add.output
-    add_payload = json.loads(add.output)
-    assert add_payload["ok"] is True
-    assert add_payload["chunks"] == 1
+    add = _run("add", sentence, "--tags", "ops", "--json")
+    assert add.returncode == 0, f"add failed:\nstdout={add.stdout}\nstderr={add.stderr}"
+    add_payload = json.loads(add.stdout)
+    assert add_payload["ok"] is True, add_payload
+    assert add_payload["chunks"] == 1, add_payload
 
-    search = runner.invoke(cli, ["search", "blue-green", "--format", "plain"])
-    assert search.exit_code == 0, search.output
-    assert sentence in search.output
+    search = _run("search", "blue-green", "--format", "plain")
+    assert search.returncode == 0, f"search failed:\nstdout={search.stdout}\nstderr={search.stderr}"
+    assert sentence in search.stdout, search.stdout
 
-    populated_status = runner.invoke(cli, ["status", "--json"])
-    assert populated_status.exit_code == 0, populated_status.output
-    assert json.loads(populated_status.output)["index"]["total_chunks"] >= 1
+    populated = _status_json(_run("status", "--json"))
+    assert populated["index"]["total_chunks"] >= 1


### PR DESCRIPTION
## Summary
- align GitHub and PyPI onboarding around a deterministic init, status, add, and search journey
- reorganize the guide map and clarify MCP config, Context Gateway, privacy audit, and security contracts
- expand documentation guards and add an isolated Quick Start smoke test

## Verification
- uv run pytest packages/memtomem/tests/test_docs_guards.py packages/memtomem/tests/test_docs_quickstart.py packages/memtomem/tests/test_cli.py::TestSubcommandHelp::test_add_help -q
- uv run ruff check on modified Python files
- uv run ruff format --check on modified Python files
- git diff --check