### PR TITLE
feat(search): per-call rerank bypass for latency-bounded callers (#1766)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **Per-call rerank bypass** (#1766) — `mem_search` and `mem_context_compose`
+  accept `rerank=false` (CLI: `mm search --no-rerank`, `mm pinned compose
+  --no-rerank`) to skip the cross-encoder rerank stage and its candidate-pool
+  oversample for a single call, letting latency-bounded callers trade rerank
+  precision for a fast un-reranked search without changing server config.
+  Omitted/`true` follows `rerank.enabled`; `true` cannot force-enable
+  reranking on a server that has it disabled.
+
 ## [0.3.11] — 2026-07-14
 
 ### Added

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -539,6 +539,8 @@ so the pool scales with the caller's requested `top_k` while staying bounded by 
 
 `rerank.enabled`, `rerank.oversample`, `rerank.min_pool`, and `rerank.max_pool` are runtime-tunable via `mm config set` or the Web UI Settings panel — no restart required. `rerank.provider` / `rerank.model` / `rerank.api_key` are load-time only because the reranker instance is cached on startup.
 
+Latency-bounded callers can also skip reranking **per call** without touching server config: pass `rerank=false` to `mem_search` or `mem_context_compose` (MCP), or `--no-rerank` to `mm search` / `mm pinned compose` (CLI). The call then skips the cross-encoder stage and collapses the candidate pool to `top_k` — trading rerank precision for an un-reranked search that typically finishes in well under a second. Omitting the parameter (or passing `true`) follows the server config; `true` cannot enable reranking on a server that has it disabled.
+
 > **Deprecated:** earlier releases exposed `MEMTOMEM_RERANK__TOP_K` / `rerank.top_k` as an absolute candidate-pool size. The field still loads (legacy configs are migrated to `rerank.min_pool` with a `DeprecationWarning`) but is slated for removal in a future release. Use `rerank.oversample` + `rerank.min_pool` + `rerank.max_pool` instead.
 
 ### Provider-specific models

--- a/docs/guides/reference/core-memory-tools.md
+++ b/docs/guides/reference/core-memory-tools.md
@@ -194,6 +194,7 @@ Combines keyword matching (exact words) with meaning-based search (similar conce
 | `context_window` | Expand each result with ±N adjacent chunks (`0` = disabled) | `1` |
 | `output_format` | `"compact"` (default), `"verbose"`, or `"structured"` (JSON with `hints` field) | `"structured"` |
 | `scope` | Memory tier filter: one value, comma list, or glob; omitted uses user plus current-project tiers | `"user,project_local"`, `"project_*"` |
+| `rerank` | Per-call rerank control: `false` skips the cross-encoder rerank stage (fast path for latency-bounded callers); omitted/`true` follows server config — `true` cannot enable reranking the server has disabled | `false` |
 
 ```
 mem_search(query="caching strategy", tag_filter="redis,cache", namespace="work")
@@ -204,12 +205,13 @@ mem_search(query="deploy pipeline", as_of="2025-Q3")    # historical query
 > **Result count with filters**: `mem_search` returns *up to* `top_k` results.
 > Increase `top_k` when one call needs more results. When reranking is enabled,
 > the candidate pool is automatically computed from `rerank.oversample`,
-> `rerank.min_pool`, and `rerank.max_pool`; `rerank_pool` is not a
-> `mem_search` argument. Post-rank filters can still reduce the final count.
+> `rerank.min_pool`, and `rerank.max_pool`; passing `rerank=false` skips
+> reranking for the call and collapses that pool to `top_k`. Post-rank filters
+> can still reduce the final count.
 
 > **source_filter tip**: Use substrings like `"docs/adr"` or `".py"` for filtering. Glob patterns (`*`, `?`) are matched against the **full absolute path** via `fnmatch`, so `"*.py"` won't work as expected — use `".py"` instead.
 
-> **Trust-UX hints**: when you don't pin a namespace, results are followed by a parenthesized hint if chunks were hidden in system namespaces (e.g. `archive:*`) or if the configured embedding dimension disagrees with what's in the database. In `output_format="structured"` those hints are emitted as a `hints` array instead.
+> **Trust-UX hints**: when you don't pin a namespace, results are followed by a parenthesized hint if chunks were hidden in system namespaces (e.g. `archive:*`) or if the configured embedding dimension disagrees with what's in the database. A third hint — independent of namespace selection — appears when you pass `rerank=true` but the server has reranking disabled (`rerank.enabled=false`), since the parameter cannot force-enable it. In `output_format="structured"` those hints are emitted as a `hints` array instead.
 
 ### Tuning search weights
 

--- a/packages/memtomem/src/memtomem/cli/pinned_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/pinned_cmd.py
@@ -180,16 +180,34 @@ async def _delete_block(
 @click.option("--agent", "agent_id", default=None)
 @click.option("--max-chars", type=click.IntRange(min=1), default=12_000)
 @click.option("--top-k", type=click.IntRange(min=1), default=10)
-def compose(query: str | None, agent_id: str | None, max_chars: int, top_k: int) -> None:
+@click.option(
+    "--no-rerank",
+    "no_rerank",
+    is_flag=True,
+    default=False,
+    help=(
+        "Skip cross-encoder reranking for the retrieval leg (faster, lower "
+        "precision; otherwise follows server config)."
+    ),
+)
+def compose(
+    query: str | None, agent_id: str | None, max_chars: int, top_k: int, no_rerank: bool
+) -> None:
     """Emit a structured pinned-first context bundle as JSON."""
-    asyncio.run(_compose(query, agent_id, max_chars, top_k))
+    asyncio.run(_compose(query, agent_id, max_chars, top_k, rerank=False if no_rerank else None))
 
 
-async def _compose(query: str | None, agent_id: str | None, max_chars: int, top_k: int) -> None:
+async def _compose(
+    query: str | None,
+    agent_id: str | None,
+    max_chars: int,
+    top_k: int,
+    rerank: bool | None = None,
+) -> None:
     from memtomem.pinned import ContextAssembler
 
     async with _store_context() as (comp, store):
         bundle = await ContextAssembler(store, comp.search_pipeline).compose(
-            query, agent_id=agent_id, max_chars=max_chars, top_k=top_k
+            query, agent_id=agent_id, max_chars=max_chars, top_k=top_k, rerank=rerank
         )
         click.echo(json.dumps(bundle.as_dict(), ensure_ascii=False))

--- a/packages/memtomem/src/memtomem/cli/search.py
+++ b/packages/memtomem/src/memtomem/cli/search.py
@@ -57,6 +57,16 @@ from memtomem.server.tools.search import (
         "(namespace-grouped, relevance-tiered truncation)."
     ),
 )
+@click.option(
+    "--no-rerank",
+    "no_rerank",
+    is_flag=True,
+    default=False,
+    help=(
+        "Skip cross-encoder reranking for this query (faster, lower "
+        "precision; otherwise follows server config)."
+    ),
+)
 def search(
     query: str,
     top_k: int,
@@ -66,10 +76,23 @@ def search(
     scope: str | None,
     as_of: str | None,
     fmt: str,
+    no_rerank: bool,
 ) -> None:
     """Search the knowledge base."""
     try:
-        asyncio.run(_search(query, top_k, source_filter, tag_filter, namespace, scope, as_of, fmt))
+        asyncio.run(
+            _search(
+                query,
+                top_k,
+                source_filter,
+                tag_filter,
+                namespace,
+                scope,
+                as_of,
+                fmt,
+                rerank=False if no_rerank else None,
+            )
+        )
     except click.ClickException:
         raise
     except Exception as e:
@@ -85,6 +108,7 @@ async def _search(
     scope: str | None,
     as_of: str | None,
     fmt: str,
+    rerank: bool | None = None,
 ) -> None:
     from memtomem.chunking.markdown import _parse_validity_bound
     from memtomem.cli._bootstrap import cli_components
@@ -109,6 +133,7 @@ async def _search(
             as_of_unix=as_of_unix,
             scope=scope,
             project_context_root=project_context_root,
+            rerank=rerank,
         )
 
     if not results and fmt in ("table", "plain"):

--- a/packages/memtomem/src/memtomem/pinned.py
+++ b/packages/memtomem/src/memtomem/pinned.py
@@ -254,6 +254,7 @@ class ContextAssembler:
         top_k: int = 10,
         namespace: str | list[str] | None = None,
         context_window: int | None = None,
+        rerank: bool | None = None,
     ) -> ContextBundle:
         pinned: list[PinnedBlock] = []
         omitted: list[str] = []
@@ -275,6 +276,7 @@ class ContextAssembler:
                 context_window=context_window,
                 project_context_root=self.store.project_root,
                 exclude_source_roots=self.store.search_exclusion_roots(),
+                rerank=rerank,
             )
             # Preserve the schema-2 matched-hit budget before spending any
             # remaining capacity on schema-3 context windows.  This keeps

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -265,6 +265,10 @@ class RetrievalStats:
     # explicit namespace — surfaces as a hint in mem_search's output so
     # users know their archived memories still exist.
     hidden_system_ns: int = 0
+    # Whether Stage 3b cross-encoder reranking actually ran for this call —
+    # the per-call effective decision (#1766), not the live server config,
+    # so hint builders stay accurate across concurrent hot reloads.
+    rerank_applied: bool = False
 
 
 if TYPE_CHECKING:
@@ -316,6 +320,16 @@ class SearchPipeline:
         # LLM query expansion cache (cleared on invalidate_cache)
         self._expansion_cache: dict[str, str] = {}
 
+    @property
+    def rerank_active(self) -> bool:
+        """True when a reranker instance is wired and configured (server-side on).
+
+        Hot reload keeps the pair consistent: it sets ``_rerank_config`` to
+        ``None`` alongside dropping the reranker when ``rerank.enabled`` is
+        turned off (``web/hot_reload.py``).
+        """
+        return self._reranker is not None and self._rerank_config is not None
+
     def _cache_key(
         self,
         query: str,
@@ -329,13 +343,27 @@ class SearchPipeline:
         metadata_filter: SearchMetadataFilter | None = None,
         exclude_source_roots: tuple[Path, ...] = (),
         effective_rrf_weights: list[float] | tuple[float, ...] | None = None,
+        apply_rerank: bool | None = None,
+        rerank_cfg: RerankConfig | None = None,
     ) -> str:
         import hashlib
 
         ctx_win = self._resolve_context_window(context_window)
-        if self._reranker is not None and self._rerank_config is not None:
-            rcfg = self._rerank_config
-            rerank_signal = f"on:{rcfg.oversample}:{rcfg.min_pool}:{rcfg.max_pool}"
+        # ``apply_rerank`` is the per-call effective decision and
+        # ``rerank_cfg`` the config snapshot taken alongside it (#1766) —
+        # ``search()`` passes both so the key never re-reads attributes a
+        # concurrent hot reload may have swapped. Direct callers omitting
+        # them fall back to the live server state. A bypassed call
+        # (rerank=False) is byte-identical to a server-off call with the
+        # same args, so both deliberately share the "off" slot.
+        if apply_rerank is None:
+            apply_rerank = self.rerank_active
+        if rerank_cfg is None:
+            rerank_cfg = self._rerank_config
+        if apply_rerank and rerank_cfg is not None:
+            rerank_signal = (
+                f"on:{rerank_cfg.oversample}:{rerank_cfg.min_pool}:{rerank_cfg.max_pool}"
+            )
         else:
             rerank_signal = "off"
         # ADR-0011: scope + project_context_root MUST participate in the cache
@@ -726,7 +754,12 @@ class SearchPipeline:
         created_from: datetime | None = None,
         created_before: datetime | None = None,
         exclude_source_roots: tuple[Path, ...] | None = None,
+        rerank: bool | None = None,
     ) -> tuple[list[SearchResult], RetrievalStats]:
+        # ``rerank`` (#1766): None = follow server config; False = skip the
+        # Stage 3b cross-encoder and collapse the candidate pool to top_k
+        # (per-call fast path for latency-bounded callers); True = follow
+        # config — it cannot force-enable when no reranker is wired.
         # #750: tag/source-only branch — no keyword to rank by, so the
         # filter takes over as the primary selector. We enumerate via
         # ``recall_chunks`` and skip BM25/dense/expansion/rescue/rerank
@@ -771,6 +804,14 @@ class SearchPipeline:
         top_k = self._config.default_top_k if top_k is None else top_k
         effective_weights = rrf_weights or self._config.rrf_weights
 
+        # Snapshot the reranker pair once: hot reload swaps (and closes) these
+        # attributes while a search may be awaiting, so every rerank-dependent
+        # site below (cache key, pool widening, Stage 3b) must read the same
+        # consistent pair rather than re-reading ``self._*`` mid-flight.
+        reranker = self._reranker
+        rerank_cfg = self._rerank_config
+        apply_rerank = reranker is not None and rerank_cfg is not None and rerank is not False
+
         # Check TTL cache for identical queries
         import time
 
@@ -792,6 +833,8 @@ class SearchPipeline:
             metadata_filter=metadata_filter,
             exclude_source_roots=normalized_exclusion_roots,
             effective_rrf_weights=effective_weights,
+            apply_rerank=apply_rerank,
+            rerank_cfg=rerank_cfg,
         )
         version_at_start = self._cache_version
         ttl_snapshot = self._cache_ttl
@@ -923,6 +966,7 @@ class SearchPipeline:
             bm25_error=bm25_error,
             dense_error=dense_error,
             hidden_system_ns=hidden_system_ns,
+            rerank_applied=apply_rerank,
         )
 
         # Stage 1 enrichment (RFC P1 Phase C): session-summary rescue.
@@ -970,13 +1014,13 @@ class SearchPipeline:
         # cross-encoder can rescue items RRF ranked just outside top_k.
         # pool = clamp(oversample * top_k, [min_pool, max_pool]) — scales
         # with the request and bounded by cost controls. Collapses to
-        # top_k when reranking is disabled so single-retriever passthrough
-        # size is unchanged.
-        if self._reranker is not None and self._rerank_config is not None:
-            rcfg = self._rerank_config
+        # top_k when reranking is disabled or bypassed per-call
+        # (rerank=False, #1766) so single-retriever passthrough size is
+        # unchanged — the widening exists only to feed the reranker.
+        if apply_rerank and rerank_cfg is not None:
             rerank_pool = max(
-                rcfg.min_pool,
-                min(rcfg.max_pool, int(rcfg.oversample * top_k)),
+                rerank_cfg.min_pool,
+                min(rerank_cfg.max_pool, int(rerank_cfg.oversample * top_k)),
             )
         else:
             rerank_pool = top_k
@@ -1038,10 +1082,11 @@ class SearchPipeline:
             fused = []
         stats.fused_total = len(fused)
 
-        # Stage 3b: Cross-encoder reranking
-        if self._reranker is not None and fused:
+        # Stage 3b: Cross-encoder reranking (skipped when bypassed per-call
+        # via rerank=False, #1766)
+        if apply_rerank and reranker is not None and fused:
             try:
-                fused = await self._reranker.rerank(query, fused, top_k=top_k)
+                fused = await reranker.rerank(query, fused, top_k=top_k)
             except Exception as exc:
                 logger.warning("Reranking failed, using original order: %s", exc)
                 # Fallback must still honor the caller's response size —

--- a/packages/memtomem/src/memtomem/server/tools/pinned.py
+++ b/packages/memtomem/src/memtomem/server/tools/pinned.py
@@ -106,9 +106,23 @@ async def mem_context_compose(
     top_k: int = 10,
     namespace: str | list[str] | None = None,
     context_window: int | None = None,
+    rerank: bool | None = None,
     ctx: CtxType = None,
 ) -> str:
-    """Compose Pinned Context first, then fill the remaining budget by retrieval."""
+    """Compose Pinned Context first, then fill the remaining budget by retrieval.
+
+    Args:
+        query: Retrieval query for the remaining budget (omit for pinned-only)
+        agent_id: Restrict pinned blocks to this agent
+        max_chars: Total character budget for the bundle (default 12,000)
+        top_k: Number of retrieval results to consider (default 10)
+        namespace: Namespace scope for retrieval
+        context_window: Expand each retrieved hit with ±N adjacent chunks
+        rerank: Per-call rerank control for the retrieval leg. ``false`` = skip
+            the cross-encoder rerank stage — the fast path for latency-bounded
+            callers. Omitted/``true`` = follow server config (``rerank.enabled``);
+            ``true`` cannot enable reranking when the server has it disabled.
+    """
     app, store = await _store(ctx)
     bundle = await ContextAssembler(store, app.search_pipeline).compose(
         query,
@@ -117,5 +131,6 @@ async def mem_context_compose(
         top_k=top_k,
         namespace=namespace,
         context_window=context_window,
+        rerank=rerank,
     )
     return json.dumps(bundle.as_dict())

--- a/packages/memtomem/src/memtomem/server/tools/search.py
+++ b/packages/memtomem/src/memtomem/server/tools/search.py
@@ -111,6 +111,7 @@ async def mem_search(
     verbose: bool = False,
     output_format: OutputFormat = "compact",
     scope: str | None = None,
+    rerank: bool | None = None,
     ctx: CtxType = None,
 ) -> str:
     """Search across indexed memory files using hybrid BM25 + semantic search.
@@ -137,12 +138,18 @@ async def mem_search(
             searches return ``user`` + the current project's project tiers; out-of-project
             searches return ``user`` only. Pass ``project_shared`` from outside any
             project context for a cross-project search.
+        rerank: Per-call rerank control. ``false`` = skip the cross-encoder rerank
+            stage for this call — the fast path for latency-bounded callers
+            (typically <100ms vs several seconds when reranking); also skips the
+            candidate-pool oversample that exists only to feed the reranker.
+            Omitted/``true`` = follow server config (``rerank.enabled``); ``true``
+            cannot enable reranking when the server has it disabled.
 
     Result count may fall below ``top_k`` when filters exclude candidates.
     Increase ``top_k`` for a wider per-call request. When reranking is enabled,
     the candidate pool is automatically derived from ``rerank.oversample``,
-    ``rerank.min_pool``, and ``rerank.max_pool``; there is no per-call
-    ``rerank_pool`` argument.
+    ``rerank.min_pool``, and ``rerank.max_pool``; passing ``rerank=false`` skips
+    reranking for the call and collapses that pool to ``top_k``.
     """
     if not query.strip():
         return "Error: query cannot be empty."
@@ -186,12 +193,21 @@ async def mem_search(
         as_of_unix=as_of_unix,
         scope=scope,
         project_context_root=project_context_root,
+        rerank=rerank,
     )
 
     # Build trust-UX hints shared across formats: archive filter count and a
     # one-shot embedding mismatch notice. Emitted for users who did NOT pin a
     # namespace (otherwise the archive filter never engaged).
     hints: list[str] = []
+    # stats.rerank_applied is the per-call effective decision, not the live
+    # config — accurate even when a hot reload flips rerank.enabled while
+    # this call is in flight.
+    if rerank is True and not stats.rerank_applied:
+        hints.append(
+            "rerank=true requested but server reranking is disabled "
+            "(rerank.enabled=false); results are un-reranked."
+        )
     if effective_ns is None and stats.hidden_system_ns > 0:
         hints.append(
             f"{stats.hidden_system_ns} result(s) hidden in system namespaces "

--- a/packages/memtomem/tests/test_pipeline.py
+++ b/packages/memtomem/tests/test_pipeline.py
@@ -622,6 +622,145 @@ class TestRerankCandidatePool:
         assert FIELD_CONSTRAINTS["rerank.enabled"]["type"] is bool
 
 
+class TestPerCallRerankBypass:
+    """#1766: ``search(rerank=False)`` must skip Stage 3b AND collapse the
+    candidate-pool oversample to ``top_k``; ``None`` follows server config;
+    ``True`` cannot force-enable and must not error when no reranker is wired.
+    """
+
+    _make_result = staticmethod(TestRerankCandidatePool._make_result)
+    _make_pipeline = TestRerankCandidatePool._make_pipeline
+    _probe_reranker = staticmethod(TestRerankCandidatePool._probe_reranker)
+
+    @pytest.mark.asyncio
+    async def test_rerank_false_skips_reranker_and_collapses_pool(self):
+        """With rerank bypassed, the chunk RRF ranked at 15 must NOT be
+        rescued (proves the pool collapsed, not just that Stage 3b was
+        skipped) and the probe must never run."""
+        from memtomem.config import RerankConfig
+
+        fused_input = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(20)]
+        relevant = fused_input[14]
+
+        received_pool_size: list[int] = []
+        pipeline = self._make_pipeline(
+            fused_input,
+            reranker=self._probe_reranker(received_pool_size, relevant.chunk.id),
+            rerank_config=RerankConfig(enabled=True),
+        )
+
+        results, stats = await pipeline.search("anything", top_k=10, rerank=False)
+
+        assert received_pool_size == []
+        assert len(results) == 10
+        assert relevant.chunk.id not in {r.chunk.id for r in results}
+        assert stats.rerank_applied is False
+
+    @pytest.mark.asyncio
+    async def test_rerank_none_follows_server_config(self):
+        from memtomem.config import RerankConfig
+
+        fused_input = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(20)]
+        relevant = fused_input[14]
+
+        received_pool_size: list[int] = []
+        pipeline = self._make_pipeline(
+            fused_input,
+            reranker=self._probe_reranker(received_pool_size, relevant.chunk.id),
+            rerank_config=RerankConfig(enabled=True),
+        )
+
+        results, stats = await pipeline.search("anything", top_k=10, rerank=None)
+
+        assert received_pool_size == [20]
+        assert results[0].chunk.id == relevant.chunk.id
+        assert stats.rerank_applied is True
+
+    @pytest.mark.asyncio
+    async def test_rerank_true_is_noop_when_server_disabled(self):
+        """Explicit True with no reranker wired follows config (documented
+        no-op) instead of erroring."""
+        fused_input = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(20)]
+
+        pipeline = self._make_pipeline(fused_input, reranker=None, rerank_config=None)
+        results, stats = await pipeline.search("anything", top_k=10, rerank=True)
+        assert len(results) == 10
+        assert stats.rerank_applied is False
+
+    def test_cache_key_bypass_shares_the_off_slot(self):
+        """A bypassed call is byte-identical to a server-off call with the
+        same args, so both deliberately share the "off" cache slot — while
+        rerank-on and bypassed calls must never alias."""
+        from memtomem.config import RerankConfig
+
+        received: list[int] = []
+        enabled = self._make_pipeline(
+            [],
+            reranker=self._probe_reranker(received),
+            rerank_config=RerankConfig(enabled=True),
+        )
+        disabled = self._make_pipeline([], reranker=None, rerank_config=None)
+
+        args = ("query", 10, None, None, None)
+        assert enabled._cache_key(*args, apply_rerank=False) == disabled._cache_key(*args)
+        assert enabled._cache_key(*args, apply_rerank=True) != enabled._cache_key(
+            *args, apply_rerank=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_bypassed_call_does_not_alias_reranked_cache_entry(self):
+        """A reranked result cached within the TTL must not be served to a
+        rerank=False call with otherwise-identical args."""
+        from memtomem.config import RerankConfig
+
+        fused_input = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(20)]
+        relevant = fused_input[14]
+
+        received_pool_size: list[int] = []
+        pipeline = self._make_pipeline(
+            fused_input,
+            reranker=self._probe_reranker(received_pool_size, relevant.chunk.id),
+            rerank_config=RerankConfig(enabled=True),
+        )
+
+        reranked, _ = await pipeline.search("anything", top_k=10)
+        assert reranked[0].chunk.id == relevant.chunk.id
+
+        bypassed, _ = await pipeline.search("anything", top_k=10, rerank=False)
+
+        assert received_pool_size == [20]  # probe ran once, for the first call only
+        assert bypassed[0].chunk.id != relevant.chunk.id
+
+    @pytest.mark.asyncio
+    async def test_hot_reload_mid_search_uses_consistent_snapshot(self):
+        """Hot reload swaps ``_reranker``/``_rerank_config`` while a search is
+        awaiting; the decision snapshot taken at entry must keep all
+        rerank-dependent sites consistent (no exception, reranked result)."""
+        from memtomem.config import RerankConfig
+
+        fused_input = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(20)]
+        relevant = fused_input[14]
+
+        received_pool_size: list[int] = []
+        pipeline = self._make_pipeline(
+            fused_input,
+            reranker=self._probe_reranker(received_pool_size, relevant.chunk.id),
+            rerank_config=RerankConfig(enabled=True),
+        )
+
+        async def flip_then_return(*args, **kwargs):
+            pipeline._reranker = None
+            pipeline._rerank_config = None
+            return fused_input
+
+        pipeline._storage.bm25_search.side_effect = flip_then_return
+
+        results, _ = await pipeline.search("anything", top_k=10)
+
+        assert received_pool_size == [20]
+        assert results[0].chunk.id == relevant.chunk.id
+
+
 class TestFilterOnlySearch:
     """Empty-query path (#750): tag/source filter is the primary selector.
 

--- a/packages/memtomem/tests/test_rerank_per_call.py
+++ b/packages/memtomem/tests/test_rerank_per_call.py
@@ -1,0 +1,218 @@
+"""Tool/CLI-level threading tests for the per-call rerank bypass (#1766).
+
+Pipeline-level behavior (pool collapse, cache isolation, hot-reload snapshot)
+is covered in ``test_pipeline.py::TestPerCallRerankBypass``; this file pins the
+plumbing above it: ``mem_search`` / ``mem_context_compose`` / ``mem_do`` /
+``mm search --no-rerank`` / ``mm pinned compose --no-rerank`` must deliver the
+caller's ``rerank`` decision to ``SearchPipeline.search`` unchanged, and
+``mem_search`` must surface the trust-UX hint when ``rerank=true`` cannot be
+honored.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.search.pipeline import RetrievalStats
+
+
+def _fake_app(*, rerank_applied: bool = True) -> MagicMock:
+    app = MagicMock()
+    app.search_pipeline.search = AsyncMock(
+        return_value=([], RetrievalStats(rerank_applied=rerank_applied))
+    )
+    app.current_namespace = None
+    app.webhook_manager = None
+    return app
+
+
+@pytest.mark.asyncio
+class TestMemSearchRerankParam:
+    async def test_rerank_false_reaches_pipeline(self):
+        from memtomem.server.tools.search import mem_search
+
+        app = _fake_app()
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(
+                "memtomem.server.tools.search._get_app_initialized", AsyncMock(return_value=app)
+            )
+            m.setattr(
+                "memtomem.server.tools.search._announce_dim_mismatch_once",
+                AsyncMock(return_value=None),
+            )
+            await mem_search(query="hello", rerank=False, ctx=SimpleNamespace())
+
+        assert app.search_pipeline.search.await_args.kwargs["rerank"] is False
+
+    async def test_rerank_omitted_defaults_to_none(self):
+        from memtomem.server.tools.search import mem_search
+
+        app = _fake_app()
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(
+                "memtomem.server.tools.search._get_app_initialized", AsyncMock(return_value=app)
+            )
+            m.setattr(
+                "memtomem.server.tools.search._announce_dim_mismatch_once",
+                AsyncMock(return_value=None),
+            )
+            await mem_search(query="hello", ctx=SimpleNamespace())
+
+        assert app.search_pipeline.search.await_args.kwargs["rerank"] is None
+
+    async def test_rerank_true_with_server_disabled_emits_hint(self):
+        from memtomem.server.tools.search import mem_search
+
+        app = _fake_app(rerank_applied=False)
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(
+                "memtomem.server.tools.search._get_app_initialized", AsyncMock(return_value=app)
+            )
+            m.setattr(
+                "memtomem.server.tools.search._announce_dim_mismatch_once",
+                AsyncMock(return_value=None),
+            )
+            text = await mem_search(query="hello", rerank=True, ctx=SimpleNamespace())
+            structured = await mem_search(
+                query="hello", rerank=True, output_format="structured", ctx=SimpleNamespace()
+            )
+
+        assert "rerank=true requested but server reranking is disabled" in text
+        hints = json.loads(structured)["hints"]
+        assert any("rerank=true requested" in h for h in hints)
+
+    async def test_rerank_true_with_server_enabled_has_no_hint(self):
+        from memtomem.server.tools.search import mem_search
+
+        app = _fake_app(rerank_applied=True)
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(
+                "memtomem.server.tools.search._get_app_initialized", AsyncMock(return_value=app)
+            )
+            m.setattr(
+                "memtomem.server.tools.search._announce_dim_mismatch_once",
+                AsyncMock(return_value=None),
+            )
+            text = await mem_search(query="hello", rerank=True, ctx=SimpleNamespace())
+
+        assert "rerank=true requested" not in text
+
+
+class _FakePinnedStore:
+    """Minimal PinnedContextStore stand-in for ContextAssembler.compose."""
+
+    project_root = None
+
+    def list(self, agent_id=None):
+        return []
+
+    def search_exclusion_roots(self):
+        return ()
+
+
+@pytest.mark.asyncio
+class TestContextComposeRerankParam:
+    async def test_compose_threads_rerank_to_pipeline(self):
+        from memtomem.pinned import ContextAssembler
+
+        pipeline = SimpleNamespace(search=AsyncMock(return_value=([], RetrievalStats())))
+        assembler = ContextAssembler(_FakePinnedStore(), pipeline)
+
+        await assembler.compose("query", rerank=False)
+
+        assert pipeline.search.await_args.kwargs["rerank"] is False
+
+    async def test_mem_context_compose_threads_rerank(self):
+        from memtomem.server.tools import pinned as pinned_tools
+
+        app = _fake_app()
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(
+                "memtomem.server.tools.pinned._store",
+                AsyncMock(return_value=(app, _FakePinnedStore())),
+            )
+            result = await pinned_tools.mem_context_compose(
+                query="query", rerank=False, ctx=SimpleNamespace()
+            )
+
+        assert app.search_pipeline.search.await_args.kwargs["rerank"] is False
+        assert json.loads(result)["retrieved"] == []
+
+    async def test_mem_do_routes_rerank_param(self):
+        from memtomem.server.tools.meta import mem_do
+
+        app = _fake_app()
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(
+                "memtomem.server.tools.pinned._store",
+                AsyncMock(return_value=(app, _FakePinnedStore())),
+            )
+            result = await mem_do("context_compose", params={"query": "query", "rerank": False})
+
+        assert app.search_pipeline.search.await_args.kwargs["rerank"] is False
+        assert "Error" not in str(result)[:40]
+
+
+class TestCliNoRerankFlag:
+    def test_mm_search_no_rerank_reaches_pipeline(self):
+        from memtomem.cli import cli
+
+        pipeline = SimpleNamespace(search=AsyncMock(return_value=([], RetrievalStats())))
+        comp = SimpleNamespace(search_pipeline=pipeline)
+
+        @asynccontextmanager
+        async def fake_components():
+            yield comp
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr("memtomem.cli._bootstrap.cli_components", fake_components)
+            m.setattr(
+                "memtomem.cli.search._resolve_project_context_root_from_cwd", lambda comp: None
+            )
+            result = CliRunner().invoke(cli, ["search", "hello", "--no-rerank"])
+
+        assert result.exit_code == 0, result.output
+        assert pipeline.search.await_args.kwargs["rerank"] is False
+
+    def test_mm_search_without_flag_follows_config(self):
+        from memtomem.cli import cli
+
+        pipeline = SimpleNamespace(search=AsyncMock(return_value=([], RetrievalStats())))
+        comp = SimpleNamespace(search_pipeline=pipeline)
+
+        @asynccontextmanager
+        async def fake_components():
+            yield comp
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr("memtomem.cli._bootstrap.cli_components", fake_components)
+            m.setattr(
+                "memtomem.cli.search._resolve_project_context_root_from_cwd", lambda comp: None
+            )
+            result = CliRunner().invoke(cli, ["search", "hello"])
+
+        assert result.exit_code == 0, result.output
+        assert pipeline.search.await_args.kwargs["rerank"] is None
+
+    def test_mm_pinned_compose_no_rerank_reaches_pipeline(self):
+        from memtomem.cli import cli
+
+        pipeline = SimpleNamespace(search=AsyncMock(return_value=([], RetrievalStats())))
+        comp = SimpleNamespace(search_pipeline=pipeline)
+
+        @asynccontextmanager
+        async def fake_store_context():
+            yield comp, _FakePinnedStore()
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr("memtomem.cli.pinned_cmd._store_context", fake_store_context)
+            result = CliRunner().invoke(cli, ["pinned", "compose", "hello", "--no-rerank"])
+
+        assert result.exit_code == 0, result.output
+        assert pipeline.search.await_args.kwargs["rerank"] is False


### PR DESCRIPTION
## Summary

Adds a per-call rerank bypass so latency-bounded callers can trade rerank
precision for an un-reranked search without changing server-wide config.
Closes #1766.

- `rerank: bool | None = None` on `mem_search`, `mem_context_compose`,
  `ContextAssembler.compose`, and `SearchPipeline.search`; CLI `--no-rerank`
  on `mm search` and `mm pinned compose`.
- `None` (default) follows server config — zero behavior change for every
  existing caller.
- `False` skips Stage 3b (cross-encoder) **and** collapses the candidate-pool
  oversample to `top_k` — the widening exists only to feed the reranker.
- `True` follows config; it cannot force-enable a reranker that was never
  built (`rerank.enabled=false` builds none). `mem_search` surfaces a trust-UX
  hint in that case, built from the per-call `RetrievalStats.rerank_applied`
  rather than the live config.

## Correctness notes

- **Cache key**: the per-call effective decision is folded into the search
  cache key. A bypassed call deliberately shares the "off" slot with
  server-disabled searches (byte-identical results); a bypassed call can
  never alias a reranked entry within the 30s TTL (pinned by test).
- **Hot-reload consistency**: `search()` snapshots `_reranker`/`_rerank_config`
  once and threads the snapshots through cache key, pool widening, and
  Stage 3b, so a concurrent hot reload cannot tear those sites apart (this
  race predates the PR; the close-while-in-flight lifetime aspect is tracked
  separately in a follow-up issue).

## Testing

- Pipeline: bypass skips the probe reranker and does **not** rescue the chunk
  RRF-ranked outside `top_k` (pool collapse proven); `None` preserves the
  widened pool; `True` with no reranker is a documented no-op; cache-slot
  sharing/isolation pinned; hot-reload mid-search snapshot pinned.
- Tool/CLI threading: `mem_search`, `mem_context_compose`, `mem_do`,
  `mm search --no-rerank`, `mm pinned compose --no-rerank` all deliver the
  caller's decision to `SearchPipeline.search`; hint presence pinned in
  compact and structured output.
- Full suite: 8,725 passed; ruff clean; mypy unchanged from baseline (18
  pre-existing errors).
- E2E against a real local store with rerank enabled
  (jina-reranker-v2-base-multilingual): same query, `mm search` 7.4s wall /
  cross-encoder score scale (~1.3) vs `mm search --no-rerank` 2.2s wall
  (≈ process + embedder startup) / RRF score scale (~0.03) — the stage
  provably ran vs was skipped.

## Docs

`core-memory-tools.md` (param table, pool callout, trust-UX hints),
`configuration.md` (per-call override paragraph), `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
