### PR TITLE
feat: add STM core capability bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - **STM capability bridge** — `mem_do(action="version")` advertises versioned
   `context_compose` and `candidate_propose` contracts. External proposals are
   privacy-gated, idempotently queued as pending review candidates, and never
-  write durable memory before approval. Their synthetic sessions use the
-  reserved `formation` namespace and are excluded from normal retrieval scope.
+  write durable memory before approval. Proposal content remains only in the
+  review queue and is not indexed as retrievable chunks.
 
 ## [0.3.8] — 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - **STM capability bridge** — `mem_do(action="version")` advertises versioned
   `context_compose` and `candidate_propose` contracts. External proposals are
   privacy-gated, idempotently queued as pending review candidates, and never
-  write durable memory before approval.
+  write durable memory before approval. Their synthetic sessions use the
+  reserved `formation` namespace and are excluded from normal retrieval scope.
 
 ## [0.3.8] — 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   older SQLite versions without `UPDATE ... RETURNING`, and a completed write
   that loses finalization is quarantined as `write_uncertain` to prevent blind
   duplicate approval.
+- **STM capability bridge** — `mem_do(action="version")` advertises versioned
+  `context_compose` and `candidate_propose` contracts. External proposals are
+  privacy-gated, idempotently queued as pending review candidates, and never
+  write durable memory before approval.
 
 ## [0.3.8] — 2026-07-13
 

--- a/packages/memtomem/src/memtomem/formation.py
+++ b/packages/memtomem/src/memtomem/formation.py
@@ -86,3 +86,71 @@ async def scan_session_candidates(storage: Any, session_id: str) -> list[dict[st
         if await storage.add_memory_candidate(candidate):
             created.append(candidate)
     return created
+
+
+async def propose_memory_candidate(
+    storage: Any,
+    content: str,
+    *,
+    source: str,
+    source_ref: str,
+    idempotency_key: str,
+) -> tuple[dict[str, Any], bool]:
+    """Queue one explicit external proposal for review without promoting it."""
+    body = content.strip()
+    if not body:
+        raise ValueError("content cannot be empty")
+    if len(body) > 2000:
+        raise ValueError("content exceeds 2000 characters")
+    if len(source) > 128 or len(source_ref) > 512 or len(idempotency_key) > 256:
+        raise ValueError("proposal metadata exceeds size limit")
+    if not source.strip() or not idempotency_key.strip():
+        raise ValueError("source and idempotency_key are required")
+    if privacy.scan(body):
+        raise ValueError("content contains sensitive data")
+
+    classification = _classify(body)
+    kind, operation, destination, confidence = classification or (
+        "proposed",
+        "add",
+        "memory",
+        1.0,
+    )
+    now = datetime.now(timezone.utc)
+    fingerprint = hashlib.sha256(
+        f"external\0{source.strip()}\0{idempotency_key.strip()}".encode()
+    ).hexdigest()
+    external_session_id = f"external:{source.strip()}:{fingerprint[:24]}"
+    await storage.create_session(
+        external_session_id,
+        source.strip(),
+        "formation",
+        metadata={"source_ref": source_ref.strip(), "external_proposal": True},
+    )
+    candidate = {
+        "id": str(uuid4()),
+        "session_id": external_session_id,
+        "kind": kind,
+        "operation": operation,
+        "destination": destination,
+        "content": body,
+        "evidence": [{"source": source.strip(), "source_ref": source_ref.strip()}],
+        "matched_existing_ids": [],
+        "confidence": confidence,
+        "sensitivity": "normal",
+        "proposed_diff": f"+ {body}",
+        "extractor_version": "external-proposal-v1",
+        "fingerprint": fingerprint,
+        "created_at": now.isoformat(timespec="seconds"),
+        "expires_at": (now + timedelta(days=30)).isoformat(timespec="seconds"),
+    }
+    created = await storage.add_memory_candidate(candidate)
+    if created:
+        return candidate, False
+
+    pending = await storage.list_memory_candidates(status="pending", limit=1000)
+    duplicate = next(
+        (item for item in pending if item.get("session_id") == candidate["session_id"]),
+        None,
+    )
+    return duplicate or candidate, True

--- a/packages/memtomem/src/memtomem/formation.py
+++ b/packages/memtomem/src/memtomem/formation.py
@@ -108,7 +108,7 @@ async def propose_memory_candidate(
         raise ValueError("source and idempotency_key are required")
     ref = source_ref.strip()
     if privacy.scan(body) or (ref and privacy.scan(ref)):
-        raise ValueError("content contains sensitive data")
+        raise ValueError("content or source_ref contains sensitive data")
 
     classification = _classify(body)
     kind, operation, destination, confidence = classification or (

--- a/packages/memtomem/src/memtomem/formation.py
+++ b/packages/memtomem/src/memtomem/formation.py
@@ -106,7 +106,8 @@ async def propose_memory_candidate(
         raise ValueError("proposal metadata exceeds size limit")
     if not source.strip() or not idempotency_key.strip():
         raise ValueError("source and idempotency_key are required")
-    if privacy.scan(body):
+    ref = source_ref.strip()
+    if privacy.scan(body) or (ref and privacy.scan(ref)):
         raise ValueError("content contains sensitive data")
 
     classification = _classify(body)
@@ -114,7 +115,7 @@ async def propose_memory_candidate(
         "proposed",
         "add",
         "memory",
-        1.0,
+        0.5,
     )
     now = datetime.now(timezone.utc)
     fingerprint = hashlib.sha256(
@@ -125,7 +126,7 @@ async def propose_memory_candidate(
         external_session_id,
         source.strip(),
         "formation",
-        metadata={"source_ref": source_ref.strip(), "external_proposal": True},
+        metadata={"source_ref": ref, "external_proposal": True},
     )
     candidate = {
         "id": str(uuid4()),
@@ -134,13 +135,14 @@ async def propose_memory_candidate(
         "operation": operation,
         "destination": destination,
         "content": body,
-        "evidence": [{"source": source.strip(), "source_ref": source_ref.strip()}],
+        "evidence": [{"source": source.strip(), "source_ref": ref}],
         "matched_existing_ids": [],
         "confidence": confidence,
         "sensitivity": "normal",
         "proposed_diff": f"+ {body}",
         "extractor_version": "external-proposal-v1",
         "fingerprint": fingerprint,
+        "status": "pending",
         "created_at": now.isoformat(timespec="seconds"),
         "expires_at": (now + timedelta(days=30)).isoformat(timespec="seconds"),
     }
@@ -148,9 +150,9 @@ async def propose_memory_candidate(
     if created:
         return candidate, False
 
-    pending = await storage.list_memory_candidates(status="pending", limit=1000)
-    duplicate = next(
-        (item for item in pending if item.get("session_id") == candidate["session_id"]),
-        None,
-    )
-    return duplicate or candidate, True
+    existing = await storage.get_memory_candidate_by_fingerprint(external_session_id, fingerprint)
+    if existing is None:
+        raise RuntimeError("idempotent candidate insert was ignored but no row exists")
+    if existing["content"] != body:
+        raise ValueError("idempotency_key was already used with different content")
+    return existing, True

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -122,6 +122,7 @@ from memtomem.server.tools.pinned import (
 from memtomem.server.tools.formation import (
     mem_candidate_list,
     mem_candidate_recover,
+    mem_candidate_propose,
     mem_candidate_review,
     mem_formation_scan,
 )

--- a/packages/memtomem/src/memtomem/server/tools/formation.py
+++ b/packages/memtomem/src/memtomem/server/tools/formation.py
@@ -51,7 +51,7 @@ async def mem_candidate_propose(
         {
             "ok": True,
             "candidate_id": candidate["id"],
-            "status": "pending",
+            "status": candidate["status"],
             "created_at": candidate["created_at"],
             "duplicate": duplicate,
         },

--- a/packages/memtomem/src/memtomem/server/tools/formation.py
+++ b/packages/memtomem/src/memtomem/server/tools/formation.py
@@ -6,7 +6,11 @@ import asyncio
 import json
 from datetime import datetime, timedelta, timezone
 
-from memtomem.formation import DEFAULT_STALE_CLAIM_MINUTES, scan_session_candidates
+from memtomem.formation import (
+    DEFAULT_STALE_CLAIM_MINUTES,
+    propose_memory_candidate,
+    scan_session_candidates,
+)
 from memtomem.pinned import PinnedContextStore
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app_initialized
@@ -22,6 +26,37 @@ async def mem_formation_scan(session_id: str, ctx: CtxType = None) -> str:
     app = await _get_app_initialized(ctx)
     candidates = await scan_session_candidates(app.storage, session_id)
     return json.dumps({"created": len(candidates), "candidates": candidates}, ensure_ascii=False)
+
+
+@mcp.tool()
+@tool_handler
+@register("formation")
+async def mem_candidate_propose(
+    content: str,
+    source: str,
+    source_ref: str,
+    idempotency_key: str,
+    ctx: CtxType = None,
+) -> str:
+    """Queue an explicit pending candidate; never write durable memory."""
+    app = await _get_app_initialized(ctx)
+    candidate, duplicate = await propose_memory_candidate(
+        app.storage,
+        content,
+        source=source,
+        source_ref=source_ref,
+        idempotency_key=idempotency_key,
+    )
+    return json.dumps(
+        {
+            "ok": True,
+            "candidate_id": candidate["id"],
+            "status": "pending",
+            "created_at": candidate["created_at"],
+            "duplicate": duplicate,
+        },
+        ensure_ascii=False,
+    )
 
 
 @mcp.tool()

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -637,6 +637,8 @@ async def mem_version(
             "version": __version__,
             "capabilities": {
                 "search_formats": ["compact", "verbose", "structured"],
+                "context_compose": {"schema_version": 1},
+                "candidate_propose": {"schema_version": 1},
             },
         },
         ensure_ascii=False,

--- a/packages/memtomem/src/memtomem/storage/mixins/formation.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/formation.py
@@ -108,6 +108,27 @@ class FormationMixin:
         ).fetchone()
         return self._candidate_row(row) if row is not None else None
 
+    async def get_memory_candidate_by_fingerprint(
+        self, session_id: str, fingerprint: str
+    ) -> dict[str, Any] | None:
+        """Return a candidate in any state for an idempotent proposal lookup."""
+        db = self._get_db()
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        db.execute(
+            "UPDATE memory_candidates SET status='expired' "
+            "WHERE session_id=? AND fingerprint=? AND status='pending' AND expires_at <= ?",
+            (session_id, fingerprint, now),
+        )
+        db.commit()
+        row = db.execute(
+            "SELECT id, session_id, kind, operation, destination, content, evidence, "
+            "matched_existing_ids, confidence, sensitivity, proposed_diff, status, "
+            "extractor_version, reviewer, decision_reason, created_at, expires_at, decided_at "
+            "FROM memory_candidates WHERE session_id=? AND fingerprint=?",
+            (session_id, fingerprint),
+        ).fetchone()
+        return self._candidate_row(row) if row is not None else None
+
     async def claim_memory_candidate(
         self, candidate_id: str, reviewer: str, reason: str = ""
     ) -> dict[str, Any] | None:

--- a/packages/memtomem/tests/test_memory_formation.py
+++ b/packages/memtomem/tests/test_memory_formation.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 import pytest
 
 from memtomem.formation import propose_memory_candidate, scan_session_candidates
+from memtomem.server.tools import formation as formation_tools
 
 
 @pytest.mark.asyncio
@@ -80,6 +81,118 @@ async def test_external_candidate_proposal_rejects_sensitive_content(storage):
             source_ref="trace",
             idempotency_key="key",
         )
+
+
+@pytest.mark.asyncio
+async def test_external_candidate_reproposal_returns_actual_decided_status(storage):
+    first, _ = await propose_memory_candidate(
+        storage,
+        "Preference: concise responses",
+        source="memtomem-stm",
+        source_ref="trace",
+        idempotency_key="decided-key",
+    )
+    assert await storage.decide_memory_candidate(first["id"], "rejected", "reviewer")
+    existing, duplicate = await propose_memory_candidate(
+        storage,
+        "Preference: concise responses",
+        source="memtomem-stm",
+        source_ref="trace",
+        idempotency_key="decided-key",
+    )
+    assert duplicate is True
+    assert existing["id"] == first["id"]
+    assert existing["status"] == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_external_candidate_reproposal_returns_expired_status(storage):
+    first, _ = await propose_memory_candidate(
+        storage,
+        "Fact: service uses SQLite",
+        source="memtomem-stm",
+        source_ref="trace",
+        idempotency_key="expired-key",
+    )
+    storage._get_db().execute(
+        "UPDATE memory_candidates SET expires_at='2000-01-01T00:00:00+00:00' WHERE id=?",
+        (first["id"],),
+    )
+    storage._get_db().commit()
+    existing, duplicate = await propose_memory_candidate(
+        storage,
+        "Fact: service uses SQLite",
+        source="memtomem-stm",
+        source_ref="trace",
+        idempotency_key="expired-key",
+    )
+    assert duplicate is True
+    assert existing["status"] == "expired"
+
+
+@pytest.mark.asyncio
+async def test_external_candidate_rejects_idempotency_key_content_mismatch(storage):
+    await propose_memory_candidate(
+        storage,
+        "Decision: use blue-green",
+        source="memtomem-stm",
+        source_ref="trace",
+        idempotency_key="reused-key",
+    )
+    with pytest.raises(ValueError, match="different content"):
+        await propose_memory_candidate(
+            storage,
+            "Decision: use canary",
+            source="memtomem-stm",
+            source_ref="trace",
+            idempotency_key="reused-key",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("content", "source", "source_ref", "key", "match"),
+    [
+        (" ", "memtomem-stm", "", "key", "empty"),
+        ("x" * 2001, "memtomem-stm", "", "key", "2000"),
+        ("valid", "s" * 129, "", "key", "size limit"),
+        ("valid", "memtomem-stm", "r" * 513, "key", "size limit"),
+        ("valid", "memtomem-stm", "api_key=sk-secret-value", "key", "sensitive"),
+    ],
+)
+async def test_external_candidate_validation(
+    storage, content: str, source: str, source_ref: str, key: str, match: str
+):
+    with pytest.raises(ValueError, match=match):
+        await propose_memory_candidate(
+            storage,
+            content,
+            source=source,
+            source_ref=source_ref,
+            idempotency_key=key,
+        )
+
+
+@pytest.mark.asyncio
+async def test_candidate_propose_tool_returns_actual_response_shape(storage, monkeypatch):
+    monkeypatch.setattr(
+        formation_tools,
+        "_get_app_initialized",
+        AsyncMock(return_value=SimpleNamespace(storage=storage)),
+    )
+    result = json.loads(
+        await formation_tools.mem_candidate_propose(
+            "Unclassified external note",
+            "memtomem-stm",
+            "trace",
+            "tool-key",
+        )
+    )
+    assert set(result) == {"ok", "candidate_id", "status", "created_at", "duplicate"}
+    assert result["status"] == "pending"
+    stored = await storage.get_memory_candidate(result["candidate_id"])
+    assert stored is not None
+    assert stored["confidence"] == 0.5
 
 
 @pytest.mark.asyncio

--- a/packages/memtomem/tests/test_memory_formation.py
+++ b/packages/memtomem/tests/test_memory_formation.py
@@ -157,6 +157,9 @@ async def test_external_candidate_rejects_idempotency_key_content_mismatch(stora
         ("x" * 2001, "memtomem-stm", "", "key", "2000"),
         ("valid", "s" * 129, "", "key", "size limit"),
         ("valid", "memtomem-stm", "r" * 513, "key", "size limit"),
+        ("valid", "memtomem-stm", "", "k" * 257, "size limit"),
+        ("valid", " ", "", "key", "required"),
+        ("valid", "memtomem-stm", "", " ", "required"),
         ("valid", "memtomem-stm", "api_key=sk-secret-value", "key", "sensitive"),
     ],
 )

--- a/packages/memtomem/tests/test_memory_formation.py
+++ b/packages/memtomem/tests/test_memory_formation.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 import pytest
 
-from memtomem.formation import scan_session_candidates
+from memtomem.formation import propose_memory_candidate, scan_session_candidates
 
 
 @pytest.mark.asyncio
@@ -46,6 +46,40 @@ async def test_scan_does_not_promote_generic_declarative_sentences(storage):
     await storage.add_session_event("session", "note", "The service is available")
     await storage.add_session_event("session", "note", "서비스입니다")
     assert await scan_session_candidates(storage, "session") == []
+
+
+@pytest.mark.asyncio
+async def test_external_candidate_proposal_is_pending_and_idempotent(storage):
+    first, first_duplicate = await propose_memory_candidate(
+        storage,
+        "Decision: use blue-green deployment",
+        source="memtomem-stm",
+        source_ref="docs/read_file/trace-1",
+        idempotency_key="stable-key",
+    )
+    second, second_duplicate = await propose_memory_candidate(
+        storage,
+        "Decision: use blue-green deployment",
+        source="memtomem-stm",
+        source_ref="docs/read_file/trace-1",
+        idempotency_key="stable-key",
+    )
+    assert first_duplicate is False
+    assert second_duplicate is True
+    assert second["id"] == first["id"]
+    assert (await storage.get_memory_candidate(first["id"]))["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_external_candidate_proposal_rejects_sensitive_content(storage):
+    with pytest.raises(ValueError, match="sensitive"):
+        await propose_memory_candidate(
+            storage,
+            "Decision: api_key=sk-secret-value",
+            source="memtomem-stm",
+            source_ref="trace",
+            idempotency_key="key",
+        )
 
 
 @pytest.mark.asyncio

--- a/packages/memtomem/tests/test_meta_tool.py
+++ b/packages/memtomem/tests/test_meta_tool.py
@@ -237,3 +237,11 @@ class TestMemVersion:
         assert "compact" in formats
         assert "verbose" in formats
         assert "structured" in formats
+
+    async def test_capabilities_stm_bridge(self):
+        parsed = json.loads(await mem_version())
+        capabilities = parsed["capabilities"]
+        assert capabilities["context_compose"] == {"schema_version": 1}
+        assert capabilities["candidate_propose"] == {"schema_version": 1}
+        assert "context_compose" in ACTIONS
+        assert "candidate_propose" in ACTIONS


### PR DESCRIPTION
## Summary
- advertise schema-versioned `context_compose` and `candidate_propose` capabilities through `mem_do(action="version")`
- expose an explicit `candidate_propose` meta-tool action backed by the existing review queue
- preserve the existing `context_compose` action as the pinned-first composition contract consumed by memtomem-stm

## Safety and compatibility
- proposals are privacy-scanned and bounded to 2,000 characters
- source metadata is bounded and idempotency keys are stored only through a SHA-256 fingerprint
- repeated proposals return the existing pending candidate
- proposal submission never writes durable memory; approval remains the only promotion path
- all additions are capability-gated and additive for older clients

## Validation
- full core suite: 8495 passed, 11 skipped
- meta/formation/pinned contract suite: 42 passed
- tool registration and logic suite: 98 passed
- Ruff check and format check passed
- changed core modules mypy passed
- repository-wide mypy still reports 14 pre-existing errors in unrelated web/CLI files
- git diff --check passed

## Related
- enables the capability-gated integration merged in memtomem-stm#691