### PR TITLE
release: v0.3.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
         "path": "packages/memtomem-claude-plugin"
       },
       "description": "Semantic memory with hybrid BM25 + dense search",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "author": { "name": "memtomem" },
       "repository": "https://github.com/memtomem/memtomem",
       "license": "Apache-2.0",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,32 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.3.8] — 2026-07-13
+
+### Added
+
+- **Web search accepts exact source, type, and date filters** (#1729). The
+  search endpoint gains `source_exact`, `chunk_type`, `created_from`, and
+  `created_before` query parameters, applied as exact matches inside the
+  backend query instead of post-filtering results. Date bounds must be
+  timezone-aware and are rejected with a 422 when naive or when
+  `created_from` is not before `created_before`.
+- **Web startup exposes readiness and missing-state contracts** (#1729).
+  Storage startup failures are now classified and partially initialized
+  components are cleaned up; the server reports readiness, returns 503 while
+  it is not yet ready or its state is missing, reconfigures the file watcher
+  on change, and surfaces truthful initial-index outcomes — partial and
+  failed indexing are reported as such rather than always as success.
+- **Web export accepts a `namespace` filter** (#1729), matching the search
+  endpoint's namespace scoping.
+
 ### Changed
 
-- Claude plugin 0.2.3 now maps to the verified core 0.3.7 release (#1727).
+- Claude plugin 0.2.4 now maps to the verified core 0.3.8 release.
+
+### Fixed
+
+- **Hash-based history navigation is repaired** in the web UI (#1729).
 
 ### Documentation
 

--- a/packages/memtomem-claude-plugin/.claude-plugin/plugin.json
+++ b/packages/memtomem-claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memtomem",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Markdown-first semantic memory for AI agents — hybrid BM25 + dense search across your markdown files",
   "author": {
     "name": "memtomem",

--- a/packages/memtomem-claude-plugin/.mcp.json
+++ b/packages/memtomem-claude-plugin/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "memtomem": {
       "command": "uvx",
-      "args": ["--from", "memtomem==0.3.7", "memtomem-server"]
+      "args": ["--from", "memtomem==0.3.8", "memtomem-server"]
     }
   }
 }

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.3.7"
+version = "0.3.8"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/packages/memtomem/tests/test_supply_chain_contracts.py
+++ b/packages/memtomem/tests/test_supply_chain_contracts.py
@@ -14,7 +14,7 @@ _ROOT = Path(__file__).resolve().parents[3]
 _ACTION_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_./-]+)?@[0-9a-f]{40}$")
 _DOCKER_RE = re.compile(r"^docker://[^\s@]+@sha256:[0-9a-f]{64}$")
 _USES_LINE_RE = re.compile(r"^\s*(?:-\s*)?uses:\s*([^\s#]+)")
-_PLUGIN_CORE_MAP = {"0.2.3": "0.3.7"}
+_PLUGIN_CORE_MAP = {"0.2.4": "0.3.8"}
 
 
 def _assert_pinned_ref(reference: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -965,7 +965,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.3.7"
+version = "0.3.8"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release **v0.3.8** — bumps the core package (`0.3.7 → 0.3.8`) and the Claude
plugin (`0.2.3 → 0.2.4`, `.mcp.json` core pin → `0.3.8`, marketplace entry),
and lands the `CHANGELOG [0.3.8]` section reconciling the three merged
commits since `v0.3.7`.

Release-mechanics only — no feature code changes here. The user-facing work
already landed on `main`:

- **#1729** — web startup readiness/503 contracts with truthful initial-index
  outcomes, exact backend search filters (`source_exact`, `chunk_type`,
  `created_from`, `created_before`), a `namespace` filter on export, and a
  hash/history navigation fix.
- **#1728** — public docs restructured around a deterministic first-success
  round trip.
- **#1727** — plugin-to-core release mapping.

## Changes in this PR

- `packages/memtomem/pyproject.toml`: `version = "0.3.8"`
- `uv.lock`: `uv sync` in the same commit (workspace `memtomem` → `0.3.8`)
- `CHANGELOG.md`: `[Unreleased]` → `[0.3.8] — 2026-07-13`
- `packages/memtomem-claude-plugin/.claude-plugin/plugin.json`: `0.2.4`
- `packages/memtomem-claude-plugin/.mcp.json`: core pin `memtomem==0.3.8`
- `.claude-plugin/marketplace.json`: plugin `0.2.4`
- `packages/memtomem/tests/test_supply_chain_contracts.py`: `_PLUGIN_CORE_MAP`
  → `{"0.2.4": "0.3.8"}` so the supply-chain guard validates the bumped pair

## Migration notes

None. No CLI, MCP, config, schema, or dependency changes — the delta is a
version bump plus the already-merged web behavior in #1729.

## Release mechanics

- No new dependencies → base-wheel smoke is sufficient.
- `#1729` is a behavior change (startup 503, search filters) → TestPyPI
  dry-run (`test-v0.3.8a1`) before the production `v0.3.8` tag.
- Plugin bumped because plugin assets changed since `v0.3.7`; the four
  plugin surfaces (manifest, marketplace, `.mcp.json` pin, `_PLUGIN_CORE_MAP`)
  are updated together in this release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
