### PR TITLE
docs: amend ADR-0020 — per-line eligibility for mm memory doctor --fix (#1757)

### DIFF
--- a/docs/adr/0020-memory-index-write-contract.md
+++ b/docs/adr/0020-memory-index-write-contract.md
@@ -1,7 +1,9 @@
 # ADR-0020: Index-file write contract for `mm memory doctor --fix`
 
-**Status:** Accepted
-**Date:** 2026-06-01
+**Status:** Accepted (amended 2026-07-15: §1 line eligibility restated as
+strict-grammar + all-links-dead, per-line skip replaces the blanket refusal;
+§5 gains two apply-time clauses; span-based entry removal rejected — #1757)
+**Date:** 2026-06-01 (amended 2026-07-15)
 **Context:** `mm memory doctor` (shipped in #1170, documented in #1171,
 `docs/guides/reference/organization-maintenance.md` §5) is **read-only by design**: it reports the
 3-way drift between disk, the agent index/TOC file (`MEMORY.md` for a
@@ -23,20 +25,93 @@ canonical-artifact scope hierarchy) and reuses the round-trip-preservation
 discipline of ADR-0008 (lockfile) and ADR-0005 (force-reindex metadata
 contract): a writer must preserve everything it did not deliberately change.
 
+**Amendment (2026-07-15, #1757).** Real indexes were found packing several
+entries — and prose around them — onto one line, and the original parser saw
+only the first link per line (#1757: false orphans, a `broken_link` blind
+spot, and whole-line deletion of lines that also carried live entries). #1760
+widened `parse_memory_index` to read every markdown link on a bullet line, so
+"one line = one entry" is no longer a parser-level given — it is a property
+`--fix` must **verify per line** before splicing. This amendment restates §1's
+eligibility rule in those terms, adds two apply-time clauses to §5, and
+records the rejection of span-based entry removal. The splice mechanism (§2)
+is unchanged. The design pass behind it is recorded on #1757 ("Design
+decision: line-splice contract preserved, span removal rejected").
+
 ## Decision
 
 ### 1. Subtractive-only, provably-dead-only
 
-`--fix` may **only delete** pointer lines the doctor classifies as
-`broken_link` with link-class `missing_target` — a `- [title](target) — hook`
-line whose `target` resolves *inside* the memory root but points at a file
-that does not exist on disk. It never adds, reorders, re-wraps, reformats, or
-rewrites any line, and never touches the DB.
+`--fix` may **only delete** whole pointer lines whose every link is provably
+dead. It never adds, reorders, re-wraps, reformats, or rewrites any line, and
+never touches the DB. A link is *dead* when the doctor classifies it
+`broken_link` with link-class `missing_target`: its target resolves *inside*
+the memory root but points at a file that does not exist on disk.
+
+As accepted, eligibility was stated for the one-entry-per-line shape the
+harness itself specifies for `MEMORY.md`: a `- [title](target) — hook` line
+whose single target is dead. **Amended 2026-07-15 (#1757):** the parser now
+reads every markdown link on a bullet line, so eligibility is restated per
+line.
+
+`--fix` considers exactly the lines carrying **at least one `missing_target`
+link** — the drift it exists to close. Every other line is simply left alone
+and is not a `--fix` concern at all: a line of live pointers, prose, or a
+heading is not "skipped", it was never a candidate. Among candidate lines,
+the unit of deletion stays the **whole line**, and a candidate qualifies for
+deletion **iff both** hold:
+
+- **Strict grammar — the parse must account for the whole line.** The line is
+  a single-line bullet (`-`/`*`) pointer entry as the CommonMark parser
+  (#1760) reads it: one or more markdown links plus inert prose. Three shapes
+  fail that test, and all three fail **closed** (the line is never eligible
+  for deletion):
+  - a list item that continues past its first line — deleting the line would
+    strand the continuation as loose prose;
+  - link syntax on the line that resolved to no link (an unclosed `[B](b.md`)
+    — the line meant a pointer the grammar could not read;
+  - a target the doctor will not resolve on a guess — a destination that is
+    not a plain relative path (it carries a `?` query, a `%` escape, a `:`
+    scheme, or whitespace) may name a file other than its literal text does,
+    so its pointer is never *provably* dead.
+
+  The last two are exactly the lines the doctor already reports as
+  `ambiguous_index_line` at `warn`: something on them could not be read, and
+  a splice must not act on a doubt. (#1757's design sketch stated this
+  ambiguity test as a scan for markdown-significant characters left outside
+  the parsed links, guarding a link *regex* that truncated
+  `[Live](notes_(v2).md)` at the inner paren. #1760 shipped a real CommonMark
+  parse instead, which subsumes that scan — balanced parentheses in a
+  destination or in hook prose read cleanly and are *not* ambiguous. The
+  contract is the parse-based test above, not the character scan.)
+- **All links dead.** *Every* link on the line classifies `missing_target`.
+  One live (or ambiguous, or out-of-root) link spares the whole line: splicing
+  it would delete a pointer memtomem cannot prove dead, and carving the dead
+  entry out of the line is span surgery this ADR rejects (see Considered &
+  rejected).
+
+A **candidate** that fails either test is **skipped and reported for manual
+repair** — a dead pointer memtomem found but will not remove itself — while
+qualifying candidates in the same file are still fixed. This is a per-line
+partition: it replaces the interim whole-run refusal (#1758, frozen through
+#1760) under which one non-conforming line blocked fixing the rest of the
+file.
+
+Skips are part of the report, not a silent omission, so the output must make
+three outcomes distinguishable in both the human and `--json` surfaces:
+nothing to do (no candidates), every candidate handled, and some candidate
+left behind. A run that skips a candidate must **not** present as clean —
+`--json`'s status has to separate "no dead pointers" from "dead pointers this
+tool refuses to touch", and a partially-fixed file must name the lines it
+left. The same applies to a candidate dropped at apply time by §5's
+re-validation (a resurrected target, a multiplicity mismatch): it is reported,
+not silently absent. The concrete payload shape is the implementing PR's to
+design; what this contract fixes is that skipped candidates are always
+visible and never counted as success.
 
 Rationale: the agent owns curation; memtomem may only remove references it can
-*prove* are dead. Deletion of a provably-dead pointer is the one curation move
-that cannot conflict with the agent's intent — the target file is gone, so no
-correct version of the TOC keeps the line.
+*prove* are dead. Deletion of a line holding *only* provably-dead pointers is
+the one curation move that cannot conflict with the agent's intent — every
+target on it is gone, so no correct version of the TOC keeps the line.
 
 ### 2. Byte-exact preservation of everything else
 
@@ -53,7 +128,8 @@ a byte-for-byte identity.
 `ParsedIndex.other_lines` cannot by themselves preserve CRLF-vs-LF or the EOF
 newline state. The contract therefore **forbids rebuilding the file from those
 fields**. `--fix` uses the parser only to identify the *line numbers* of the
-`missing_target` entries, then removes exactly those lines from the **original
+lines eligible under §1 (strict grammar satisfied, every link on the line
+`missing_target`), then removes exactly those lines from the **original
 text** — re-split with `splitlines(keepends=True)` (same 1-based indexing as
 the parser's terminator-stripped split), drop the identified indices, re-join —
 so every surviving line keeps its original terminator and the EOF state is
@@ -77,6 +153,7 @@ deliberately left to the human / agent:
 | Finding | Why `--fix` won't touch it |
 |---|---|
 | `broken_link` / `outside_root` | A link escaping the root may be a typo'd path *or* an intentional out-of-tree reference. Removing it could drop a real pointer — ambiguous intent. |
+| `ambiguous_index_line` | Something on the line could not be read (unresolved link syntax, or a target carrying URI machinery — §1's strict-grammar failures). Reported at `warn` for manual repair; a splice must not act on a doubt. *(Row added by the 2026-07-15 amendment, #1757.)* |
 | `budget` | Trimming an over-budget TOC means choosing *which entries to cut* — prose judgement, i.e. curation. |
 | `index_orphan` | *Adding* a missing pointer requires generating a title + hook and choosing insertion order. Generation, not deletion. |
 | `stale_source`, `convention_violation` | DB-side. Fixed by `mem_do(action="cleanup_orphans")` / `mm purge --matching-excluded`, not by editing the index file. |
@@ -115,6 +192,22 @@ contract) are **unchanged**: no flag, no write, no behavior change.
      the line must still be present *and* still classify as `missing_target`
      (handles the agent having rewritten the file, or the target file having
      reappeared, since analysis). Lines that no longer qualify are skipped.
+     **Amended 2026-07-15 (#1757)** — two clauses, matching §1's per-line
+     eligibility:
+     - **All links still dead.** A fresh line qualifies only if *all* of its
+       links still classify `missing_target`. One resurrected target spares
+       the whole line — the line-unit deletion of §1 applies at apply time
+       too, not only at analysis time.
+     - **Multiplicity guard.** Candidate matching is count-bounded on the raw
+       line text, counted in **physical line occurrences**: a line's entries
+       are collapsed by line number before counting, on both the analysis
+       side and the fresh side — an all-dead line carrying two links is *one*
+       occurrence, not two. Counts preserve *how many* copies survive, not
+       *which* position survives. A raw line whose fresh occurrence count
+       differs from its analysis-time count is therefore skipped entirely: when
+       byte-identical lines sit in different sections, silently picking one
+       to remove could delete the copy the agent meant to keep. The mismatch
+       fails closed and is reported for manual repair.
   3. Builds the new text by splicing only the still-qualifying lines out of
      **that fresh content**, so entries the agent added before the lock are
      carried through, never dropped.
@@ -153,10 +246,43 @@ contract) are **unchanged**: no flag, no write, no behavior change.
 - The contract is testable as a docs-as-tests parity guard like #1171: a
   round-trip test asserts byte-exact identity on a no-`missing_target` file
   and asserts only the targeted lines disappear otherwise, and a guard asserts
-  `--fix` acts on no link-class other than `missing_target`.
+  `--fix` acts on no link-class other than `missing_target`. Amended
+  2026-07-15 (#1757) — the per-line partition adds its own pins: a mixed
+  live/dead line survives byte-exact while eligible lines in the same file
+  are removed; ambiguous and multiline lines are skipped *and reported*; and
+  an apply-time multiplicity mismatch removes no copy of that raw line.
+- **Amended 2026-07-15 (#1757) — contract-first, again.** As with the original
+  ADR, this amendment lands before the code: shipped `--fix` keeps the frozen
+  fail-closed semantics (#1758's whole-run refusal, write scope pinned to the
+  pre-#1757 single-link shape through #1760) until the follow-up PR implements
+  the per-line partition above. That PR also updates the `--fix` section of
+  `docs/guides/reference/organization-maintenance.md` §5, which documents
+  shipped behavior and deliberately keeps the "refuses" wording until then.
 
 ## Considered & rejected
 
+- **Span-based entry removal** (proposed on #1757, rejected by the 2026-07-15
+  amendment): give each entry a column span and splice only the dead entry's
+  span out of a multi-entry line. Rejected because:
+  - *The span is not well-defined.* Removing `[b](y.md)` from
+    `- NS: [a](x.md) · [b](y.md) — hook` leaves a dangling ` · `. Stripping
+    the adjacent separator means parsing free-form agent prose (` · `, `, `,
+    `—`, parens) — exactly the reconstruction §2 forbids. Which prose belongs
+    to which entry is a curation judgement this ADR assigns to the agent, not
+    to `--fix`.
+  - *Nested hook links make span ownership ambiguous.* On
+    `- [Title](topic.md) — decision=NO-GO([rationale](other.md))`, whether the
+    second link is a sibling entry or part of the first entry's hook is
+    unanswerable from syntax. A line-unit fixer never has to answer it.
+  - *Blast radius.* It would rewrite §1 (the unit of deletion), §2 (the splice
+    mechanism itself), and §5 — including moving count-bounded re-validation
+    off whole-line raw text, which breaks the "agent edited the line → line
+    spared" property that makes the non-cooperating-writer race tolerable.
+
+  Multi-entry lines are already non-conforming (the harness states one entry
+  per line for `MEMORY.md`); auto-surgery inside them is high risk for
+  near-zero demand. The amendment instead keeps line-unit deletion and gates
+  it on §1's strict-grammar + all-links-dead test.
 - **Full curation `--fix` (reflow, budget-trim, orphan-add).** Rejected: it
   fights the agent's curation, requires generation/judgement, and has a large
   blast radius on a file loaded into the agent's context every session.


### PR DESCRIPTION
## Summary

Docs-only amendment to ADR-0020, recording the design pass from #1757 ("Design decision: line-splice contract preserved, span removal rejected") in the write contract **before** the code changes — the same contract-first pattern as the original ADR. Part 2 of the 4-PR split recorded on #1757 (part 1 was the parser fix, #1760; parts 3–4 follow).

#1760 widened the index parser to read every markdown link on a bullet line, so "one line = one entry" is no longer a parser-level given — it is a property `--fix` must verify per line before splicing. This amendment restates the contract in those terms:

- **§1** — eligibility becomes *strict grammar* (single-line bullet item, no unresolved link syntax, no unreadable target — the last two are exactly `ambiguous_index_line`) **+ all-links-dead**. The unit of deletion stays the whole line. A line failing either test is **skipped and reported for manual repair**, replacing the interim whole-run refusal (#1758) under which one non-conforming line blocked fixing the rest of the file.
- **§5** — two apply-time clauses: a fresh line qualifies only if *all* its links still classify `missing_target` (one resurrected target spares the whole line), and count-bounded candidate matching is defined in **physical line occurrences** (entries collapsed by line number), failing closed on a multiplicity mismatch.
- **Considered & rejected** — span-based entry removal, with the reasons of record: the span is not well-defined (stripping separators means parsing free-form agent prose, the reconstruction §2 forbids), nested hook links make span ownership unanswerable from syntax, and the blast radius covers §§1/2/5 including the "agent edited the line → line spared" property.
- **§3** — `ambiguous_index_line` recorded as reported-only; **§2** wording aligned to §1 eligibility; the testability consequence extended to the per-line-partition pins; header/context amended per the ADR-0008 convention.

Shipped `--fix` keeps the frozen fail-closed semantics (#1758, write scope pinned through #1760) until part 3 implements this contract. `docs/guides/reference/organization-maintenance.md` §5 deliberately keeps its current "refuses" wording until then (noted in Consequences).

One deviation from the #1757 design sketch, on purpose: the sketch stated the ambiguity test as a scan for markdown-significant characters outside the parsed links, guarding a link *regex* that truncated `[Live](notes_(v2).md)`. #1760 shipped a real CommonMark parse that subsumes that scan (balanced parentheses read cleanly and are pinned as non-ambiguous in `test_memory_doctor.py`), so the amendment records the parse-based test and explains the evolution inline — otherwise the ADR would mislead part 3 into reintroducing the obsolete regex failure.

## Verification

- Docs-only diff: one file, `docs/adr/0020-memory-index-write-contract.md`.
- Every behavioral claim checked against the decision of record (#1757 design comment) and shipped code (`memory_doctor_cmd.py`: `_unfixable_reason`, `_LEGACY_ENTRY_SHAPE_RE`, the whole-run refusal, `_apply_fix`'s count-bounded budget, `ambiguous_index_line`; parser tests for parenthesized destinations).
- `uv run pytest packages/memtomem/tests/test_memory_doctor.py packages/memtomem/tests/test_docs_guards.py -m "not ollama"` — 201 passed.
- `ruff check` + `ruff format --check` over src/tests/tools — clean.

Refs #1757 (does not close it — parts 3–4 remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
