### PR TITLE
fix: a wikilink's `]](` is not an unclosed link either

### DIFF
--- a/packages/memtomem/src/memtomem/cli/memory_doctor_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/memory_doctor_cmd.py
@@ -178,7 +178,15 @@ class ParsedIndex:
 # could not resolve (an unclosed ``- [B](b.md``). Only ever applied to text the
 # parser handed back as text — a code span holding ``[x](y)`` is quoting, not
 # pointing, and the parser tells the two apart for us.
-_UNRESOLVED_LINK_SYNTAX_RE = re.compile(r"\]\(")
+#
+# The lookbehind spares wikilinks. ``[[memo]](note)`` closes with ``]](``, and
+# when the note holds a space CommonMark won't read it as a link at all — so the
+# whole thing stays text, and without the lookbehind its ``](`` reads as a
+# pointer someone failed to close. Same wikilink-vs-CommonMark collision as
+# :data:`_WIKILINK_LABEL_RE`, reached down the text path instead of the link
+# path. A genuinely unclosed link has something other than ``]`` before its
+# ``](``.
+_UNRESOLVED_LINK_SYNTAX_RE = re.compile(r"(?<!\])\]\(")
 
 # What a path-resolved destination must look like for the doctor to act on it:
 # a plain relative path. CommonMark hands back the destination the file

--- a/packages/memtomem/tests/test_memory_doctor.py
+++ b/packages/memtomem/tests/test_memory_doctor.py
@@ -226,6 +226,21 @@ class TestWikilinks:
         targets = [e.target for e in parse_memory_index(line + "\n").entries]
         assert "미커밋" not in targets and "wip" not in targets and "x.md" not in targets, why
 
+    SPACED_NOTES = [
+        ("- [Real](real.md) — built → [[memo-b]](PR#42 merged)", "spaced note"),
+        ("- [Real](real.md) — [[a]](PR#1 merged)·[[b]](not yet)", "two of them"),
+    ]
+
+    @pytest.mark.parametrize("line,why", SPACED_NOTES, ids=[w for _, w in SPACED_NOTES])
+    def test_wikilink_with_a_spaced_note_is_not_unresolved_syntax(self, line, why):
+        # A space means CommonMark won't read `(...)` as a destination, so the
+        # whole `[[memo]](note)` stays literal text — and its `]](` then looks
+        # like a pointer someone failed to close. Same collision as above, down
+        # the text path rather than the link path.
+        parsed = parse_memory_index(line + "\n")
+        assert parsed.unresolved_syntax_lines == frozenset(), why
+        assert [e.target for e in parsed.entries] == ["real.md"], why
+
     STILL_POINTERS = [
         ("- [[draft] Title](file.md)", "bracketed prefix in the title"),
         ("- [Title [note]](file.md)", "bracketed suffix in the title"),


### PR DESCRIPTION
Finishes the wikilink fix from #1761. Same collision, same line of the same real
index, one code path over — and it was sitting in the post-merge smoke output
after #1761 landed.

## What was left

#1761 taught the **link** path that `[[memo]](note)` is a wikilink followed by
prose. The **text** path still didn't know. When the note holds a space:

```markdown
- [Topic](topic.md) — built → [[memo-b]](PR#42 merged)
```

CommonMark won't read `(PR#42 merged)` as a destination at all (destinations with
spaces need `<>`), so the whole `[[memo-b]](PR#42 merged)` stays literal **text**.
The unresolved-link-syntax check then found its `]](` and warned that the line
holds a pointer someone failed to close — about a line that is exactly as its
author meant it.

So #1761 fixed the error-severity half (`broken_link` against a file named
`미커밋`) and left the warn-severity half on the same line. Reported honestly:
I stopped at the half the smoke run made loud.

## The fix

A genuinely unclosed link has something other than `]` before its `](`; a
wikilink's closer is `]](`. A lookbehind separates them, so the check doesn't
need to learn about wikilinks a second time.

| text | unclosed link? |
|---|---|
| `[B](b.md` | yes — flagged |
| `— and [B](b.md` | yes — flagged |
| `[[wiki]](PR#42 merged)` | no — wikilink + note |
| `[[wiki]](미커밋)` | no — wikilink + note |
| `see [note] later` | no — plain prose |

## Verification

- 8634 passed (`-m "not ollama"`), ruff clean.
- Mutation-verified: removing the lookbehind reds both new pins (the mutation
  asserts its anchor applied before running).
- `mm memory doctor` over all 48 real memory dirs on merged main + this fix: the
  line that started this — with a real markdown pointer, a wikilink+spaced-note
  and a wikilink+note all on it — now reports **nothing at all**, and its real
  pointer is still read. Across every dir: `broken_link` 0, `ambiguous_index_line`
  0. The only error-severity finding anywhere is an unrelated pre-existing
  `stale_source` in `~/.claude/plans`.

Whether wikilinks should be link-checked at all is #1762; this PR keeps them
invisible, as before.

Refs #1757

🤖 Generated with [Claude Code](https://claude.com/claude-code)
