### PR TITLE
fix(rerank): a closed reranker refuses to resurrect its resources (#1778)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   an in-flight search still holds it; the close is deferred until the last
   such search releases its lease. Swaps with no search in flight close
   immediately, as before.
+- **Closed rerankers no longer resurrect their resources** (#1778) — using a
+  reranker after `close()` previously re-created what close had released
+  (cohere: a new `httpx` client nothing ever closes; fastembed/local: a
+  silent full model reload). The lazy loaders now raise `RuntimeError`
+  instead; a stray call through the search pipeline degrades to the existing
+  un-reranked fallback with a warning.
 
 ## [0.3.11] — 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   Omitted/`true` follows `rerank.enabled`; `true` cannot force-enable
   reranking on a server that has it disabled.
 
+### Fixed
+
+- **Reranker hot-swap use-after-close** (#1777) — hot reload (disk config
+  edit or `PATCH /api/config`) no longer closes the outgoing reranker while
+  an in-flight search still holds it; the close is deferred until the last
+  such search releases its lease. Swaps with no search in flight close
+  immediately, as before.
+
 ## [0.3.11] — 2026-07-14
 
 ### Added

--- a/packages/memtomem/src/memtomem/search/reranker/cohere.py
+++ b/packages/memtomem/src/memtomem/search/reranker/cohere.py
@@ -20,8 +20,14 @@ class CohereReranker:
     def __init__(self, config: RerankConfig):
         self._config = config
         self._client: AsyncClient | None = None
+        self._closed = False
 
     def _get_client(self) -> AsyncClient:
+        # A closed instance must not resurrect: re-creating the client here
+        # would leak it — nothing ever closes a client born after close()
+        # on a swapped-out instance (#1778).
+        if self._closed:
+            raise RuntimeError("CohereReranker is closed")
         if self._client is None:
             import httpx
 
@@ -75,6 +81,7 @@ class CohereReranker:
         return reranked[:top_k]
 
     async def close(self) -> None:
+        self._closed = True
         if self._client:
             await self._client.aclose()
             self._client = None

--- a/packages/memtomem/src/memtomem/search/reranker/fastembed.py
+++ b/packages/memtomem/src/memtomem/search/reranker/fastembed.py
@@ -48,11 +48,14 @@ class FastEmbedReranker:
         """
         # A closed instance must not resurrect: re-downloading/re-initializing
         # the released ONNX model here is silent expensive work on an
-        # instance nobody owns (#1778).
+        # instance nobody owns (#1778). Cached reads go through a local
+        # snapshot so a concurrent close() nulling ``_model`` between the
+        # check and the return cannot hand the caller ``None``.
         if self._closed:
             raise RuntimeError("FastEmbedReranker is closed")
-        if self._model is not None:
-            return self._model
+        model = self._model
+        if model is not None:
+            return model
         with self._load_lock:
             # Re-check under the lock: a warmup/readiness thread that passed
             # the guard above can lose the race to a concurrent close() on
@@ -60,8 +63,9 @@ class FastEmbedReranker:
             # the closed instance (#1778).
             if self._closed:
                 raise RuntimeError("FastEmbedReranker is closed")
-            if self._model is not None:
-                return self._model
+            model = self._model
+            if model is not None:
+                return model
             try:
                 from fastembed.rerank.cross_encoder import (  # type: ignore[import-untyped]
                     TextCrossEncoder,
@@ -81,9 +85,7 @@ class FastEmbedReranker:
             self._loading = True
             self._load_error = None
             try:
-                self._model = TextCrossEncoder(
-                    model_name=self._config.model, cache_dir=str(cache_dir)
-                )
+                model = TextCrossEncoder(model_name=self._config.model, cache_dir=str(cache_dir))
             except ValueError as exc:
                 supported = [m.get("model", "") for m in TextCrossEncoder.list_supported_models()]
                 self._load_error = str(exc)
@@ -101,7 +103,16 @@ class FastEmbedReranker:
                 raise
             finally:
                 self._loading = False
-            return self._model
+            # Publish-then-verify: close() does not take this lock, so it can
+            # land while the (seconds-long) construction above is in flight.
+            # Publishing first and re-checking makes every interleaving of
+            # close()'s (flag, _model=None) writes end with the closed
+            # instance holding no model (#1778).
+            self._model = model
+            if self._closed:
+                self._model = None
+                raise RuntimeError("FastEmbedReranker is closed")
+            return model
 
     def _rerank_sync(self, query: str, documents: list[str]) -> list[float]:
         """Run inference synchronously — called inside ``asyncio.to_thread``."""

--- a/packages/memtomem/src/memtomem/search/reranker/fastembed.py
+++ b/packages/memtomem/src/memtomem/search/reranker/fastembed.py
@@ -29,6 +29,7 @@ class FastEmbedReranker:
     def __init__(self, config: RerankConfig) -> None:
         self._config = config
         self._model: object | None = None
+        self._closed = False
         # Observability flags read by ``GET /api/system/model-readiness``.
         # Match ``OnnxEmbedder`` so the endpoint can introspect both via a
         # single contract without each provider having a bespoke surface.
@@ -45,6 +46,11 @@ class FastEmbedReranker:
         Double-checked lock so concurrent first-callers (search path vs
         warmup) share a single construction.
         """
+        # A closed instance must not resurrect: re-downloading/re-initializing
+        # the released ONNX model here is silent expensive work on an
+        # instance nobody owns (#1778).
+        if self._closed:
+            raise RuntimeError("FastEmbedReranker is closed")
         if self._model is not None:
             return self._model
         with self._load_lock:
@@ -128,5 +134,6 @@ class FastEmbedReranker:
         # pytest cleans up tmp_path on Windows. See #206.
         import gc
 
+        self._closed = True
         self._model = None
         gc.collect()

--- a/packages/memtomem/src/memtomem/search/reranker/fastembed.py
+++ b/packages/memtomem/src/memtomem/search/reranker/fastembed.py
@@ -54,6 +54,12 @@ class FastEmbedReranker:
         if self._model is not None:
             return self._model
         with self._load_lock:
+            # Re-check under the lock: a warmup/readiness thread that passed
+            # the guard above can lose the race to a concurrent close() on
+            # the event loop — loading here would resurrect the model onto
+            # the closed instance (#1778).
+            if self._closed:
+                raise RuntimeError("FastEmbedReranker is closed")
             if self._model is not None:
                 return self._model
             try:

--- a/packages/memtomem/src/memtomem/search/reranker/local.py
+++ b/packages/memtomem/src/memtomem/search/reranker/local.py
@@ -19,12 +19,17 @@ class LocalReranker:
     def __init__(self, config: RerankConfig):
         self._config = config
         self._model = None
+        self._closed = False
         # Serializes the first load — same contract as ``OnnxEmbedder``:
         # the search path and the opt-in warmup task (#1621) can race into
         # ``_get_model`` from different threads.
         self._load_lock = threading.Lock()
 
     def _get_model(self):
+        # A closed instance must not resurrect: reloading the released model
+        # here is silent expensive work on an instance nobody owns (#1778).
+        if self._closed:
+            raise RuntimeError("LocalReranker is closed")
         if self._model is None:
             with self._load_lock:
                 if self._model is None:
@@ -59,4 +64,5 @@ class LocalReranker:
         ]
 
     async def close(self) -> None:
+        self._closed = True
         self._model = None

--- a/packages/memtomem/src/memtomem/search/reranker/local.py
+++ b/packages/memtomem/src/memtomem/search/reranker/local.py
@@ -32,6 +32,12 @@ class LocalReranker:
             raise RuntimeError("LocalReranker is closed")
         if self._model is None:
             with self._load_lock:
+                # Re-check under the lock: a warmup/readiness thread that
+                # passed the guard above can lose the race to a concurrent
+                # close() — loading here would resurrect the model onto the
+                # closed instance (#1778).
+                if self._closed:
+                    raise RuntimeError("LocalReranker is closed")
                 if self._model is None:
                     from sentence_transformers import CrossEncoder
 

--- a/packages/memtomem/src/memtomem/search/reranker/local.py
+++ b/packages/memtomem/src/memtomem/search/reranker/local.py
@@ -28,9 +28,13 @@ class LocalReranker:
     def _get_model(self):
         # A closed instance must not resurrect: reloading the released model
         # here is silent expensive work on an instance nobody owns (#1778).
+        # Cached reads go through a local snapshot so a concurrent close()
+        # nulling ``_model`` between the check and the return cannot hand
+        # the caller ``None``.
         if self._closed:
             raise RuntimeError("LocalReranker is closed")
-        if self._model is None:
+        model = self._model
+        if model is None:
             with self._load_lock:
                 # Re-check under the lock: a warmup/readiness thread that
                 # passed the guard above can lose the race to a concurrent
@@ -38,12 +42,22 @@ class LocalReranker:
                 # closed instance (#1778).
                 if self._closed:
                     raise RuntimeError("LocalReranker is closed")
-                if self._model is None:
+                model = self._model
+                if model is None:
                     from sentence_transformers import CrossEncoder
 
-                    self._model = CrossEncoder(self._config.model)
+                    model = CrossEncoder(self._config.model)
+                    # Publish-then-verify: close() does not take this lock,
+                    # so it can land while the construction above is in
+                    # flight. Publishing first and re-checking makes every
+                    # interleaving of close()'s (flag, _model=None) writes
+                    # end with the closed instance holding no model (#1778).
+                    self._model = model
+                    if self._closed:
+                        self._model = None
+                        raise RuntimeError("LocalReranker is closed")
                     logger.info("Loaded local reranker: %s", self._config.model)
-        return self._model
+        return model
 
     async def rerank(
         self, query: str, results: list[SearchResult], top_k: int

--- a/packages/memtomem/tests/test_reranker.py
+++ b/packages/memtomem/tests/test_reranker.py
@@ -121,6 +121,36 @@ class TestLocalReranker:
 
         await reranker.close()  # idempotent
 
+    def test_close_landing_at_lock_acquisition_refuses_load(self):
+        """A loader thread can pass the outer _closed guard, then lose the
+        race to a concurrent close() before acquiring _load_lock; the
+        re-check under the lock must refuse the load (#1778 review).
+        Deterministic pin: a lock wrapper flips _closed at the acquisition
+        point instead of racing real threads."""
+        import threading
+
+        from memtomem.config import RerankConfig
+        from memtomem.search.reranker.local import LocalReranker
+
+        reranker = LocalReranker(RerankConfig(enabled=True, provider="local"))
+
+        class _CloseOnAcquire:
+            def __init__(self) -> None:
+                self._inner = threading.Lock()
+
+            def __enter__(self):
+                reranker._closed = True  # the concurrent close() lands here
+                return self._inner.__enter__()
+
+            def __exit__(self, *exc):
+                return self._inner.__exit__(*exc)
+
+        reranker._load_lock = _CloseOnAcquire()
+
+        with pytest.raises(RuntimeError, match="closed"):
+            reranker._get_model()
+        assert reranker._model is None
+
 
 class TestRerankerFactory:
     def test_disabled(self):

--- a/packages/memtomem/tests/test_reranker.py
+++ b/packages/memtomem/tests/test_reranker.py
@@ -151,6 +151,59 @@ class TestLocalReranker:
             reranker._get_model()
         assert reranker._model is None
 
+    @pytest.mark.asyncio
+    async def test_close_during_construction_does_not_publish_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """close() landing while the model constructor is in flight must not
+        leave the finished model published on the closed instance (#1780
+        codex review). The real async close() runs mid-construction, gated
+        by events. sentence_transformers is not a test dependency, so a
+        pausing stand-in module is injected."""
+        import asyncio
+        import sys
+        import threading
+        import types
+
+        from memtomem.config import RerankConfig
+        from memtomem.search.reranker.local import LocalReranker
+
+        entered = threading.Event()
+        release = threading.Event()
+
+        class _PausingModel:
+            def __init__(self, model_name: str) -> None:
+                entered.set()
+                assert release.wait(5)
+
+        monkeypatch.setitem(
+            sys.modules,
+            "sentence_transformers",
+            types.SimpleNamespace(CrossEncoder=_PausingModel),
+        )
+
+        reranker = LocalReranker(RerankConfig(enabled=True, provider="local"))
+        errors: list[BaseException] = []
+
+        def load() -> None:
+            try:
+                reranker._get_model()
+            except RuntimeError as exc:
+                errors.append(exc)
+
+        loader = threading.Thread(target=load)
+        loader.start()
+        assert await asyncio.to_thread(entered.wait, 5)  # constructor in flight
+
+        await reranker.close()  # lands mid-construction
+
+        release.set()
+        await asyncio.to_thread(loader.join, 5)
+        assert not loader.is_alive()
+
+        assert reranker._model is None  # the finished model was not published
+        assert errors and "closed" in str(errors[0])
+
 
 class TestRerankerFactory:
     def test_disabled(self):

--- a/packages/memtomem/tests/test_reranker.py
+++ b/packages/memtomem/tests/test_reranker.py
@@ -46,6 +46,27 @@ class TestCohereReranker:
         await reranker.close()
         assert reranker._client is None
 
+    @pytest.mark.asyncio
+    async def test_closed_instance_refuses_resurrect(self):
+        """#1778: post-close use must raise, not re-create the httpx client —
+        a client born after close() on a swapped-out instance leaks."""
+        from memtomem.config import RerankConfig
+        from memtomem.search.reranker.cohere import CohereReranker
+
+        config = RerankConfig(enabled=True, provider="cohere", api_key="test")
+        reranker = CohereReranker(config)
+        # Positive control: a live instance builds its client on demand.
+        assert reranker._get_client() is not None
+
+        await reranker.close()
+        assert reranker._client is None
+
+        with pytest.raises(RuntimeError, match="closed"):
+            await reranker.rerank("query", [_make_result("a", 1.0)], top_k=5)
+        assert reranker._client is None  # no new client materialized
+
+        await reranker.close()  # idempotent
+
 
 class TestLocalReranker:
     def test_init(self):
@@ -77,6 +98,28 @@ class TestLocalReranker:
         reranker = LocalReranker(config)
         await reranker.close()
         assert reranker._model is None
+
+    @pytest.mark.asyncio
+    async def test_closed_instance_refuses_resurrect(self):
+        """#1778: post-close use must raise, not silently reload the model."""
+        from memtomem.config import RerankConfig
+        from memtomem.search.reranker.local import LocalReranker
+
+        config = RerankConfig(enabled=True, provider="local")
+        reranker = LocalReranker(config)
+        # Positive control: a live instance serves its cached model.
+        sentinel = object()
+        reranker._model = sentinel
+        assert reranker._get_model() is sentinel
+
+        await reranker.close()
+        assert reranker._model is None
+
+        with pytest.raises(RuntimeError, match="closed"):
+            await reranker.rerank("query", [_make_result("a", 1.0)], top_k=5)
+        assert reranker._model is None  # no reload
+
+        await reranker.close()  # idempotent
 
 
 class TestRerankerFactory:

--- a/packages/memtomem/tests/test_reranker_fastembed.py
+++ b/packages/memtomem/tests/test_reranker_fastembed.py
@@ -183,3 +183,56 @@ def test_close_landing_at_lock_acquisition_refuses_load() -> None:
     with pytest.raises(RuntimeError, match="closed"):
         reranker._get_model()
     assert reranker._model is None  # no model resurrected onto the closed instance
+
+
+async def test_close_during_construction_does_not_publish_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """close() landing while the model constructor is in flight (a
+    wall-clock-wide window — construction takes seconds) must not leave the
+    finished model published on the closed instance (#1780 codex review).
+    The real async close() runs mid-construction, gated by events."""
+    import asyncio
+    import threading
+
+    from memtomem.config import RerankConfig
+    from memtomem.search.reranker.fastembed import FastEmbedReranker
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    class _PausingModel:
+        def __init__(self, model_name: str, cache_dir: str) -> None:
+            entered.set()
+            assert release.wait(5)
+
+    monkeypatch.setattr("fastembed.rerank.cross_encoder.TextCrossEncoder", _PausingModel)
+
+    reranker = FastEmbedReranker(
+        RerankConfig(
+            enabled=True,
+            provider="fastembed",
+            model="Xenova/ms-marco-MiniLM-L-6-v2",
+        )
+    )
+
+    errors: list[BaseException] = []
+
+    def load() -> None:
+        try:
+            reranker._get_model()
+        except RuntimeError as exc:
+            errors.append(exc)
+
+    loader = threading.Thread(target=load)
+    loader.start()
+    assert await asyncio.to_thread(entered.wait, 5)  # constructor is in flight
+
+    await reranker.close()  # lands mid-construction
+
+    release.set()
+    await asyncio.to_thread(loader.join, 5)
+    assert not loader.is_alive()
+
+    assert reranker._model is None  # the finished model was not published
+    assert errors and "closed" in str(errors[0])

--- a/packages/memtomem/tests/test_reranker_fastembed.py
+++ b/packages/memtomem/tests/test_reranker_fastembed.py
@@ -95,9 +95,16 @@ async def test_unknown_model_error_surfaces_supported_hint() -> None:
     assert "add_custom_model" in msg
 
 
-async def test_close_resets_model() -> None:
-    """close() must release the cached model so the reranker can be reused."""
+async def test_close_releases_model_and_refuses_reuse() -> None:
+    """close() releases the cached model AND further use raises (#1778) —
+    a closed instance must not silently re-download/re-init the model.
+    (Supersedes the pre-#1778 "can be reused" contract, which no caller
+    ever relied on.)"""
+    from pathlib import Path
+    from uuid import uuid4
+
     from memtomem.config import RerankConfig
+    from memtomem.models import Chunk, ChunkMetadata, SearchResult
     from memtomem.search.reranker.fastembed import FastEmbedReranker
 
     reranker = FastEmbedReranker(
@@ -107,6 +114,35 @@ async def test_close_resets_model() -> None:
             model="Xenova/ms-marco-MiniLM-L-6-v2",
         )
     )
-    reranker._model = object()  # simulate loaded state
+
+    class _FakeModel:
+        def rerank(self, query, documents):
+            return [0.5] * len(documents)
+
+    chunk = Chunk(
+        content="any content",
+        metadata=ChunkMetadata(source_file=Path("test.md")),
+        id=uuid4(),
+        embedding=[],
+    )
+    candidate = SearchResult(chunk=chunk, score=1.0, rank=1, source="fused")
+
+    # Positive control: the same instance reranks successfully pre-close.
+    reranker._model = _FakeModel()
+    reranked = await reranker.rerank("query", [candidate], top_k=5)
+    assert reranked[0].source == "reranked"
+
     await reranker.close()
     assert reranker._model is None
+
+    with pytest.raises(RuntimeError, match="closed"):
+        reranker._get_model()
+
+    # rerank() degrades through its own except-Exception fallback: the
+    # original candidates come back untouched, and no model reload happens.
+    fallback = await reranker.rerank("query", [candidate], top_k=5)
+    assert [r.chunk.id for r in fallback] == [candidate.chunk.id]
+    assert fallback[0].source == "fused"
+    assert reranker._model is None
+
+    await reranker.close()  # idempotent

--- a/packages/memtomem/tests/test_reranker_fastembed.py
+++ b/packages/memtomem/tests/test_reranker_fastembed.py
@@ -146,3 +146,40 @@ async def test_close_releases_model_and_refuses_reuse() -> None:
     assert reranker._model is None
 
     await reranker.close()  # idempotent
+
+
+def test_close_landing_at_lock_acquisition_refuses_load() -> None:
+    """A loader thread can pass the outer _closed guard, then lose the race
+    to a concurrent close() before acquiring _load_lock; the re-check under
+    the lock must refuse the load (#1778 review). The interleaving is pinned
+    deterministically: a lock wrapper flips _closed at the exact acquisition
+    point instead of racing real threads."""
+    import threading
+
+    from memtomem.config import RerankConfig
+    from memtomem.search.reranker.fastembed import FastEmbedReranker
+
+    reranker = FastEmbedReranker(
+        RerankConfig(
+            enabled=True,
+            provider="fastembed",
+            model="Xenova/ms-marco-MiniLM-L-6-v2",
+        )
+    )
+
+    class _CloseOnAcquire:
+        def __init__(self) -> None:
+            self._inner = threading.Lock()
+
+        def __enter__(self):
+            reranker._closed = True  # the concurrent close() lands here
+            return self._inner.__enter__()
+
+        def __exit__(self, *exc):
+            return self._inner.__exit__(*exc)
+
+    reranker._load_lock = _CloseOnAcquire()  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeError, match="closed"):
+        reranker._get_model()
+    assert reranker._model is None  # no model resurrected onto the closed instance


### PR DESCRIPTION
## Summary

All three reranker providers treated `close()` as resettable state, so using
a closed instance silently re-created what close had released — cohere built
a brand-new `httpx.AsyncClient` that nothing on an orphaned instance ever
closes (connection leak), fastembed/local silently re-downloaded /
re-initialized the model. Closes #1778.

Since #1777/#1779 the swap sites lease-defer closes, so no production path
invokes a closed reranker — this is defense-in-depth that makes the
invariant loud instead of trusting it:

- A `_closed` flag set in `close()` makes the lazy loaders (`_get_client` /
  `_get_model`) raise `RuntimeError("<Provider> is closed")`. The guard sits
  at the loader — the single choke point shared by `rerank()`, warmup, the
  PATCH readiness validation (`_validate_reranker_ready`), and the
  hot-reload eager load. (The `GET /system/model-readiness` endpoint only
  inspects loader state; it never drives a load.)
- For the threaded providers (fastembed/local) the guard holds across the
  whole load, not just at entry: `_closed` is re-checked under `_load_lock`,
  and a model whose construction straddled a `close()` is
  published-then-verified — the loader unpublishes and raises rather than
  parking the finished model on the closed instance. `close()` never takes
  the load lock (it must not block the event loop behind an in-flight
  download).
- Through the search pipeline a stray call degrades to the existing
  un-reranked fallback with a warning (cohere/local propagate to Stage 3b's
  catch; fastembed's own `except Exception` fallback catches it — its
  `ImportError`/`ValueError` setup-error carve-out is untouched). Direct
  loader callers get the loud error, which is correct: reaching a closed
  instance there is a lifecycle bug worth surfacing.
- `close()` stays idempotent for all three providers.

Also adds the CHANGELOG entry for #1777 that #1779 landed without (separate
commit).

## Behavior change

- `rerank()` / lazy-load on a closed reranker previously "worked" (silent
  resurrect); it now raises at the loader. Pipeline callers see a logged
  warning + un-reranked results for the stray call; nothing changes for any
  live instance.
- `test_close_resets_model` pinned the opposite contract ("so the reranker
  can be reused") — wording from the provider's introduction (#222); `git
  log -S` shows no caller ever reused a closed instance. The test now pins
  release-and-refuse (`test_close_releases_model_and_refuses_reuse`).

## Testing

- Per-provider post-close tests with positive controls: cohere pins that no
  new client materializes after close (`_client` stays `None` — the leak);
  local/fastembed pin no model reload; fastembed additionally pins the
  original-order fallback through its own except path; double close is a
  no-op for all three.
- Red-first: with the guard neutered all three new tests fail — the
  neutered fastembed run visibly re-downloads the model from HuggingFace,
  demonstrating the exact cost being fenced.
- Full suite: 8,781 passed, 11 skipped; ruff clean; mypy unchanged from baseline (18
  pre-existing errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
