### PR TITLE
fix: resolve uncertain memory candidates safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   timestamps receive a one-time grace-period backfill; recovery supports
   older SQLite versions without `UPDATE ... RETURNING`, and a completed write
   that loses finalization is quarantined as `write_uncertain` to prevent blind
-  duplicate approval.
+  duplicate approval. Operators can close that quarantine through the normal
+  CLI/MCP reject action with a required reviewer and reason; resolution writes
+  no additional durable memory and records an audited transition.
 
 ## [0.3.8] — 2026-07-13
 

--- a/docs/guides/pinned-context.md
+++ b/docs/guides/pinned-context.md
@@ -52,8 +52,17 @@ approval finalization, does not touch fresh claims, and records a persistent
 If a recovered claim's original process later reports that its durable write
 already completed, memtomem moves the candidate to `write_uncertain` and
 reports the destination. Do not approve it again: inspect the Markdown or
-Pinned Context block first, then resolve the candidate manually. This
-quarantine prevents a blind retry from duplicating the persisted content.
+Pinned Context block first, then close the quarantine without another write:
+
+```bash
+mm review reject CANDIDATE_ID \
+  --reviewer alice \
+  --reason "confirmed the durable entry already exists"
+```
+
+The same `mem_candidate_review` MCP action accepts `decision="reject"` with a
+non-empty reviewer and reason. The atomic `write_uncertain → rejected`
+transition is audit-recorded; direct re-approval remains blocked.
 
 ## LangGraph
 

--- a/packages/memtomem/src/memtomem/cli/review_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/review_cmd.py
@@ -118,8 +118,33 @@ async def _decide(candidate_id: str, decision: str, reviewer: str, reason: str) 
 
     async with cli_components() as comp:
         candidate = await comp.storage.get_memory_candidate(candidate_id)
-        if candidate is None or candidate["status"] != "pending":
-            raise click.ClickException("Candidate is not pending")
+        if candidate is None:
+            raise click.ClickException("Candidate not found")
+        if decision == "rejected" and candidate["status"] == "write_uncertain":
+            if not reviewer.strip():
+                raise click.ClickException("Resolution reviewer cannot be empty")
+            if not reason.strip():
+                raise click.ClickException(
+                    "Resolving write_uncertain requires --reason after inspecting "
+                    "the durable destination"
+                )
+            changed = await comp.storage.resolve_uncertain_memory_candidate(
+                candidate_id, reviewer=reviewer, reason=reason
+            )
+            if not changed:
+                raise click.ClickException("Candidate state changed concurrently")
+            click.echo(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "status": "rejected",
+                        "resolved_from": "write_uncertain",
+                    }
+                )
+            )
+            return
+        if candidate["status"] != "pending":
+            raise click.ClickException(f"Candidate is not pending (status={candidate['status']})")
         if decision == "approved":
             from memtomem import privacy
 
@@ -210,5 +235,5 @@ def approve(candidate_id: str, reviewer: str, reason: str) -> None:
 @click.option("--reviewer", default="user")
 @click.option("--reason", default="")
 def reject(candidate_id: str, reviewer: str, reason: str) -> None:
-    """Reject a candidate without writing durable memory."""
+    """Reject without writing; uncertain writes require --reason."""
     asyncio.run(_decide(candidate_id, "rejected", reviewer, reason))

--- a/packages/memtomem/src/memtomem/server/tools/formation.py
+++ b/packages/memtomem/src/memtomem/server/tools/formation.py
@@ -82,15 +82,44 @@ async def mem_candidate_review(
     """Approve or reject a candidate; only approval writes durable memory."""
     app = await _get_app_initialized(ctx)
     candidate = await app.storage.get_memory_candidate(candidate_id)
-    if candidate is None or candidate["status"] != "pending":
-        return json.dumps({"ok": False, "reason": "candidate not pending"})
+    if candidate is None:
+        return json.dumps({"ok": False, "reason": "candidate not found"})
     if decision == "reject":
+        if candidate["status"] == "write_uncertain":
+            if not reviewer.strip():
+                return json.dumps({"ok": False, "reason": "reviewer cannot be empty"})
+            if not reason.strip():
+                return json.dumps(
+                    {
+                        "ok": False,
+                        "reason": (
+                            "resolving write_uncertain requires a reason after "
+                            "inspecting the durable destination"
+                        ),
+                    }
+                )
+            changed = await app.storage.resolve_uncertain_memory_candidate(
+                candidate_id, reviewer=reviewer, reason=reason
+            )
+            return json.dumps(
+                {
+                    "ok": changed,
+                    "status": "rejected" if changed else "state_changed",
+                    "resolved_from": "write_uncertain",
+                }
+            )
+        if candidate["status"] != "pending":
+            return json.dumps(
+                {"ok": False, "reason": f"candidate not pending ({candidate['status']})"}
+            )
         changed = await app.storage.decide_memory_candidate(
             candidate_id, "rejected", reviewer, reason
         )
         return json.dumps({"ok": changed, "status": "rejected"})
     if decision != "approve":
         return json.dumps({"ok": False, "reason": "decision must be approve or reject"})
+    if candidate["status"] != "pending":
+        return json.dumps({"ok": False, "reason": f"candidate not pending ({candidate['status']})"})
 
     claimed = await app.storage.claim_memory_candidate(candidate_id, reviewer, reason)
     if claimed is None:

--- a/packages/memtomem/src/memtomem/storage/mixins/formation.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/formation.py
@@ -283,6 +283,39 @@ class FormationMixin:
         db.commit()
         return cursor.rowcount > 0
 
+    async def resolve_uncertain_memory_candidate(
+        self,
+        candidate_id: str,
+        *,
+        reviewer: str,
+        reason: str,
+    ) -> bool:
+        """Atomically close a quarantined candidate without another write."""
+        if not reviewer.strip():
+            raise ValueError("write_uncertain resolution reviewer cannot be empty")
+        if not reason.strip():
+            raise ValueError("write_uncertain resolution reason cannot be empty")
+        db = self._get_db()
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        cursor = db.execute(
+            "UPDATE memory_candidates SET status='rejected', reviewer=?, "
+            "decision_reason=?, decided_at=?, claim_started_at=NULL "
+            "WHERE id=? AND status='write_uncertain'",
+            (reviewer, reason, now, candidate_id),
+        )
+        if cursor.rowcount > 0:
+            self._record_candidate_transition(
+                db,
+                candidate_id,
+                "write_uncertain",
+                "rejected",
+                reviewer,
+                reason,
+                now,
+            )
+        db.commit()
+        return cursor.rowcount > 0
+
     async def list_memory_candidate_transitions(self, candidate_id: str) -> list[dict[str, Any]]:
         db = self._get_db()
         rows = db.execute(

--- a/packages/memtomem/tests/test_memory_formation.py
+++ b/packages/memtomem/tests/test_memory_formation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -152,6 +153,31 @@ async def test_recovered_completed_write_is_quarantined_from_reapproval(storage)
     assert row["status"] == "write_uncertain"
     assert "already persisted" in row["decision_reason"]
 
+    assert await storage.resolve_uncertain_memory_candidate(
+        candidate["id"],
+        reviewer="operator-alice",
+        reason="confirmed the durable entry already exists",
+    )
+    assert not await storage.resolve_uncertain_memory_candidate(
+        candidate["id"], reviewer="operator-bob", reason="second attempt"
+    )
+    resolved = await storage.get_memory_candidate(candidate["id"])
+    assert resolved["status"] == "rejected"
+    transitions = await storage.list_memory_candidate_transitions(candidate["id"])
+    assert transitions[-1]["from_status"] == "write_uncertain"
+    assert transitions[-1]["to_status"] == "rejected"
+    assert transitions[-1]["actor"] == "operator-alice"
+
+
+@pytest.mark.asyncio
+async def test_uncertain_resolution_requires_reviewer_and_reason(storage):
+    with pytest.raises(ValueError, match="reviewer"):
+        await storage.resolve_uncertain_memory_candidate(
+            "candidate", reviewer="", reason="inspected"
+        )
+    with pytest.raises(ValueError, match="reason"):
+        await storage.resolve_uncertain_memory_candidate("candidate", reviewer="alice", reason="")
+
 
 @pytest.mark.asyncio
 async def test_recovery_limit_returns_oldest_claims_first(storage):
@@ -253,6 +279,66 @@ async def test_mcp_review_reports_persisted_write_after_concurrent_recovery(monk
     assert result["durable_write_persisted"] is True
     assert "do not re-approve" in result["reason"]
     storage.mark_memory_candidate_write_uncertain.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_mcp_resolves_write_uncertain_without_another_write():
+    from memtomem.server.tools.formation import mem_candidate_review
+
+    storage = SimpleNamespace(
+        get_memory_candidate=AsyncMock(
+            return_value={"id": "candidate-1", "status": "write_uncertain"}
+        ),
+        resolve_uncertain_memory_candidate=AsyncMock(return_value=True),
+    )
+    app = SimpleNamespace(storage=storage, ensure_initialized=AsyncMock())
+    ctx = SimpleNamespace(request_context=SimpleNamespace(lifespan_context=app))
+
+    missing_reason = json.loads(
+        await mem_candidate_review("candidate-1", "reject", reviewer="alice", reason="", ctx=ctx)
+    )
+    assert missing_reason["ok"] is False
+    assert "requires a reason" in missing_reason["reason"]
+    resolved = json.loads(
+        await mem_candidate_review(
+            "candidate-1",
+            "reject",
+            reviewer="alice",
+            reason="confirmed durable write",
+            ctx=ctx,
+        )
+    )
+    assert resolved == {
+        "ok": True,
+        "status": "rejected",
+        "resolved_from": "write_uncertain",
+    }
+    storage.resolve_uncertain_memory_candidate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cli_uncertain_resolution_requires_reason_and_reports_success(monkeypatch, capsys):
+    import click
+
+    from memtomem.cli.review_cmd import _decide
+
+    storage = SimpleNamespace(
+        get_memory_candidate=AsyncMock(
+            return_value={"id": "candidate-1", "status": "write_uncertain"}
+        ),
+        resolve_uncertain_memory_candidate=AsyncMock(return_value=True),
+    )
+
+    @asynccontextmanager
+    async def fake_components():
+        yield SimpleNamespace(storage=storage)
+
+    monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", fake_components)
+    with pytest.raises(click.ClickException, match="requires --reason"):
+        await _decide("candidate-1", "rejected", "alice", "")
+    await _decide("candidate-1", "rejected", "alice", "confirmed durable write")
+    assert json.loads(capsys.readouterr().out)["resolved_from"] == "write_uncertain"
+    storage.resolve_uncertain_memory_candidate.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- allow an inspected `write_uncertain` candidate to transition atomically to `rejected` without another durable write
- require a non-empty reviewer and resolution reason
- expose the resolution through the existing `mm review reject` and `mem_candidate_review(decision="reject")` surfaces
- preserve normal `pending -> rejected` behavior while keeping uncertain re-approval blocked
- record `write_uncertain -> rejected` in the candidate transition audit
- document the concrete operator inspection and resolution workflow

## Safety properties

- resolution writes no memory or Pinned Context content
- only one concurrent resolver can match `status="write_uncertain"`
- a second resolution attempt fails closed
- direct re-approval remains unavailable
- actor and reason are persisted in the audit transition

## Verification

- 227 focused storage/schema/CLI/server tests passed
- direct CLI and MCP resolution paths tested
- missing reviewer/reason and concurrent second-attempt behavior tested
- Ruff and format check passed
- focused mypy passed
- Bandit 1.9.4 passed
- `git diff --check` passed

Closes #1737
