### PR TITLE
chore: keep internal plans and QA audits out of the public repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ node_modules/
 docs/testing/
 docs/marketing/
 docs/reports/
+docs/plans/
+docs/qa/
 .claude-memory/
 BUG_REPORT.md
 *.png


### PR DESCRIPTION
## What

Adds `docs/plans/` and `docs/qa/` to the internal-development-artifacts block
in `.gitignore`.

## Why

`docs/testing/`, `docs/marketing/`, and `docs/reports/` are already ignored
there. `docs/plans/` and `docs/qa/` hold the same class of content — release
handoffs and UI/UX audit write-ups that are working notes, not part of the
documentation surface this repo publishes — but were missing from the list.

Without the ignore they sit untracked in a working copy, one `git add .` away
from landing in a public repo.

## Scope

Nothing under either path is tracked today (`git ls-files docs/plans docs/qa`
is empty), so this masks no existing file and only affects future ones.
Verified with `git check-ignore` that both paths now resolve as ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
