### PR TITLE
feat: expose secret-free LTM runtime profile

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -27,7 +27,11 @@ logger = logging.getLogger(__name__)
 
 def _dependency_state(module: str, distribution: str | None = None) -> dict[str, object]:
     """Return a secret-free, non-importing dependency availability report."""
-    available = importlib.util.find_spec(module) is not None
+    try:
+        available = importlib.util.find_spec(module) is not None
+    except (ImportError, ValueError):
+        # Test doubles and partially initialized imports may have no __spec__.
+        available = False
     installed_version: str | None = None
     if available:
         try:

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -61,14 +61,18 @@ def collect_runtime_profile() -> dict[str, object]:
         provider == "onnx" and not bool(fastembed["available"])
     )
     bm25_available = bool(config.search.enable_bm25)
-    if bm25_available and dense_available:
-        mode = "hybrid"
-    elif bm25_available:
-        mode = "bm25_only"
-    elif dense_available:
-        mode = "dense_only"
-    else:
-        mode = "disabled"
+
+    def retrieval_mode(*, dense: bool) -> str:
+        if bm25_available and dense:
+            return "hybrid"
+        if bm25_available:
+            return "bm25_only"
+        if dense:
+            return "dense_only"
+        return "disabled"
+
+    configured_mode = retrieval_mode(dense=dense_configured)
+    effective_mode = retrieval_mode(dense=dense_available)
 
     missing_extras: list[str] = []
     fastembed_required_for: list[str] = []
@@ -95,7 +99,8 @@ def collect_runtime_profile() -> dict[str, object]:
             "enable_bm25": bool(config.search.enable_bm25),
             "enable_dense": bool(config.search.enable_dense),
             "tokenizer": str(config.search.tokenizer),
-            "configured_mode": mode,
+            "configured_mode": configured_mode,
+            "effective_mode": effective_mode,
         },
         "rerank": {
             "enabled": bool(config.rerank.enabled),

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import importlib.util
+from importlib.metadata import PackageNotFoundError, version as distribution_version
 import logging
 import os
 from dataclasses import dataclass, field
@@ -21,6 +23,83 @@ if TYPE_CHECKING:
     from memtomem.server.context import AppContext
 
 logger = logging.getLogger(__name__)
+
+
+def _dependency_state(module: str, distribution: str | None = None) -> dict[str, object]:
+    """Return a secret-free, non-importing dependency availability report."""
+    available = importlib.util.find_spec(module) is not None
+    installed_version: str | None = None
+    if available:
+        try:
+            installed_version = distribution_version(distribution or module)
+        except PackageNotFoundError:
+            pass
+    return {"available": available, "version": installed_version}
+
+
+def collect_runtime_profile() -> dict[str, object]:
+    """Describe the effective retrieval runtime without initializing models or storage."""
+    try:
+        from memtomem.config import Mem2MemConfig, load_config_d, load_config_overrides
+
+        config = Mem2MemConfig()
+        load_config_d(config, quiet=True)
+        load_config_overrides(config, migrate=False)
+    except Exception:
+        logger.debug("Unable to collect runtime profile", exc_info=True)
+        return {"schema_version": 1, "config_state": "error"}
+
+    fastembed = _dependency_state("fastembed")
+    kiwi = _dependency_state("kiwipiepy")
+    provider = str(config.embedding.provider)
+    dense_configured = bool(config.search.enable_dense and provider != "none")
+    dense_available = dense_configured and not (
+        provider == "onnx" and not bool(fastembed["available"])
+    )
+    bm25_available = bool(config.search.enable_bm25)
+    if bm25_available and dense_available:
+        mode = "hybrid"
+    elif bm25_available:
+        mode = "bm25_only"
+    elif dense_available:
+        mode = "dense_only"
+    else:
+        mode = "disabled"
+
+    missing_extras: list[str] = []
+    fastembed_required_for: list[str] = []
+    if provider == "onnx":
+        fastembed_required_for.append("embedding")
+    if config.rerank.enabled and config.rerank.provider == "fastembed":
+        fastembed_required_for.append("rerank")
+    if fastembed_required_for and not fastembed["available"]:
+        missing_extras.append("onnx")
+    if config.search.tokenizer == "kiwipiepy" and not kiwi["available"]:
+        missing_extras.append("korean")
+
+    fastembed["required_for"] = fastembed_required_for
+    kiwi["required_for"] = ["tokenizer"] if config.search.tokenizer == "kiwipiepy" else []
+    return {
+        "schema_version": 1,
+        "config_state": "ok",
+        "embedding": {
+            "provider": provider,
+            "model": str(config.embedding.model),
+            "dimension": int(config.embedding.dimension),
+        },
+        "search": {
+            "enable_bm25": bool(config.search.enable_bm25),
+            "enable_dense": bool(config.search.enable_dense),
+            "tokenizer": str(config.search.tokenizer),
+            "configured_mode": mode,
+        },
+        "rerank": {
+            "enabled": bool(config.rerank.enabled),
+            "provider": str(config.rerank.provider),
+        },
+        "dependencies": {"fastembed": fastembed, "kiwipiepy": kiwi},
+        "missing_extras": missing_extras,
+    }
 
 
 @mcp.tool()
@@ -670,6 +749,7 @@ async def mem_version(
     Used by external systems (e.g. memtomem-stm) to discover which features
     are available before using them. Callable via mem_do(action="version").
     """
+    runtime_profile = collect_runtime_profile()
     return json.dumps(
         {
             "version": __version__,
@@ -677,7 +757,9 @@ async def mem_version(
                 "search_formats": ["compact", "verbose", "structured"],
                 "context_compose": {"schema_version": 3},
                 "candidate_propose": {"schema_version": 1},
+                "runtime_profile": {"schema_version": 1},
             },
+            "runtime_profile": runtime_profile,
         },
         ensure_ascii=False,
     )

--- a/packages/memtomem/tests/test_meta_tool.py
+++ b/packages/memtomem/tests/test_meta_tool.py
@@ -250,6 +250,13 @@ class TestMemVersion:
         from memtomem import config as config_mod
 
         monkeypatch.setattr(config_mod, "_override_path", lambda: tmp_path / "config.json")
+        monkeypatch.setattr(config_mod, "_config_d_path", lambda: tmp_path / "config.d")
+        for key in (
+            "MEMTOMEM_SEARCH__ENABLE_BM25",
+            "MEMTOMEM_SEARCH__ENABLE_DENSE",
+            "MEMTOMEM_SEARCH__TOKENIZER",
+        ):
+            monkeypatch.delenv(key, raising=False)
         monkeypatch.setenv("MEMTOMEM_EMBEDDING__API_KEY", "do-not-leak")
         parsed = json.loads(await mem_version())
         assert parsed["capabilities"]["runtime_profile"] == {"schema_version": 1}
@@ -275,6 +282,13 @@ class TestMemVersion:
         from memtomem.server.tools import status_config
 
         monkeypatch.setattr(config_mod, "_override_path", lambda: tmp_path / "config.json")
+        monkeypatch.setattr(config_mod, "_config_d_path", lambda: tmp_path / "config.d")
+        for key in (
+            "MEMTOMEM_SEARCH__ENABLE_BM25",
+            "MEMTOMEM_SEARCH__ENABLE_DENSE",
+            "MEMTOMEM_SEARCH__TOKENIZER",
+        ):
+            monkeypatch.delenv(key, raising=False)
         monkeypatch.setenv("MEMTOMEM_EMBEDDING__PROVIDER", "onnx")
         monkeypatch.setenv("MEMTOMEM_EMBEDDING__MODEL", "bge-m3")
         monkeypatch.setenv("MEMTOMEM_EMBEDDING__DIMENSION", "1024")

--- a/packages/memtomem/tests/test_meta_tool.py
+++ b/packages/memtomem/tests/test_meta_tool.py
@@ -246,7 +246,12 @@ class TestMemVersion:
         assert "context_compose" in ACTIONS
         assert "candidate_propose" in ACTIONS
 
-    async def test_runtime_profile_is_additive_and_secret_free(self, monkeypatch):
+    async def test_runtime_profile_is_additive_and_secret_free(
+        self, monkeypatch, tmp_path
+    ):
+        from memtomem import config as config_mod
+
+        monkeypatch.setattr(config_mod, "_override_path", lambda: tmp_path / "config.json")
         monkeypatch.setenv("MEMTOMEM_EMBEDDING__API_KEY", "do-not-leak")
         parsed = json.loads(await mem_version())
         assert parsed["capabilities"]["runtime_profile"] == {"schema_version": 1}
@@ -259,11 +264,21 @@ class TestMemVersion:
             "dense_only",
             "disabled",
         }
+        assert profile["search"]["effective_mode"] in {
+            "hybrid",
+            "bm25_only",
+            "dense_only",
+            "disabled",
+        }
         assert "do-not-leak" not in json.dumps(parsed)
 
-    async def test_runtime_profile_reports_onnx_dependency_gap(self, monkeypatch):
+    async def test_runtime_profile_reports_onnx_dependency_gap(
+        self, monkeypatch, tmp_path
+    ):
+        from memtomem import config as config_mod
         from memtomem.server.tools import status_config
 
+        monkeypatch.setattr(config_mod, "_override_path", lambda: tmp_path / "config.json")
         monkeypatch.setenv("MEMTOMEM_EMBEDDING__PROVIDER", "onnx")
         monkeypatch.setenv("MEMTOMEM_EMBEDDING__MODEL", "bge-m3")
         monkeypatch.setenv("MEMTOMEM_EMBEDDING__DIMENSION", "1024")
@@ -278,5 +293,6 @@ class TestMemVersion:
             ),
         )
         profile = json.loads(await mem_version())["runtime_profile"]
-        assert profile["search"]["configured_mode"] == "bm25_only"
+        assert profile["search"]["configured_mode"] == "hybrid"
+        assert profile["search"]["effective_mode"] == "bm25_only"
         assert profile["missing_extras"] == ["onnx"]

--- a/packages/memtomem/tests/test_meta_tool.py
+++ b/packages/memtomem/tests/test_meta_tool.py
@@ -246,9 +246,7 @@ class TestMemVersion:
         assert "context_compose" in ACTIONS
         assert "candidate_propose" in ACTIONS
 
-    async def test_runtime_profile_is_additive_and_secret_free(
-        self, monkeypatch, tmp_path
-    ):
+    async def test_runtime_profile_is_additive_and_secret_free(self, monkeypatch, tmp_path):
         from memtomem import config as config_mod
 
         monkeypatch.setattr(config_mod, "_override_path", lambda: tmp_path / "config.json")
@@ -272,9 +270,7 @@ class TestMemVersion:
         }
         assert "do-not-leak" not in json.dumps(parsed)
 
-    async def test_runtime_profile_reports_onnx_dependency_gap(
-        self, monkeypatch, tmp_path
-    ):
+    async def test_runtime_profile_reports_onnx_dependency_gap(self, monkeypatch, tmp_path):
         from memtomem import config as config_mod
         from memtomem.server.tools import status_config
 

--- a/packages/memtomem/tests/test_meta_tool.py
+++ b/packages/memtomem/tests/test_meta_tool.py
@@ -245,3 +245,38 @@ class TestMemVersion:
         assert capabilities["candidate_propose"] == {"schema_version": 1}
         assert "context_compose" in ACTIONS
         assert "candidate_propose" in ACTIONS
+
+    async def test_runtime_profile_is_additive_and_secret_free(self, monkeypatch):
+        monkeypatch.setenv("MEMTOMEM_EMBEDDING__API_KEY", "do-not-leak")
+        parsed = json.loads(await mem_version())
+        assert parsed["capabilities"]["runtime_profile"] == {"schema_version": 1}
+        profile = parsed["runtime_profile"]
+        assert profile["schema_version"] == 1
+        assert profile["config_state"] == "ok"
+        assert profile["search"]["configured_mode"] in {
+            "hybrid",
+            "bm25_only",
+            "dense_only",
+            "disabled",
+        }
+        assert "do-not-leak" not in json.dumps(parsed)
+
+    async def test_runtime_profile_reports_onnx_dependency_gap(self, monkeypatch):
+        from memtomem.server.tools import status_config
+
+        monkeypatch.setenv("MEMTOMEM_EMBEDDING__PROVIDER", "onnx")
+        monkeypatch.setenv("MEMTOMEM_EMBEDDING__MODEL", "bge-m3")
+        monkeypatch.setenv("MEMTOMEM_EMBEDDING__DIMENSION", "1024")
+        original = status_config._dependency_state
+        monkeypatch.setattr(
+            status_config,
+            "_dependency_state",
+            lambda module, distribution=None: (
+                {"available": False, "version": None}
+                if module == "fastembed"
+                else original(module, distribution)
+            ),
+        )
+        profile = json.loads(await mem_version())["runtime_profile"]
+        assert profile["search"]["configured_mode"] == "bm25_only"
+        assert profile["missing_extras"] == ["onnx"]


### PR DESCRIPTION
## Summary
- expose an additive `runtime_profile` schema from `mem_do(action="version")`
- report effective embedding/search/rerank configuration and actual fastembed/kiwipiepy availability without importing models
- classify effective retrieval as hybrid, dense-only, BM25-only, or disabled
- keep the payload secret-free and load persisted configuration with migrations disabled

## Compatibility
- existing `version` and `capabilities` fields are preserved
- the new payload is additive and does not initialize storage or download models
- configuration read failures return a bounded `config_state=error` profile

## Tests
- `27 passed` in `packages/memtomem/tests/test_meta_tool.py`
- Ruff and MyPy passed for the changed files
- `git diff --check` passed