### PR TITLE
feat: preserve context windows in compose schema 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes will be documented in this file.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
+## [Unreleased]
+
+### Added
+
+- **Context Compose schema 3** — composed retrieval results can include
+  de-duplicated adjacent chunks with source and namespace metadata after all
+  matched hits claim their schema 2 budget; remaining context is selected
+  globally by distance. Schema 2 remains
+  the immutable scoped-composition contract released in 0.3.9; clients can use
+  the integer capability to distinguish visible context-window support.
+
 ## [0.3.9] — 2026-07-13
 
 ### Added

--- a/docs/guides/pinned-context.md
+++ b/docs/guides/pinned-context.md
@@ -21,11 +21,20 @@ default composed bundle to 12,000. A block is never cut in the middle; omitted
 ids are returned explicitly.
 
 `mem_context_compose` schema 2 accepts the same optional `namespace` and
-`context_window` retrieval controls used by search. Pinned files remain
-searchable through legacy `mem_search`, but the composed path excludes every
-file under the active user and project `pinned/` roots from its retrieved leg,
+`context_window` retrieval controls used by search. Schema 3 additionally
+returns adjacent chunks under each retrieved item's optional `context` object.
+Matched hits retain schema 2 budget priority; de-duplicated adjacent chunks use
+only the remaining composed bundle character budget, selected globally by
+distance with hit rank and before/after as deterministic tie-breakers. Pinned
+files remain searchable through legacy `mem_search`, but the composed path
+excludes every file under the active user and project `pinned/` roots from its retrieved leg,
 including shadowed, agent-specific, and malformed blocks. This prevents pinned
 content from appearing a second time as an ordinary search result.
+
+Schema 3 is a new capability instead of an in-place schema 2 change because
+schema 2 shipped in memtomem 0.3.9 without adjacent chunks in its response.
+Keeping that released contract immutable lets clients distinguish scoped
+composition from composition that also preserves visible context windows.
 
 ## Review-first candidates
 

--- a/docs/guides/reference/operations.md
+++ b/docs/guides/reference/operations.md
@@ -151,7 +151,15 @@ Running both `memtomem-server` (MCP) and `memtomem-web` simultaneously is suppor
 
 ## STM: Proactive Memory Surfacing (Optional)
 
-The **[memtomem-stm](https://github.com/memtomem/memtomem-stm)** package adds a proxy that sits between your AI agent and other MCP servers. It automatically recalls relevant memories when your agent uses any tool. STM is distributed as a separate package; it communicates with memtomem core entirely through the MCP protocol — no direct code coupling. Enhanced composition is negotiated from `mem_do(action="version").capabilities`, not inferred from an installed package version: `context_compose` schema 2 enables scoped Pinned Context composition, while `candidate_propose` schema 1 independently enables review-first proposals.
+The **[memtomem-stm](https://github.com/memtomem/memtomem-stm)** package adds a
+proxy that sits between your AI agent and other MCP servers. It automatically
+recalls relevant memories when your agent uses any tool. STM is distributed as
+a separate package; it communicates with memtomem core entirely through the MCP
+protocol — no direct code coupling. Enhanced composition is negotiated from
+`mem_do(action="version").capabilities`, not inferred from an installed package
+version: `context_compose` schema 2 enables scoped Pinned Context composition,
+schema 3 additionally preserves adjacent context-window chunks, and
+`candidate_propose` schema 1 independently enables review-first proposals.
 
 ### How it works
 

--- a/packages/memtomem/src/memtomem/pinned.py
+++ b/packages/memtomem/src/memtomem/pinned.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -55,6 +55,18 @@ class ContextBundle:
             "omitted_block_ids": list(self.omitted_block_ids),
             "warnings": list(self.warnings),
         }
+
+
+@dataclass(slots=True)
+class _ContextWindowSelection:
+    """Mutable schema-3 selection state for one matched result."""
+
+    context: Any
+    item: dict[str, Any]
+    before: tuple[Any, ...]
+    after: tuple[Any, ...]
+    selected_before: list[Any] = field(default_factory=list)
+    selected_after: list[Any] = field(default_factory=list)
 
 
 def _validate_id(value: str, kind: str) -> str:
@@ -264,20 +276,83 @@ class ContextAssembler:
                 project_context_root=self.store.project_root,
                 exclude_source_roots=self.store.search_exclusion_roots(),
             )
+            # Preserve the schema-2 matched-hit budget before spending any
+            # remaining capacity on schema-3 context windows.  This keeps
+            # adjacent chunks additive and prevents a high-ranked hit's
+            # neighbors from crowding out a lower-ranked hit.
+            matched: list[tuple[Any, dict[str, Any]]] = []
+            emitted_chunk_ids: set[str] = set()
             for result in results:
                 content = result.chunk.content
                 if used + len(content) > max_chars:
                     continue
-                retrieved.append(
-                    {
-                        "id": str(result.chunk.id),
-                        "content": content,
-                        "source": str(result.chunk.metadata.source_file),
-                        "namespace": str(result.chunk.metadata.namespace),
-                        "score": result.score,
-                    }
-                )
+                chunk_id = str(result.chunk.id)
+                item: dict[str, Any] = {
+                    "id": chunk_id,
+                    "content": content,
+                    "source": str(result.chunk.metadata.source_file),
+                    "namespace": str(result.chunk.metadata.namespace),
+                    "score": result.score,
+                }
                 used += len(content)
+                retrieved.append(item)
+                matched.append((result, item))
+                emitted_chunk_ids.add(chunk_id)
+
+            context_windows: list[_ContextWindowSelection] = []
+            for result, item in matched:
+                context = getattr(result, "context", None)
+                if context is not None:
+                    context_windows.append(
+                        _ContextWindowSelection(
+                            context=context,
+                            item=item,
+                            before=tuple(context.window_before),
+                            after=tuple(context.window_after),
+                        )
+                    )
+
+            max_distance = max(
+                (max(len(window.before), len(window.after)) for window in context_windows),
+                default=0,
+            )
+            # Allocate context globally by distance. Search rank breaks ties,
+            # then the before side precedes the after side deterministically.
+            for distance in range(max_distance):
+                for window in context_windows:
+                    candidates = (
+                        (window.selected_before, window.before[-(distance + 1)])
+                        if distance < len(window.before)
+                        else None,
+                        (window.selected_after, window.after[distance])
+                        if distance < len(window.after)
+                        else None,
+                    )
+                    for candidate in candidates:
+                        if candidate is None:
+                            continue
+                        destination, chunk = candidate
+                        chunk_id = str(chunk.id)
+                        if chunk_id in emitted_chunk_ids:
+                            continue
+                        if used + len(chunk.content) <= max_chars:
+                            destination.append(chunk)
+                            used += len(chunk.content)
+                            emitted_chunk_ids.add(chunk_id)
+
+            for window in context_windows:
+                if window.selected_before or window.selected_after:
+                    window.item["context"] = {
+                        "before": [
+                            self._context_chunk_payload(chunk)
+                            for chunk in reversed(window.selected_before)
+                        ],
+                        "after": [
+                            self._context_chunk_payload(chunk) for chunk in window.selected_after
+                        ],
+                        "chunk_position": window.context.chunk_position,
+                        "total_chunks_in_file": window.context.total_chunks_in_file,
+                    }
         warnings = (
             ("Pinned Context blocks omitted because the character budget was exhausted",)
             if omitted
@@ -291,3 +366,13 @@ class ContextAssembler:
             omitted_block_ids=tuple(omitted),
             warnings=warnings,
         )
+
+    @staticmethod
+    def _context_chunk_payload(chunk: Any) -> dict[str, str]:
+        """Serialize one adjacent chunk without changing the matched-hit contract."""
+        return {
+            "id": str(chunk.id),
+            "content": chunk.content,
+            "source": str(chunk.metadata.source_file),
+            "namespace": str(chunk.metadata.namespace),
+        }

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -637,7 +637,7 @@ async def mem_version(
             "version": __version__,
             "capabilities": {
                 "search_formats": ["compact", "verbose", "structured"],
-                "context_compose": {"schema_version": 2},
+                "context_compose": {"schema_version": 3},
                 "candidate_propose": {"schema_version": 1},
             },
         },

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -73,6 +73,9 @@ class TestCLIGroup:
             "web",
             "shell",
             "init",
+            "mem",
+            "pinned",
+            "review",
             "version",
         ):
             assert cmd in result.output, f"'{cmd}' not found in help output"

--- a/packages/memtomem/tests/test_meta_tool.py
+++ b/packages/memtomem/tests/test_meta_tool.py
@@ -241,7 +241,7 @@ class TestMemVersion:
     async def test_capabilities_stm_bridge(self):
         parsed = json.loads(await mem_version())
         capabilities = parsed["capabilities"]
-        assert capabilities["context_compose"] == {"schema_version": 2}
+        assert capabilities["context_compose"] == {"schema_version": 3}
         assert capabilities["candidate_propose"] == {"schema_version": 1}
         assert "context_compose" in ACTIONS
         assert "candidate_propose" in ACTIONS

--- a/packages/memtomem/tests/test_pinned_context.py
+++ b/packages/memtomem/tests/test_pinned_context.py
@@ -100,7 +100,144 @@ async def test_compose_pinned_first_then_retrieval(pinned_store):
 
 
 @pytest.mark.asyncio
-async def test_mem_context_compose_tool_threads_schema_two_scope(monkeypatch, pinned_store):
+async def test_compose_schema_three_budgets_neighbors_and_preserves_source_order(pinned_store):
+    def adjacent(chunk_id: str, content: str):
+        return SimpleNamespace(
+            id=chunk_id,
+            content=content,
+            metadata=SimpleNamespace(source_file="memory.md", namespace="work"),
+        )
+
+    before_far = adjacent("before-far", "BFAR")
+    before_near = adjacent("before-near", "BN")
+    hit = adjacent("hit", "HIT")
+    after_near = adjacent("after-near", "AN")
+    after_far = adjacent("after-far", "AFAR")
+    result = SimpleNamespace(
+        chunk=hit,
+        score=0.9,
+        context=SimpleNamespace(
+            window_before=(before_far, before_near),
+            window_after=(after_near, after_far),
+            chunk_position=3,
+            total_chunks_in_file=5,
+        ),
+    )
+
+    class Pipeline:
+        async def search(self, **kwargs):
+            return [result], None
+
+    bundle = await ContextAssembler(pinned_store, Pipeline()).compose(
+        "deployment", max_chars=11, context_window=2
+    )
+
+    retrieved = bundle.retrieved[0]
+    assert retrieved["content"] == "HIT"
+    assert [item["id"] for item in retrieved["context"]["before"]] == [
+        "before-far",
+        "before-near",
+    ]
+    assert [item["id"] for item in retrieved["context"]["after"]] == ["after-near"]
+    assert retrieved["context"]["chunk_position"] == 3
+    assert retrieved["context"]["total_chunks_in_file"] == 5
+    assert bundle.used_chars == 11
+
+
+@pytest.mark.asyncio
+async def test_compose_schema_three_keeps_hit_when_neighbors_exceed_budget(pinned_store):
+    neighbor = SimpleNamespace(
+        id="before",
+        content="TOO-LARGE",
+        metadata=SimpleNamespace(source_file="memory.md", namespace="work"),
+    )
+    hit = SimpleNamespace(
+        id="hit",
+        content="HIT",
+        metadata=SimpleNamespace(source_file="memory.md", namespace="work"),
+    )
+    result = SimpleNamespace(
+        chunk=hit,
+        score=0.9,
+        context=SimpleNamespace(
+            window_before=(neighbor,),
+            window_after=(),
+            chunk_position=2,
+            total_chunks_in_file=2,
+        ),
+    )
+
+    class Pipeline:
+        async def search(self, **kwargs):
+            return [result], None
+
+    bundle = await ContextAssembler(pinned_store, Pipeline()).compose(
+        "deployment", max_chars=3, context_window=1
+    )
+
+    assert bundle.retrieved == (
+        {
+            "id": "hit",
+            "content": "HIT",
+            "source": "memory.md",
+            "namespace": "work",
+            "score": 0.9,
+        },
+    )
+    assert bundle.used_chars == 3
+
+
+@pytest.mark.asyncio
+async def test_compose_schema_three_preserves_hits_and_deduplicates_context(pinned_store):
+    def chunk(chunk_id: str, content: str):
+        return SimpleNamespace(
+            id=chunk_id,
+            content=content,
+            metadata=SimpleNamespace(source_file="memory.md", namespace="work"),
+        )
+
+    first = chunk("first", "AAAA")
+    second = chunk("second", "BBBB")
+    shared = chunk("shared", "CC")
+    results = [
+        SimpleNamespace(
+            chunk=first,
+            score=0.9,
+            context=SimpleNamespace(
+                window_before=(),
+                window_after=(second, shared),
+                chunk_position=0,
+                total_chunks_in_file=3,
+            ),
+        ),
+        SimpleNamespace(
+            chunk=second,
+            score=0.8,
+            context=SimpleNamespace(
+                window_before=(first,),
+                window_after=(shared,),
+                chunk_position=1,
+                total_chunks_in_file=3,
+            ),
+        ),
+    ]
+
+    class Pipeline:
+        async def search(self, **kwargs):
+            return results, None
+
+    bundle = await ContextAssembler(pinned_store, Pipeline()).compose(
+        "deployment", max_chars=10, context_window=2
+    )
+
+    assert [item["id"] for item in bundle.retrieved] == ["first", "second"]
+    assert "context" not in bundle.retrieved[0]
+    assert [item["id"] for item in bundle.retrieved[1]["context"]["after"]] == ["shared"]
+    assert bundle.used_chars == 10
+
+
+@pytest.mark.asyncio
+async def test_mem_context_compose_tool_threads_schema_three_scope(monkeypatch, pinned_store):
     from memtomem.server.tools import pinned as pinned_tools
 
     pinned_store.set("profile", "always visible", priority=1)


### PR DESCRIPTION
## Summary
- add context-compose schema 3 as an additive superset of the released schema 2 contract
- serialize budgeted adjacent chunks with source and namespace metadata
- preserve matched-hit priority, whole-chunk budgeting, and original before/after order
- advertise schema 3 and document why schema 2 remains immutable

## Compatibility
Core 0.3.9 already released schema 2 without adjacent chunks in the response. Reusing schema 2 would make identical capability advertisements behave differently by release. Existing clients can ignore the optional context field; schema-aware clients can require schema 3 for visible windows.

## Validation
- 159 focused tests passed across pinned context, capability, CLI help, and docs
- ruff check and format passed for all 301 source files
- mypy passed for the changed pinned module; repository-wide advisory mypy retains 14 unrelated baseline errors
- real stdio core-to-STM schema 3 smoke passed
- full local suite reaches a platform SIGTRAP on macOS under both Python 3.12 and 3.13; Ubuntu CI remains the authoritative full gate