### PR TITLE
fix: recover stale memory formation claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - **Interrupted approval recovery** — `mm review recover` and
   `mem_candidate_recover` atomically return stale `writing` candidates to the
   pending queue after a conservative threshold and persist an audited status
-  transition without reclaiming fresh approvals.
+  transition without reclaiming fresh approvals. Pre-upgrade NULL claim
+  timestamps receive a one-time grace-period backfill; recovery supports
+  older SQLite versions without `UPDATE ... RETURNING`, and a completed write
+  that loses finalization is quarantined as `write_uncertain` to prevent blind
+  duplicate approval.
 
 ## [0.3.8] — 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   evidence-linked candidates from exact session events and write durable
   memory only after approval. Additive temporal assertion tables preserve
   direction and multiple `supersedes`/`contradicts`/`supports` edges.
+- **Interrupted approval recovery** — `mm review recover` and
+  `mem_candidate_recover` atomically return stale `writing` candidates to the
+  pending queue after a conservative threshold and persist an audited status
+  transition without reclaiming fresh approvals.
 
 ## [0.3.8] — 2026-07-13
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -897,7 +897,7 @@ The keys may come either from the config surface above or from the Langfuse SDK'
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MEMTOMEM_TOOL_MODE` | `core` | Which MCP tools are exposed: `core` (9 tools), `standard` (38 incl. `mem_do`), `full` (95) |
+| `MEMTOMEM_TOOL_MODE` | `core` | Which MCP tools are exposed: `core` (9 tools), `standard` (38 incl. `mem_do`), `full` (96) |
 
 In `core` mode, use `mem_do(action="...", params={...})` to access any of the 70+ non-core actions. Fewer tools means less context usage for AI agents.
 

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -381,7 +381,7 @@ mm status
 uses, so the output is identical. Useful as a sanity check between
 `mm init` and the first editor-side call.
 
-### Available MCP Tools (95)
+### Available MCP Tools (96)
 
 | Category | Tools |
 |----------|-------|
@@ -416,12 +416,12 @@ uses, so the output is identical. Useful as a sanity check between
 | **Evaluation** | `mem_eval` |
 | **Context** | `mem_context_detect`, `mem_context_init`, `mem_context_generate`, `mem_context_diff`, `mem_context_sync`, `mem_context_memory_migrate`, `mem_context_artifact_migrate`, `mem_context_artifact_transfer`, `mem_context_version`, `mem_context_promote` — cross-runtime artifact sync (`mm context`). Parameters: [Context tool reference](reference.md#context-tool-parameters); workflow: [Context Gateway](context-gateway.md) |
 | **Pinned Context** | `mem_pinned_list`, `mem_pinned_get`, `mem_pinned_set`, `mem_pinned_delete`, `mem_context_compose` |
-| **Formation** | `mem_formation_scan`, `mem_candidate_list`, `mem_candidate_review` |
+| **Formation** | `mem_formation_scan`, `mem_candidate_list`, `mem_candidate_review`, `mem_candidate_recover` |
 
 
 \* Requires `MEMTOMEM_TOOL_MODE=full`. In `core` or `standard` mode, use `mm config` (CLI) or the Web UI Settings tab instead.
 
-> **Tool mode**: Set `MEMTOMEM_TOOL_MODE` to `core` (9 tools, default), `standard` (core + common packs + `mem_do`), or `full` (all 95 tools individually) to control how many tools are exposed. In `core` mode, use `mem_do(action="...", params={...})` to access any non-core action. Fewer tools = less context usage for AI agents.
+> **Tool mode**: Set `MEMTOMEM_TOOL_MODE` to `core` (9 tools, default), `standard` (core + common packs + `mem_do`), or `full` (all 96 tools individually) to control how many tools are exposed. In `core` mode, use `mem_do(action="...", params={...})` to access any non-core action. Fewer tools = less context usage for AI agents.
 
 ### STM Proxy Tools (optional, separate package)
 

--- a/docs/guides/pinned-context.md
+++ b/docs/guides/pinned-context.md
@@ -49,6 +49,12 @@ The equivalent MCP action is `mem_candidate_recover`. Recovery is atomic with
 approval finalization, does not touch fresh claims, and records a persistent
 `writing → pending` transition with the operator and reason.
 
+If a recovered claim's original process later reports that its durable write
+already completed, memtomem moves the candidate to `write_uncertain` and
+reports the destination. Do not approve it again: inspect the Markdown or
+Pinned Context block first, then resolve the candidate manually. This
+quarantine prevents a blind retry from duplicating the persisted content.
+
 ## LangGraph
 
 Install the optional adapter and pass it to a graph as its store:

--- a/docs/guides/pinned-context.md
+++ b/docs/guides/pinned-context.md
@@ -36,6 +36,19 @@ Candidates use only events belonging to the selected session and retain event
 and chunk evidence. Secret-bearing events are skipped. Pending candidates
 expire after 30 days; only approval invokes the normal durable file write.
 
+Approval first claims a candidate as `writing`. Normal write failures and
+cancellation return it to `pending`. If the process is forcibly terminated,
+inspect and recover claims older than the conservative 15-minute threshold:
+
+```bash
+mm review list --status writing
+mm review recover --stale-after-minutes 15 --actor alice
+```
+
+The equivalent MCP action is `mem_candidate_recover`. Recovery is atomic with
+approval finalization, does not touch fresh claims, and records a persistent
+`writing → pending` transition with the operator and reason.
+
 ## LangGraph
 
 Install the optional adapter and pass it to a graph as its store:

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -87,7 +87,7 @@ sequenceDiagram
 
 ## MCP Tools at a Glance
 
-memtomem provides **95 MCP tools** organized into categories:
+memtomem provides **96 MCP tools** organized into categories:
 
 | Category | Tools | What they do |
 |----------|-------|-------------|
@@ -103,7 +103,7 @@ memtomem provides **95 MCP tools** organized into categories:
 | **Working Memory** | `mem_scratch_set/get/promote` | Ephemeral key-value scratch space |
 | **Config** | `mem_stats`, `mem_status`, `mem_config`\*, `mem_embedding_reset`\*, `mem_reset`\* | Monitor and configure |
 | **Pinned Context** | `mem_pinned_list/get/set/delete`, `mem_context_compose` | Keep bounded instructions ahead of retrieved memory |
-| **Formation** | `mem_formation_scan`, `mem_candidate_list/review` | Review proposed memories before durable writes |
+| **Formation** | `mem_formation_scan`, `mem_candidate_list/review/recover` | Review proposed memories and recover interrupted approvals |
 
 \* Requires `MEMTOMEM_TOOL_MODE=full`. In `core` or `standard` mode, use `mm config` (CLI) or the Web UI Settings tab instead.
 
@@ -143,4 +143,4 @@ The `mem_context_*` tools (CLI: `mm context`) sync canonical artifacts — skill
 - [LLM Providers](llm-providers.md) — Optional LLM features (auto-tag, entity extraction, ask)
 - [MCP Client Setup](mcp-clients.md) — Editor-specific configuration
 - [memtomem-stm](https://github.com/memtomem/memtomem-stm) — Proactive surfacing, compression, caching (separate package)
-- [Full Tool Reference](../../packages/memtomem/README.md) — All 95 tools with parameters
+- [Full Tool Reference](../../packages/memtomem/README.md) — All 96 tools with parameters

--- a/docs/guides/use-cases.md
+++ b/docs/guides/use-cases.md
@@ -103,6 +103,9 @@ mm review approve CANDIDATE_ID --reviewer alice
 Decisions, preferences, procedures, action items, and narrowly signalled facts
 enter a review queue with evidence. Rejection writes no long-term memory;
 approval rechecks privacy and atomically claims the candidate before writing.
+After an abnormal process termination, operators can inspect
+`mm review list --status writing` and run `mm review recover`; fresh claims are
+left untouched and every recovery is audit-recorded.
 
 ## Public evaluation corpus
 

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -55,14 +55,14 @@ If `mm init` registered an MCP client, ask it to `Call the mem_status tool`. See
 - **🌐 Web UI** — polished SPA dashboard for search, sources, indexing, tags, and timeline (`mm web --dev` unlocks the full maintainer surface including Sessions, Working Memory, and Health Report)
 - **🧭 Context Gateway** — keep canonical Skills, Commands, and Subagents in a project or user Store, optionally install reusable Wiki assets, then sync them to supported runtimes
 - **⚙️ Scriptable CLI** — `--json` output on `mm status` and write commands (`mm add` / `mm reset` / `mm purge`); `mm warmup` pre-loads local models so the first query skips cold-start
-- **🛠️ 95 MCP tools** — full feature surface as MCP tools, with `mem_do` meta-tool routing all registered actions in `core` mode (default) for minimal context usage
+- **🛠️ 96 MCP tools** — full feature surface as MCP tools, with `mem_do` meta-tool routing all registered actions in `core` mode (default) for minimal context usage
 - **📌 Pinned Context** — small file-backed user/project/agent blocks are composed before retrieved memory
 - **🕸️ LangGraph Store** — optional `MemtomemBaseStore` supplies tuple-namespace JSON persistence and search
 
-The 95-tool surface includes the new Pinned Context actions
+The 96-tool surface includes the new Pinned Context actions
 (`mem_pinned_list/get/set/delete`, `mem_context_compose`) and review-first
-formation actions (`mem_formation_scan`, `mem_candidate_list/review`). See the
-[complete MCP table](https://github.com/memtomem/memtomem/blob/main/docs/guides/mcp-clients.md#available-mcp-tools-95)
+formation actions (`mem_formation_scan`, `mem_candidate_list/review/recover`). See the
+[complete MCP table](https://github.com/memtomem/memtomem/blob/main/docs/guides/mcp-clients.md#available-mcp-tools-96)
 for every category.
 
 ## Documentation

--- a/packages/memtomem/src/memtomem/cli/review_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/review_cmd.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import click
+
+from memtomem.formation import DEFAULT_STALE_CLAIM_MINUTES
 
 
 @click.group("review")
@@ -68,6 +70,44 @@ async def _show(candidate_id: str) -> None:
         if candidate is None:
             raise click.ClickException("Candidate not found")
         click.echo(json.dumps(candidate, ensure_ascii=False, indent=2))
+
+
+@review.command("recover")
+@click.option(
+    "--stale-after-minutes",
+    type=click.IntRange(min=1, max=1440),
+    default=DEFAULT_STALE_CLAIM_MINUTES,
+    show_default=True,
+)
+@click.option("--limit", type=click.IntRange(min=1, max=1000), default=100)
+@click.option("--actor", default="cli-operator")
+def recover(stale_after_minutes: int, limit: int, actor: str) -> None:
+    """Return stale interrupted approval claims to the pending queue."""
+    asyncio.run(_recover(stale_after_minutes, limit, actor))
+
+
+async def _recover(stale_after_minutes: int, limit: int, actor: str) -> None:
+    from memtomem.cli._bootstrap import cli_components
+
+    if not actor.strip():
+        raise click.ClickException("Recovery actor cannot be empty")
+    stale_before = datetime.now(timezone.utc) - timedelta(minutes=stale_after_minutes)
+    async with cli_components() as comp:
+        recovered = await comp.storage.recover_stale_memory_candidates(
+            stale_before=stale_before.isoformat(timespec="seconds"),
+            actor=actor,
+            limit=limit,
+        )
+        click.echo(
+            json.dumps(
+                {
+                    "ok": True,
+                    "recovered": len(recovered),
+                    "candidate_ids": recovered,
+                    "stale_before": stale_before.isoformat(timespec="seconds"),
+                }
+            )
+        )
 
 
 async def _decide(candidate_id: str, decision: str, reviewer: str, reason: str) -> None:

--- a/packages/memtomem/src/memtomem/cli/review_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/review_cmd.py
@@ -131,15 +131,17 @@ async def _decide(candidate_id: str, decision: str, reviewer: str, reason: str) 
             claimed = await comp.storage.claim_memory_candidate(candidate_id, reviewer, reason)
             if claimed is None:
                 raise click.ClickException("Candidate state changed concurrently")
+            write_location = "the durable destination"
             try:
                 if candidate["destination"] == "pinned":
-                    PinnedContextStore(
+                    block = PinnedContextStore(
                         comp.config, project_root=_resolve_project_context_root(comp)
                     ).set(
                         f"candidate-{candidate_id[:8]}",
                         candidate["content"],
                         description=f"Approved {candidate['kind']} candidate",
                     )
+                    write_location = str(block.source_path)
                 else:
                     from memtomem.context._atomic import (
                         _CRUD_SIDECAR_LOCK_BUDGET_S,
@@ -149,6 +151,7 @@ async def _decide(candidate_id: str, decision: str, reviewer: str, reason: str) 
 
                     base = Path(comp.config.indexing.memory_dirs[0]).expanduser().resolve()
                     target = base / f"{datetime.now(timezone.utc):%Y-%m-%d}.md"
+                    write_location = str(target)
                     async with async_file_lock(
                         _lock_path_for(target), timeout=_CRUD_SIDECAR_LOCK_BUDGET_S
                     ):
@@ -169,7 +172,21 @@ async def _decide(candidate_id: str, decision: str, reviewer: str, reason: str) 
                 await comp.storage.release_memory_candidate(candidate_id)
                 raise
             if not await comp.storage.finalize_memory_candidate(candidate_id):
-                raise click.ClickException("Candidate claim was lost before finalization")
+                warning = (
+                    "Durable write completed, but the approval claim was recovered "
+                    "concurrently. The content already persists at "
+                    f"{write_location}; inspect it before taking further action and "
+                    "do not re-approve this candidate."
+                )
+                quarantined = await comp.storage.mark_memory_candidate_write_uncertain(
+                    candidate_id, actor="cli-finalizer", reason=warning
+                )
+                suffix = (
+                    " Candidate moved to write_uncertain."
+                    if quarantined
+                    else " Candidate state changed again; inspect the review queue."
+                )
+                raise click.ClickException(warning + suffix)
         else:
             changed = await comp.storage.decide_memory_candidate(
                 candidate_id, decision, reviewer, reason

--- a/packages/memtomem/src/memtomem/formation.py
+++ b/packages/memtomem/src/memtomem/formation.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 from memtomem import privacy
 
 EXTRACTOR_VERSION = "heuristic-v1"
+DEFAULT_STALE_CLAIM_MINUTES = 15
 _KIND_PATTERNS = (
     ("decision", 0.95, re.compile(r"(?i)\b(decision|decided|chosen)\b|결정|채택")),
     ("preference", 0.9, re.compile(r"(?i)\b(prefer|preference)\b|선호")),

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -121,6 +121,7 @@ from memtomem.server.tools.pinned import (
 )
 from memtomem.server.tools.formation import (
     mem_candidate_list,
+    mem_candidate_recover,
     mem_candidate_review,
     mem_formation_scan,
 )

--- a/packages/memtomem/src/memtomem/server/tools/formation.py
+++ b/packages/memtomem/src/memtomem/server/tools/formation.py
@@ -132,7 +132,26 @@ async def mem_candidate_review(
         await app.storage.release_memory_candidate(candidate_id)
         raise
     changed = await app.storage.finalize_memory_candidate(candidate_id)
+    if not changed:
+        warning = (
+            "Durable write completed, but the approval claim was recovered concurrently. "
+            "The write already persists; inspect the returned write details before taking "
+            "further action and do not re-approve this candidate."
+        )
+        quarantined = await app.storage.mark_memory_candidate_write_uncertain(
+            candidate_id, actor="mcp-finalizer", reason=warning
+        )
+        return json.dumps(
+            {
+                "ok": False,
+                "status": "write_uncertain" if quarantined else "state_changed",
+                "durable_write_persisted": True,
+                "reason": warning,
+                "write": write_result,
+            },
+            ensure_ascii=False,
+        )
     return json.dumps(
-        {"ok": changed, "status": "approved", "write": write_result},
+        {"ok": True, "status": "approved", "write": write_result},
         ensure_ascii=False,
     )

--- a/packages/memtomem/src/memtomem/server/tools/formation.py
+++ b/packages/memtomem/src/memtomem/server/tools/formation.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import datetime, timedelta, timezone
 
-from memtomem.formation import scan_session_candidates
+from memtomem.formation import DEFAULT_STALE_CLAIM_MINUTES, scan_session_candidates
 from memtomem.pinned import PinnedContextStore
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app_initialized
@@ -32,6 +33,39 @@ async def mem_candidate_list(status: str = "pending", limit: int = 100, ctx: Ctx
     return json.dumps(
         await app.storage.list_memory_candidates(status=status, limit=limit),
         ensure_ascii=False,
+    )
+
+
+@mcp.tool()
+@tool_handler
+@register("formation")
+async def mem_candidate_recover(
+    stale_after_minutes: int = DEFAULT_STALE_CLAIM_MINUTES,
+    limit: int = 100,
+    actor: str = "mcp-operator",
+    ctx: CtxType = None,
+) -> str:
+    """Return stale interrupted approval claims to the pending queue."""
+    if not 1 <= stale_after_minutes <= 1440:
+        return json.dumps({"ok": False, "reason": "stale_after_minutes must be between 1 and 1440"})
+    if not 1 <= limit <= 1000:
+        return json.dumps({"ok": False, "reason": "limit must be between 1 and 1000"})
+    if not actor.strip():
+        return json.dumps({"ok": False, "reason": "actor cannot be empty"})
+    app = await _get_app_initialized(ctx)
+    stale_before = datetime.now(timezone.utc) - timedelta(minutes=stale_after_minutes)
+    recovered = await app.storage.recover_stale_memory_candidates(
+        stale_before=stale_before.isoformat(timespec="seconds"),
+        actor=actor,
+        limit=limit,
+    )
+    return json.dumps(
+        {
+            "ok": True,
+            "recovered": len(recovered),
+            "candidate_ids": recovered,
+            "stale_before": stale_before.isoformat(timespec="seconds"),
+        }
     )
 
 

--- a/packages/memtomem/src/memtomem/storage/mixins/formation.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/formation.py
@@ -215,30 +215,73 @@ class FormationMixin:
             raise ValueError("stale_before must include a timezone")
         normalized_cutoff = cutoff.astimezone(timezone.utc).isoformat(timespec="seconds")
         db = self._get_db()
-        rows = db.execute(
-            "UPDATE memory_candidates SET status='pending', reviewer=NULL, "
-            "decision_reason=NULL, claim_started_at=NULL "
-            "WHERE id IN (SELECT id FROM memory_candidates "
-            "WHERE status='writing' AND claim_started_at IS NOT NULL "
-            "AND claim_started_at <= ? ORDER BY claim_started_at LIMIT ?) "
-            "AND status='writing' RETURNING id",
-            (normalized_cutoff, limit),
-        ).fetchall()
-        recovered = [str(row[0]) for row in rows]
+        recovered: list[str] = []
+        try:
+            # Serialize selection and updates across processes without relying
+            # on SQLite 3.35's ``UPDATE ... RETURNING`` extension.
+            db.execute("BEGIN IMMEDIATE")
+            rows = db.execute(
+                "SELECT id FROM memory_candidates "
+                "WHERE status='writing' AND claim_started_at IS NOT NULL "
+                "AND claim_started_at <= ? ORDER BY claim_started_at, id LIMIT ?",
+                (normalized_cutoff, limit),
+            ).fetchall()
+            now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+            reason = f"stale approval claim recovered (claim_started_at <= {normalized_cutoff})"
+            for row in rows:
+                candidate_id = str(row[0])
+                cursor = db.execute(
+                    "UPDATE memory_candidates SET status='pending', reviewer=NULL, "
+                    "decision_reason=NULL, claim_started_at=NULL "
+                    "WHERE id=? AND status='writing'",
+                    (candidate_id,),
+                )
+                if cursor.rowcount == 0:
+                    continue
+                recovered.append(candidate_id)
+                self._record_candidate_transition(
+                    db,
+                    candidate_id,
+                    "writing",
+                    "pending",
+                    actor,
+                    reason,
+                    now,
+                )
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        return recovered
+
+    async def mark_memory_candidate_write_uncertain(
+        self,
+        candidate_id: str,
+        *,
+        actor: str,
+        reason: str,
+    ) -> bool:
+        """Quarantine a recovered claim after its durable write completed."""
+        db = self._get_db()
         now = datetime.now(timezone.utc).isoformat(timespec="seconds")
-        reason = f"stale approval claim recovered (claim_started_at <= {normalized_cutoff})"
-        for candidate_id in recovered:
+        cursor = db.execute(
+            "UPDATE memory_candidates SET status='write_uncertain', reviewer=?, "
+            "decision_reason=?, decided_at=?, claim_started_at=NULL "
+            "WHERE id=? AND status='pending'",
+            (actor, reason, now, candidate_id),
+        )
+        if cursor.rowcount > 0:
             self._record_candidate_transition(
                 db,
                 candidate_id,
-                "writing",
                 "pending",
+                "write_uncertain",
                 actor,
                 reason,
                 now,
             )
         db.commit()
-        return recovered
+        return cursor.rowcount > 0
 
     async def list_memory_candidate_transitions(self, candidate_id: str) -> list[dict[str, Any]]:
         db = self._get_db()

--- a/packages/memtomem/src/memtomem/storage/mixins/formation.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/formation.py
@@ -27,6 +27,7 @@ class FormationMixin:
         "created_at",
         "expires_at",
         "decided_at",
+        "claim_started_at",
     )
 
     @classmethod
@@ -81,7 +82,8 @@ class FormationMixin:
         rows = db.execute(
             "SELECT id, session_id, kind, operation, destination, content, evidence, "
             "matched_existing_ids, confidence, sensitivity, proposed_diff, status, "
-            "extractor_version, reviewer, decision_reason, created_at, expires_at, decided_at "
+            "extractor_version, reviewer, decision_reason, created_at, expires_at, "
+            "decided_at, claim_started_at "
             "FROM memory_candidates WHERE status=? ORDER BY created_at LIMIT ?",
             (status, limit),
         ).fetchall()
@@ -99,7 +101,8 @@ class FormationMixin:
         row = db.execute(
             "SELECT id, session_id, kind, operation, destination, content, evidence, "
             "matched_existing_ids, confidence, sensitivity, proposed_diff, status, "
-            "extractor_version, reviewer, decision_reason, created_at, expires_at, decided_at "
+            "extractor_version, reviewer, decision_reason, created_at, expires_at, "
+            "decided_at, claim_started_at "
             "FROM memory_candidates WHERE id=?",
             (candidate_id,),
         ).fetchone()
@@ -110,29 +113,59 @@ class FormationMixin:
     ) -> dict[str, Any] | None:
         """Atomically claim a pending candidate before any durable write."""
         db = self._get_db()
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
         cursor = db.execute(
-            "UPDATE memory_candidates SET status='writing', reviewer=?, decision_reason=? "
+            "UPDATE memory_candidates SET status='writing', reviewer=?, decision_reason=?, "
+            "claim_started_at=? "
             "WHERE id=? AND status='pending' AND expires_at > ?",
             (
                 reviewer,
                 reason,
+                now,
                 candidate_id,
-                datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                now,
             ),
         )
+        if cursor.rowcount > 0:
+            self._record_candidate_transition(
+                db,
+                candidate_id,
+                "pending",
+                "writing",
+                reviewer,
+                reason or "approval claim",
+                now,
+            )
         db.commit()
         if cursor.rowcount == 0:
             return None
         return await self.get_memory_candidate(candidate_id)
 
-    async def release_memory_candidate(self, candidate_id: str) -> bool:
+    async def release_memory_candidate(
+        self,
+        candidate_id: str,
+        *,
+        actor: str = "system",
+        reason: str = "durable write failed or was cancelled",
+    ) -> bool:
         """Release a failed write claim so the candidate can be retried."""
         db = self._get_db()
         cursor = db.execute(
             "UPDATE memory_candidates SET status='pending', reviewer=NULL, "
-            "decision_reason=NULL WHERE id=? AND status='writing'",
+            "decision_reason=NULL, claim_started_at=NULL "
+            "WHERE id=? AND status='writing'",
             (candidate_id,),
         )
+        if cursor.rowcount > 0:
+            self._record_candidate_transition(
+                db,
+                candidate_id,
+                "writing",
+                "pending",
+                actor,
+                reason,
+                datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            )
         db.commit()
         return cursor.rowcount > 0
 
@@ -141,12 +174,98 @@ class FormationMixin:
         db = self._get_db()
         now = datetime.now(timezone.utc).isoformat(timespec="seconds")
         cursor = db.execute(
-            "UPDATE memory_candidates SET status='approved', decided_at=? "
+            "UPDATE memory_candidates SET status='approved', decided_at=?, claim_started_at=NULL "
             "WHERE id=? AND status='writing'",
             (now, candidate_id),
         )
+        if cursor.rowcount > 0:
+            self._record_candidate_transition(
+                db,
+                candidate_id,
+                "writing",
+                "approved",
+                "system",
+                "durable write completed",
+                now,
+            )
         db.commit()
         return cursor.rowcount > 0
+
+    async def recover_stale_memory_candidates(
+        self,
+        *,
+        stale_before: str,
+        actor: str = "operator",
+        limit: int = 100,
+    ) -> list[str]:
+        """Atomically return stale ``writing`` claims to ``pending``.
+
+        A concurrent finalize and this recovery update serialize in SQLite;
+        only the operation that first matches ``status='writing'`` succeeds.
+        """
+        if limit < 1 or limit > 1000:
+            raise ValueError("recovery limit must be between 1 and 1000")
+        if not actor.strip():
+            raise ValueError("recovery actor cannot be empty")
+        try:
+            cutoff = datetime.fromisoformat(stale_before)
+        except ValueError as exc:
+            raise ValueError("stale_before must be an ISO-8601 datetime") from exc
+        if cutoff.tzinfo is None:
+            raise ValueError("stale_before must include a timezone")
+        normalized_cutoff = cutoff.astimezone(timezone.utc).isoformat(timespec="seconds")
+        db = self._get_db()
+        rows = db.execute(
+            "UPDATE memory_candidates SET status='pending', reviewer=NULL, "
+            "decision_reason=NULL, claim_started_at=NULL "
+            "WHERE id IN (SELECT id FROM memory_candidates "
+            "WHERE status='writing' AND claim_started_at IS NOT NULL "
+            "AND claim_started_at <= ? ORDER BY claim_started_at LIMIT ?) "
+            "AND status='writing' RETURNING id",
+            (normalized_cutoff, limit),
+        ).fetchall()
+        recovered = [str(row[0]) for row in rows]
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        reason = f"stale approval claim recovered (claim_started_at <= {normalized_cutoff})"
+        for candidate_id in recovered:
+            self._record_candidate_transition(
+                db,
+                candidate_id,
+                "writing",
+                "pending",
+                actor,
+                reason,
+                now,
+            )
+        db.commit()
+        return recovered
+
+    async def list_memory_candidate_transitions(self, candidate_id: str) -> list[dict[str, Any]]:
+        db = self._get_db()
+        rows = db.execute(
+            "SELECT from_status, to_status, actor, reason, created_at "
+            "FROM memory_candidate_transitions WHERE candidate_id=? ORDER BY id",
+            (candidate_id,),
+        ).fetchall()
+        keys = ("from_status", "to_status", "actor", "reason", "created_at")
+        return [dict(zip(keys, row)) for row in rows]
+
+    @staticmethod
+    def _record_candidate_transition(
+        db: Any,
+        candidate_id: str,
+        from_status: str,
+        to_status: str,
+        actor: str,
+        reason: str,
+        created_at: str,
+    ) -> None:
+        db.execute(
+            "INSERT INTO memory_candidate_transitions "
+            "(candidate_id, from_status, to_status, actor, reason, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (candidate_id, from_status, to_status, actor, reason, created_at),
+        )
 
     async def decide_memory_candidate(
         self, candidate_id: str, status: str, reviewer: str, reason: str = ""
@@ -160,6 +279,16 @@ class FormationMixin:
             "WHERE id=? AND status='pending'",
             (status, reviewer, reason, now, candidate_id),
         )
+        if cursor.rowcount > 0:
+            self._record_candidate_transition(
+                db,
+                candidate_id,
+                "pending",
+                status,
+                reviewer,
+                reason or f"candidate {status}",
+                now,
+            )
         db.commit()
         return cursor.rowcount > 0
 

--- a/packages/memtomem/src/memtomem/storage/sqlite_schema.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_schema.py
@@ -38,7 +38,7 @@ _UNICODE_ESCAPE_RE = re.compile(r"\\u[0-9a-fA-F]{4}")
 # whenever create_tables gains a migration an older binary must not run
 # under. Same-or-older stored versions always pass (migrations stay
 # additive + idempotent); only stored > SCHEMA_VERSION is fatal.
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 _SCHEMA_VERSION_KEY = "schema_version"
 
@@ -585,12 +585,37 @@ def create_tables(
             created_at TEXT NOT NULL,
             expires_at TEXT NOT NULL,
             decided_at TEXT,
+            claim_started_at TEXT,
             UNIQUE(session_id, fingerprint)
         )
     """)
+    try:
+        db.execute("ALTER TABLE memory_candidates ADD COLUMN claim_started_at TEXT")
+    except sqlite3.OperationalError as e:
+        if "duplicate column" not in str(e).lower():
+            raise
     db.execute(
         "CREATE INDEX IF NOT EXISTS idx_memory_candidates_status "
         "ON memory_candidates(status, created_at)"
+    )
+    db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_candidates_stale_claim "
+        "ON memory_candidates(status, claim_started_at)"
+    )
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS memory_candidate_transitions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            candidate_id TEXT NOT NULL REFERENCES memory_candidates(id) ON DELETE CASCADE,
+            from_status TEXT NOT NULL,
+            to_status TEXT NOT NULL,
+            actor TEXT NOT NULL,
+            reason TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )
+    """)
+    db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_candidate_transitions_candidate "
+        "ON memory_candidate_transitions(candidate_id, created_at)"
     )
 
     # --- Provenance-bearing temporal assertions (derived, rebuildable index) ---

--- a/packages/memtomem/src/memtomem/storage/sqlite_schema.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_schema.py
@@ -38,7 +38,7 @@ _UNICODE_ESCAPE_RE = re.compile(r"\\u[0-9a-fA-F]{4}")
 # whenever create_tables gains a migration an older binary must not run
 # under. Same-or-older stored versions always pass (migrations stay
 # additive + idempotent); only stored > SCHEMA_VERSION is fatal.
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 1
 
 _SCHEMA_VERSION_KEY = "schema_version"
 
@@ -594,6 +594,16 @@ def create_tables(
     except sqlite3.OperationalError as e:
         if "duplicate column" not in str(e).lower():
             raise
+    # Existing ``writing`` rows predate claim timestamps. Stamp them at
+    # upgrade time rather than treating them as immediately stale: a still
+    # running old process gets the full recovery grace period, while a truly
+    # stranded row becomes recoverable after the documented threshold. This
+    # is idempotent because only NULL timestamps are touched.
+    db.execute(
+        "UPDATE memory_candidates SET claim_started_at=? "
+        "WHERE status='writing' AND claim_started_at IS NULL",
+        (datetime.now(timezone.utc).isoformat(timespec="seconds"),),
+    )
     db.execute(
         "CREATE INDEX IF NOT EXISTS idx_memory_candidates_status "
         "ON memory_candidates(status, created_at)"

--- a/packages/memtomem/tests/test_memory_formation.py
+++ b/packages/memtomem/tests/test_memory_formation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 import pytest
@@ -72,6 +72,80 @@ async def test_candidate_claim_is_atomic_and_releasable(storage):
     assert await storage.claim_memory_candidate(candidate["id"], "bob") is not None
     assert await storage.finalize_memory_candidate(candidate["id"])
     assert (await storage.get_memory_candidate(candidate["id"]))["status"] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_stale_claim_recovery_skips_fresh_claim_and_records_transition(storage):
+    await storage.create_session("session", "agent", "default")
+    await storage.add_session_event("session", "note", "Decision: stale candidate")
+    await storage.add_session_event("session", "note", "Preference: fresh candidate")
+    stale, fresh = await scan_session_candidates(storage, "session")
+    assert await storage.claim_memory_candidate(stale["id"], "alice") is not None
+    assert await storage.claim_memory_candidate(fresh["id"], "bob") is not None
+
+    old = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat(timespec="seconds")
+    cutoff = (datetime.now(timezone.utc) - timedelta(minutes=15)).isoformat(timespec="seconds")
+    storage._get_db().execute(
+        "UPDATE memory_candidates SET claim_started_at=? WHERE id=?",
+        (old, stale["id"]),
+    )
+    storage._get_db().commit()
+
+    recovered = await storage.recover_stale_memory_candidates(
+        stale_before=cutoff, actor="operator-alice"
+    )
+    assert recovered == [stale["id"]]
+    assert (await storage.get_memory_candidate(stale["id"]))["status"] == "pending"
+    assert (await storage.get_memory_candidate(fresh["id"]))["status"] == "writing"
+    transitions = await storage.list_memory_candidate_transitions(stale["id"])
+    assert transitions[-1]["from_status"] == "writing"
+    assert transitions[-1]["to_status"] == "pending"
+    assert transitions[-1]["actor"] == "operator-alice"
+    assert "stale approval claim recovered" in transitions[-1]["reason"]
+
+
+@pytest.mark.asyncio
+async def test_recovery_and_finalize_are_mutually_exclusive(storage):
+    await storage.create_session("session", "agent", "default")
+    await storage.add_session_event("session", "note", "Decision: recover or finalize")
+    candidate = (await scan_session_candidates(storage, "session"))[0]
+    assert await storage.claim_memory_candidate(candidate["id"], "alice") is not None
+    old = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat(timespec="seconds")
+    storage._get_db().execute(
+        "UPDATE memory_candidates SET claim_started_at=? WHERE id=?",
+        (old, candidate["id"]),
+    )
+    storage._get_db().commit()
+
+    recovered = await storage.recover_stale_memory_candidates(
+        stale_before=datetime.now(timezone.utc).isoformat(timespec="seconds")
+    )
+    assert recovered == [candidate["id"]]
+    assert not await storage.finalize_memory_candidate(candidate["id"])
+
+
+@pytest.mark.asyncio
+async def test_recovery_requires_timezone_and_operator_identity(storage):
+    with pytest.raises(ValueError, match="timezone"):
+        await storage.recover_stale_memory_candidates(
+            stale_before="2026-07-13T00:00:00", actor="alice"
+        )
+    with pytest.raises(ValueError, match="actor"):
+        await storage.recover_stale_memory_candidates(
+            stale_before="2026-07-13T00:00:00+00:00", actor=""
+        )
+
+
+def test_review_recovery_cli_and_mcp_action_are_public():
+    from click.testing import CliRunner
+
+    from memtomem.cli.review_cmd import review
+    from memtomem.server.tool_registry import ACTIONS
+
+    result = CliRunner().invoke(review, ["recover", "--help"])
+    assert result.exit_code == 0
+    assert "--stale-after-minutes" in result.output
+    assert "candidate_recover" in ACTIONS
 
 
 @pytest.mark.asyncio

--- a/packages/memtomem/tests/test_memory_formation.py
+++ b/packages/memtomem/tests/test_memory_formation.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
@@ -125,6 +128,59 @@ async def test_recovery_and_finalize_are_mutually_exclusive(storage):
 
 
 @pytest.mark.asyncio
+async def test_recovered_completed_write_is_quarantined_from_reapproval(storage):
+    await storage.create_session("session", "agent", "default")
+    await storage.add_session_event("session", "note", "Decision: write completed")
+    candidate = (await scan_session_candidates(storage, "session"))[0]
+    assert await storage.claim_memory_candidate(candidate["id"], "alice") is not None
+    old = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat(timespec="seconds")
+    storage._get_db().execute(
+        "UPDATE memory_candidates SET claim_started_at=? WHERE id=?",
+        (old, candidate["id"]),
+    )
+    storage._get_db().commit()
+    assert await storage.recover_stale_memory_candidates(
+        stale_before=datetime.now(timezone.utc).isoformat(timespec="seconds")
+    ) == [candidate["id"]]
+
+    # Simulate the original writer returning after its durable write landed.
+    assert await storage.mark_memory_candidate_write_uncertain(
+        candidate["id"], actor="test-finalizer", reason="write already persisted"
+    )
+    assert await storage.claim_memory_candidate(candidate["id"], "bob") is None
+    row = await storage.get_memory_candidate(candidate["id"])
+    assert row["status"] == "write_uncertain"
+    assert "already persisted" in row["decision_reason"]
+
+
+@pytest.mark.asyncio
+async def test_recovery_limit_returns_oldest_claims_first(storage):
+    await storage.create_session("session", "agent", "default")
+    for content in (
+        "Decision: oldest claim",
+        "Decision: middle claim",
+        "Decision: newest claim",
+    ):
+        await storage.add_session_event("session", "note", content)
+    candidates = await scan_session_candidates(storage, "session")
+    for candidate in candidates:
+        assert await storage.claim_memory_candidate(candidate["id"], "alice") is not None
+    base = datetime.now(timezone.utc) - timedelta(minutes=40)
+    for offset, candidate in enumerate(candidates):
+        claimed_at = (base + timedelta(minutes=offset * 5)).isoformat(timespec="seconds")
+        storage._get_db().execute(
+            "UPDATE memory_candidates SET claim_started_at=? WHERE id=?",
+            (claimed_at, candidate["id"]),
+        )
+    storage._get_db().commit()
+    recovered = await storage.recover_stale_memory_candidates(
+        stale_before=datetime.now(timezone.utc).isoformat(timespec="seconds"), limit=2
+    )
+    assert recovered == [candidates[0]["id"], candidates[1]["id"]]
+    assert (await storage.get_memory_candidate(candidates[2]["id"]))["status"] == "writing"
+
+
+@pytest.mark.asyncio
 async def test_recovery_requires_timezone_and_operator_identity(storage):
     with pytest.raises(ValueError, match="timezone"):
         await storage.recover_stale_memory_candidates(
@@ -146,6 +202,57 @@ def test_review_recovery_cli_and_mcp_action_are_public():
     assert result.exit_code == 0
     assert "--stale-after-minutes" in result.output
     assert "candidate_recover" in ACTIONS
+
+
+@pytest.mark.asyncio
+async def test_mcp_recovery_validation_returns_structured_errors():
+    from memtomem.server.tools.formation import mem_candidate_recover
+
+    invalid_age = json.loads(await mem_candidate_recover(stale_after_minutes=0))
+    invalid_limit = json.loads(await mem_candidate_recover(limit=0))
+    invalid_actor = json.loads(await mem_candidate_recover(actor=""))
+    assert invalid_age == {
+        "ok": False,
+        "reason": "stale_after_minutes must be between 1 and 1440",
+    }
+    assert invalid_limit == {"ok": False, "reason": "limit must be between 1 and 1000"}
+    assert invalid_actor == {"ok": False, "reason": "actor cannot be empty"}
+
+
+@pytest.mark.asyncio
+async def test_mcp_review_reports_persisted_write_after_concurrent_recovery(monkeypatch):
+    from memtomem.server.tools.formation import mem_candidate_review
+
+    storage = SimpleNamespace(
+        get_memory_candidate=AsyncMock(
+            return_value={
+                "id": "candidate-1",
+                "status": "pending",
+                "destination": "memory",
+                "content": "Decision: persisted once",
+                "kind": "decision",
+            }
+        ),
+        claim_memory_candidate=AsyncMock(return_value={"status": "writing"}),
+        release_memory_candidate=AsyncMock(),
+        finalize_memory_candidate=AsyncMock(return_value=False),
+        mark_memory_candidate_write_uncertain=AsyncMock(return_value=True),
+    )
+    app = SimpleNamespace(storage=storage, ensure_initialized=AsyncMock())
+    ctx = SimpleNamespace(request_context=SimpleNamespace(lifespan_context=app))
+    monkeypatch.setattr(
+        "memtomem.server.tools.memory_crud._mem_add_core",
+        AsyncMock(return_value=("saved", SimpleNamespace(new_chunk_ids=[]))),
+    )
+
+    result = json.loads(
+        await mem_candidate_review("candidate-1", "approve", reviewer="alice", ctx=ctx)
+    )
+    assert result["ok"] is False
+    assert result["status"] == "write_uncertain"
+    assert result["durable_write_persisted"] is True
+    assert "do not re-approve" in result["reason"]
+    storage.mark_memory_candidate_write_uncertain.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/packages/memtomem/tests/test_sqlite_schema.py
+++ b/packages/memtomem/tests/test_sqlite_schema.py
@@ -343,6 +343,9 @@ class TestFormationClaimRecoverySchema:
                 "CREATE TABLE memory_candidates ("
                 "id TEXT PRIMARY KEY, status TEXT NOT NULL, created_at TEXT NOT NULL)"
             )
+            db.execute(
+                "INSERT INTO memory_candidates VALUES ('legacy-writing', 'writing', '2026-01-01')"
+            )
             create_tables(
                 db,
                 MetaManager(lambda: db),
@@ -352,6 +355,10 @@ class TestFormationClaimRecoverySchema:
             )
             columns = {row[1] for row in db.execute("PRAGMA table_info(memory_candidates)")}
             assert "claim_started_at" in columns
+            backfilled = db.execute(
+                "SELECT claim_started_at FROM memory_candidates WHERE id='legacy-writing'"
+            ).fetchone()
+            assert backfilled is not None and backfilled[0] is not None
             transition_table = db.execute(
                 "SELECT 1 FROM sqlite_master "
                 "WHERE type='table' AND name='memory_candidate_transitions'"

--- a/packages/memtomem/tests/test_sqlite_schema.py
+++ b/packages/memtomem/tests/test_sqlite_schema.py
@@ -333,3 +333,29 @@ class TestIdempotencyLedgerSchema:
             assert n == 1
         finally:
             db.close()
+
+
+class TestFormationClaimRecoverySchema:
+    def test_legacy_candidate_table_gains_claim_column_and_audit_table(self) -> None:
+        db = _connect_with_vec()
+        try:
+            db.execute(
+                "CREATE TABLE memory_candidates ("
+                "id TEXT PRIMARY KEY, status TEXT NOT NULL, created_at TEXT NOT NULL)"
+            )
+            create_tables(
+                db,
+                MetaManager(lambda: db),
+                dimension=0,
+                embedding_provider="none",
+                embedding_model="",
+            )
+            columns = {row[1] for row in db.execute("PRAGMA table_info(memory_candidates)")}
+            assert "claim_started_at" in columns
+            transition_table = db.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='memory_candidate_transitions'"
+            ).fetchone()
+            assert transition_table is not None
+        finally:
+            db.close()


### PR DESCRIPTION
## Summary

- timestamp approval claims when candidates enter `writing`
- backfill pre-upgrade NULL `writing` timestamps at migration time so they receive one full grace period
- atomically recover only claims older than a timezone-aware cutoff with a SQLite-compatible `BEGIN IMMEDIATE` select/update transaction
- serialize recovery against finalize so only one status transition can succeed
- quarantine a durable write that loses finalization as `write_uncertain`, preventing blind duplicate re-approval and explicitly telling CLI/MCP operators that the write already persisted
- persist candidate status transitions with actor, reason, and timestamp for auditability
- expose recovery through `mm review recover` and `mem_candidate_recover` with a conservative 15-minute default
- add the forward nullable-column migration while retaining the existing schema fence version, consistent with prior additive nullable migrations
- update the 96-tool documentation

## Safety properties

- fresh `writing` claims are never reclaimed
- pre-upgrade NULL claims become recoverable only after a new grace period
- recovery and finalize are mutually exclusive at the SQLite transaction/status predicate
- a completed write that loses its claim cannot be blindly re-approved
- invalid/naive cutoffs and empty actor identities are rejected
- recovery is oldest-first with a bounded 1-1000 row limit
- no SQLite `RETURNING` dependency is introduced

## Verification

- 224 focused storage/schema/CLI/server tests passed
- added NULL-backfill, oldest-first/limit, recovery-finalize, write-uncertain/reapproval, MCP response, and MCP validation tests
- Ruff and format check passed
- focused mypy passed
- Bandit 1.9.4 passed
- full registry reports 96 tools and includes `mem_candidate_recover`
- `git diff --check` passed

Closes #1734
