### PR TITLE
test: cover remaining strip_llm_response acceptance cases from #1664

### DIFF
--- a/packages/memtomem/tests/test_llm_utils.py
+++ b/packages/memtomem/tests/test_llm_utils.py
@@ -48,6 +48,12 @@ def test_strip_llm_response_mid_line_backticks():
     assert strip_llm_response(text) == text
 
 
+def test_strip_llm_response_mid_line_triple_backticks():
+    # Even a full ``` marker is left alone unless it opens the text.
+    text = "prefix ``` suffix"
+    assert strip_llm_response(text) == text
+
+
 def test_strip_llm_response_surrounding_whitespace():
     text = '  \n```json\n{"a": 1}\n```\n  '
     assert strip_llm_response(text) == '{"a": 1}'

--- a/packages/memtomem/tests/test_llm_utils.py
+++ b/packages/memtomem/tests/test_llm_utils.py
@@ -25,3 +25,29 @@ def test_strip_llm_response_only_backticks():
     # A lone fence is both the first and last line, so nothing is left.
     text = "```"
     assert strip_llm_response(text) == ""
+
+
+def test_strip_llm_response_no_language_tag():
+    text = "```\nhello\n```"
+    assert strip_llm_response(text) == "hello"
+
+
+def test_strip_llm_response_unclosed_fence():
+    # No closing fence: only the opening fence line is peeled.
+    text = '```json\n{"a": 1}'
+    assert strip_llm_response(text) == '{"a": 1}'
+
+
+def test_strip_llm_response_whitespace_only():
+    assert strip_llm_response("   \n\t ") == ""
+
+
+def test_strip_llm_response_mid_line_backticks():
+    # Backticks that don't open a fence are payload, not a wrapper.
+    text = "use `foo` and ``bar`` mid-line"
+    assert strip_llm_response(text) == text
+
+
+def test_strip_llm_response_surrounding_whitespace():
+    text = '  \n```json\n{"a": 1}\n```\n  '
+    assert strip_llm_response(text) == '{"a": 1}'


### PR DESCRIPTION
Follow-up to #1678 (issue #1664).

The initial test suite for `strip_llm_response` landed in #1678 but missed three of the cases the issue explicitly listed, plus one adjacent form. This adds:

- **unclosed fence** — only the opening fence line is peeled (pins the `else` branch in `strip_llm_response`)
- **whitespace-only input** → `""` (pins the `raw.strip()` contract)
- **mid-line backticks** — not a fence, returned unchanged
- **fence without a language tag** — the "with or without a language tag" half not previously covered
- **surrounding whitespace around a fenced block** — payload only

All assertions were verified against the current implementation before writing (10 passed, ruff clean). No production changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
