### PR TITLE
fix: name the exception class when a Tier 1 index read fails blank (#1771)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/memory_doctor_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/memory_doctor_cmd.py
@@ -534,6 +534,19 @@ class DirReport:
         }
 
 
+def _read_error_message(exc: Exception) -> str:
+    """Render a read failure for a report — never empty.
+
+    ``str(OSError())`` is ``""``, so interpolating the exception directly can
+    leave a message that trails off (``"could not read MEMORY.md: "``) or, in
+    Tier 2, one that vanishes under a truthiness check and turns a real failure
+    back into "clean" (#1769). Both read paths route through here: the message
+    falls back to the exception class name, and Tier 2's presence check stays
+    ``error is not None`` regardless.
+    """
+    return str(exc) or type(exc).__name__
+
+
 # ── Read-only config + engine plumbing ──────────────────────────────
 
 
@@ -812,7 +825,7 @@ def _analyze_index_file(
             Finding(
                 check="index_missing",
                 severity="warn",
-                summary=f"could not read {index_file_name}: {exc}",
+                summary=f"could not read {index_file_name}: {_read_error_message(exc)}",
             )
         )
         return
@@ -1077,17 +1090,6 @@ def _emit_json(reports: list[DirReport]) -> None:
 #      each candidate against fresh content so concurrent agent edits survive.
 
 
-def _read_error_message(exc: Exception) -> str:
-    """Render a read failure for the report — never empty.
-
-    ``str(OSError())`` is ``""``; an empty message would vanish under any
-    truthiness check downstream and turn a real failure back into "clean"
-    (#1769) — so presence is ``error is not None`` everywhere, and the message
-    itself falls back to the exception class name.
-    """
-    return str(exc) or type(exc).__name__
-
-
 class _IndexUnreadable(Exception):
     """The locked fresh read inside :func:`_apply_fix` could not decode the index.
 
@@ -1114,7 +1116,8 @@ class FixFileResult:
     skipped: list[tuple[int, str, str]] = field(default_factory=list)
     # The index could not be read: nothing about this file is verified, so the
     # run must not read as clean (#1769). Presence checks compare against None,
-    # never truthiness — see _read_error_message.
+    # never truthiness — the message itself is never empty (see
+    # _read_error_message), but "" would still be a real failure.
     error: str | None = None
 
     def to_json(self) -> dict[str, object]:

--- a/packages/memtomem/tests/test_memory_doctor.py
+++ b/packages/memtomem/tests/test_memory_doctor.py
@@ -1188,6 +1188,33 @@ class TestCli:
         assert finding["severity"] == "warn"
         assert "could not read MEMORY.md" in finding["summary"]
 
+    def test_blank_oserror_message_names_the_exception_class(self, doctor_env, monkeypatch):
+        """``str(OSError())`` is empty — the summary must not trail off (#1771).
+
+        Tier 1's finding never depended on the message being truthy (unlike
+        Tier 2's per-file error), so this is about what the reader sees: the
+        shared helper falls back to the exception class name rather than
+        leaving "could not read MEMORY.md: ".
+        """
+        config, mem_dir = doctor_env
+        self._patch_loader(monkeypatch, config)
+        index = (mem_dir / "MEMORY.md").resolve()
+
+        real_read_text = Path.read_text
+
+        def deny_index(self, *args, **kwargs):
+            if self.resolve() == index:
+                raise OSError()
+            return real_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", deny_index)
+
+        result = CliRunner().invoke(cli, ["memory", "doctor", "--json"])
+
+        assert result.exit_code == 0
+        finding = self._index_missing_finding(json.loads(result.output))
+        assert finding["summary"] == "could not read MEMORY.md: OSError"
+
 
 # ── Docs-as-tests parity ────────────────────────────────────────────
 #


### PR DESCRIPTION
## Summary

`_analyze_index_file` interpolated the exception straight into its `index_missing` summary, and `str(OSError())` is the empty string — so a blank-message I/O failure rendered as a line that trails off where the reason belongs:

```
! could not read MEMORY.md:
```

`_read_error_message` already solves exactly this for Tier 2's `--fix` path (#1770): it falls back to the exception class name. This routes Tier 1's read failure through the same helper rather than keeping two spellings of the same rendering:

```
! could not read MEMORY.md: OSError
```

## Changes

- `_analyze_index_file`'s `(OSError, UnicodeDecodeError)` arm calls `_read_error_message(exc)`. The `FileNotFoundError` arm above it has its own message and is untouched.
- The helper **moves** out of the Tier 2 section up to the shared report-model section, since both tiers now use it.
- Its docstring drops the Tier-2-only framing. The two callers differ in what's at stake, and the docstring now says so: for `--fix` an empty message would vanish under a truthiness check and resurrect the false `clean` of #1769; in Tier 1 nothing but readability is at stake — the finding is appended unconditionally, and its severity, count and exit-code contribution never consult the message. **Tier 2's presence check stays `error is not None` regardless** — the helper is not what makes it safe, and this PR doesn't make it depend on one.

No behavior change beyond the rendered string; no status, severity, exit-code or schema change.

## Tests

`TestCli::test_blank_oserror_message_names_the_exception_class` — monkeypatches `Path.read_text` to raise a bare `OSError()` and asserts the summary is exactly `"could not read MEMORY.md: OSError"`, not `"could not read MEMORY.md: "`. Mutation-validated: reverting the arm to interpolate `exc` directly turns the pin red.

The sibling `PermissionError` pin (`test_oserror_index_read_is_index_missing_warn`) and Tier 2's `test_fix_blank_oserror_message_is_still_an_error` cover the non-blank and Tier 2 sides unchanged.

`uv run pytest -m "not ollama"`: 8669 passed. Ruff clean on `src`/`tests`/`tools`. Verified against a real isolated `HOME` that the rendered finding reads `could not read MEMORY.md: OSError`.

Raised in review of #1770 as an explicitly optional follow-up.

Closes #1771

🤖 Generated with [Claude Code](https://claude.com/claude-code)
