### PR TITLE
feat(web): harden startup readiness and search filters

### DIFF
--- a/packages/memtomem/src/memtomem/cli/web.py
+++ b/packages/memtomem/src/memtomem/cli/web.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import atexit
 import contextlib
+import http.client
 import json
 import os
 import signal
@@ -252,7 +253,11 @@ def _run_foreground(config: _WebRunConfig) -> None:
         f"Starting memtomem Web UI at http://{config.host}:{config.port} (mode={resolved_mode})"
     )
 
-    async def after_started(server: uvicorn.Server, timeout: float) -> None:
+    async def after_started(
+        server: uvicorn.Server,
+        serve_task: asyncio.Task[None],
+        timeout: float,
+    ) -> None:
         if not config.open_browser:
             return
 
@@ -265,9 +270,19 @@ def _run_foreground(config: _WebRunConfig) -> None:
         else:
             deadline = time.monotonic() + timeout
         while not server.started:
+            if serve_task.done():
+                return
             if time.monotonic() >= deadline:
                 click.secho(
                     "Warning: Web server did not start within the timeout period; not opening browser.",
+                    fg="yellow",
+                )
+                return
+            await asyncio.sleep(0.1)
+        while not await asyncio.to_thread(_readiness_ok, config.host, config.port):
+            if serve_task.done() or time.monotonic() >= deadline:
+                click.secho(
+                    "Warning: Web backend did not become ready; not opening browser.",
                     fg="yellow",
                 )
                 return
@@ -294,10 +309,13 @@ def _run_foreground(config: _WebRunConfig) -> None:
         )
         web_server = uvicorn.Server(web_config)
 
-        await asyncio.gather(
-            web_server.serve(),
-            after_started(web_server, timeout=float(config.timeout)),
+        serve_task = asyncio.create_task(web_server.serve())
+        opener_task = asyncio.create_task(
+            after_started(web_server, serve_task, timeout=float(config.timeout))
         )
+        await asyncio.gather(serve_task, opener_task)
+        if not web_server.started:
+            raise click.ClickException("Web UI failed during startup. See the startup log above.")
 
     with _web_pid_lock(config.port):
         asyncio.run(start_server())
@@ -330,6 +348,36 @@ def _wait_for_tcp(host: str, port: int, *, timeout: float, child: subprocess.Pop
                 return True
         except OSError:
             time.sleep(0.1)
+    return False
+
+
+def _readiness_ok(host: str, port: int) -> bool:
+    conn = http.client.HTTPConnection(_connect_host(host), port, timeout=0.5)
+    try:
+        conn.request("GET", "/api/readiness")
+        response = conn.getresponse()
+        response.read()
+        return response.status == 200
+    except (OSError, http.client.HTTPException):
+        return False
+    finally:
+        conn.close()
+
+
+def _wait_for_readiness(
+    host: str,
+    port: int,
+    *,
+    timeout: float,
+    child: subprocess.Popen[bytes],
+) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if child.poll() is not None:
+            return False
+        if _readiness_ok(host, port):
+            return True
+        time.sleep(0.1)
     return False
 
 
@@ -407,11 +455,19 @@ def _spawn_background(config: _WebRunConfig, log_file: Path | None) -> None:
         )
 
     timeout = float(config.timeout if config.timeout > 0 else 30)
-    if not _wait_for_tcp(config.host, port, timeout=timeout, child=child):
+    if not _wait_for_readiness(config.host, port, timeout=timeout, child=child):
         tail = _tail_file(log_path)
         if child.poll() is None:
             with contextlib.suppress(OSError):
                 child.terminate()
+            try:
+                child.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                with contextlib.suppress(OSError):
+                    child.kill()
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    child.wait(timeout=2)
+        _remove_stale_web_files()
         message = f"Web UI did not start within {timeout:g}s. See log: {log_path}"
         if tail:
             message = f"{message}\n\nLast log output:\n{tail.rstrip()}"

--- a/packages/memtomem/src/memtomem/errors.py
+++ b/packages/memtomem/src/memtomem/errors.py
@@ -9,6 +9,27 @@ class StorageError(Mem2MemError):
     """Storage backend error."""
 
 
+class StorageStartupError(StorageError):
+    """Classified, path-safe storage initialization failure."""
+
+    def __init__(
+        self,
+        *,
+        reason_code: str,
+        stage: str,
+        retryable: bool = False,
+        sqlite_code: int | None = None,
+    ) -> None:
+        self.reason_code = reason_code
+        self.stage = stage
+        self.retryable = retryable
+        self.sqlite_code = sqlite_code
+        super().__init__(
+            f"Storage startup failed ({reason_code}, stage={stage}). "
+            "Check the configured database directory and its SQLite WAL/SHM permissions."
+        )
+
+
 class EmbeddingDimensionMismatchError(StorageError):
     """Raised when stored embedding dimension is 0 but a real provider is configured.
 

--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -13,7 +13,7 @@ from watchdog.observers import Observer
 from memtomem.config import IndexingConfig
 
 if TYPE_CHECKING:
-    from watchdog.observers.api import BaseObserver
+    from watchdog.observers.api import BaseObserver, ObservedWatch
 
     from memtomem.indexing.engine import IndexEngine
 
@@ -123,10 +123,14 @@ class FileWatcher:
         self._queue: asyncio.Queue[Path] = asyncio.Queue(maxsize=_WATCHER_QUEUE_MAXSIZE)
         self._task: asyncio.Task[None] | None = None
         self._backfill_task: asyncio.Task[None] | None = None
+        self._handler: _MarkdownEventHandler | None = None
+        self._watches: dict[Path, ObservedWatch] = {}
+        self._reconfigure_lock = asyncio.Lock()
 
     async def start(self) -> None:
         loop = asyncio.get_running_loop()
         handler = _MarkdownEventHandler(self._queue, loop, self._config.supported_extensions)
+        self._handler = handler
         self._observer = Observer()
 
         watched: list[Path] = []
@@ -137,7 +141,8 @@ class FileWatcher:
         for watch_dir in self._config.all_index_roots():
             expanded = Path(watch_dir).expanduser().resolve()
             if expanded.exists():
-                self._observer.schedule(handler, str(expanded), recursive=True)
+                watch = self._observer.schedule(handler, str(expanded), recursive=True)
+                self._watches[expanded] = watch
                 logger.info("Watching %s for changes", expanded)
                 watched.append(expanded)
 
@@ -145,6 +150,41 @@ class FileWatcher:
         self._task = asyncio.create_task(self._process_events())
         if watched and self._config.startup_backfill:
             self._backfill_task = asyncio.create_task(self._backfill_existing(watched))
+
+    async def reconfigure(self, config: IndexingConfig) -> None:
+        """Reconcile live watchdog roots after a successful config change."""
+        async with self._reconfigure_lock:
+            observer = self._observer
+            handler = self._handler
+            if observer is None or handler is None:
+                self._config = config
+                return
+
+            desired = {
+                Path(path).expanduser().resolve()
+                for path in config.all_index_roots()
+                if Path(path).expanduser().resolve().exists()
+            }
+            current = set(self._watches)
+            added: list[Path] = []
+            try:
+                for path in sorted(desired - current):
+                    watch = observer.schedule(handler, str(path), recursive=True)
+                    self._watches[path] = watch
+                    added.append(path)
+                for path in sorted(current - desired):
+                    observer.unschedule(self._watches.pop(path))
+            except Exception:
+                for path in added:
+                    rollback_watch = self._watches.pop(path, None)
+                    if rollback_watch is not None:
+                        try:
+                            observer.unschedule(rollback_watch)
+                        except Exception:
+                            logger.debug("Failed to rollback watcher schedule", exc_info=True)
+                raise
+            handler._supported = config.supported_extensions
+            self._config = config
 
     async def stop(self) -> None:
         if self._backfill_task is not None and not self._backfill_task.done():
@@ -174,6 +214,11 @@ class FileWatcher:
         if self._observer:
             self._observer.stop()
             self._observer.join()
+        self._observer = None
+        self._handler = None
+        self._watches.clear()
+        self._task = None
+        self._backfill_task = None
 
     async def _backfill_existing(self, dirs: list[Path]) -> None:
         """Index pre-existing files the observer can't see.

--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -167,13 +167,16 @@ class FileWatcher:
             }
             current = set(self._watches)
             added: list[Path] = []
+            removed: list[Path] = []
             try:
                 for path in sorted(desired - current):
                     watch = observer.schedule(handler, str(path), recursive=True)
                     self._watches[path] = watch
                     added.append(path)
                 for path in sorted(current - desired):
-                    observer.unschedule(self._watches.pop(path))
+                    observer.unschedule(self._watches[path])
+                    self._watches.pop(path)
+                    removed.append(path)
             except Exception:
                 for path in added:
                     rollback_watch = self._watches.pop(path, None)
@@ -182,6 +185,11 @@ class FileWatcher:
                             observer.unschedule(rollback_watch)
                         except Exception:
                             logger.debug("Failed to rollback watcher schedule", exc_info=True)
+                for path in removed:
+                    try:
+                        self._watches[path] = observer.schedule(handler, str(path), recursive=True)
+                    except Exception:
+                        logger.error("Failed to restore watcher during rollback: %s", path)
                 raise
             handler._supported = config.supported_extensions
             self._config = config

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -183,12 +183,17 @@ def _matches_metadata(result: SearchResult, metadata_filter: SearchMetadataFilte
     if metadata_filter.chunk_types:
         if str(chunk.metadata.chunk_type) not in set(metadata_filter.chunk_types):
             return False
-    if metadata_filter.created_from is not None and chunk.created_at < metadata_filter.created_from:
+    created_at = chunk.created_at
+    if created_at.tzinfo is None:
+        # Legacy/imported rows may carry an offset-less ISO timestamp. The
+        # storage contract has always treated those values as UTC, so preserve
+        # that meaning before comparing with the route's aware UTC bounds.
+        created_at = created_at.replace(tzinfo=UTC)
+    else:
+        created_at = created_at.astimezone(UTC)
+    if metadata_filter.created_from is not None and created_at < metadata_filter.created_from:
         return False
-    if (
-        metadata_filter.created_before is not None
-        and chunk.created_at >= metadata_filter.created_before
-    ):
+    if metadata_filter.created_before is not None and created_at >= metadata_filter.created_before:
         return False
     return True
 
@@ -597,25 +602,15 @@ class SearchPipeline:
         # workflow; revisit if a "show me old-but-important by tag" need
         # surfaces.
         candidate_limit = max(top_k * 5, 100)
-        if metadata_filter is not None:
-            chunks = await self._storage.recall_chunks(
-                source_filter=source_filter,
-                tag_filter=tag_filter,
-                namespace_filter=ns_filter,
-                scope_filter=scope_filter,
-                project_context_root=project_context_root,
-                limit=candidate_limit,
-                metadata_filter=metadata_filter,
-            )
-        else:
-            chunks = await self._storage.recall_chunks(
-                source_filter=source_filter,
-                tag_filter=tag_filter,
-                namespace_filter=ns_filter,
-                scope_filter=scope_filter,
-                project_context_root=project_context_root,
-                limit=candidate_limit,
-            )
+        chunks = await self._storage.recall_chunks(
+            source_filter=source_filter,
+            tag_filter=tag_filter,
+            namespace_filter=ns_filter,
+            scope_filter=scope_filter,
+            project_context_root=project_context_root,
+            limit=candidate_limit,
+            metadata_filter=metadata_filter,
+        )
 
         fused: list[SearchResult] = [
             SearchResult(chunk=c, score=1.0, rank=i + 1, source="recall")
@@ -1079,8 +1074,14 @@ class SearchPipeline:
         ctx_win = self._resolve_context_window(context_window)
         if ctx_win > 0 and fused:
             fused = await self._expand_context(fused, ctx_win)
-            if metadata_filter is not None:
-                fused = [r for r in fused if _matches_metadata(r, metadata_filter)]
+            if metadata_filter is not None and metadata_filter.source_exact:
+                # Context neighbors belong to the selected source but may have
+                # a different chunk type or timestamp. Keep that surrounding
+                # context while preserving the exact-source boundary.
+                allowed_sources = {norm_path(Path(value)) for value in metadata_filter.source_exact}
+                fused = [
+                    r for r in fused if norm_path(r.chunk.metadata.source_file) in allowed_sources
+                ]
 
         # Re-stamp ``via_session_summary`` for any chunk that came in
         # via the rescue leg. Downstream stages (decay, MMR, access,

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import datetime
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -58,6 +59,8 @@ from memtomem.config import (
 )
 from memtomem.models import ContextInfo, NamespaceFilter, ScopeFilter, SearchResult
 from memtomem.search.fusion import reciprocal_rank_fusion
+from memtomem.storage.base import SearchMetadataFilter
+from memtomem.storage.sqlite_helpers import norm_path
 
 logger = logging.getLogger(__name__)
 
@@ -169,6 +172,27 @@ def match_source_filter_glob(filter_str: str, source_path: str) -> bool:
     return fnmatch(source_path.replace("\\", "/"), filter_str.replace("\\", "/"))
 
 
+def _matches_metadata(result: SearchResult, metadata_filter: SearchMetadataFilter | None) -> bool:
+    if metadata_filter is None:
+        return True
+    chunk = result.chunk
+    if metadata_filter.source_exact:
+        allowed = {norm_path(Path(value)) for value in metadata_filter.source_exact}
+        if norm_path(chunk.metadata.source_file) not in allowed:
+            return False
+    if metadata_filter.chunk_types:
+        if str(chunk.metadata.chunk_type) not in set(metadata_filter.chunk_types):
+            return False
+    if metadata_filter.created_from is not None and chunk.created_at < metadata_filter.created_from:
+        return False
+    if (
+        metadata_filter.created_before is not None
+        and chunk.created_at >= metadata_filter.created_before
+    ):
+        return False
+    return True
+
+
 def _apply_validity_filter(results: list[SearchResult], as_of_unix: int) -> list[SearchResult]:
     """Drop chunks whose temporal-validity window excludes ``as_of_unix``.
 
@@ -276,6 +300,7 @@ class SearchPipeline:
         context_window: int | None = None,
         scope: str | list[str] | None = None,
         project_context_root: Path | None = None,
+        metadata_filter: SearchMetadataFilter | None = None,
     ) -> str:
         import hashlib
 
@@ -299,6 +324,7 @@ class SearchPipeline:
             f"|ctx_win={ctx_win}"
             f"|rerank={rerank_signal}"
             f"|scope={scope_signal}"
+            f"|metadata={metadata_filter}"
         )
         return hashlib.md5(raw.encode()).hexdigest()
 
@@ -406,6 +432,7 @@ class SearchPipeline:
         use_dense: bool,
         scope_filter: ScopeFilter | None = None,
         project_context_root: Path | None = None,
+        metadata_filter: SearchMetadataFilter | None = None,
     ) -> list[SearchResult]:
         """Parallel BM25+dense retrieval restricted to boost_sources.
 
@@ -426,6 +453,9 @@ class SearchPipeline:
         # Cast a slightly wider net so source filtering still leaves a
         # useful candidate pool. Bounded by existing candidate caps.
         oversample = max(top_k, self._config.bm25_candidates)
+        metadata_kwargs = (
+            {"metadata_filter": metadata_filter} if metadata_filter is not None else {}
+        )
 
         async def _bm25_leg() -> list[SearchResult]:
             if not use_bm25:
@@ -437,6 +467,7 @@ class SearchPipeline:
                     namespace_filter=None,
                     scope_filter=scope_filter,
                     project_context_root=project_context_root,
+                    **metadata_kwargs,
                 )
             except Exception:
                 _log_rescue_failure("bm25_leg", "rescue bm25 leg failed")
@@ -453,6 +484,7 @@ class SearchPipeline:
                     namespace_filter=None,
                     scope_filter=scope_filter,
                     project_context_root=project_context_root,
+                    **metadata_kwargs,
                 )
             except Exception:
                 _log_rescue_failure("dense_leg", "rescue dense leg failed")
@@ -530,6 +562,7 @@ class SearchPipeline:
         as_of_unix: int | None,
         scope_filter: ScopeFilter | None = None,
         project_context_root: Path | None = None,
+        metadata_filter: SearchMetadataFilter | None = None,
     ) -> tuple[list[SearchResult], RetrievalStats]:
         """Empty-query path (#750): enumerate by filter, skip retrievers.
 
@@ -564,14 +597,25 @@ class SearchPipeline:
         # workflow; revisit if a "show me old-but-important by tag" need
         # surfaces.
         candidate_limit = max(top_k * 5, 100)
-        chunks = await self._storage.recall_chunks(
-            source_filter=source_filter,
-            tag_filter=tag_filter,
-            namespace_filter=ns_filter,
-            scope_filter=scope_filter,
-            project_context_root=project_context_root,
-            limit=candidate_limit,
-        )
+        if metadata_filter is not None:
+            chunks = await self._storage.recall_chunks(
+                source_filter=source_filter,
+                tag_filter=tag_filter,
+                namespace_filter=ns_filter,
+                scope_filter=scope_filter,
+                project_context_root=project_context_root,
+                limit=candidate_limit,
+                metadata_filter=metadata_filter,
+            )
+        else:
+            chunks = await self._storage.recall_chunks(
+                source_filter=source_filter,
+                tag_filter=tag_filter,
+                namespace_filter=ns_filter,
+                scope_filter=scope_filter,
+                project_context_root=project_context_root,
+                limit=candidate_limit,
+            )
 
         fused: list[SearchResult] = [
             SearchResult(chunk=c, score=1.0, rank=i + 1, source="recall")
@@ -644,6 +688,10 @@ class SearchPipeline:
         as_of_unix: int | None = None,
         scope: str | list[str] | None = None,
         project_context_root: Path | None = None,
+        source_exact: list[str] | tuple[str, ...] | None = None,
+        chunk_types: list[str] | tuple[str, ...] | None = None,
+        created_from: datetime | None = None,
+        created_before: datetime | None = None,
     ) -> tuple[list[SearchResult], RetrievalStats]:
         # #750: tag/source-only branch — no keyword to rank by, so the
         # filter takes over as the primary selector. We enumerate via
@@ -652,9 +700,25 @@ class SearchPipeline:
         # importance, ctx-window) still apply so ranking reflects
         # recency × access × importance.
         scope_filter = ScopeFilter.parse(scope)
+        metadata_candidate = SearchMetadataFilter(
+            source_exact=tuple(sorted(set(source_exact or ()))),
+            chunk_types=tuple(sorted(set(chunk_types or ()))),
+            created_from=created_from,
+            created_before=created_before,
+        )
+        metadata_filter: SearchMetadataFilter | None = metadata_candidate
+        if not any(
+            (
+                metadata_candidate.source_exact,
+                metadata_candidate.chunk_types,
+                metadata_candidate.created_from,
+                metadata_candidate.created_before,
+            )
+        ):
+            metadata_filter = None
         query = (query or "").strip()
         if not query:
-            if not (tag_filter or source_filter):
+            if not (tag_filter or source_filter or metadata_filter):
                 return [], RetrievalStats()
             return await self._filter_only_search(
                 top_k=top_k,
@@ -665,6 +729,7 @@ class SearchPipeline:
                 as_of_unix=as_of_unix,
                 scope_filter=scope_filter,
                 project_context_root=project_context_root,
+                metadata_filter=metadata_filter,
             )
 
         top_k = self._config.default_top_k if top_k is None else top_k
@@ -688,6 +753,7 @@ class SearchPipeline:
             context_window,
             scope=scope,
             project_context_root=project_context_root,
+            metadata_filter=metadata_filter,
         )
         version_at_start = self._cache_version
         ttl_snapshot = self._cache_ttl
@@ -718,6 +784,9 @@ class SearchPipeline:
 
         use_bm25 = self._config.enable_bm25
         use_dense = self._config.enable_dense
+        metadata_kwargs = (
+            {"metadata_filter": metadata_filter} if metadata_filter is not None else {}
+        )
 
         # Stage 0: Query expansion
         if self._expansion_config and getattr(self._expansion_config, "enabled", False):
@@ -777,6 +846,7 @@ class SearchPipeline:
                     namespace_filter=ns_filter,
                     scope_filter=scope_filter,
                     project_context_root=project_context_root,
+                    **metadata_kwargs,
                 )
             )
         dense_error: str | None = None
@@ -789,6 +859,7 @@ class SearchPipeline:
                     namespace_filter=ns_filter,
                     scope_filter=scope_filter,
                     project_context_root=project_context_root,
+                    **metadata_kwargs,
                 )
             except Exception as exc:
                 logger.warning("Dense search unavailable: %s", exc)
@@ -844,6 +915,7 @@ class SearchPipeline:
                         use_dense=use_dense,
                         scope_filter=scope_filter,
                         project_context_root=project_context_root,
+                        metadata_filter=metadata_filter,
                     )
                     rescue_chunk_ids = {r.chunk.id for r in rescue_results}
             except Exception:
@@ -944,6 +1016,9 @@ class SearchPipeline:
             required = {t.strip() for t in tag_filter.split(",") if t.strip()}
             fused = [r for r in fused if required & set(r.chunk.metadata.tags)]
 
+        if metadata_filter is not None:
+            fused = [r for r in fused if _matches_metadata(r, metadata_filter)]
+
         # Stage β': temporal-validity filter (RFC §Pipeline integration).
         # AND-combined with source/tag filter via sequential application —
         # a chunk must pass both to survive. Default ``as_of`` is the
@@ -1004,6 +1079,8 @@ class SearchPipeline:
         ctx_win = self._resolve_context_window(context_window)
         if ctx_win > 0 and fused:
             fused = await self._expand_context(fused, ctx_win)
+            if metadata_filter is not None:
+                fused = [r for r in fused if _matches_metadata(r, metadata_filter)]
 
         # Re-stamp ``via_session_summary`` for any chunk that came in
         # via the rescue leg. Downstream stages (decay, MMR, access,

--- a/packages/memtomem/src/memtomem/server/component_factory.py
+++ b/packages/memtomem/src/memtomem/server/component_factory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+import inspect
 import logging
 
 from memtomem.chunking.base import Chunker
@@ -25,6 +26,21 @@ if TYPE_CHECKING:
     from memtomem.llm.base import LLMProvider
 
 _log = logging.getLogger(__name__)
+
+
+async def _close_resource(resource: object | None, label: str) -> None:
+    """Best-effort close used by both startup rollback and normal shutdown."""
+    if resource is None:
+        return
+    close = getattr(resource, "close", None)
+    if not callable(close):
+        return
+    try:
+        result = close()
+        if inspect.isawaitable(result):
+            await result
+    except BaseException:
+        _log.warning("Failed to close %s", label, exc_info=True)
 
 
 @dataclass
@@ -61,6 +77,9 @@ async def create_components(config: Mem2MemConfig | None = None) -> Components:
     storage = create_storage(config)
     embedder: EmbeddingProvider | None = None
     embedding_broken: dict | None = None
+    reranker: object | None = None
+    llm: LLMProvider | None = None
+    search_pipeline: SearchPipeline | None = None
     try:
         embedder = create_embedder(config.embedding)
         await storage.initialize()
@@ -104,91 +123,94 @@ async def create_components(config: Mem2MemConfig | None = None) -> Components:
         raise
     assert embedder is not None
 
-    # Build chunker registry with optional code chunkers
-    chunkers: list[Chunker] = [
-        MarkdownChunker(indexing_config=config.indexing),
-        StructuredChunker(indexing_config=config.indexing),
-        ReStructuredTextChunker(),
-    ]
     try:
-        from memtomem.chunking.python_code import PythonChunker
+        # Build chunker registry with optional code chunkers
+        chunkers: list[Chunker] = [
+            MarkdownChunker(indexing_config=config.indexing),
+            StructuredChunker(indexing_config=config.indexing),
+            ReStructuredTextChunker(),
+        ]
+        try:
+            from memtomem.chunking.python_code import PythonChunker
 
-        chunkers.append(PythonChunker())
-    except Exception:
-        _log.warning(
-            "PythonChunker unavailable — install memtomem[all] to enable tree-sitter code chunking",
-            exc_info=True,
+            chunkers.append(PythonChunker())
+        except Exception:
+            _log.warning(
+                "PythonChunker unavailable — install memtomem[all] to enable tree-sitter code chunking",
+                exc_info=True,
+            )
+        try:
+            from memtomem.chunking.javascript import JavaScriptChunker
+
+            chunkers.append(JavaScriptChunker())
+        except Exception:
+            _log.warning(
+                "JavaScriptChunker unavailable — install memtomem[all] to enable tree-sitter code chunking",
+                exc_info=True,
+            )
+        registry = ChunkerRegistry(chunkers)
+
+        if config.rerank.enabled:
+            from memtomem.search.reranker.factory import create_reranker
+
+            reranker = create_reranker(config.rerank)
+
+        # One shared LLM client serves indexing and search.
+        if config.llm.enabled:
+            from memtomem.llm.factory import create_llm
+
+            llm = create_llm(config.llm)
+
+        index_engine = IndexEngine(
+            storage=storage,
+            embedder=embedder,
+            config=config.indexing,
+            registry=registry,
+            namespace_config=config.namespace,
+            progress_threshold=config.embedding.progress_threshold,
+            llm=llm,
         )
-    try:
-        from memtomem.chunking.javascript import JavaScriptChunker
 
-        chunkers.append(JavaScriptChunker())
-    except Exception:
-        _log.warning(
-            "JavaScriptChunker unavailable — install memtomem[all] to enable tree-sitter code chunking",
-            exc_info=True,
+        search_pipeline = SearchPipeline(
+            storage=storage,
+            embedder=embedder,
+            config=config.search,
+            decay_config=config.decay,
+            mmr_config=config.mmr,
+            access_config=config.access,
+            reranker=reranker,
+            rerank_config=config.rerank,
+            expansion_config=config.query_expansion,
+            importance_config=config.importance,
+            context_window_config=config.context_window,
+            llm_provider=llm,
+            session_summary_config=config.session_summary,
         )
-    registry = ChunkerRegistry(chunkers)
 
-    # Create optional reranker
-    reranker = None
-    if config.rerank.enabled:
-        from memtomem.search.reranker.factory import create_reranker
-
-        reranker = create_reranker(config.rerank)
-
-    # Create optional LLM provider once and share it with both the index
-    # engine (per-source AI summary) and the search pipeline. Created
-    # before ``IndexEngine`` so the engine can hold the same instance —
-    # one shared client keeps connection-pool / rate-limit behaviour
-    # consistent across the two consumers.
-    llm: LLMProvider | None = None
-    if config.llm.enabled:
-        from memtomem.llm.factory import create_llm
-
-        llm = create_llm(config.llm)
-
-    index_engine = IndexEngine(
-        storage=storage,
-        embedder=embedder,
-        config=config.indexing,
-        registry=registry,
-        namespace_config=config.namespace,
-        progress_threshold=config.embedding.progress_threshold,
-        llm=llm,
-    )
-
-    search_pipeline = SearchPipeline(
-        storage=storage,
-        embedder=embedder,
-        config=config.search,
-        decay_config=config.decay,
-        mmr_config=config.mmr,
-        access_config=config.access,
-        reranker=reranker,
-        rerank_config=config.rerank,
-        expansion_config=config.query_expansion,
-        importance_config=config.importance,
-        context_window_config=config.context_window,
-        llm_provider=llm,
-        session_summary_config=config.session_summary,
-    )
-
-    return Components(
-        config=config,
-        storage=storage,
-        embedder=embedder,
-        index_engine=index_engine,
-        search_pipeline=search_pipeline,
-        llm=llm,
-        embedding_broken=embedding_broken,
-    )
+        return Components(
+            config=config,
+            storage=storage,
+            embedder=embedder,
+            index_engine=index_engine,
+            search_pipeline=search_pipeline,
+            llm=llm,
+            embedding_broken=embedding_broken,
+        )
+    except BaseException:
+        # Once SearchPipeline exists it owns the reranker. Before that point
+        # the factory owns and closes a standalone reranker itself.
+        await _close_resource(search_pipeline, "search pipeline")
+        if search_pipeline is None:
+            await _close_resource(reranker, "reranker")
+        await _close_resource(llm, "LLM provider")
+        await _close_resource(embedder, "embedder")
+        await _close_resource(storage, "storage")
+        raise
 
 
 async def close_components(comp: Components) -> None:
-    """Shut down components in reverse order."""
-    if comp.llm is not None:
-        await comp.llm.close()
-    await comp.search_pipeline.close()
-    await comp.embedder.close()
-    await comp.storage.close()
+    """Shut down every component even when an earlier close fails."""
+    await _close_resource(comp.search_pipeline, "search pipeline")
+    await _close_resource(comp.llm, "LLM provider")
+    await _close_resource(comp.embedder, "embedder")
+    await _close_resource(comp.storage, "storage")

--- a/packages/memtomem/src/memtomem/storage/base.py
+++ b/packages/memtomem/src/memtomem/storage/base.py
@@ -32,6 +32,16 @@ class ChunkAuditRow:
     project_root: Path | None
 
 
+@dataclass(frozen=True, slots=True)
+class SearchMetadataFilter:
+    """Exact metadata constraints applied before retrieval limits."""
+
+    source_exact: tuple[str, ...] = ()
+    chunk_types: tuple[str, ...] = ()
+    created_from: datetime | None = None
+    created_before: datetime | None = None
+
+
 class StorageBackend(Protocol):
     async def initialize(self) -> None: ...
     async def close(self) -> None: ...
@@ -72,6 +82,7 @@ class StorageBackend(Protocol):
         namespace_filter: NamespaceFilter | None = None,
         scope_filter: ScopeFilter | None = None,
         project_context_root: Path | None = None,
+        metadata_filter: SearchMetadataFilter | None = None,
     ) -> list[SearchResult]: ...
     async def dense_search(
         self,
@@ -80,6 +91,7 @@ class StorageBackend(Protocol):
         namespace_filter: NamespaceFilter | None = None,
         scope_filter: ScopeFilter | None = None,
         project_context_root: Path | None = None,
+        metadata_filter: SearchMetadataFilter | None = None,
     ) -> list[SearchResult]: ...
 
     # Metadata
@@ -108,6 +120,7 @@ class StorageBackend(Protocol):
         tag_filter: str | None = None,
         scope_filter: ScopeFilter | None = None,
         project_context_root: Path | None = None,
+        metadata_filter: SearchMetadataFilter | None = None,
     ) -> list[Chunk]: ...
 
     # Audit enumeration (independent of search / recall paths)

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import hashlib
 import json
 import logging
@@ -17,8 +18,13 @@ from uuid import UUID
 import sqlite_vec
 
 from memtomem.config import StorageConfig
-from memtomem.errors import StorageError
-from memtomem.storage.base import ChunkAuditRow
+from memtomem.errors import (
+    EmbeddingDimensionMismatchError,
+    SchemaDowngradeError,
+    StorageError,
+    StorageStartupError,
+)
+from memtomem.storage.base import ChunkAuditRow, SearchMetadataFilter
 from memtomem.models import (
     Chunk,
     ChunkMetadata,
@@ -77,6 +83,73 @@ _REBUILD_FTS_BATCH_SIZE = 1000
 _AI_SUMMARY_KEY_PREFIX = "ai_summary:"
 
 
+def _classify_startup_error(exc: BaseException, stage: str) -> StorageStartupError:
+    sqlite_code = getattr(exc, "sqlite_errorcode", None)
+    base_code = sqlite_code & 0xFF if isinstance(sqlite_code, int) else None
+    os_errno = getattr(exc, "errno", None)
+
+    if (
+        isinstance(exc, PermissionError)
+        or os_errno in {errno.EACCES, errno.EPERM}
+        or base_code == sqlite3.SQLITE_READONLY
+    ):
+        reason = "storage_permission_denied"
+    elif base_code in {sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED}:
+        reason = "storage_locked"
+    elif (
+        isinstance(exc, (FileNotFoundError, NotADirectoryError))
+        or os_errno in {errno.ENOENT, errno.ENOTDIR}
+        or base_code in {sqlite3.SQLITE_CANTOPEN, sqlite3.SQLITE_IOERR}
+    ):
+        reason = "storage_path_unavailable"
+    else:
+        # Some Python/SQLite builds omit ``sqlite_errorcode``. Keep a narrow
+        # compatibility fallback without exposing the original message.
+        text = str(exc).lower()
+        if "readonly" in text or "permission denied" in text:
+            reason = "storage_permission_denied"
+        elif "database is locked" in text or "database table is locked" in text:
+            reason = "storage_locked"
+        elif "unable to open database" in text or "disk i/o" in text:
+            reason = "storage_path_unavailable"
+        else:
+            reason = "storage_unavailable"
+
+    return StorageStartupError(
+        reason_code=reason,
+        stage=stage,
+        retryable=reason == "storage_locked",
+        sqlite_code=sqlite_code if isinstance(sqlite_code, int) else None,
+    )
+
+
+def _metadata_filter_sql(
+    metadata_filter: SearchMetadataFilter | None,
+    *,
+    column_alias: str = "",
+) -> tuple[str, list[object]]:
+    if metadata_filter is None:
+        return "", []
+    conditions: list[str] = []
+    params: list[object] = []
+    if metadata_filter.source_exact:
+        values = [norm_path(Path(value)) for value in metadata_filter.source_exact]
+        conditions.append(f"{column_alias}source_file IN ({placeholders(len(values))})")
+        params.extend(values)
+    if metadata_filter.chunk_types:
+        conditions.append(
+            f"{column_alias}chunk_type IN ({placeholders(len(metadata_filter.chunk_types))})"
+        )
+        params.extend(metadata_filter.chunk_types)
+    if metadata_filter.created_from is not None:
+        conditions.append(f"{column_alias}created_at >= ?")
+        params.append(metadata_filter.created_from.isoformat())
+    if metadata_filter.created_before is not None:
+        conditions.append(f"{column_alias}created_at < ?")
+        params.append(metadata_filter.created_before.isoformat())
+    return " AND ".join(conditions), params
+
+
 def _ai_summary_key(source_file: Path) -> str:
     return f"{_AI_SUMMARY_KEY_PREFIX}{norm_path(source_file)}"
 
@@ -131,6 +204,9 @@ class SqliteBackend(
         self._meta: MetaManager | None = None
         self._ns: NamespaceOps | None = None
         self._in_transaction: bool = False
+        self._read_pool: list[sqlite3.Connection] = []
+        self._read_pool_idx = 0
+        self._read_pool_lock = threading.Lock()
         # In-process serialization for tag-management read-modify-write
         # paths (rename / delete / merge) and ``auto_tag_storage`` so they
         # can't interleave on the same chunks.tags column. Cross-process
@@ -145,15 +221,19 @@ class SqliteBackend(
 
     async def initialize(self) -> None:
         db_path = Path(self._config.sqlite_path).expanduser()
-        db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        stage = "parent"
+        try:
+            db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
 
-        self._db = sqlite3.connect(str(db_path), timeout=10)
-        # Restrict DB file to owner-only access
-        try:
-            db_path.chmod(0o600)
-        except OSError:
-            pass  # May fail on some filesystems
-        try:
+            stage = "open"
+            self._db = sqlite3.connect(str(db_path), timeout=10)
+            # Restrict DB file to owner-only access
+            try:
+                db_path.chmod(0o600)
+            except OSError:
+                pass  # May fail on some filesystems
+
+            stage = "extension"
             self._db.enable_load_extension(True)
             sqlite_vec.load(self._db)
             self._db.enable_load_extension(False)
@@ -161,33 +241,28 @@ class SqliteBackend(
             # below mutate the DB file, and a refused open (newer DB, older
             # binary) must leave it byte-identical for the newer release.
             check_schema_downgrade(self._db)
-        except Exception:
-            self._db.close()
-            self._db = None
-            raise
 
-        self._db.execute("PRAGMA journal_mode=WAL")
-        self._db.execute("PRAGMA wal_autocheckpoint=1000")
-        self._db.execute("PRAGMA synchronous=NORMAL")
-        self._db.execute("PRAGMA foreign_keys=ON")
+            stage = "journal"
+            self._db.execute("PRAGMA journal_mode=WAL")
+            self._db.execute("PRAGMA wal_autocheckpoint=1000")
+            self._db.execute("PRAGMA synchronous=NORMAL")
+            self._db.execute("PRAGMA foreign_keys=ON")
 
-        # Read-only connection pool for concurrent search operations
-        self._read_pool: list[sqlite3.Connection] = []
-        self._read_pool_idx = 0
-        self._read_pool_lock = threading.Lock()
-        for _ in range(3):
-            rconn = sqlite3.connect(str(db_path), timeout=10, check_same_thread=False)
-            rconn.execute("PRAGMA journal_mode=WAL")
-            rconn.execute("PRAGMA query_only=ON")
-            try:
-                rconn.enable_load_extension(True)
-                sqlite_vec.load(rconn)
-                rconn.enable_load_extension(False)
-            except Exception as exc:
-                logger.warning("Failed to load sqlite-vec for read pool connection: %s", exc)
-            self._read_pool.append(rconn)
+            # Read-only connection pool for concurrent search operations
+            stage = "read_pool"
+            for _ in range(3):
+                rconn = sqlite3.connect(str(db_path), timeout=10, check_same_thread=False)
+                rconn.execute("PRAGMA journal_mode=WAL")
+                rconn.execute("PRAGMA query_only=ON")
+                try:
+                    rconn.enable_load_extension(True)
+                    sqlite_vec.load(rconn)
+                    rconn.enable_load_extension(False)
+                except Exception as exc:
+                    logger.warning("Failed to load sqlite-vec for read pool connection: %s", exc)
+                self._read_pool.append(rconn)
 
-        try:
+            stage = "schema"
             self._meta = MetaManager(self._get_db)
             self._ns = NamespaceOps(self._get_db, lambda: self._has_vec_table)
 
@@ -205,9 +280,29 @@ class SqliteBackend(
                 ).fetchone()
                 is not None
             )
-        except Exception:
-            await self.close()
+        except (EmbeddingDimensionMismatchError, SchemaDowngradeError):
+            self._discard_partial_connections()
             raise
+        except BaseException as exc:
+            self._discard_partial_connections()
+            if isinstance(exc, (asyncio.CancelledError, KeyboardInterrupt, SystemExit)):
+                raise
+            raise _classify_startup_error(exc, stage) from exc
+
+    def _discard_partial_connections(self) -> None:
+        """Close a failed initialization without checkpointing/mutating the DB."""
+        for conn in self._read_pool:
+            try:
+                conn.close()
+            except Exception:
+                logger.debug("Failed to close partial read connection", exc_info=True)
+        self._read_pool.clear()
+        if self._db is not None:
+            try:
+                self._db.close()
+            except Exception:
+                logger.debug("Failed to close partial write connection", exc_info=True)
+            self._db = None
 
     def _get_db(self) -> sqlite3.Connection:
         if self._db is None:
@@ -1154,6 +1249,7 @@ class SqliteBackend(
         namespace_filter: NamespaceFilter | None = None,
         scope_filter: ScopeFilter | None = None,
         project_context_root: Path | None = None,
+        metadata_filter: SearchMetadataFilter | None = None,
     ) -> list[SearchResult]:
         db = self._get_read_db()
         try:
@@ -1172,6 +1268,10 @@ class SqliteBackend(
             )
             scope_clause = f"AND ({scope_frag})"
             tie_break = scope_sort_priority_case("c.")
+            metadata_frag, metadata_params = _metadata_filter_sql(
+                metadata_filter, column_alias="c."
+            )
+            metadata_clause = f"AND ({metadata_frag})" if metadata_frag else ""
 
             # ADR-0011 §6 + PR-D review #2: filter must run *inside* the
             # FTS candidate selection, not after a post-LIMIT join. With
@@ -1191,19 +1291,22 @@ class SqliteBackend(
             sql = f"""SELECT c.*, fts.rank
                    FROM chunks_fts fts
                    JOIN chunks c ON c.rowid = fts.rowid
-                   WHERE chunks_fts MATCH ? {ns_clause} {scope_clause}
+                   WHERE chunks_fts MATCH ? {ns_clause} {scope_clause} {metadata_clause}
                    ORDER BY fts.rank, {tie_break}
                    LIMIT ?"""
 
             # Try AND first (default FTS5 behaviour)
             fts_query = _fts.tokenize_for_fts(query, for_query=True)
-            rows = db.execute(sql, [fts_query] + ns_params + scope_params + [top_k]).fetchall()
+            rows = db.execute(
+                sql, [fts_query] + ns_params + scope_params + metadata_params + [top_k]
+            ).fetchall()
 
             # Fall back to OR if AND returns nothing and query has multiple terms
             if not rows and " " in query.strip():
                 fts_query_or = _fts.tokenize_for_fts(query, for_query=True, use_or=True)
                 rows = db.execute(
-                    sql, [fts_query_or] + ns_params + scope_params + [top_k]
+                    sql,
+                    [fts_query_or] + ns_params + scope_params + metadata_params + [top_k],
                 ).fetchall()
 
         except sqlite3.OperationalError:
@@ -1226,6 +1329,7 @@ class SqliteBackend(
         namespace_filter: NamespaceFilter | None = None,
         scope_filter: ScopeFilter | None = None,
         project_context_root: Path | None = None,
+        metadata_filter: SearchMetadataFilter | None = None,
     ) -> list[SearchResult]:
         # bm25-only mode (dimension=0) — no chunks_vec table to query. Return
         # early instead of raising OperationalError that the search pipeline
@@ -1247,6 +1351,8 @@ class SqliteBackend(
         )
         scope_clause = f"AND ({scope_frag})"
         tie_break = scope_sort_priority_case("c.")
+        metadata_frag, metadata_params = _metadata_filter_sql(metadata_filter, column_alias="c.")
+        metadata_clause = f"AND ({metadata_frag})" if metadata_frag else ""
 
         import sqlite3 as _sqlite3
 
@@ -1275,7 +1381,7 @@ class SqliteBackend(
                    ORDER BY distance
                    LIMIT ?
                ) sub
-               JOIN chunks c ON c.rowid = sub.rowid {ns_clause} {scope_clause}
+               JOIN chunks c ON c.rowid = sub.rowid {ns_clause} {scope_clause} {metadata_clause}
                ORDER BY sub.distance, {tie_break}
                LIMIT ?"""
 
@@ -1300,7 +1406,11 @@ class SqliteBackend(
             try:
                 rows = db.execute(
                     sql,
-                    [serialize_f32(embedding), inner_k] + ns_params + scope_params + [top_k],
+                    [serialize_f32(embedding), inner_k]
+                    + ns_params
+                    + scope_params
+                    + metadata_params
+                    + [top_k],
                 ).fetchall()
             except _sqlite3.OperationalError as exc:
                 if "Dimension mismatch" in str(exc):
@@ -1549,6 +1659,7 @@ class SqliteBackend(
         tag_filter: str | None = None,
         scope_filter: ScopeFilter | None = None,
         project_context_root: Path | None = None,
+        metadata_filter: SearchMetadataFilter | None = None,
     ) -> list[Chunk]:
         db = self._get_read_db()
         conditions: list[str] = []
@@ -1581,6 +1692,11 @@ class SqliteBackend(
                     f"WHERE json_each.value IN ({placeholders}))"
                 )
                 params.extend(tags)
+
+        metadata_frag, metadata_params = _metadata_filter_sql(metadata_filter)
+        if metadata_frag:
+            conditions.append(metadata_frag)
+            params.extend(metadata_params)
 
         # ADR-0011 §6: always-on scope-context fragment.
         scope_frag, scope_params = scope_context_sql(scope_filter, project_context_root)

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -141,6 +141,9 @@ def _metadata_filter_sql(
             f"{column_alias}chunk_type IN ({placeholders(len(metadata_filter.chunk_types))})"
         )
         params.extend(metadata_filter.chunk_types)
+    # ``chunks.created_at`` is stored as a UTC ISO-8601 string. Bounds from
+    # the web route are normalized to UTC too, so lexical ordering is temporal
+    # ordering for this column.
     if metadata_filter.created_from is not None:
         conditions.append(f"{column_alias}created_at >= ?")
         params.append(metadata_filter.created_from.isoformat())

--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -195,6 +195,8 @@ def create_app(lifespan=None, mode: WebMode = "prod") -> FastAPI:
         redoc_url=None,
     )
     app.state.web_mode = mode
+    app.state.startup_state = "not_started"
+    app.state.startup_reason_code = None
 
     # Per-process CSRF token (RFC #787). Generated fresh on every
     # ``create_app`` so token rotation is just a restart; never persisted.
@@ -332,97 +334,127 @@ def create_app(lifespan=None, mode: WebMode = "prod") -> FastAPI:
 async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     from memtomem.indexing.watcher import FileWatcher
     from memtomem.server.component_factory import close_components, create_components
+    from memtomem.web import hot_reload
 
-    comp = await create_components()
-
-    from memtomem.search.dedup import DedupScanner
-    from memtomem.context.scope_resolver import find_project_root
-
-    # Walk up to the project root (.git / pyproject.toml) so launching
-    # ``mm web`` from a subdirectory resolves the same canonical .memtomem tree
-    # the CLI/MCP write to — not ``<subdir>/.memtomem``. Single shared helper.
-    app.state.project_root = find_project_root()
-    app.state.config = comp.config
-    app.state.storage = comp.storage
-    app.state.embedder = comp.embedder
-    app.state.search_pipeline = comp.search_pipeline
-    app.state.index_engine = comp.index_engine
-    app.state.dedup_scanner = DedupScanner(comp.storage, comp.embedder)
-    # Per-source AI summary regeneration job state (singleton, in-memory).
-    # ``None`` when no job has run; otherwise a counter dict mutated by the
-    # background task and read by ``GET /api/sources/regenerate-status``.
-    app.state.summary_regen = None
-    # Shared LLM provider (or ``None``) — exposed for the bulk-regenerate
-    # endpoint, which mirrors the indexing engine's per-source flow.
-    app.state.llm = comp.llm
-
-    # Sync config to match DB-stored embedding info (prevents mismatch banner).
-    # Skipped when the server entered degraded mode (issue #349) — in the
-    # dim=0 / real-provider case the stored "embedding" is NoopEmbedder
-    # (provider=none, dim=0), so an auto-sync would silently downgrade the
-    # user's configured onnx/bge-m3 to BM25-only and swallow the broken
-    # state instead of surfacing it. The banner + ``/api/embedding-reset``
-    # flow recovers explicitly; soft-syncing would defeat it.
-    stored_info = getattr(comp.storage, "stored_embedding_info", None)
-    if stored_info and comp.embedding_broken is None:
-        cfg = comp.config.embedding
-        if cfg.model != stored_info["model"] or cfg.dimension != stored_info["dimension"]:
-            logger.info(
-                "Syncing config to DB embedding: %s/%s (%dd)",
-                stored_info["provider"],
-                stored_info["model"],
-                stored_info["dimension"],
-            )
-            cfg.model = stored_info["model"]
-            cfg.dimension = stored_info["dimension"]
-            if stored_info.get("provider"):
-                cfg.provider = stored_info["provider"]
-            # Clear mismatch flags since config now matches DB
-            comp.storage.clear_embedding_mismatch()
-
-    # Ensure memory_dirs exist
-    for d in comp.config.indexing.memory_dirs:
-        Path(d).expanduser().resolve().mkdir(parents=True, exist_ok=True)
-
-    # P2 cron Phase A footgun: ``mm web`` does not run the schedule
-    # dispatcher (HealthWatchdog is wired only in the MCP server lifespan,
-    # see server/context.py). Mirror the warning emitted there so users who
-    # register schedules against a web-only entry get a loud signal at
-    # startup instead of silently null ``last_run_status``.
-    if comp.config.scheduler.enabled:
-        logger.warning(
-            "scheduler.enabled=true but ``mm web`` does not dispatch schedules — "
-            "run ``memtomem-server`` (MCP) for the watchdog tick that fires registered jobs"
-        )
-    if comp.config.policy.enabled:
-        logger.warning(
-            "policy.enabled=true but ``mm web`` does not run the policy scheduler — "
-            "run ``memtomem-server`` (MCP) for the lifespan that starts PolicyScheduler"
-        )
-
-    # File watcher: monitors memory_dirs for fs-event-driven re-indexing
-    # and runs a one-shot startup backfill so files added while ``mm web``
-    # was down (or before the dir was registered) get indexed without the
-    # user clicking Reindex. Skipped in degraded mode (broken embedding) —
-    # the indexer would crash on the missing chunks_vec table; recovery
-    # via ``mem_embedding_reset``. Mirrors the wiring in
-    # ``server/context.py``; without this ``mm web`` ran with no fs
-    # watcher at all.
+    comp = None
     watcher: FileWatcher | None = None
-    if comp.embedding_broken is None:
-        watcher = FileWatcher(comp.index_engine, comp.config.indexing)
-        await watcher.start()
-        app.state.file_watcher = watcher
+    published = False
+    failed = False
+    app.state.startup_state = "starting"
+    app.state.startup_reason_code = None
 
     try:
+        comp = await create_components()
+
+        from memtomem.context.scope_resolver import find_project_root
+        from memtomem.search.dedup import DedupScanner
+
+        project_root = find_project_root()
+
+        # Sync config to match DB-stored embedding info (prevents mismatch banner).
+        # Skipped when the server entered degraded mode (issue #349) — in the
+        # dim=0 / real-provider case the stored "embedding" is NoopEmbedder
+        # (provider=none, dim=0), so an auto-sync would silently downgrade the
+        # user's configured onnx/bge-m3 to BM25-only and swallow the broken
+        # state instead of surfacing it. The banner + ``/api/embedding-reset``
+        # flow recovers explicitly; soft-syncing would defeat it.
+        stored_info = getattr(comp.storage, "stored_embedding_info", None)
+        if stored_info and comp.embedding_broken is None:
+            cfg = comp.config.embedding
+            if cfg.model != stored_info["model"] or cfg.dimension != stored_info["dimension"]:
+                logger.info(
+                    "Syncing config to DB embedding: %s/%s (%dd)",
+                    stored_info["provider"],
+                    stored_info["model"],
+                    stored_info["dimension"],
+                )
+                cfg.model = stored_info["model"]
+                cfg.dimension = stored_info["dimension"]
+                if stored_info.get("provider"):
+                    cfg.provider = stored_info["provider"]
+                comp.storage.clear_embedding_mismatch()
+
+        # Ensure memory_dirs exist
+        for d in comp.config.indexing.memory_dirs:
+            Path(d).expanduser().resolve().mkdir(parents=True, exist_ok=True)
+
+        # P2 cron Phase A footgun: ``mm web`` does not run the schedule
+        # dispatcher (HealthWatchdog is wired only in the MCP server lifespan,
+        # see server/context.py). Mirror the warning emitted there so users who
+        # register schedules against a web-only entry get a loud signal at
+        # startup instead of silently null ``last_run_status``.
+        if comp.config.scheduler.enabled:
+            logger.warning(
+                "scheduler.enabled=true but ``mm web`` does not dispatch schedules — "
+                "run ``memtomem-server`` (MCP) for the watchdog tick that fires registered jobs"
+            )
+        if comp.config.policy.enabled:
+            logger.warning(
+                "policy.enabled=true but ``mm web`` does not run the policy scheduler — "
+                "run ``memtomem-server`` (MCP) for the lifespan that starts PolicyScheduler"
+            )
+
+        # File watcher: monitors memory_dirs for fs-event-driven re-indexing
+        # and runs a one-shot startup backfill so files added while ``mm web``
+        # was down (or before the dir was registered) get indexed without the
+        # user clicking Reindex. Skipped in degraded mode (broken embedding) —
+        # the indexer would crash on the missing chunks_vec table; recovery
+        # via ``mem_embedding_reset``. Mirrors the wiring in
+        # ``server/context.py``; without this ``mm web`` ran with no fs
+        # watcher at all.
+        if comp.embedding_broken is None:
+            watcher = FileWatcher(comp.index_engine, comp.config.indexing)
+            await watcher.start()
+
+        # Publish one coherent state only after every startup step succeeded.
+        app.state.project_root = project_root
+        app.state.config = comp.config
+        app.state.storage = comp.storage
+        app.state.embedder = comp.embedder
+        app.state.search_pipeline = comp.search_pipeline
+        app.state.index_engine = comp.index_engine
+        app.state.dedup_scanner = DedupScanner(comp.storage, comp.embedder)
+        app.state.summary_regen = None
+        app.state.llm = comp.llm
+        if watcher is not None:
+            app.state.file_watcher = watcher
+        hot_reload.initialize_reload_state(app)
+        published = True
+        app.state.startup_state = "ready"
         yield
+    except BaseException as exc:
+        failed = True
+        app.state.startup_state = "failed"
+        app.state.startup_reason_code = getattr(exc, "reason_code", "startup_unavailable")
+        raise
     finally:
         if watcher is not None:
             try:
                 await watcher.stop()
-            except Exception as exc:
+            except BaseException as exc:
                 logger.warning("file watcher stop failed: %s", exc)
-        await close_components(comp)
+        if comp is not None:
+            await close_components(comp)
+        if published:
+            for name in (
+                "project_root",
+                "config",
+                "storage",
+                "embedder",
+                "search_pipeline",
+                "index_engine",
+                "dedup_scanner",
+                "summary_regen",
+                "llm",
+                "file_watcher",
+                "config_signature",
+                "last_reload_error",
+            ):
+                if hasattr(app.state, name):
+                    delattr(app.state, name)
+        if not failed:
+            app.state.startup_state = "not_started"
+            app.state.startup_reason_code = None
 
 
 _app_singleton: FastAPI | None = None

--- a/packages/memtomem/src/memtomem/web/deps.py
+++ b/packages/memtomem/src/memtomem/web/deps.py
@@ -26,32 +26,45 @@ if TYPE_CHECKING:
     from memtomem.storage.sqlite_backend import SqliteBackend
 
 
+_STARTUP_UNAVAILABLE = {
+    "reason_code": "startup_unavailable",
+    "message": "Web backend startup is unavailable.",
+}
+
+
+def _require_app_state(request: Request, name: str):
+    try:
+        return getattr(request.app.state, name)
+    except AttributeError as exc:
+        raise HTTPException(status_code=503, detail=_STARTUP_UNAVAILABLE) from exc
+
+
 def get_storage(request: Request) -> SqliteBackend:
-    return request.app.state.storage
+    return _require_app_state(request, "storage")
 
 
 def get_search_pipeline(request: Request) -> SearchPipeline:
-    return request.app.state.search_pipeline
+    return _require_app_state(request, "search_pipeline")
 
 
 def get_index_engine(request: Request) -> IndexEngine:
-    return request.app.state.index_engine
+    return _require_app_state(request, "index_engine")
 
 
 def get_embedder(request: Request) -> EmbeddingProvider:
-    return request.app.state.embedder
+    return _require_app_state(request, "embedder")
 
 
 def get_config(request: Request) -> Mem2MemConfig:
-    return request.app.state.config
+    return _require_app_state(request, "config")
 
 
 def get_dedup_scanner(request: Request):
-    return request.app.state.dedup_scanner
+    return _require_app_state(request, "dedup_scanner")
 
 
 def get_project_root(request: Request) -> Path:
-    return request.app.state.project_root
+    return _require_app_state(request, "project_root")
 
 
 def get_hooks_target_scope(request: Request) -> str:
@@ -62,7 +75,7 @@ def get_hooks_target_scope(request: Request) -> str:
     automatically pick up scope changes without a server restart
     (mirrors :func:`get_config`).
     """
-    return request.app.state.config.hooks.target_scope
+    return get_config(request).hooks.target_scope
 
 
 def require_configured() -> None:

--- a/packages/memtomem/src/memtomem/web/hot_reload.py
+++ b/packages/memtomem/src/memtomem/web/hot_reload.py
@@ -151,6 +151,12 @@ def commit_writer_signature(app: FastAPI) -> None:
     _set_last_signature(app, current_signature())
 
 
+def initialize_reload_state(app: FastAPI) -> None:
+    """Seed the lifespan-loaded config as the current on-disk view."""
+    _set_last_signature(app, current_signature())
+    _set_reload_error(app, None)
+
+
 # ---------------------------------------------------------------------------
 # Reload
 # ---------------------------------------------------------------------------
@@ -260,6 +266,17 @@ async def reload_if_stale(
 
     old_cfg = getattr(app.state, "config", None)
     app.state.config = new_cfg
+    index_engine = getattr(app.state, "index_engine", None)
+    if index_engine is not None:
+        # Routes resolve the engine before calling ``reload_if_stale``. Update
+        # the existing object in place so that request-local dependency still
+        # validates against the freshly installed indexing roots.
+        index_engine._config = new_cfg.indexing
+    watcher = getattr(app.state, "file_watcher", None)
+    if watcher is not None:
+        reconfigured = watcher.reconfigure(new_cfg.indexing)
+        if inspect.isawaitable(reconfigured):
+            await reconfigured
     _set_last_signature(app, sig)
     _set_reload_error(app, None)
 

--- a/packages/memtomem/src/memtomem/web/routes/export.py
+++ b/packages/memtomem/src/memtomem/web/routes/export.py
@@ -43,6 +43,7 @@ async def export_stats(
     source: str | None = Query(None),
     tag: str | None = Query(None),
     since: datetime | None = Query(None),
+    namespace: str | None = Query(None),
     storage=Depends(get_storage),
 ) -> ExportStatsResponse:
     """Return chunk count that would be exported (without downloading)."""
@@ -51,7 +52,12 @@ async def export_stats(
     # Count-only preview: skip provenance signing so this read endpoint neither
     # creates the per-install key file nor fails on a key-file problem.
     bundle = await export_chunks(
-        storage, source_filter=source, tag_filter=tag, since=since, stamp_provenance=False
+        storage,
+        source_filter=source,
+        tag_filter=tag,
+        since=since,
+        namespace_filter=namespace,
+        stamp_provenance=False,
     )
     return ExportStatsResponse(total_chunks=bundle.total_chunks)
 

--- a/packages/memtomem/src/memtomem/web/routes/search.py
+++ b/packages/memtomem/src/memtomem/web/routes/search.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
@@ -21,6 +22,10 @@ async def search(
     q: str | None = Query(None, description="Search query", max_length=10_000),
     top_k: int | None = Query(None, ge=1, le=500),
     source_filter: str | None = Query(None),
+    source_exact: list[str] | None = Query(None),
+    chunk_type: list[str] | None = Query(None),
+    created_from: datetime | None = Query(None),
+    created_before: datetime | None = Query(None),
     tag_filter: str | None = Query(None),
     namespace: str | None = Query(None),
     context_window: int = Query(0, ge=0, le=10, description="Expand ±N adjacent chunks"),
@@ -32,10 +37,27 @@ async def search(
     # (filter becomes the primary selector); the API guard here only
     # rejects "no axis at all" — search needs *something* to scope by.
     q = (q or "").strip()
-    if not q and not (tag_filter or source_filter):
+    source_exact = [value.strip() for value in (source_exact or []) if value.strip()]
+    chunk_type = [value.strip() for value in (chunk_type or []) if value.strip()]
+    for name, value in (("created_from", created_from), ("created_before", created_before)):
+        if value is not None and value.utcoffset() is None:
+            raise HTTPException(status_code=422, detail=f"{name} must include a timezone offset")
+    if created_from is not None:
+        created_from = created_from.astimezone(UTC)
+    if created_before is not None:
+        created_before = created_before.astimezone(UTC)
+    if created_from is not None and created_before is not None and created_from >= created_before:
+        raise HTTPException(status_code=422, detail="created_from must be before created_before")
+
+    if not q and not (
+        tag_filter or source_filter or source_exact or chunk_type or created_from or created_before
+    ):
         raise HTTPException(
             status_code=400,
-            detail="Provide at least one of q, tag_filter, or source_filter.",
+            detail=(
+                "Provide at least one of q, tag_filter, source_filter, source_exact, "
+                "chunk_type, created_from, or created_before."
+            ),
         )
 
     # ADR-0011 PR-D round 9: thread project context onto the always-on
@@ -51,6 +73,10 @@ async def search(
             query=q,
             top_k=top_k,
             source_filter=source_filter,
+            source_exact=source_exact,
+            chunk_types=chunk_type,
+            created_from=created_from,
+            created_before=created_before,
             tag_filter=tag_filter,
             namespace=namespace,
             context_window=context_window if context_window > 0 else None,

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -42,6 +42,7 @@ from memtomem.web.deps import (
     get_config,
     get_embedder,
     get_index_engine,
+    get_project_root,
     get_search_pipeline,
     get_storage,
     require_configured,
@@ -187,6 +188,20 @@ async def health_liveness() -> dict[str, Any]:
     return {"status": "ok", "checks": {"process": "ok"}}
 
 
+@router.get("/readiness")
+async def readiness(request: Request) -> JSONResponse:
+    state = getattr(request.app.state, "startup_state", "not_started")
+    ready = state == "ready"
+    content: dict[str, Any] = {"ready": ready, "state": state}
+    if not ready:
+        content["reason_code"] = "startup_unavailable"
+    return JSONResponse(
+        status_code=200 if ready else 503,
+        content=content,
+        headers={"Cache-Control": "no-store"},
+    )
+
+
 @router.post("/health", response_model=None)
 async def health_active(
     storage: Any = Depends(get_storage),
@@ -302,7 +317,12 @@ def _build_config_response(
 
 
 @router.get("/config", response_model=ConfigResponse)
-async def get_config_endpoint(request: Request) -> ConfigResponse:
+async def get_config_endpoint(
+    request: Request,
+    config=Depends(get_config),
+    storage=Depends(get_storage),
+    search_pipeline=Depends(get_search_pipeline),
+) -> ConfigResponse:
     # Read-through reload is opportunistic and lock-free: if a write is in
     # flight, the writer will serve the fresh view on its own return. This
     # keeps the common GET path cheap while still catching CLI-side edits.
@@ -310,13 +330,13 @@ async def get_config_endpoint(request: Request) -> ConfigResponse:
     try:
         await _hot_reload.reload_if_stale(
             app,
-            storage=getattr(app.state, "storage", None),
-            search_pipeline=getattr(app.state, "search_pipeline", None),
+            storage=storage,
+            search_pipeline=search_pipeline,
         )
     except Exception:
         logger.warning("reload_if_stale raised unexpectedly during GET /config", exc_info=True)
 
-    cfg = app.state.config
+    cfg = app.state.config if getattr(app.state, "config", None) is not None else config
     err = _hot_reload.get_reload_error(app)
     return _build_config_response(
         cfg,
@@ -738,11 +758,23 @@ async def add_memory_dir(
     except TimeoutError:
         raise HTTPException(503, "memory-dirs/add timed out — another update may be in progress")
 
+    watcher = getattr(request.app.state, "file_watcher", None)
+    if watcher is not None:
+        try:
+            await watcher.reconfigure(config.indexing)
+        except Exception as exc:
+            logger.error("Failed to activate memory directory watcher", exc_info=True)
+            raise HTTPException(
+                status_code=503,
+                detail="Directory was registered, but watcher activation failed. Retry or restart mm web.",
+            ) from exc
+
     # Index outside the config lock so a slow scan doesn't block other
     # config writers (the watcher invariant — path inside ``memory_dirs``
     # — is already satisfied by the register block above, so
     # ``index_path`` will pass its own validation).
     indexed: dict[str, object] | None = None
+    index_status = "not_requested"
     if auto_index:
         try:
             stats = await index_engine.index_path(
@@ -760,8 +792,18 @@ async def add_memory_dir(
                 "blocked_paths": list(stats.blocked_paths),
                 "blocked_project_shared_files": stats.blocked_project_shared_files,
             }
-        except Exception as err:  # pragma: no cover — surface partial result
-            indexed = {"error": str(err)}
+            has_issues = bool(stats.errors or stats.blocked_files)
+            has_processed_chunks = (stats.indexed_chunks + stats.skipped_chunks) > 0
+            if not has_issues:
+                index_status = "success"
+            elif has_processed_chunks:
+                index_status = "partial"
+            else:
+                index_status = "failed"
+        except Exception:  # pragma: no cover — surface partial result
+            logger.exception("Initial indexing failed for newly registered memory directory")
+            indexed = {"error": "Initial indexing failed"}
+            index_status = "failed"
 
     return {
         "ok": True,
@@ -769,6 +811,7 @@ async def add_memory_dir(
         "memory_dirs": memory_dirs_snapshot,
         "kind": kind,
         "indexed": indexed,
+        "index_status": index_status,
     }
 
 
@@ -848,6 +891,10 @@ async def remove_memory_dir(
                         source_path = row[0]
                         if norm_path(source_path).startswith(prefix):
                             deleted_chunks += await storage.delete_by_source(source_path)
+
+                watcher = getattr(request.app.state, "file_watcher", None)
+                if watcher is not None:
+                    await watcher.reconfigure(config.indexing)
 
                 return {
                     "ok": True,
@@ -1136,6 +1183,7 @@ async def get_model_readiness(
     request: Request,
     embedder=Depends(get_embedder),
     config=Depends(get_config),
+    pipeline=Depends(get_search_pipeline),
 ) -> ModelReadinessResponse:
     """Snapshot the load state of the embedder + reranker (issue #696).
 
@@ -1157,7 +1205,6 @@ async def get_model_readiness(
     # always exists (lifespan creates it), but ``_reranker`` is None when
     # ``config.rerank.enabled is False`` — skip the readiness check then.
     rerank_cfg = config.rerank
-    pipeline = getattr(request.app.state, "search_pipeline", None)
     reranker_holder = getattr(pipeline, "_reranker", None) if pipeline else None
     reranker_component = _component_for(
         provider=rerank_cfg.provider,
@@ -1637,6 +1684,7 @@ async def add_memory(
     index_engine=Depends(get_index_engine),
     storage=Depends(get_storage),
     config=Depends(get_config),
+    server_project_root=Depends(get_project_root),
 ) -> AddMemoryResponse:
     from datetime import datetime, timezone
 
@@ -1763,7 +1811,7 @@ async def add_memory(
         pmdirs = config.indexing.project_memory_dirs
         project_root = _resolve_project_context_from_dirs(pmdirs)
         if project_root is None:
-            project_root = Path(request.app.state.project_root)
+            project_root = Path(server_project_root)
         try:
             base = resolve_memory_scope_dir(req.scope, project_root, user_base=user_base)
         except MemoryScopeError as exc:

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -41,6 +41,7 @@ const STATE = {
   viewMode: 'card',
   scoreMin: 0,
   currentSortMode: 'score',
+  showRetrievalDebug: false,
   maxResultScore: 0,
   resultScoreViews: {},
   sourcesBrowserStale: false,
@@ -174,14 +175,12 @@ const STATE = {
     if (hash) {
       if (_visibleMainTabs().includes(hash)) {
         activateTab(hash);
-      } else if (document.querySelector(`.tab-btn[data-tab="${hash}"]`)) {
-        // A real tab that the current mode hides (e.g. a deep-link to #timeline
-        // while in Simple). Don't strand on an empty panel — the statically
-        // active tab stays; surface *why* the link didn't open so the user can
-        // flip to Advanced. (No dev main-tabs exist, so the advanced copy fits.)
-        showToast(t('toast.advanced_only_section'), 'info');
-        activateTab(_visibleMainTabs()[0] || 'home', { historyMode: 'replace' });
       } else {
+        if (document.querySelector(`.tab-btn[data-tab="${hash}"]`)) {
+          // A real tab that the current mode hides (e.g. a deep-link to #timeline
+          // while in Simple). Explain the redirect so the user can switch modes.
+          showToast(t('toast.advanced_only_section'), 'info');
+        }
         activateTab(_visibleMainTabs()[0] || 'home', { historyMode: 'replace' });
       }
     }
@@ -1914,7 +1913,7 @@ window.addEventListener('popstate', (e) => {
   // Gate on current visibility (mirrors the boot-hash dispatch): a history
   // entry pushed while Tags/Timeline were visible must not replay
   // activateTab('timeline') after the user flipped to Simple — that would strand
-  // them on a panel with no active tab button. Staying put is the safe floor.
+  // them on a panel with no active tab button. Redirect to the first visible tab.
   if (tab && _visibleMainTabs().includes(tab)) {
     activateTab(tab, { historyMode: 'none' });
   } else {
@@ -1923,7 +1922,8 @@ window.addEventListener('popstate', (e) => {
 });
 window.addEventListener('hashchange', () => {
   const tab = location.hash.slice(1);
-  if (tab && _visibleMainTabs().includes(tab)) {
+  const activeTab = document.querySelector('.tab-btn.active')?.dataset.tab;
+  if (tab && tab !== activeTab && _visibleMainTabs().includes(tab)) {
     activateTab(tab, { historyMode: 'none' });
   }
 });

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -180,6 +180,9 @@ const STATE = {
         // active tab stays; surface *why* the link didn't open so the user can
         // flip to Advanced. (No dev main-tabs exist, so the advanced copy fits.)
         showToast(t('toast.advanced_only_section'), 'info');
+        activateTab(_visibleMainTabs()[0] || 'home', { historyMode: 'replace' });
+      } else {
+        activateTab(_visibleMainTabs()[0] || 'home', { historyMode: 'replace' });
       }
     }
   });
@@ -432,9 +435,11 @@ async function api(method, path, body, opts = {}) {
     // (e.g. structured 4xx that isn't redaction_blocked).
     const msg = typeof err.detail === 'string'
       ? err.detail
-      : (err.detail && typeof err.detail === 'object' && typeof err.detail.detail === 'string'
-        ? err.detail.detail
-        : res.statusText);
+      : (err.detail && typeof err.detail === 'object' && typeof err.detail.message === 'string'
+        ? err.detail.message
+        : (err.detail && typeof err.detail === 'object' && typeof err.detail.detail === 'string'
+          ? err.detail.detail
+          : res.statusText));
     // Thrown errors expose `.status` so callers can branch on HTTP code
     // (e.g. 404 → mark resource missing instead of generic toast).
     const apiErr = new Error(msg);
@@ -1495,6 +1500,7 @@ function activateTab(tabName, opts = {}) {
   //   * history mutation uses replaceState so cycling N tabs does not push
   //     N entries the user has to press Back through to escape
   const fromKeyboard = opts.fromKeyboard === true;
+  const historyMode = opts.historyMode || (fromKeyboard ? 'replace' : 'push');
   // Redirect to the first visible tab when the target is hidden by EITHER
   // visibility axis (dev-only in prod, or advanced-only in Simple mode) instead
   // of showing a panel whose tab button is off-screen. This single guard catches
@@ -1557,11 +1563,19 @@ function activateTab(tabName, opts = {}) {
   // History API — enable back button and deep linking. Arrow-nav uses
   // replaceState so a cycle through siblings produces one history entry
   // instead of N (otherwise Back becomes unusable).
-  if (location.hash !== `#${tabName}`) {
-    if (fromKeyboard) {
-      history.replaceState({ tab: tabName }, '', `#${tabName}`);
+  if (historyMode !== 'none') {
+    const targetHash = `#${tabName}`;
+    if (location.hash === targetHash) {
+      // Direct hash entry has a null history.state. Seed the existing entry
+      // so the next Back/Forward traversal can restore the panel as well as
+      // the URL.
+      if (history.state?.tab !== tabName) {
+        history.replaceState({ tab: tabName }, '', targetHash);
+      }
+    } else if (historyMode === 'replace') {
+      history.replaceState({ tab: tabName }, '', targetHash);
     } else {
-      history.pushState({ tab: tabName }, '', `#${tabName}`);
+      history.pushState({ tab: tabName }, '', targetHash);
     }
   }
 
@@ -1896,12 +1910,22 @@ qs('mobile-back-btn').addEventListener('click', () => {
 
 // ── History API: back/forward navigation + hash deep link ──
 window.addEventListener('popstate', (e) => {
-  const tab = e.state?.tab;
+  const tab = e.state?.tab || location.hash.slice(1);
   // Gate on current visibility (mirrors the boot-hash dispatch): a history
   // entry pushed while Tags/Timeline were visible must not replay
   // activateTab('timeline') after the user flipped to Simple — that would strand
   // them on a panel with no active tab button. Staying put is the safe floor.
-  if (tab && _visibleMainTabs().includes(tab)) activateTab(tab);
+  if (tab && _visibleMainTabs().includes(tab)) {
+    activateTab(tab, { historyMode: 'none' });
+  } else {
+    activateTab(_visibleMainTabs()[0] || 'home', { historyMode: 'replace' });
+  }
+});
+window.addEventListener('hashchange', () => {
+  const tab = location.hash.slice(1);
+  if (tab && _visibleMainTabs().includes(tab)) {
+    activateTab(tab, { historyMode: 'none' });
+  }
 });
 // Note: initial hash-based activateTab dispatch moved into the i18n init
 // handler above so ``t()``-backed JS widgets (Sources tab's Memory Dirs
@@ -2776,6 +2800,8 @@ function _hasSearchAxis() {
     qs('search-input').value.trim()
     || qs('tag-filter').value.trim()
     || _getSelectedSourceFilters().length
+    || qs('chunk-type-filter')?.value
+    || qs('date-range-preset')?.value
   );
 }
 
@@ -2790,7 +2816,14 @@ function _buildSearchParams(topK) {
   const ctxWin = parseInt((qs('context-window') || {}).value || '0', 10);
   if (ctxWin > 0) params.set('context_window', ctxWin);
   const selectedSources = _getSelectedSourceFilters();
-  if (selectedSources.length) params.set('source_filter', selectedSources.join(','));
+  selectedSources.forEach(source => params.append('source_exact', source));
+  const chunkType = qs('chunk-type-filter')?.value || '';
+  if (chunkType) params.append('chunk_type', chunkType);
+  const dateRange = _getDateRange();
+  if (dateRange) {
+    if (dateRange.from) params.set('created_from', new Date(dateRange.from).toISOString());
+    if (dateRange.to) params.set('created_before', new Date(dateRange.to).toISOString());
+  }
   return params;
 }
 
@@ -3241,20 +3274,9 @@ function renderResults(results, retrievalStats) {
   if (STATE.currentSortMode === 'date-desc') display.sort((a, b) => new Date(b.chunk.created_at) - new Date(a.chunk.created_at));
   else if (STATE.currentSortMode === 'date-asc') display.sort((a, b) => new Date(a.chunk.created_at) - new Date(b.chunk.created_at));
   else if (STATE.currentSortMode === 'source') display.sort((a, b) => (a.chunk.source_file || '').localeCompare(b.chunk.source_file || ''));
-  const typeFilter = (qs('chunk-type-filter') || {}).value || '';
-  const selectedSources = _getSelectedSourceFilters();
-  let filtered = typeFilter ? display.filter(r => r.chunk.chunk_type === typeFilter) : display;
-  if (selectedSources.length) filtered = filtered.filter(r => selectedSources.includes(r.chunk.source_file));
+  let filtered = display;
   if (STATE.scoreMin > 0) {
     filtered = filtered.filter(r => (_scoreViewForResult(r).percent / 100) >= STATE.scoreMin);
-  }
-  // Date range filter
-  const dateRange = _getDateRange();
-  if (dateRange) {
-    filtered = filtered.filter(r => {
-      const t = new Date(r.chunk.created_at).getTime();
-      return t >= dateRange.from && t <= dateRange.to;
-    });
   }
   const list = qs('results-list');
   const empty = qs('results-empty');
@@ -7293,6 +7315,7 @@ document.addEventListener('keydown', e => {
 qs('chunk-type-filter').addEventListener('change', () => {
   _updateFilterCountBadge();
   renderResults(STATE.lastResults);
+  if (_hasSearchAxis()) doSearch();
 });
 qs('ns-filter').addEventListener('change', () => {
   _updateFilterCountBadge();
@@ -7701,7 +7724,7 @@ function _getDateRange() {
     const fromVal = qs('date-from').value;
     const toVal = qs('date-to').value;
     const from = fromVal ? new Date(fromVal).getTime() : 0;
-    const to = toVal ? new Date(toVal + 'T23:59:59').getTime() : now;
+    const to = toVal ? new Date(toVal + 'T00:00:00').getTime() + dayMs : now;
     return { from, to };
   }
   return null;
@@ -7712,14 +7735,17 @@ qs('date-range-preset').addEventListener('change', () => {
   custom.hidden = qs('date-range-preset').value !== 'custom';
   _updateFilterCountBadge();
   if (STATE.lastResults.length) renderResults(STATE.lastResults);
+  if (_hasSearchAxis()) doSearch();
 });
 qs('date-from').addEventListener('change', () => {
   _updateFilterCountBadge();
   if (STATE.lastResults.length) renderResults(STATE.lastResults);
+  if (_hasSearchAxis()) doSearch();
 });
 qs('date-to').addEventListener('change', () => {
   _updateFilterCountBadge();
   if (STATE.lastResults.length) renderResults(STATE.lastResults);
+  if (_hasSearchAxis()) doSearch();
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1780,10 +1780,10 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=7"></script>
-  <script src="/app.js?v=149"></script>
+  <script src="/app.js?v=150"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=15"></script>
-  <script src="/sources-memory-dirs.js?v=14"></script>
+  <script src="/sources-memory-dirs.js?v=15"></script>
   <script src="/settings-maintenance.js?v=5"></script>
   <script src="/settings-namespaces.js?v=12"></script>
   <script src="/settings-harness.js?v=6"></script>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1780,7 +1780,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=7"></script>
-  <script src="/app.js?v=150"></script>
+  <script src="/app.js?v=151"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=15"></script>
   <script src="/sources-memory-dirs.js?v=15"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -1524,6 +1524,8 @@
   "confirm.memory_dir_delete_chunks_label": "Also delete {count} indexed chunks from this directory",
   "toast.memory_dir.added": "Added {path}",
   "toast.memory_dir.added_indexed": "Added {path} · {chunks} chunks from {files} files",
+  "toast.memory_dir.added_index_partial": "Added {path}, but indexing was partial · {chunks} chunks from {files} files",
+  "toast.memory_dir.added_index_failed": "Added {path}, but indexing failed",
   "toast.memory_dir.removed": "Removed {path}",
   "toast.memory_dir.removed_with_chunks": "Removed {path} and {count} chunks",
   "toast.memory_dir.opened": "Opened {path}",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -1524,6 +1524,8 @@
   "confirm.memory_dir_delete_chunks_label": "이 디렉터리에서 인덱싱된 청크 {count} 개도 함께 삭제",
   "toast.memory_dir.added": "{path} 추가됨",
   "toast.memory_dir.added_indexed": "{path} 추가 · 파일 {files}개에서 청크 {chunks}개 인덱싱",
+  "toast.memory_dir.added_index_partial": "{path} 추가됨 · 일부만 인덱싱됨 (파일 {files}개, 청크 {chunks}개)",
+  "toast.memory_dir.added_index_failed": "{path}는 추가됐지만 인덱싱에 실패했습니다",
   "toast.memory_dir.removed": "{path} 제거됨",
   "toast.memory_dir.removed_with_chunks": "{path} 및 청크 {count} 개 삭제됨",
   "toast.memory_dir.opened": "{path} 열기 시도",

--- a/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
+++ b/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
@@ -135,19 +135,7 @@ function _buildMemoryDirsPanel(initialDirs) {
       if (resp && Array.isArray(resp.memory_dirs)) {
         refreshDirs(resp.memory_dirs);
       }
-      const stats = resp && resp.indexed;
-      if (stats && typeof stats.indexed_chunks === 'number') {
-        showToast(
-          t('toast.memory_dir.added_indexed', {
-            path: trimmed,
-            chunks: stats.indexed_chunks,
-            files: stats.total_files,
-          }),
-          'success',
-        );
-      } else {
-        showToast(t('toast.memory_dir.added', { path: trimmed }), 'success');
-      }
+      _showMemoryDirAddOutcome(resp, trimmed);
     } catch (err) {
       showToast(t('toast.memory_dir.add_failed', { error: _apiErrorText(err) }), 'error');
     }
@@ -994,6 +982,48 @@ function _mdApiErrorText(err) {
   return (err && err.message) ? err.message : String(err);
 }
 
+function _showMemoryDirAddOutcome(resp, path) {
+  const stats = resp && resp.indexed;
+  const status = resp && resp.index_status;
+  if (status === 'failed') {
+    showToast(
+      t('toast.memory_dir.added_index_failed', { path }),
+      'error',
+      { action: { label: t('common.retry'), onClick: () => mdReindexOne(path, null) } },
+    );
+    return;
+  }
+  if (status === 'partial') {
+    showToast(
+      t('toast.memory_dir.added_index_partial', {
+        path,
+        chunks: stats?.indexed_chunks || 0,
+        files: stats?.total_files || 0,
+      }),
+      'warning',
+      { action: { label: t('common.retry'), onClick: () => mdReindexOne(path, null) } },
+    );
+    return;
+  }
+  if (status === 'not_requested') {
+    showToast(t('toast.memory_dir.added', { path }), 'info');
+    return;
+  }
+  if (stats && typeof stats.indexed_chunks === 'number') {
+    showToast(
+      t('toast.memory_dir.added_indexed', {
+        path,
+        chunks: stats.indexed_chunks,
+        files: stats.total_files,
+      }),
+      'success',
+    );
+    return;
+  }
+  // Backward-compatible fallback for an older server without index_status.
+  showToast(t('toast.memory_dir.added', { path }), 'success');
+}
+
 async function mdAdd(path, opts = {}) {
   const trimmed = (path || '').trim();
   if (!trimmed) return;
@@ -1011,18 +1041,7 @@ async function mdAdd(path, opts = {}) {
       STATE.memoryDirs = [...resp.memory_dirs];
     }
     const stats = resp && resp.indexed;
-    if (stats && typeof stats.indexed_chunks === 'number') {
-      showToast(
-        t('toast.memory_dir.added_indexed', {
-          path: trimmed,
-          chunks: stats.indexed_chunks,
-          files: stats.total_files,
-        }),
-        'success',
-      );
-    } else {
-      showToast(t('toast.memory_dir.added', { path: trimmed }), 'success');
-    }
+    _showMemoryDirAddOutcome(resp, trimmed);
     // ADR-0006 PR-B: surface files the redaction gate skipped during
     // auto-index (silent before PR-B — the dir registered, some files dropped).
     if (stats && typeof _blockedIndexToast === 'function') {

--- a/packages/memtomem/tests-js/app-simple-mode.test.mjs
+++ b/packages/memtomem/tests-js/app-simple-mode.test.mjs
@@ -138,11 +138,11 @@ describe('App-level Simple/Advanced (S2.2)', () => {
     // dropped back to Simple — must be swallowed, not re-activated.
     window.dispatchEvent(new window.PopStateEvent('popstate', { state: { tab: 'timeline' } }));
     expect(calls).not.toContain('timeline');
-    expect(calls).toHaveLength(0);
+    expect(calls).toEqual(['home']);
 
     // A visible tab still navigates on Back/Forward.
     window.dispatchEvent(new window.PopStateEvent('popstate', { state: { tab: 'sources' } }));
-    expect(calls).toEqual(['sources']);
+    expect(calls).toEqual(['home', 'sources']);
   });
 
   it('the Cmd+K palette omits advanced commands in Simple, lists them in Advanced', async () => {

--- a/packages/memtomem/tests-js/search-filter-ux.test.mjs
+++ b/packages/memtomem/tests-js/search-filter-ux.test.mjs
@@ -77,15 +77,34 @@ describe('Search filters - add/remove UX', () => {
 
   it('runs source-only search from the Search tab', async () => {
     addSourceOption('/repo/docs/cache.md');
+    addSourceOption('/repo/docs/other,comma.md');
 
     await window.doSearch();
     await flush();
 
     expect(searchUrls).toHaveLength(1);
     const params = new URL(`http://localhost${searchUrls[0]}`).searchParams;
-    expect(params.get('source_filter')).toBe('/repo/docs/cache.md');
+    expect(params.getAll('source_exact')).toEqual([
+      '/repo/docs/cache.md',
+      '/repo/docs/other,comma.md',
+    ]);
     expect(params.get('q')).toBeNull();
     expect(params.get('tag_filter')).toBeNull();
+  });
+
+  it('runs type/date-only search as server-side metadata bounds', async () => {
+    document.getElementById('chunk-type-filter').value = 'markdown_section';
+    document.getElementById('date-range-preset').value = 'today';
+
+    await window.doSearch();
+    await flush();
+
+    expect(searchUrls).toHaveLength(1);
+    const params = new URL(`http://localhost${searchUrls[0]}`).searchParams;
+    expect(params.get('q')).toBeNull();
+    expect(params.getAll('chunk_type')).toEqual(['markdown_section']);
+    expect(params.get('created_from')).toMatch(/T/);
+    expect(params.get('created_before')).toMatch(/T/);
   });
 
   it('preserves server-side filters when loading more results', async () => {
@@ -107,7 +126,7 @@ describe('Search filters - add/remove UX', () => {
     expect(params.get('top_k')).toBe('20');
     expect(params.get('namespace')).toBe('work');
     expect(params.get('context_window')).toBe('2');
-    expect(params.get('source_filter')).toBe('/repo/docs/cache.md');
+    expect(params.getAll('source_exact')).toEqual(['/repo/docs/cache.md']);
   });
 
   it('shows reranked results with rank percentile instead of raw negative score', () => {

--- a/packages/memtomem/tests/test_context_window.py
+++ b/packages/memtomem/tests/test_context_window.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -10,7 +11,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from memtomem.config import ContextWindowConfig, SearchConfig
-from memtomem.models import Chunk, ChunkMetadata, ContextInfo, SearchResult
+from memtomem.models import Chunk, ChunkMetadata, ChunkType, ContextInfo, SearchResult
 from memtomem.search.pipeline import SearchPipeline
 from memtomem.server.formatters import _format_single_result
 
@@ -488,3 +489,23 @@ class TestPipelineIntegration:
         assert len(ctx.window_after) == 2
         assert ctx.chunk_position == 3
         assert ctx.total_chunks_in_file == 5
+
+    async def test_chunk_type_filter_keeps_different_type_context_neighbors(self):
+        chunks = _make_file_chunks("/tmp/doc.md", 3)
+        chunks[0].metadata = dataclasses.replace(chunks[0].metadata, chunk_type=ChunkType.RAW_TEXT)
+        chunks[1].metadata = dataclasses.replace(
+            chunks[1].metadata, chunk_type=ChunkType.MARKDOWN_SECTION
+        )
+        chunks[2].metadata = dataclasses.replace(chunks[2].metadata, chunk_type=ChunkType.RAW_TEXT)
+        pipeline = _make_pipeline(
+            {Path("/tmp/doc.md"): chunks},
+            bm25_results=[SearchResult(chunk=chunks[1], score=0.9, rank=1, source="bm25")],
+            context_window_config=ContextWindowConfig(enabled=True, window_size=1),
+        )
+
+        results, _ = await pipeline.search("test", chunk_types=[ChunkType.MARKDOWN_SECTION.value])
+
+        assert len(results) == 1
+        assert results[0].context is not None
+        assert results[0].context.window_before == (chunks[0],)
+        assert results[0].context.window_after == (chunks[2],)

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic import ValidationError
@@ -2441,6 +2441,60 @@ class TestFileWatcher:
             debounce_ms=2000,
         )
         assert watcher._debounce_s == 2.0
+
+    async def test_reconfigure_reconciles_added_and_removed_roots(self, components, tmp_path):
+        from memtomem.config import IndexingConfig
+        from memtomem.indexing.watcher import FileWatcher
+
+        old_root = tmp_path / "old"
+        new_root = tmp_path / "new"
+        old_root.mkdir()
+        new_root.mkdir()
+        watcher = FileWatcher(components.index_engine, IndexingConfig(memory_dirs=[old_root]))
+        observer = MagicMock()
+        old_watch = object()
+        new_watch = object()
+        observer.schedule.return_value = new_watch
+        handler = MagicMock()
+        watcher._observer = observer
+        watcher._handler = handler
+        watcher._watches = {old_root.resolve(): old_watch}
+
+        config = IndexingConfig(memory_dirs=[new_root], supported_extensions=frozenset({".md"}))
+        await watcher.reconfigure(config)
+
+        observer.schedule.assert_called_once_with(handler, str(new_root.resolve()), recursive=True)
+        observer.unschedule.assert_called_once_with(old_watch)
+        assert watcher._watches == {new_root.resolve(): new_watch}
+        assert handler._supported == frozenset({".md"})
+        assert watcher._config is config
+
+    async def test_reconfigure_rolls_back_added_root_when_removal_fails(self, components, tmp_path):
+        from memtomem.config import IndexingConfig
+        from memtomem.indexing.watcher import FileWatcher
+
+        old_root = tmp_path / "old"
+        new_root = tmp_path / "new"
+        old_root.mkdir()
+        new_root.mkdir()
+        original_config = IndexingConfig(memory_dirs=[old_root])
+        watcher = FileWatcher(components.index_engine, original_config)
+        observer = MagicMock()
+        old_watch = object()
+        new_watch = object()
+        observer.schedule.return_value = new_watch
+        observer.unschedule.side_effect = [RuntimeError("remove failed"), None]
+        handler = MagicMock()
+        watcher._observer = observer
+        watcher._handler = handler
+        watcher._watches = {old_root.resolve(): old_watch}
+
+        with pytest.raises(RuntimeError, match="remove failed"):
+            await watcher.reconfigure(IndexingConfig(memory_dirs=[new_root]))
+
+        assert watcher._watches == {old_root.resolve(): old_watch}
+        assert observer.unschedule.call_args_list[1].args == (new_watch,)
+        assert watcher._config is original_config
 
     async def test_startup_backfill_default_off_skips_walk(self, components, memory_dir):
         """``startup_backfill`` defaults to False — guards against the

--- a/packages/memtomem/tests/test_storage.py
+++ b/packages/memtomem/tests/test_storage.py
@@ -9,7 +9,8 @@ from uuid import uuid4
 import pytest
 
 from helpers import make_chunk as _make_chunk
-from memtomem.models import Chunk, ChunkMetadata, ChunkType
+from memtomem.models import Chunk, ChunkMetadata, ChunkType, SearchResult
+from memtomem.search.pipeline import _matches_metadata
 from memtomem.storage.base import SearchMetadataFilter
 from memtomem.storage.sqlite_backend import _classify_startup_error
 from memtomem.storage.sqlite_helpers import norm_path
@@ -39,6 +40,20 @@ class TestChunkCRUD:
 
 
 class TestSearchMetadataFilters:
+    def test_post_filter_treats_legacy_naive_timestamp_as_utc(self):
+        created_at = datetime(2026, 7, 12, 12, 0)
+        chunk = _make_chunk("legacy timestamp")
+        chunk.created_at = created_at
+        result = SearchResult(chunk=chunk, score=1.0, rank=1, source="bm25")
+
+        assert _matches_metadata(
+            result,
+            SearchMetadataFilter(
+                created_from=datetime(2026, 7, 12, 11, 0, tzinfo=UTC),
+                created_before=datetime(2026, 7, 12, 13, 0, tzinfo=UTC),
+            ),
+        )
+
     @pytest.mark.asyncio
     async def test_bm25_applies_exact_source_type_and_date_before_limit(self, storage):
         now = datetime.now(UTC)

--- a/packages/memtomem/tests/test_storage.py
+++ b/packages/memtomem/tests/test_storage.py
@@ -2,13 +2,16 @@
 
 import dataclasses
 import unicodedata
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from uuid import uuid4
 
 import pytest
 
 from helpers import make_chunk as _make_chunk
-from memtomem.models import Chunk, ChunkMetadata
+from memtomem.models import Chunk, ChunkMetadata, ChunkType
+from memtomem.storage.base import SearchMetadataFilter
+from memtomem.storage.sqlite_backend import _classify_startup_error
 from memtomem.storage.sqlite_helpers import norm_path
 
 
@@ -33,6 +36,57 @@ class TestChunkCRUD:
     async def test_get_nonexistent(self, storage):
         result = await storage.get_chunk(uuid4())
         assert result is None
+
+
+class TestSearchMetadataFilters:
+    @pytest.mark.asyncio
+    async def test_bm25_applies_exact_source_type_and_date_before_limit(self, storage):
+        now = datetime.now(UTC)
+        excluded = _make_chunk("shared marker", source="outside,comma.md")
+        included = _make_chunk("shared marker", source="inside.md")
+        excluded.metadata = dataclasses.replace(excluded.metadata, chunk_type=ChunkType.RAW_TEXT)
+        included.metadata = dataclasses.replace(
+            included.metadata, chunk_type=ChunkType.MARKDOWN_SECTION
+        )
+        excluded.created_at = now - timedelta(days=30)
+        included.created_at = now
+        await storage.upsert_chunks([excluded, included])
+
+        results = await storage.bm25_search(
+            "shared",
+            top_k=1,
+            metadata_filter=SearchMetadataFilter(
+                source_exact=(str(included.metadata.source_file),),
+                chunk_types=(ChunkType.MARKDOWN_SECTION.value,),
+                created_from=now - timedelta(days=1),
+                created_before=now + timedelta(days=1),
+            ),
+        )
+
+        assert [result.chunk.id for result in results] == [included.id]
+
+
+class TestStorageStartupClassification:
+    @pytest.mark.parametrize(
+        ("error", "stage", "reason", "retryable"),
+        [
+            (PermissionError("denied"), "parent", "storage_permission_denied", False),
+            (RuntimeError("database is locked"), "journal", "storage_locked", True),
+            (
+                RuntimeError("unable to open database file"),
+                "open",
+                "storage_path_unavailable",
+                False,
+            ),
+            (RuntimeError("boom"), "schema", "storage_unavailable", False),
+        ],
+    )
+    def test_classifies_without_leaking_original_detail(self, error, stage, reason, retryable):
+        classified = _classify_startup_error(error, stage)
+        assert classified.reason_code == reason
+        assert classified.stage == stage
+        assert classified.retryable is retryable
+        assert "boom" not in str(classified)
 
 
 class TestChunkUniqueness:

--- a/packages/memtomem/tests/test_web_cli.py
+++ b/packages/memtomem/tests/test_web_cli.py
@@ -114,6 +114,7 @@ def _patch_web_stack(server_mock: MagicMock):
         patch("uvicorn.Server", return_value=server_mock),
         patch("memtomem.web.app.create_app", return_value=MagicMock()),
         patch("memtomem.web.app._lifespan", MagicMock()),
+        patch("memtomem.cli.web._readiness_ok", return_value=True),
     ]
 
 
@@ -162,10 +163,9 @@ def test_web_open_timeout_warns_and_skips_browser() -> None:
                 ["--host", "127.0.0.1", "--port", "9999", "--open", "--timeout", "1"],
             )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 1
     mock_browser.assert_not_called()
-    assert "Warning" in result.output
-    assert "timeout" in result.output.lower()
+    assert "failed during startup" in result.output.lower()
 
 
 def test_web_open_zero_timeout_shows_warning() -> None:
@@ -435,7 +435,7 @@ def test_web_background_spawns_internal_foreground_child(
         return FakeChild()
 
     monkeypatch.setattr(web_cmd.subprocess, "Popen", fake_popen)
-    monkeypatch.setattr(web_cmd, "_wait_for_tcp", lambda *args, **kwargs: True)
+    monkeypatch.setattr(web_cmd, "_wait_for_readiness", lambda *args, **kwargs: True)
 
     runner = CliRunner()
     with patch("memtomem.cli.web._missing_web_deps", return_value=None):

--- a/packages/memtomem/tests/test_web_lifespan.py
+++ b/packages/memtomem/tests/test_web_lifespan.py
@@ -292,8 +292,12 @@ async def test_lifespan_starts_and_stops_file_watcher():
         async with _lifespan(app):
             assert fake_watcher.start.await_count == 1
             assert app.state.file_watcher is fake_watcher
+            assert app.state.startup_state == "ready"
+            assert app.state.config_signature is not None
+            assert app.state.last_reload_error is None
 
     assert fake_watcher.stop.await_count == 1
+    assert app.state.startup_state == "not_started"
 
 
 async def test_lifespan_skips_watcher_in_degraded_mode():

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -269,6 +269,7 @@ def app():
     cfg.indexing.project_memory_dirs = []
     application.state.config = cfg
     application.state.dedup_scanner = dedup_scanner
+    application.state.project_root = Path.cwd()
 
     # Pin the hot-reload signature to the current on-disk state so these
     # FakeConfig-based tests don't get their state.config swapped out for a
@@ -305,6 +306,30 @@ async def client(app):
 
 
 class TestHealth:
+    async def test_lifespan_free_readiness_and_missing_component_contract(self):
+        bare_app = create_app(lifespan=None, mode="prod")
+        async with AsyncClient(
+            transport=ASGITransport(app=bare_app), base_url="http://test"
+        ) as bare_client:
+            ready = await bare_client.get("/api/readiness")
+            assert ready.status_code == 503
+            assert ready.json() == {
+                "ready": False,
+                "state": "not_started",
+                "reason_code": "startup_unavailable",
+            }
+            stats = await bare_client.get("/api/stats")
+            assert stats.status_code == 503
+            assert stats.json() == {
+                "detail": {
+                    "reason_code": "startup_unavailable",
+                    "message": "Web backend startup is unavailable.",
+                }
+            }
+            assert (await bare_client.get("/api/health")).status_code == 200
+            assert (await bare_client.get("/api/session")).status_code == 200
+            assert (await bare_client.get("/api/config/defaults")).status_code == 200
+
     async def test_health_liveness_is_local_only(self, app, client: AsyncClient):
         resp = await client.get("/api/health")
         assert resp.status_code == 200
@@ -858,6 +883,37 @@ class TestSearch:
             params={"q": "test", "top_k": 5, "namespace": "work"},
         )
         assert resp.status_code == 200
+
+    async def test_search_threads_repeatable_exact_metadata_filters(self, app, client: AsyncClient):
+        app.state.search_pipeline.search.reset_mock()
+        resp = await client.get(
+            "/api/search",
+            params=[
+                ("source_exact", "/tmp/a,comma.md"),
+                ("source_exact", "/tmp/b.md"),
+                ("chunk_type", "markdown_section"),
+                ("created_from", "2026-07-01T00:00:00+09:00"),
+                ("created_before", "2026-07-13T00:00:00+09:00"),
+            ],
+        )
+        assert resp.status_code == 200, resp.text
+        kwargs = app.state.search_pipeline.search.await_args.kwargs
+        assert kwargs["source_exact"] == ["/tmp/a,comma.md", "/tmp/b.md"]
+        assert kwargs["chunk_types"] == ["markdown_section"]
+        assert kwargs["created_from"].tzinfo is not None
+        assert kwargs["created_before"] > kwargs["created_from"]
+
+    async def test_search_rejects_naive_or_reversed_date_bounds(self, client: AsyncClient):
+        naive = await client.get("/api/search", params={"created_from": "2026-07-01T00:00:00"})
+        assert naive.status_code == 422
+        reversed_range = await client.get(
+            "/api/search",
+            params={
+                "created_from": "2026-07-02T00:00:00Z",
+                "created_before": "2026-07-01T00:00:00Z",
+            },
+        )
+        assert reversed_range.status_code == 422
 
     async def test_search_pipeline_error_returns_500(self, app, client: AsyncClient):
         app.state.search_pipeline.search.side_effect = RuntimeError("search failed")
@@ -2930,6 +2986,7 @@ class TestUnicodePaths:
         assert body["indexed"] is not None
         assert body["indexed"]["indexed_chunks"] == 2
         assert body["indexed"]["total_files"] == 1
+        assert body["index_status"] == "success"
         # ``index_path`` was called with the resolved path of the dir we
         # just added — watcher invariant naturally satisfied.
         called_args, _ = app.state.index_engine.index_path.call_args
@@ -2980,6 +3037,7 @@ class TestUnicodePaths:
         assert resp.status_code == 200
         body = resp.json()
         assert body["indexed"] is None
+        assert body["index_status"] == "not_requested"
         assert app.state.index_engine.index_path.call_count == 0
 
     async def test_add_memory_dir_explicit_null_skips_index(
@@ -3006,7 +3064,27 @@ class TestUnicodePaths:
         assert resp.status_code == 200
         body = resp.json()
         assert body["indexed"] is None
+        assert body["index_status"] == "not_requested"
         assert app.state.index_engine.index_path.call_count == 0
+
+    async def test_add_memory_dir_reports_failed_index_without_lying_about_registration(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        app.state.config.indexing.memory_dirs = []
+        app.state.index_engine.index_path.side_effect = RuntimeError("/private/secret/path failed")
+
+        with patch("memtomem.web.routes.system.save_config_overrides"):
+            resp = await client.post(
+                "/api/memory-dirs/add",
+                json={"path": str(memory_dir), "auto_index": True},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["index_status"] == "failed"
+        assert "/private/secret" not in body["indexed"]["error"]
 
     async def test_remove_memory_dir_matches_nfd_and_nfc(self, app, client: AsyncClient, tmp_path):
         # Config has the target dir in NFD form plus a second entry (the

--- a/packages/memtomem/tests/web/test_actual_lifespan_golden.py
+++ b/packages/memtomem/tests/web/test_actual_lifespan_golden.py
@@ -1,0 +1,145 @@
+"""No-interception golden for the real ``mm web`` lifespan."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.fixture
+def actual_web_server(tmp_path: Path) -> Iterator[tuple[str, Path]]:
+    home = tmp_path / "home"
+    runtime = tmp_path / "runtime"
+    temp_dir = tmp_path / "tmp"
+    project = tmp_path / "project"
+    source = tmp_path / "source"
+    for directory in (home, runtime, temp_dir, project, source):
+        directory.mkdir(mode=0o700)
+    (source / "golden.md").write_text(
+        "# Golden\n\nactual-lifespan-unique-marker\n", encoding="utf-8"
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home),
+            "TMPDIR": str(temp_dir),
+            "XDG_RUNTIME_DIR": str(runtime),
+            "MEMTOMEM_WEB__CSRF_ENFORCE": "1",
+            "MEMTOMEM_STORAGE__SQLITE_PATH": str(home / ".memtomem" / "golden.db"),
+        }
+    )
+    cli = [sys.executable, "-c", "from memtomem.cli import cli; cli()"]
+    subprocess.run(
+        cli
+        + [
+            "init",
+            "--non-interactive",
+            "--provider",
+            "none",
+            "--preset",
+            "minimal",
+            "--mcp",
+            "skip",
+        ],
+        cwd=project,
+        env=env,
+        check=True,
+        capture_output=True,
+    )
+
+    port = _free_port()
+    url = f"http://127.0.0.1:{port}"
+    log_path = tmp_path / "web.log"
+    with log_path.open("wb") as log:
+        process = subprocess.Popen(
+            cli + ["web", "--mode", "prod", "--host", "127.0.0.1", "--port", str(port)],
+            cwd=project,
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+        )
+    try:
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                raise RuntimeError(log_path.read_text(encoding="utf-8", errors="replace"))
+            try:
+                response = httpx.get(f"{url}/api/readiness", timeout=1)
+                if response.status_code == 200:
+                    break
+            except httpx.HTTPError:
+                pass
+            time.sleep(0.1)
+        else:
+            raise RuntimeError("real lifespan server did not become ready")
+        yield url, source
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=2)
+
+
+def test_actual_lifespan_add_search_export_and_history(page, actual_web_server):
+    url, source = actual_web_server
+    session = httpx.get(f"{url}/api/session").json()
+    added = httpx.post(
+        f"{url}/api/memory-dirs/add",
+        json={"path": str(source), "auto_index": True},
+        headers={"X-Memtomem-CSRF": session["csrf"]},
+        timeout=20,
+    )
+    assert added.status_code == 200, added.text
+    payload = added.json()
+    assert payload["index_status"] == "success"
+    assert payload["indexed"]["total_files"] == 1
+    assert payload["indexed"]["indexed_chunks"] > 0
+
+    console_errors: list[str] = []
+    page_errors: list[str] = []
+    network_5xx: list[str] = []
+    page.on("console", lambda msg: console_errors.append(msg.text) if msg.type == "error" else None)
+    page.on("pageerror", lambda exc: page_errors.append(str(exc)))
+    page.on(
+        "response",
+        lambda response: network_5xx.append(response.url) if response.status >= 500 else None,
+    )
+
+    page.set_viewport_size({"width": 1440, "height": 900})
+    page.goto(f"{url}/#search")
+    page.fill("#search-input", "actual-lifespan-unique-marker")
+    page.click("#search-btn")
+    page.wait_for_selector("#results-list .result-item")
+    page.click('.tab-btn[data-tab="sources"]')
+    page.go_back()
+    page.wait_for_selector('.tab-btn[data-tab="search"].active')
+    assert page.url.endswith("#search")
+    assert page.locator("#tab-search").is_visible()
+
+    preview = httpx.get(f"{url}/api/export/stats").json()["total_chunks"]
+    bundle = json.loads(httpx.get(f"{url}/api/export").text)
+    assert preview == bundle["total_chunks"]
+    assert preview > 0
+    assert console_errors == []
+    assert page_errors == []
+    assert network_5xx == []

--- a/packages/memtomem/tests/web/test_ui_refresh_contract.py
+++ b/packages/memtomem/tests/web/test_ui_refresh_contract.py
@@ -59,7 +59,7 @@ def test_changed_static_assets_bump_cache_versions() -> None:
     html = (STATIC / "index.html").read_text(encoding="utf-8")
 
     assert "/style.css?v=136" in html
-    assert "/app.js?v=149" in html
+    assert "/app.js?v=150" in html
 
 
 def test_theme_icon_follows_document_theme_without_duplicate_js_state() -> None:

--- a/packages/memtomem/tests/web/test_ui_refresh_contract.py
+++ b/packages/memtomem/tests/web/test_ui_refresh_contract.py
@@ -59,7 +59,7 @@ def test_changed_static_assets_bump_cache_versions() -> None:
     html = (STATIC / "index.html").read_text(encoding="utf-8")
 
     assert "/style.css?v=136" in html
-    assert "/app.js?v=150" in html
+    assert "/app.js?v=151" in html
 
 
 def test_theme_icon_follows_document_theme_without_duplicate_js_state() -> None:

--- a/packages/memtomem/tests/web/test_ui_smoke_matrix.py
+++ b/packages/memtomem/tests/web/test_ui_smoke_matrix.py
@@ -339,8 +339,10 @@ def test_ui_smoke_matrix(page, mode: str, viewport: tuple[int, int]) -> None:
             "() => document.querySelectorAll('#results-list .result-item').length > 0",
             timeout=5_000,
         )
-        assert page.locator("#results-list .result-debug-meta").first.evaluate(
-            "el => getComputedStyle(el).display === 'none'"
+        page.wait_for_function(
+            "() => getComputedStyle(document.querySelector("
+            "'#results-list .result-debug-meta')).display === 'none'",
+            timeout=2_000,
         )
         assert (
             page.locator("#results-list .results-debug-details summary").inner_text()

--- a/packages/memtomem/tests/web/test_ui_smoke_matrix.py
+++ b/packages/memtomem/tests/web/test_ui_smoke_matrix.py
@@ -112,7 +112,7 @@ def _api_payload(url: str, mode: str) -> dict[str, object]:
     if path == "/api/system/model-readiness":
         return {"ready": True}
     if path == "/api/session":
-        return {"csrf_token": "smoke-token"}
+        return {"csrf": "smoke-token", "mode": mode}
     if path == "/api/config":
         return {
             "embedding": {"provider": "none", "model": "none", "dimension": 0},
@@ -547,3 +547,26 @@ def test_direct_hash_entry_populates_header_stats(page, route: str) -> None:
         captured_errors = page.evaluate("() => window.__smokeErrors || []")
 
     assert captured_errors == []
+
+
+def test_hash_history_back_forward_keeps_url_tab_and_panel_in_sync(page) -> None:
+    page.set_viewport_size({"width": 1440, "height": 900})
+    _install_error_capture(page)
+    _install_smoke_stubs(page, "prod")
+
+    with _web_server("prod") as base_url:
+        page.goto(f"{base_url}/#search", wait_until="domcontentloaded")
+        page.wait_for_selector('.tab-btn[data-tab="search"].active')
+        page.click('.tab-btn[data-tab="sources"]')
+        page.wait_for_selector('.tab-btn[data-tab="sources"].active')
+
+        page.go_back()
+        page.wait_for_selector('.tab-btn[data-tab="search"].active')
+        assert page.url.endswith("#search")
+        assert page.locator("#tab-search").is_visible()
+        assert page.locator("#search-input").bounding_box()["height"] > 0
+
+        page.go_forward()
+        page.wait_for_selector('.tab-btn[data-tab="sources"].active')
+        assert page.url.endswith("#sources")
+        assert page.locator("#tab-sources").is_visible()


### PR DESCRIPTION
## Summary
- classify storage startup failures and clean up partially initialized components
- add readiness and missing-state 503 contracts, watcher reconfiguration, and truthful initial-index outcomes
- move exact source/type/date filtering into backend search and align export namespace stats
- repair hash/history navigation and add actual-lifespan golden QA coverage

## Validation
- Python suite: 8,440 passed; 34 HOME-writing tests passed separately outside the sandbox
- JavaScript: 69 files, 461 tests passed
- ruff check and format check passed
- mypy passed for 12 changed source modules
- git diff --check passed
- isolated actual-lifespan flow verified: readiness, registration/indexing, exact search, export parity, clean shutdown

## Browser note
- Playwright golden test is included and auto-skips when Chromium is unavailable; local Chromium was not installed.