### PR TITLE
feat(search): name the score scale in structured search output (#1767)

### DIFF
--- a/docs/guides/reference/core-memory-tools.md
+++ b/docs/guides/reference/core-memory-tools.md
@@ -213,6 +213,20 @@ mem_search(query="deploy pipeline", as_of="2025-Q3")    # historical query
 
 > **Trust-UX hints**: when you don't pin a namespace, results are followed by a parenthesized hint if chunks were hidden in system namespaces (e.g. `archive:*`) or if the configured embedding dimension disagrees with what's in the database. A third hint — independent of namespace selection — appears when you pass `rerank=true` but the server has reranking disabled (`rerank.enabled=false`), since the parameter cannot force-enable it. In `output_format="structured"` those hints are emitted as a `hints` array instead.
 
+> **Score scale**: `score` values are only comparable within one scale, and the
+> scale follows server config. Structured output names the base scale in a
+> top-level `score_scale` key: `"rerank"` (cross-encoder output — range depends
+> on the model, reported alongside in a `reranker` key), `"rrf"`
+> (reciprocal-rank fusion), `"bm25"` / `"dense"` (unfused single-retriever
+> scores when only one retriever is enabled), or `"none"` (filter-only
+> enumeration — no relevance scale; the filter is the selector). Optional
+> modifier stages (time decay, access/importance boosts; all off by default)
+> multiply on top of the base scale when enabled. Pick score thresholds per
+> scale — or skip score gating for a scale you don't recognize — instead of
+> inferring the scale from the value range. Both keys are omitted when there
+> are no results. `mm search --format json` carries the same value as a
+> per-item `score_scale` key.
+
 ### Tuning search weights
 
 Use `bm25_weight` and `dense_weight` to shift between keyword and semantic matching:

--- a/docs/guides/reference/core-memory-tools.md
+++ b/docs/guides/reference/core-memory-tools.md
@@ -224,8 +224,8 @@ mem_search(query="deploy pipeline", as_of="2025-Q3")    # historical query
 > multiply on top of the base scale when enabled. Pick score thresholds per
 > scale — or skip score gating for a scale you don't recognize — instead of
 > inferring the scale from the value range. Both keys are omitted when there
-> are no results. `mm search --format json` carries the same value as a
-> per-item `score_scale` key.
+> are no results. `mm search --format json` carries the same values as
+> per-item `score_scale` / `reranker` keys.
 
 ### Tuning search weights
 

--- a/packages/memtomem/src/memtomem/cli/search.py
+++ b/packages/memtomem/src/memtomem/cli/search.py
@@ -199,12 +199,15 @@ async def _search(
 
     if fmt == "json":
         # The payload is a bare list, so score provenance rides per item
-        # (#1767): key omitted when the pipeline produced no ranked scale.
+        # (#1767): keys omitted when the pipeline produced no ranked scale.
+        # ``reranker`` accompanies the "rerank" scale because rerank score
+        # ranges are model-dependent — mirroring the MCP structured payload.
         out = [
             {
                 "rank": r.rank,
                 "score": round(r.score, 4),
                 **({"score_scale": stats.score_scale} if stats.score_scale is not None else {}),
+                **({"reranker": stats.reranker_model} if stats.reranker_model is not None else {}),
                 "source": str(r.chunk.metadata.source_file),
                 "content": r.chunk.content[:200],
             }

--- a/packages/memtomem/src/memtomem/cli/search.py
+++ b/packages/memtomem/src/memtomem/cli/search.py
@@ -198,10 +198,13 @@ async def _search(
         return
 
     if fmt == "json":
+        # The payload is a bare list, so score provenance rides per item
+        # (#1767): key omitted when the pipeline produced no ranked scale.
         out = [
             {
                 "rank": r.rank,
                 "score": round(r.score, 4),
+                **({"score_scale": stats.score_scale} if stats.score_scale is not None else {}),
                 "source": str(r.chunk.metadata.source_file),
                 "content": r.chunk.content[:200],
             }

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -288,6 +288,25 @@ class RetrievalStats:
     # the per-call effective decision (#1766), not the live server config,
     # so hint builders stay accurate across concurrent hot reloads.
     rerank_applied: bool = False
+    # Which BASE scale the returned ``score`` values are on (#1767):
+    # "rerank" (cross-encoder output — range is model-dependent, see
+    # ``reranker_model``), "rrf" (reciprocal-rank fusion, bounded near
+    # ``legs/rrf_k``), "bm25"/"dense" (single-retriever passthrough:
+    # unfused BM25 / cosine scores), "none" (filter-only enumeration —
+    # no relevance scale, the filter is the selector), or None (no ranked
+    # results produced). Base means pre-modifier: decay / access /
+    # importance boosts (Stages 4/6/7, all default-off) multiply on top
+    # when enabled, so absolute thresholds are only portable across
+    # servers with the same modifier config. Unlike ``rerank_applied``
+    # (the pre-Stage-3b decision), this is derived from the results
+    # actually returned, so a reranker that fails and silently falls back
+    # to the fused order keeps the label truthful.
+    score_scale: str | None = None
+    # Rerank model identifier, set only when ``score_scale == "rerank"`` —
+    # rerank ranges differ per provider (local cross-encoders emit raw
+    # logits, Cohere emits [0, 1] relevance), so clients calibrating a
+    # threshold need the model, not just the scale family.
+    reranker_model: str | None = None
 
 
 if TYPE_CHECKING:
@@ -776,7 +795,11 @@ class SearchPipeline:
             for i, c in enumerate(chunks)
         ]
         fused = _exclude_source_roots(fused, exclude_source_roots)
-        stats = RetrievalStats(fused_total=len(fused))
+        # score_scale="none": there is no relevance scale — the filter is
+        # the selector. Scores start at 1.0 and only the decay/access/
+        # importance modifiers (when enabled) differentiate them, so there
+        # is no relevance magnitude to gate on.
+        stats = RetrievalStats(fused_total=len(fused), score_scale="none")
 
         effective_as_of = as_of_unix if as_of_unix is not None else int(time.time())
         if fused:
@@ -1151,6 +1174,7 @@ class SearchPipeline:
                     weights=fusion_weights,
                     list_labels=fusion_labels,
                 )
+                stats.score_scale = "rrf"
             elif use_bm25:
                 if rescue_results:
                     fused = reciprocal_rank_fusion(
@@ -1160,8 +1184,13 @@ class SearchPipeline:
                         weights=[effective_weights[0], rescue_w],
                         list_labels=["bm25", "session_rescue"],
                     )
+                    stats.score_scale = "rrf"
                 else:
+                    # Passthrough keeps raw retriever scores — a distinct
+                    # scale (#1767): Okapi BM25 is unbounded positive, far
+                    # outside the RRF ceiling.
                     fused = bm25_results[:rerank_pool]
+                    stats.score_scale = "bm25"
             elif use_dense:
                 if rescue_results:
                     fused = reciprocal_rank_fusion(
@@ -1174,8 +1203,10 @@ class SearchPipeline:
                         ],
                         list_labels=["dense", "session_rescue"],
                     )
+                    stats.score_scale = "rrf"
                 else:
                     fused = dense_results[:rerank_pool]
+                    stats.score_scale = "dense"
             else:
                 fused = []
             stats.fused_total = len(fused)
@@ -1190,6 +1221,15 @@ class SearchPipeline:
                     # Fallback must still honor the caller's response size —
                     # fused is at rerank_pool (e.g. 20) right now, not top_k.
                     fused = fused[:top_k]
+                else:
+                    # Providers also fall back silently (returning the input
+                    # unchanged) on their own errors, so the decision flag
+                    # alone can't label the scale — only a list the reranker
+                    # actually re-scored (every item re-stamped "reranked")
+                    # switches it (#1767).
+                    if fused and all(r.source == "reranked" for r in fused):
+                        stats.score_scale = "rerank"
+                        stats.reranker_model = rerank_cfg.model if rerank_cfg is not None else None
 
             # Filter by source file if requested
             if source_filter:

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -293,8 +293,11 @@ class RetrievalStats:
     # ``reranker_model``), "rrf" (reciprocal-rank fusion, bounded near
     # ``legs/rrf_k``), "bm25"/"dense" (single-retriever passthrough:
     # unfused BM25 / cosine scores), "none" (filter-only enumeration —
-    # no relevance scale, the filter is the selector), or None (no ranked
-    # results produced). Base means pre-modifier: decay / access /
+    # no relevance scale, the filter is the selector), or None (no
+    # scoring path taken, e.g. both retrievers disabled; a taken path
+    # keeps its scale even when it yielded zero results — public
+    # formatters omit the key for empty responses either way). Base
+    # means pre-modifier: decay / access /
     # importance boosts (Stages 4/6/7, all default-off) multiply on top
     # when enabled, so absolute thresholds are only portable across
     # servers with the same modifier config. Unlike ``rerank_applied``
@@ -1212,8 +1215,10 @@ class SearchPipeline:
             stats.fused_total = len(fused)
 
             # Stage 3b: Cross-encoder reranking (skipped when bypassed per-call
-            # via rerank=False, #1766)
-            if apply_rerank and reranker is not None and fused:
+            # via rerank=False, #1766). ``apply_rerank`` already implies the
+            # reranker pair is non-None; restating both here is for type
+            # narrowing, mirroring the cache-key and pool-widening sites.
+            if apply_rerank and reranker is not None and rerank_cfg is not None and fused:
                 try:
                     fused = await reranker.rerank(query, fused, top_k=top_k)
                 except Exception as exc:
@@ -1229,7 +1234,7 @@ class SearchPipeline:
                     # switches it (#1767).
                     if fused and all(r.source == "reranked" for r in fused):
                         stats.score_scale = "rerank"
-                        stats.reranker_model = rerank_cfg.model if rerank_cfg is not None else None
+                        stats.reranker_model = rerank_cfg.model
 
             # Filter by source file if requested
             if source_filter:

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -42,7 +42,7 @@ from collections.abc import Iterator
 from datetime import UTC, datetime
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from dataclasses import dataclass
 
@@ -270,6 +270,12 @@ def _apply_validity_filter(results: list[SearchResult], as_of_unix: int) -> list
     return filtered
 
 
+# Closed vocabulary for ``RetrievalStats.score_scale`` (#1767) — typing the
+# field makes a misspelled label fail at the assignment site instead of
+# escaping into structured output.
+ScoreScale = Literal["rerank", "rrf", "bm25", "dense", "none"]
+
+
 @dataclass
 class RetrievalStats:
     bm25_candidates: int = 0
@@ -304,7 +310,7 @@ class RetrievalStats:
     # (the pre-Stage-3b decision), this is derived from the results
     # actually returned, so a reranker that fails and silently falls back
     # to the fused order keeps the label truthful.
-    score_scale: str | None = None
+    score_scale: ScoreScale | None = None
     # Rerank model identifier, set only when ``score_scale == "rerank"`` —
     # rerank ranges differ per provider (local cross-encoders emit raw
     # logits, Cohere emits [0, 1] relevance), so clients calibrating a

--- a/packages/memtomem/src/memtomem/server/formatters.py
+++ b/packages/memtomem/src/memtomem/server/formatters.py
@@ -116,7 +116,12 @@ def _format_verbose_result(r) -> str:
     )
 
 
-def _format_structured_results(results: list, hints: list[str] | None = None) -> str:
+def _format_structured_results(
+    results: list,
+    hints: list[str] | None = None,
+    score_scale: str | None = None,
+    reranker: str | None = None,
+) -> str:
     """JSON structured format for machine consumption.
 
     Returns a JSON string with all result fields untruncated.
@@ -126,6 +131,16 @@ def _format_structured_results(results: list, hints: list[str] | None = None) ->
     When ``hints`` is non-empty, the output also includes a ``hints`` array
     so machine consumers can surface the same trust-UX notices (archive
     filter, embedding mismatch, etc.) that compact/verbose append as text.
+
+    ``score_scale`` (#1767) names the base scale the ``score`` values are
+    on ("rerank" | "rrf" | "bm25" | "dense" | "none") so consumers can
+    pick a threshold per scale — or skip score gating for a scale they
+    don't recognize — instead of inferring from the value range. Optional
+    modifier stages (time decay, access/importance boosts; all
+    default-off) multiply on top of the base scale when the server has
+    them enabled. ``reranker`` carries the rerank model ID when the scale
+    is "rerank" (ranges are model-dependent). Both are top-level keys,
+    omitted when None.
     """
     out = []
     for r in results:
@@ -147,6 +162,10 @@ def _format_structured_results(results: list, hints: list[str] | None = None) ->
             entry["via_session_summary"] = True
         out.append(entry)
     payload: dict[str, object] = {"results": out}
+    if score_scale is not None:
+        payload["score_scale"] = score_scale
+    if reranker is not None:
+        payload["reranker"] = reranker
     if hints:
         payload["hints"] = list(hints)
     return json.dumps(payload, ensure_ascii=False)

--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -219,7 +219,12 @@ async def mem_agent_search(
         return f"No results found for agent '{agent_id or 'current'}'."
 
     if output_format == "structured":
-        return _format_structured_results(results, hints=hints or None)
+        return _format_structured_results(
+            results,
+            hints=hints or None,
+            score_scale=stats.score_scale,
+            reranker=stats.reranker_model,
+        )
     return _format_results(results, verbose=output_format == "verbose")
 
 

--- a/packages/memtomem/src/memtomem/server/tools/search.py
+++ b/packages/memtomem/src/memtomem/server/tools/search.py
@@ -150,6 +150,18 @@ async def mem_search(
     the candidate pool is automatically derived from ``rerank.oversample``,
     ``rerank.min_pool``, and ``rerank.max_pool``; passing ``rerank=false`` skips
     reranking for the call and collapses that pool to ``top_k``.
+
+    Structured output includes a top-level ``score_scale`` naming the base
+    scale the ``score`` values are on — ``"rerank"`` (cross-encoder output;
+    model-dependent range, see the accompanying ``reranker`` model ID),
+    ``"rrf"`` (reciprocal-rank fusion), ``"bm25"``/``"dense"`` (unfused
+    single-retriever scores), or ``"none"`` (filter-only enumeration — no
+    relevance scale, the filter is the selector) — so score thresholds can
+    be chosen per scale instead of inferred from the value range. Optional
+    modifier stages (time decay, access/importance boosts; all default-off)
+    multiply on top of the base scale when the server has them enabled, so
+    absolute thresholds are only portable across servers sharing the same
+    modifier config.
     """
     if not query.strip():
         return "Error: query cannot be empty."
@@ -264,7 +276,12 @@ async def mem_search(
         return "No results found." + tail
 
     if effective_format == "structured":
-        output = _format_structured_results(results, hints=hints or None)
+        output = _format_structured_results(
+            results,
+            hints=hints or None,
+            score_scale=stats.score_scale,
+            reranker=stats.reranker_model,
+        )
     else:
         is_verbose = effective_format == "verbose"
         output = _format_results(results, verbose=is_verbose)

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -105,6 +105,46 @@ class TestSearchCLI:
         result = runner.invoke(cli, ["search"])
         assert result.exit_code != 0
 
+    def test_search_json_reranked_carries_scale_and_model(
+        self, runner: CliRunner, monkeypatch
+    ) -> None:
+        """#1767: on the "rerank" scale the JSON items must also carry the
+        model ID — rerank score ranges are model-dependent, so the scale
+        alone can't calibrate a threshold (parity with the MCP payload)."""
+        import json
+        from contextlib import asynccontextmanager
+        from unittest.mock import AsyncMock
+        from uuid import uuid4
+
+        from memtomem.models import Chunk, ChunkMetadata, SearchResult
+        from memtomem.search.pipeline import RetrievalStats
+
+        chunk = Chunk(
+            content="reranked hit",
+            metadata=ChunkMetadata(source_file=Path("/tmp/hit.md")),
+            id=uuid4(),
+            embedding=[],
+        )
+        results = [SearchResult(chunk=chunk, score=1.0928, rank=1, source="reranked")]
+        stats = RetrievalStats(
+            final_total=1, score_scale="rerank", reranker_model="test-reranker-v1"
+        )
+
+        comp = MagicMock()
+        comp.search_pipeline.search = AsyncMock(return_value=(results, stats))
+
+        @asynccontextmanager
+        async def fake_components():
+            yield comp
+
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", lambda: fake_components())
+
+        result = runner.invoke(cli, ["search", "--format", "json", "anything"])
+        assert result.exit_code == 0, result.output
+        items = json.loads(result.output)
+        assert items[0]["score_scale"] == "rerank"
+        assert items[0]["reranker"] == "test-reranker-v1"
+
 
 # ── Config commands ─────────────────────────────────────────────────────
 

--- a/packages/memtomem/tests/test_cli_index_noop_e2e.py
+++ b/packages/memtomem/tests/test_cli_index_noop_e2e.py
@@ -99,6 +99,16 @@ class TestFreshNoopIndexInline:
         assert r.exit_code == 0, f"search failed: {r.output}"
         assert "hello world" in r.output
 
+        # #1767: the JSON format carries score provenance per item.
+        # ``--provider none`` keeps ``enable_dense`` on (the dense leg just
+        # returns nothing), so fusion still runs and the scale is "rrf" —
+        # observable in the score itself: 1/(rrf_k + 1) ≈ 0.0164, not a raw
+        # BM25 magnitude.
+        r = runner.invoke(cli, ["search", "--format", "json", "hello"])
+        assert r.exit_code == 0, f"json search failed: {r.output}"
+        items = json.loads(r.output)
+        assert items and all(item["score_scale"] == "rrf" for item in items)
+
 
 class TestFreshNoopIndexSubprocess:
     def test_init_index_search_via_subprocess(self, tmp_path):

--- a/packages/memtomem/tests/test_multi_agent_integration.py
+++ b/packages/memtomem/tests/test_multi_agent_integration.py
@@ -601,6 +601,11 @@ class TestCaseFOutputFormat:
         assert "results" in payload
         assert len(payload["results"]) >= 1
         assert "chunk_id" in payload["results"][0]
+        # #1767 parity with mem_search: the payload names the score scale.
+        # BM25-only components take the single-retriever passthrough, so
+        # the base scale is "bm25"; no reranker is wired → no model key.
+        assert payload["score_scale"] == "bm25"
+        assert "reranker" not in payload
         # Empty-result branch also returns valid JSON shape for the
         # structured path (consumers can rely on the schema).
         empty = await mem_agent_search(  # type: ignore[arg-type]
@@ -611,6 +616,7 @@ class TestCaseFOutputFormat:
         )
         empty_payload = json.loads(empty)
         assert empty_payload["results"] == []
+        assert "score_scale" not in empty_payload  # no scores → no scale key
 
     @pytest.mark.asyncio
     async def test_verbose_output_includes_full_uuid(self, bm25_only_components):

--- a/packages/memtomem/tests/test_pipeline.py
+++ b/packages/memtomem/tests/test_pipeline.py
@@ -762,6 +762,256 @@ class TestPerCallRerankBypass:
         assert results[0].chunk.id == relevant.chunk.id
 
 
+class TestScoreScale:
+    """#1767: ``RetrievalStats.score_scale`` must name the scale the returned
+    scores are actually on — derived from the results, not the rerank
+    decision, so silent reranker fallbacks keep the label truthful.
+    """
+
+    _make_result = staticmethod(TestRerankCandidatePool._make_result)
+    _probe_reranker = staticmethod(TestRerankCandidatePool._probe_reranker)
+
+    def _make_pipeline(
+        self,
+        bm25_results: list[SearchResult],
+        dense_results: list[SearchResult] | None = None,
+        *,
+        enable_dense: bool = False,
+        reranker: object | None = None,
+        rerank_config: object | None = None,
+    ):
+        from unittest.mock import AsyncMock
+
+        from memtomem.config import SearchConfig
+        from memtomem.search.pipeline import SearchPipeline
+
+        storage = AsyncMock()
+        storage.bm25_search = AsyncMock(return_value=bm25_results)
+        storage.dense_search = AsyncMock(return_value=dense_results or [])
+        storage.increment_access = AsyncMock()
+        storage.save_query_history = AsyncMock()
+        storage.get_access_counts = AsyncMock(return_value={})
+        storage.get_embeddings_for_chunks = AsyncMock(return_value={})
+        storage.get_importance_scores = AsyncMock(return_value={})
+        storage.count_chunks_by_ns_prefix = AsyncMock(return_value=0)
+
+        embedder = AsyncMock()
+        embedder.embed_query = AsyncMock(return_value=[0.1] * 8)
+
+        return SearchPipeline(
+            storage=storage,
+            embedder=embedder,
+            config=SearchConfig(enable_bm25=True, enable_dense=enable_dense),
+            reranker=reranker,
+            rerank_config=rerank_config,
+        )
+
+    @pytest.mark.asyncio
+    async def test_hybrid_fusion_is_rrf(self):
+        results_in = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(5)]
+        pipeline = self._make_pipeline(results_in, results_in, enable_dense=True)
+
+        _, stats = await pipeline.search("anything", top_k=5)
+
+        assert stats.score_scale == "rrf"
+        assert stats.reranker_model is None
+
+    @pytest.mark.asyncio
+    async def test_bm25_passthrough_is_bm25(self):
+        """Single-retriever passthrough skips RRF and keeps raw retriever
+        scores — it must NOT be labeled "rrf"."""
+        results_in = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(5)]
+        pipeline = self._make_pipeline(results_in)
+
+        _, stats = await pipeline.search("anything", top_k=5)
+
+        assert stats.score_scale == "bm25"
+
+    @pytest.mark.asyncio
+    async def test_dense_passthrough_is_dense(self):
+        from unittest.mock import AsyncMock
+
+        from memtomem.config import SearchConfig
+        from memtomem.search.pipeline import SearchPipeline
+
+        results_in = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(5)]
+        storage = AsyncMock()
+        storage.dense_search = AsyncMock(return_value=results_in)
+        storage.get_access_counts = AsyncMock(return_value={})
+        storage.get_embeddings_for_chunks = AsyncMock(return_value={})
+        storage.get_importance_scores = AsyncMock(return_value={})
+        storage.count_chunks_by_ns_prefix = AsyncMock(return_value=0)
+        embedder = AsyncMock()
+        embedder.embed_query = AsyncMock(return_value=[0.1] * 8)
+        pipeline = SearchPipeline(
+            storage=storage,
+            embedder=embedder,
+            config=SearchConfig(enable_bm25=False, enable_dense=True),
+        )
+
+        _, stats = await pipeline.search("anything", top_k=5)
+
+        assert stats.score_scale == "dense"
+
+    @pytest.mark.asyncio
+    async def test_successful_rerank_is_rerank_with_model(self):
+        from memtomem.config import RerankConfig
+
+        results_in = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(20)]
+        received: list[int] = []
+        pipeline = self._make_pipeline(
+            results_in,
+            reranker=self._probe_reranker(received, results_in[0].chunk.id),
+            rerank_config=RerankConfig(enabled=True, model="test-reranker-v1"),
+        )
+
+        _, stats = await pipeline.search("anything", top_k=10)
+
+        assert received == [20]
+        assert stats.score_scale == "rerank"
+        assert stats.reranker_model == "test-reranker-v1"
+
+    @pytest.mark.asyncio
+    async def test_rerank_exception_fallback_keeps_base_scale(self):
+        """Stage 3b catches reranker exceptions and keeps the fused order —
+        the scale label must stay on the base scale, not claim "rerank"."""
+        from memtomem.config import RerankConfig
+
+        class _Exploding:
+            async def rerank(self, query, results, top_k):
+                raise RuntimeError("model gone")
+
+        results_in = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(20)]
+        pipeline = self._make_pipeline(
+            results_in,
+            reranker=_Exploding(),
+            rerank_config=RerankConfig(enabled=True, model="test-reranker-v1"),
+        )
+
+        results, stats = await pipeline.search("anything", top_k=10)
+
+        assert len(results) == 10
+        assert stats.rerank_applied is True  # the decision flag alone would lie
+        assert stats.score_scale == "bm25"
+        assert stats.reranker_model is None
+
+    @pytest.mark.asyncio
+    async def test_provider_silent_fallback_keeps_base_scale(self):
+        """Both shipped rerankers swallow their own errors and return the
+        input unchanged (no "reranked" re-stamp) — the label must not
+        promote to "rerank" on a normally-returning no-op."""
+        from memtomem.config import RerankConfig
+
+        results_in = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(20)]
+        received: list[int] = []
+        pipeline = self._make_pipeline(
+            results_in,
+            # target_chunk_id=None → probe returns its input untouched,
+            # mimicking the providers' internal error fallback.
+            reranker=self._probe_reranker(received),
+            rerank_config=RerankConfig(enabled=True, model="test-reranker-v1"),
+        )
+
+        _, stats = await pipeline.search("anything", top_k=10)
+
+        assert received == [20]
+        assert stats.score_scale == "bm25"
+        assert stats.reranker_model is None
+
+    @pytest.mark.asyncio
+    async def test_per_call_bypass_keeps_base_scale(self):
+        from memtomem.config import RerankConfig
+
+        results_in = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(20)]
+        received: list[int] = []
+        pipeline = self._make_pipeline(
+            results_in,
+            reranker=self._probe_reranker(received, results_in[0].chunk.id),
+            rerank_config=RerankConfig(enabled=True),
+        )
+
+        _, stats = await pipeline.search("anything", top_k=10, rerank=False)
+
+        assert received == []
+        assert stats.score_scale == "bm25"
+
+    @pytest.mark.asyncio
+    async def test_filter_only_path_is_none_scale(self):
+        """The #750 enumeration path has no relevance scale — labeled
+        "none" so consumers know there is no magnitude to gate. With
+        modifiers off (the default) the scores are the 1.0 seed."""
+        from unittest.mock import AsyncMock
+
+        chunk = Chunk(
+            content="a",
+            metadata=ChunkMetadata(source_file=Path("/tmp/a.md"), tags=("redis",)),
+            id=uuid4(),
+            embedding=[],
+        )
+        pipeline = self._make_pipeline([])
+        pipeline._storage.recall_chunks = AsyncMock(return_value=[chunk])
+
+        results, stats = await pipeline.search(query="", tag_filter="redis", top_k=5)
+
+        assert [r.score for r in results] == [1.0]
+        assert stats.score_scale == "none"
+
+    @pytest.mark.asyncio
+    async def test_filter_only_stays_none_scale_under_modifiers(self):
+        """ "none" means *no relevance scale*, not *constant value*: with
+        decay enabled the filter-only scores vary (recency ordering), and
+        the label must still be "none" — there is a scale of sorts, but
+        not one that carries relevance magnitude."""
+        from datetime import datetime, timedelta, timezone
+        from unittest.mock import AsyncMock
+
+        from memtomem.config import DecayConfig
+        from memtomem.search.pipeline import SearchPipeline
+
+        old = Chunk(
+            content="old note",
+            metadata=ChunkMetadata(source_file=Path("/tmp/old.md"), tags=("redis",)),
+            id=uuid4(),
+            embedding=[],
+            updated_at=datetime.now(timezone.utc) - timedelta(days=60),
+        )
+        base = self._make_pipeline([])
+        pipeline = SearchPipeline(
+            storage=base._storage,
+            embedder=base._embedder,
+            config=base._config,
+            decay_config=DecayConfig(enabled=True, half_life_days=30.0),
+        )
+        pipeline._storage.recall_chunks = AsyncMock(return_value=[old])
+
+        results, stats = await pipeline.search(query="", tag_filter="redis", top_k=5)
+
+        assert results[0].score < 1.0  # decay transformed the 1.0 seed
+        assert stats.score_scale == "none"
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_preserves_scale(self):
+        """Stats ride the TTL cache alongside results, so a cache hit must
+        report the same scale without re-running the reranker."""
+        from memtomem.config import RerankConfig
+
+        results_in = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(20)]
+        received: list[int] = []
+        pipeline = self._make_pipeline(
+            results_in,
+            reranker=self._probe_reranker(received, results_in[0].chunk.id),
+            rerank_config=RerankConfig(enabled=True, model="test-reranker-v1"),
+        )
+
+        _, first = await pipeline.search("anything", top_k=10)
+        _, second = await pipeline.search("anything", top_k=10)
+
+        assert received == [20]  # reranker ran once — second call was cached
+        assert first.score_scale == "rerank"
+        assert second.score_scale == "rerank"
+        assert second.reranker_model == "test-reranker-v1"
+
+
 class CloseAwareFakeReranker:
     """Counts rerank/close calls and refuses to rerank after close (#1777).
 

--- a/packages/memtomem/tests/test_server_helpers.py
+++ b/packages/memtomem/tests/test_server_helpers.py
@@ -272,6 +272,35 @@ class TestFormatStructuredResults:
         parsed = json.loads(_format_structured_results([r]))
         assert parsed["results"][0]["score"] == 0.9235
 
+    def test_score_scale_emitted_top_level(self):
+        """#1767: the scale rides the payload, not each item — per-result
+        keys stay the stable narrow shape pinned above."""
+        import json
+
+        r = self._make_result()
+        parsed = json.loads(_format_structured_results([r], score_scale="rrf"))
+        assert parsed["score_scale"] == "rrf"
+        assert "score_scale" not in parsed["results"][0]
+        assert "reranker" not in parsed
+
+    def test_score_scale_with_reranker_model(self):
+        import json
+
+        r = self._make_result()
+        parsed = json.loads(
+            _format_structured_results([r], score_scale="rerank", reranker="test-reranker-v1")
+        )
+        assert parsed["score_scale"] == "rerank"
+        assert parsed["reranker"] == "test-reranker-v1"
+
+    def test_score_scale_omitted_when_none(self):
+        import json
+
+        r = self._make_result()
+        parsed = json.loads(_format_structured_results([r]))
+        assert "score_scale" not in parsed
+        assert "reranker" not in parsed
+
     def test_source_filename_only(self):
         import json
 

--- a/packages/memtomem/tests/test_trust_ux.py
+++ b/packages/memtomem/tests/test_trust_ux.py
@@ -300,6 +300,26 @@ class TestArchiveHint:
         assert parsed["results"] == []
         # No archive chunks, no dim mismatch, no filter → no hints key.
         assert "hints" not in parsed
+        # No scores → no scale to name (#1767).
+        assert "score_scale" not in parsed
+
+    async def test_search_structured_emits_score_scale(self, trust_components):
+        """#1767: structured payloads name the scale the scores are on so
+        consumers can threshold per scale. The BM25-only fixture takes the
+        single-retriever passthrough, so the scale is raw "bm25" — not
+        "rrf", which would misdescribe the unfused scores."""
+        from memtomem.server.tools.search import mem_search
+
+        comp, _ = trust_components
+        await comp.storage.upsert_chunks([make_chunk("notes about pipelines")])
+
+        ctx = _search_ctx(comp)
+        out = await mem_search(query="pipelines", output_format="structured", ctx=ctx)
+
+        parsed = json.loads(out)
+        assert parsed["results"]
+        assert parsed["score_scale"] == "bm25"
+        assert "reranker" not in parsed  # only set when the scale is "rerank"
 
     async def test_search_structured_empty_surfaces_archive_hint(self, trust_components):
         """When archive chunks exist but none match the query, the structured


### PR DESCRIPTION
## Summary

`mem_search`'s structured output emits a bare `score` whose scale silently follows server config — RRF fusion (~0.033 ceiling) vs cross-encoder rerank (model-dependent: raw logits locally, [0,1] on Cohere). Programmatic consumers can't threshold portably and can't detect which scale they're on (#1767).

This PR names the scale in the payload. Additive fields only; no ranking or default changes.

- **`RetrievalStats.score_scale`** is recorded at the pipeline branch that produced the scores: `"rrf"` (fused legs), `"bm25"` / `"dense"` (single-retriever passthrough — raw scores that never touch RRF; a third and fourth scale beyond the issue's two-value framing), `"none"` (filter-only enumeration, #750 — no relevance scale), `"rerank"` (Stage 3b actually re-scored the list).
- **The `"rerank"` label is derived from the returned results** (every item re-stamped `source="reranked"`), not from the decision flag — both the pipeline's `except` fallback and the providers' internal error fallbacks silently keep the fused order, so a decision-based label would lie exactly when it matters. Verified against all three reranker implementations.
- **Structured payloads** (`mem_search`, `mem_agent_search`) gain top-level `score_scale` + `reranker` (rerank model ID, since ranges are model-dependent); both omitted when there are no results. Per-result shape unchanged.
- **`mm search --format json`** carries `score_scale` per item (its payload is a bare list).
- Stats ride the TTL cache, so cache hits report the scale of the cached scores; the #1766 per-call bypass keys the same path.
- Labels name the **base** scale: decay/access/importance modifiers (all default-off) multiply on top when enabled — documented in the tool docstring and `core-memory-tools.md`.

## Review

`codex` review round 1: NEEDS-FIX — flagged that "constant 1.0" / "raw" wording was false under enabled modifier stages, plus two coverage gaps (filter-only under modifiers, `mem_agent_search` wiring). All three addressed: wording reframed as base scale, `TestScoreScale.test_filter_only_stays_none_scale_under_modifiers` pins the "none ≠ constant" contract, and the agent-search integration test now asserts the new keys.

## Testing

- `uv run pytest -m "not ollama"` — 8747 passed. New coverage: `TestScoreScale` (10 pipeline-branch cases incl. both silent rerank fallbacks, per-call bypass, cache hit), formatter emission/omission, tool-level (`mem_search` + `mem_agent_search`), CLI e2e JSON.
- `uv run ruff check` + `ruff format --check` clean; no new mypy findings in touched files.
- Real-store smoke (4k+ chunks, rerank enabled): `mm search --format json` → `"score_scale": "rerank"` with logit scores; `--no-rerank` → `"score_scale": "rrf"` with scores ≤ 0.0323, matching the distribution table in #1767.

Closes #1767

🤖 Generated with [Claude Code](https://claude.com/claude-code)
