### PR TITLE
fix(langgraph): preserve programmatic config precedence

### DIFF
--- a/packages/memtomem/src/memtomem/integrations/langgraph.py
+++ b/packages/memtomem/src/memtomem/integrations/langgraph.py
@@ -84,12 +84,19 @@ class MemtomemStore:
     async def _ensure_init(self) -> Components:
         """Initialize components on first call; return the cached instance."""
         if self._components is None:
-            from memtomem.config import Mem2MemConfig
+            from memtomem.config import (
+                Mem2MemConfig,
+                load_config_d,
+                load_config_overrides,
+            )
             from memtomem.server.component_factory import create_components
 
             config = Mem2MemConfig()
+            load_config_d(config)
+            load_config_overrides(config)
 
-            # Apply overrides. Unknown sections / keys raise immediately:
+            # Apply programmatic overrides after ambient config. Unknown
+            # sections / keys raise immediately:
             # ``config_overrides`` is a programmatic constructor argument, so
             # a typo like ``{"storge": ...}`` or ``{"storage":
             # {"sqlite_pat": ...}}`` would otherwise fall back to the default
@@ -117,7 +124,11 @@ class MemtomemStore:
                         )
                     setattr(section_obj, key, value)
 
-            self._components = await create_components(config)
+            # Ambient config was resolved above so the constructor arguments
+            # remain the final, highest-precedence layer. Loading it again in
+            # the factory would overwrite an isolated sqlite_path or
+            # memory_dirs with ~/.memtomem settings.
+            self._components = await create_components(config, load_ambient_config=False)
         return self._components
 
     async def close(self) -> None:

--- a/packages/memtomem/src/memtomem/server/component_factory.py
+++ b/packages/memtomem/src/memtomem/server/component_factory.py
@@ -60,13 +60,24 @@ class Components:
     embedding_broken: dict | None = None
 
 
-async def create_components(config: Mem2MemConfig | None = None) -> Components:
-    """Create and initialise all core components."""
+async def create_components(
+    config: Mem2MemConfig | None = None,
+    *,
+    load_ambient_config: bool = True,
+) -> Components:
+    """Create and initialise all core components.
+
+    ``load_ambient_config=False`` is reserved for callers that have already
+    resolved the complete configuration precedence chain.  The default keeps
+    the existing server and CLI behaviour of loading ``config.d``, persisted
+    overrides, and environment variables before constructing components.
+    """
     from memtomem.config import load_config_d, load_config_overrides
 
     config = config or Mem2MemConfig()
-    load_config_d(config)
-    load_config_overrides(config)
+    if load_ambient_config:
+        load_config_d(config)
+        load_config_overrides(config)
 
     # Initialize FTS tokenizer from config
     from memtomem.storage.fts_tokenizer import set_tokenizer

--- a/packages/memtomem/tests/test_component_factory_config.py
+++ b/packages/memtomem/tests/test_component_factory_config.py
@@ -1,0 +1,28 @@
+"""Configuration precedence tests for the component factory."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_factory_can_skip_already_resolved_ambient_config(monkeypatch):
+    import memtomem.config as _cfg
+    import memtomem.server.component_factory as _factory
+
+    def _unexpected(_config):
+        raise AssertionError("ambient configuration was loaded again")
+
+    monkeypatch.setattr(_cfg, "load_config_d", _unexpected)
+    monkeypatch.setattr(_cfg, "load_config_overrides", _unexpected)
+
+    config = _cfg.Mem2MemConfig()
+    config.storage.sqlite_path = ":memory:"
+
+    # Reaching create_storage proves the ambient loaders were skipped. Abort
+    # there to keep this unit test hermetic.
+    monkeypatch.setattr(
+        _factory,
+        "create_storage",
+        lambda _config: (_ for _ in ()).throw(RuntimeError("factory reached")),
+    )
+    with pytest.raises(RuntimeError, match="factory reached"):
+        await _factory.create_components(config, load_ambient_config=False)

--- a/packages/memtomem/tests/test_langgraph.py
+++ b/packages/memtomem/tests/test_langgraph.py
@@ -56,7 +56,7 @@ class TestConfigOverridesStrict:
         import memtomem.config as _cfg
         import memtomem.server.component_factory as _factory
 
-        async def _fake_create(_):
+        async def _fake_create(_, **_kwargs):
             return MagicMock()
 
         async def _fake_close(_):
@@ -112,6 +112,41 @@ class TestConfigOverridesStrict:
         store = MemtomemStore(config_overrides={"storage": {"sqlite_path": "/tmp/x.db"}})
         # Should complete without raising.
         await store._ensure_init()
+
+    @pytest.mark.asyncio
+    async def test_programmatic_override_wins_over_ambient_config(self, monkeypatch, tmp_path):
+        """Constructor overrides are the final config precedence layer.
+
+        This guards isolated integrators from silently writing to a user's
+        ambient ``~/.memtomem`` database or memory directories.
+        """
+        import memtomem.config as _cfg
+        import memtomem.server.component_factory as _factory
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        isolated_db = tmp_path / "isolated.db"
+        ambient_db = tmp_path / "ambient.db"
+        captured = {}
+
+        def _ambient(config):
+            config.storage.sqlite_path = ambient_db
+
+        async def _fake_create(config, *, load_ambient_config=True):
+            captured["sqlite_path"] = config.storage.sqlite_path
+            captured["load_ambient_config"] = load_ambient_config
+            return MagicMock()
+
+        monkeypatch.setattr(_cfg, "load_config_d", _ambient)
+        monkeypatch.setattr(_cfg, "load_config_overrides", lambda config: None)
+        monkeypatch.setattr(_factory, "create_components", _fake_create)
+
+        store = MemtomemStore(config_overrides={"storage": {"sqlite_path": isolated_db}})
+        await store._ensure_init()
+
+        assert captured == {
+            "sqlite_path": isolated_db,
+            "load_ambient_config": False,
+        }
 
 
 class TestResolveSearchNamespace:
@@ -917,7 +952,7 @@ class TestCloseAndContextManager:
         comp = MagicMock()
         closed = []
 
-        async def _fake_create(_config):
+        async def _fake_create(_config, **_kwargs):
             return comp
 
         async def _fake_close(c):


### PR DESCRIPTION
## Summary

- resolve ambient config before applying `MemtomemStore(config_overrides=...)`
- let the component factory skip reloading ambient config for already-resolved callers
- add regression coverage proving isolated SQLite paths cannot be replaced by `~/.memtomem` settings

## Why

`create_components(config)` reloaded `config.d`, persisted config, and environment values after `MemtomemStore` applied its constructor overrides. Integrators that explicitly selected an isolated database could therefore write to the ambient user database instead.

## Validation

- `uv run pytest -q packages/memtomem/tests/test_langgraph.py packages/memtomem/tests/test_component_factory_config.py packages/memtomem/tests/test_multi_agent_integration.py packages/memtomem/tests/test_lazy_init_acceptance.py` (87 passed)
- targeted Ruff checks passed
- `git diff --check` passed
- broader suite reached 3,286 passed / 1 skipped before manual interruption; the displayed multiprocessing failure was caused by the Ctrl-C interruption