### PR TITLE
chore(dependabot): ignore TypeScript major bumps for opencode plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,14 @@ updates:
     groups:
       opencode-plugin:
         patterns: ["*"]
+    # TypeScript 7.x is the native (Go) port `tsgo`: it drops the `tsserver`
+    # bin and changes @types default inclusion, which broke `tsc` build here
+    # (TS2591 on `node:*` imports) — see the closed dependabot PR #1742. Stay
+    # on the 5.x classic compiler until the native port stabilizes; revisit by
+    # dropping this ignore when we intentionally adopt tsgo.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   # uv workspace: the single root uv.lock holds everything (member runtime deps
   # are declared in packages/memtomem/pyproject.toml but resolved/locked here;


### PR DESCRIPTION
## What

Add a semver-major `ignore` on `typescript` for the `opencode-plugin` npm
updater in `.github/dependabot.yml`.

## Why

The grouped dependabot bump #1742 raised `typescript` 5.8.3 → **7.0.2**.
TypeScript 7.x is the native (Go) port `tsgo`: the lockfile shows the
`tsserver` bin dropped (only `tsc` remains) and 20 `@typescript/typescript-*`
platform binaries added as optional deps. Under that compiler the plugin's
`tsc` build fails with:

```
src/server.ts(1,24): error TS2591: Cannot find name 'node:fs/promises'. …
src/server.ts(2,25): error TS2591: Cannot find name 'node:os'. …
src/server.ts(3,55): error TS2591: Cannot find name 'node:path'. …
src/server.ts(4,31): error TS2591: Cannot find name 'node:url'. …
```

(`@types` are no longer auto-included without an explicit `types` field.)

The opencode plugin only compiles a handful of files and has no reason to
adopt the preview native compiler on an automated chore bump. Pin the 5.x
classic line. `@types/node` continues to receive grouped bumps as before.
Drop this ignore when we intentionally migrate to `tsgo`.

## Notes

- Closes the failing dependabot PR #1742 (superseded by this ignore rule).
- Docs-only workflow change; no source or runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
