### PR TITLE
fix: empty indexing.memory_dirs is a state, not a crash (#1768)

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -353,6 +353,16 @@ running).
 > behavior (config-write without the seed scan) — useful for staging a
 > large folder before a controlled `mm index` run.
 
+An **empty list** (`"memory_dirs": []`, set by editing `config.json` or
+via the env override) is a valid "index nothing" state — useful for
+keeping a throwaway server's file watcher off your live memory
+directories. Search and project-tier operations keep working, and read
+surfaces like `mem_context_compose` simply return no user-tier pinned
+blocks. Writes that need the user-tier base directory (`mem_add`
+without a project scope, `mem_pinned_set`, approving a review
+candidate) refuse with a configuration error naming
+`indexing.memory_dirs` instead of writing anywhere else.
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MEMTOMEM_INDEXING__MEMORY_DIRS` | `["~/.memtomem/memories"]` (+ provider folders selected in `mm init`) | Directories watched for reactive re-index (see above) |

--- a/packages/memtomem/src/memtomem/cli/_errors.py
+++ b/packages/memtomem/src/memtomem/cli/_errors.py
@@ -84,8 +84,8 @@ def _hint_for(e: Exception) -> str | None:
         )
     if isinstance(e, ConfigError):
         return (
-            "configuration failed to load — inspect it with `mm config show`, check "
-            "~/.memtomem/config.json permissions, or re-run `mm init`."
+            "check the active configuration with `mm config show`, then edit "
+            "~/.memtomem/config.json or re-run `mm init`."
         )
     if isinstance(e, StorageError):
         return "storage backend error — run `mm status` to check the DB path and health."

--- a/packages/memtomem/src/memtomem/cli/agent_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/agent_cmd.py
@@ -297,12 +297,16 @@ async def _run_share(chunk_id: str, target: str, force_unsafe: bool = False) -> 
             else "Shared: memory"
         )
 
-        if not comp.config.indexing.memory_dirs:
-            raise click.ClickException("No memory directories configured. Run `mm init` first.")
         from datetime import datetime, timezone
-        from pathlib import Path
 
-        base = Path(comp.config.indexing.memory_dirs[0]).expanduser().resolve()
+        from memtomem.cli._errors import raise_cli_error
+        from memtomem.errors import ConfigError
+        from memtomem.memory_scope import require_user_base
+
+        try:
+            base = require_user_base(comp.config.indexing.memory_dirs)
+        except ConfigError as exc:
+            raise_cli_error(exc)
         date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         path = base / f"{date_str}.md"
         append_entry(path, chunk.content, title=title, tags=tags)

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -4943,10 +4943,12 @@ async def _memory_migrate_run(
         _lock_path_for,
         async_file_lock,
     )
+    from memtomem.errors import ConfigError
     from memtomem.memory_scope import (
         MemoryScopeError,
         is_project_tier_registered,
         project_tier_registration_error,
+        require_user_base,
         resolve_memory_scope_dir,
     )
 
@@ -5000,12 +5002,21 @@ async def _memory_migrate_run(
         # Use the configured user-tier directory rather than the
         # ``~/.memtomem/memories`` default — keeps CLI behaviour consistent
         # with the active config (and lets tests isolate via ``memory_dirs``).
-        mdirs = comp.config.indexing.memory_dirs
-        user_base = Path(mdirs[0]) if mdirs else Path("~/.memtomem/memories")
+        # A migration touching the user tier refuses on an empty
+        # ``memory_dirs`` instead of falling back to the historical
+        # literal: ``--apply`` moves files, and the "index nothing" state
+        # must not move them into or out of a directory the active config
+        # disabled (#1768). Project-to-project migrations resolve
+        # independently of the user tier.
         try:
-            from_dir = resolve_memory_scope_dir(from_scope, project_root, user_base=user_base)
-            to_dir = resolve_memory_scope_dir(to_scope, project_root, user_base=user_base)
-        except MemoryScopeError as exc:
+            if "user" in (from_scope, to_scope):
+                user_base = require_user_base(comp.config.indexing.memory_dirs)
+                from_dir = resolve_memory_scope_dir(from_scope, project_root, user_base=user_base)
+                to_dir = resolve_memory_scope_dir(to_scope, project_root, user_base=user_base)
+            else:
+                from_dir = resolve_memory_scope_dir(from_scope, project_root)
+                to_dir = resolve_memory_scope_dir(to_scope, project_root)
+        except (MemoryScopeError, ConfigError) as exc:
             raise click.ClickException(str(exc)) from exc
 
         # ADR-0011: the migrated row's scope/project_root only become

--- a/packages/memtomem/src/memtomem/cli/memory.py
+++ b/packages/memtomem/src/memtomem/cli/memory.py
@@ -25,10 +25,16 @@ _MEMORY_SCOPE_CHOICES = list(get_args(TargetScope))
 def _resolve_memory_scope_dir(
     scope: TargetScope,
     project_root: Path | None,
-    user_base: Path,
+    user_base: Path | None = None,
 ) -> Path:
-    """ADR-0011 scope → directory, surfaced as ``ClickException`` for the CLI."""
+    """ADR-0011 scope → directory, surfaced as ``ClickException`` for the CLI.
+
+    ``user_base`` is only meaningful for ``scope="user"``; project tiers
+    resolve from ``project_root`` alone (#1768).
+    """
     try:
+        if user_base is None:
+            return _resolve_memory_scope_dir_core(scope, project_root)
         return _resolve_memory_scope_dir_core(scope, project_root, user_base)
     except MemoryScopeError as exc:
         raise click.ClickException(str(exc)) from exc
@@ -196,14 +202,18 @@ async def _add(
         # read from ``indexing.memory_dirs[0]`` so the CLI agrees with
         # MCP ``_mem_add_core`` and ``mm context memory-migrate`` —
         # users who remap ``memory_dirs`` would otherwise see split
-        # writes between CLI and MCP. The hardcoded literal stays only
-        # as a fallback for the (unsupported) empty-list case.
-        mdirs = comp.config.indexing.memory_dirs
-        if mdirs:
-            user_base = Path(mdirs[0]).expanduser()
+        # writes between CLI and MCP. An empty list refuses instead of
+        # falling back to the historical literal: the "index nothing"
+        # state must not write into a directory the active config
+        # disabled (#1768). Project tiers resolve independently.
+        if scope == "user":
+            from memtomem.memory_scope import require_user_base
+
+            base = _resolve_memory_scope_dir(
+                scope, project_root, require_user_base(comp.config.indexing.memory_dirs)
+            )
         else:
-            user_base = Path("~/.memtomem/memories").expanduser()
-        base = _resolve_memory_scope_dir(scope, project_root, user_base)
+            base = _resolve_memory_scope_dir(scope, project_root)
         if scope != "user":
             from memtomem.memory_scope import (
                 is_project_tier_registered,

--- a/packages/memtomem/src/memtomem/cli/pinned_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/pinned_cmd.py
@@ -124,6 +124,9 @@ async def _set_block(
     confirm_project_shared: bool,
     force_unsafe: bool,
 ) -> None:
+    from memtomem.cli._errors import raise_cli_error
+    from memtomem.errors import ConfigError
+
     async with _store_context() as (_, store):
         try:
             block = store.set(
@@ -138,6 +141,8 @@ async def _set_block(
             )
         except ValueError as exc:
             raise click.ClickException(str(exc)) from exc
+        except ConfigError as exc:
+            raise_cli_error(exc)
         click.echo(block.source_path)
 
 
@@ -162,6 +167,9 @@ async def _delete_block(
     agent_id: str | None,
     confirm_project_shared: bool,
 ) -> None:
+    from memtomem.cli._errors import raise_cli_error
+    from memtomem.errors import ConfigError
+
     async with _store_context() as (_, store):
         try:
             deleted = store.delete(
@@ -172,6 +180,8 @@ async def _delete_block(
             )
         except ValueError as exc:
             raise click.ClickException(str(exc)) from exc
+        except ConfigError as exc:
+            raise_cli_error(exc)
         click.echo("Deleted." if deleted else "Not found.")
 
 

--- a/packages/memtomem/src/memtomem/cli/review_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/review_cmd.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import json
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 import click
 
@@ -174,7 +173,9 @@ async def _decide(candidate_id: str, decision: str, reviewer: str, reason: str) 
                         async_file_lock,
                     )
 
-                    base = Path(comp.config.indexing.memory_dirs[0]).expanduser().resolve()
+                    from memtomem.memory_scope import require_user_base
+
+                    base = require_user_base(comp.config.indexing.memory_dirs)
                     target = base / f"{datetime.now(timezone.utc):%Y-%m-%d}.md"
                     write_location = str(target)
                     async with async_file_lock(
@@ -227,7 +228,13 @@ async def _decide(candidate_id: str, decision: str, reviewer: str, reason: str) 
 @click.option("--reason", default="")
 def approve(candidate_id: str, reviewer: str, reason: str) -> None:
     """Approve and persist a candidate."""
-    asyncio.run(_decide(candidate_id, "approved", reviewer, reason))
+    from memtomem.cli._errors import raise_cli_error
+    from memtomem.errors import ConfigError
+
+    try:
+        asyncio.run(_decide(candidate_id, "approved", reviewer, reason))
+    except ConfigError as e:
+        raise_cli_error(e)
 
 
 @review.command("reject")

--- a/packages/memtomem/src/memtomem/cli/shell.py
+++ b/packages/memtomem/src/memtomem/cli/shell.py
@@ -208,7 +208,9 @@ async def _cmd_add(comp, args: list[str]) -> None:
         return
 
     if not comp.config.indexing.memory_dirs:
-        click.secho("No memory directories configured. Run 'mm init' first.", fg="red")
+        from memtomem.memory_scope import EMPTY_MEMORY_DIRS_ERROR
+
+        click.secho(EMPTY_MEMORY_DIRS_ERROR, fg="red")
         return
     base = Path(comp.config.indexing.memory_dirs[0]).expanduser().resolve()
     date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
@@ -288,7 +290,9 @@ async def _cmd_index(comp, args: list[str]) -> None:
         path = Path(args[0]).expanduser().resolve()
     else:
         if not comp.config.indexing.memory_dirs:
-            click.secho("No memory directories configured. Run 'mm init' first.", fg="red")
+            from memtomem.memory_scope import EMPTY_MEMORY_DIRS_ERROR
+
+            click.secho(EMPTY_MEMORY_DIRS_ERROR, fg="red")
             return
         path = Path(comp.config.indexing.memory_dirs[0]).expanduser().resolve()
 

--- a/packages/memtomem/src/memtomem/integrations/langgraph.py
+++ b/packages/memtomem/src/memtomem/integrations/langgraph.py
@@ -310,9 +310,13 @@ class MemtomemStore:
         if file:
             target = Path(file).expanduser().resolve()
         else:
-            if not comp.config.indexing.memory_dirs:
-                return {"error": "No memory directories configured. Run 'mm init' first."}
-            base = Path(comp.config.indexing.memory_dirs[0]).expanduser().resolve()
+            from memtomem.errors import ConfigError
+            from memtomem.memory_scope import require_user_base
+
+            try:
+                base = require_user_base(comp.config.indexing.memory_dirs)
+            except ConfigError as exc:
+                return {"error": str(exc)}
             date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
             target = base / f"{date_str}.md"
 

--- a/packages/memtomem/src/memtomem/integrations/langgraph_store.py
+++ b/packages/memtomem/src/memtomem/integrations/langgraph_store.py
@@ -37,7 +37,7 @@ from memtomem.config import EmbeddingConfig, Mem2MemConfig, TargetScope
 from memtomem.context._atomic import atomic_write_text
 from memtomem.embedding.base import EmbeddingProvider
 from memtomem.embedding.factory import create_embedder
-from memtomem.memory_scope import resolve_memory_scope_dir
+from memtomem.memory_scope import require_user_base, resolve_memory_scope_dir
 
 _TOKEN_RE = re.compile(r"[\w.-]+", re.UNICODE)
 
@@ -160,12 +160,15 @@ class MemtomemBaseStore(BaseStore):
 
             load_config_d(config)
             load_config_overrides(config)
-            user_base = Path(config.indexing.memory_dirs[0]).expanduser()
-            base = resolve_memory_scope_dir(
-                scope,
-                Path(project_root).expanduser().resolve() if project_root else None,
-                user_base,
-            )
+            project = Path(project_root).expanduser().resolve() if project_root else None
+            if scope == "user":
+                # Raises ConfigError on empty ``memory_dirs`` — this store
+                # mkdirs its root, so it needs a real write target (#1768).
+                base = resolve_memory_scope_dir(
+                    scope, project, require_user_base(config.indexing.memory_dirs)
+                )
+            else:
+                base = resolve_memory_scope_dir(scope, project)
             root = base / "langgraph-store"
         self.root = Path(root).expanduser().resolve()
         self.root.mkdir(parents=True, exist_ok=True, mode=0o700)

--- a/packages/memtomem/src/memtomem/memory_scope.py
+++ b/packages/memtomem/src/memtomem/memory_scope.py
@@ -16,12 +16,19 @@ both surfaces.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 
 from memtomem.config import TargetScope
+from memtomem.errors import ConfigError
 
 
 DEFAULT_USER_MEMORY_DIR = Path("~/.memtomem/memories")
+
+EMPTY_MEMORY_DIRS_ERROR = (
+    "indexing.memory_dirs is empty — no memory directories configured. "
+    "Run 'mm init' first or add a directory to ~/.memtomem/config.json."
+)
 
 
 class MemoryScopeError(ValueError):
@@ -31,6 +38,22 @@ class MemoryScopeError(ValueError):
     plain string error messages for MCP tool returns) catch and rewrap
     so each layer surfaces user-facing errors in its native vocabulary.
     """
+
+
+def require_user_base(memory_dirs: Sequence[Path | str]) -> Path:
+    """Return the user-tier base directory (``memory_dirs[0]``), expanded and resolved.
+
+    An empty ``indexing.memory_dirs`` is a valid "index nothing" state
+    (#1768): read surfaces degrade gracefully, but any write that needs
+    the user-tier base must refuse with an error that names the config
+    field instead of crashing with ``IndexError``.
+
+    Raises:
+        ConfigError: When ``memory_dirs`` is empty.
+    """
+    if not memory_dirs:
+        raise ConfigError(EMPTY_MEMORY_DIRS_ERROR)
+    return Path(memory_dirs[0]).expanduser().resolve()
 
 
 def resolve_memory_scope_dir(

--- a/packages/memtomem/src/memtomem/pinned.py
+++ b/packages/memtomem/src/memtomem/pinned.py
@@ -12,7 +12,8 @@ import yaml
 from memtomem import privacy
 from memtomem.config import Mem2MemConfig, TargetScope
 from memtomem.context._atomic import atomic_write_text
-from memtomem.memory_scope import resolve_memory_scope_dir
+from memtomem.errors import ConfigError
+from memtomem.memory_scope import EMPTY_MEMORY_DIRS_ERROR, resolve_memory_scope_dir
 
 PINNED_BLOCK_MAX_CHARS = 2_000
 PINNED_TOTAL_MAX_CHARS = 6_000
@@ -96,10 +97,18 @@ class PinnedContextStore:
     ) -> None:
         self.config = config
         self.project_root = project_root.resolve() if project_root else None
-        self.user_base = Path(config.indexing.memory_dirs[0]).expanduser().resolve()
+        # Empty ``memory_dirs`` is a valid "index nothing" state (#1768):
+        # the store constructs, reads skip the user tier, and only writes
+        # that need the user-tier base refuse (via ``_base``).
+        mdirs = config.indexing.memory_dirs
+        self.user_base: Path | None = Path(mdirs[0]).expanduser().resolve() if mdirs else None
 
     def _base(self, scope: TargetScope) -> Path:
-        return resolve_memory_scope_dir(scope, self.project_root, self.user_base) / "pinned"
+        if scope == "user":
+            if self.user_base is None:
+                raise ConfigError(EMPTY_MEMORY_DIRS_ERROR)
+            return resolve_memory_scope_dir(scope, self.project_root, self.user_base) / "pinned"
+        return resolve_memory_scope_dir(scope, self.project_root) / "pinned"
 
     def search_exclusion_roots(self) -> tuple[Path, ...]:
         """Return every in-scope pinned root, independent of parsing or shadowing."""
@@ -108,7 +117,11 @@ class PinnedContextStore:
             if self.project_root is not None
             else ("user",)
         )
-        return tuple(self._base(scope).resolve(strict=False) for scope in scopes)
+        return tuple(
+            self._base(scope).resolve(strict=False)
+            for scope in scopes
+            if not (scope == "user" and self.user_base is None)
+        )
 
     def _path(self, scope: TargetScope, block_id: str, agent_id: str | None) -> Path:
         block_id = _validate_id(block_id, "block id")
@@ -167,6 +180,8 @@ class PinnedContextStore:
         scope: TargetScope = "user",
         agent_id: str | None = None,
     ) -> PinnedBlock | None:
+        if scope == "user" and self.user_base is None:
+            return None
         path = self._path(scope, block_id, agent_id)
         try:
             text = path.read_text(encoding="utf-8")
@@ -199,6 +214,8 @@ class PinnedContextStore:
         return existed
 
     def _read_scope(self, scope: TargetScope) -> list[PinnedBlock]:
+        if scope == "user" and self.user_base is None:
+            return []
         base = self._base(scope)
         if not base.exists():
             return []

--- a/packages/memtomem/src/memtomem/server/tools/importers.py
+++ b/packages/memtomem/src/memtomem/server/tools/importers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from memtomem.errors import ConfigError
+from memtomem.memory_scope import require_user_base
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
@@ -38,9 +40,10 @@ async def mem_import_notion(
     if not export_path.exists():
         return f"Error: Path not found: {export_path}"
 
-    if not app.config.indexing.memory_dirs:
-        return "Error: no memory directories configured. Run 'mm init' first."
-    memory_dir = Path(app.config.indexing.memory_dirs[0]).expanduser().resolve()
+    try:
+        memory_dir = require_user_base(app.config.indexing.memory_dirs)
+    except ConfigError as exc:
+        return f"Error: {exc}"
     output_dir = memory_dir / "_imported" / "notion"
 
     from memtomem.config import classify_scope
@@ -137,9 +140,10 @@ async def mem_import_obsidian(
     if not vault.exists() or not vault.is_dir():
         return f"Error: Obsidian vault not found: {vault}"
 
-    if not app.config.indexing.memory_dirs:
-        return "Error: no memory directories configured. Run 'mm init' first."
-    memory_dir = Path(app.config.indexing.memory_dirs[0]).expanduser().resolve()
+    try:
+        memory_dir = require_user_base(app.config.indexing.memory_dirs)
+    except ConfigError as exc:
+        return f"Error: {exc}"
     output_dir = memory_dir / "_imported" / "obsidian"
 
     from memtomem.config import classify_scope

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -214,7 +214,7 @@ def _validate_path(
     on failure.
     """
     raw = Path(path_str).expanduser()
-    user_bases = [Path(d).expanduser().resolve() for d in (memory_dirs or [Path(".")])]
+    user_bases = [Path(d).expanduser().resolve() for d in memory_dirs]
     project_bases = [Path(d).expanduser().resolve() for d in (project_memory_dirs or [])]
     bases = user_bases + project_bases
 
@@ -242,8 +242,9 @@ def _validate_path(
         )
 
         try:
-            user_base = user_bases[0] if user_bases else Path("~/.memtomem/memories")
-            base = resolve_memory_scope_dir(scope, project_root, user_base=user_base)
+            # ``user_base`` is unused for project tiers — don't index a
+            # possibly-empty ``memory_dirs`` here (#1768).
+            base = resolve_memory_scope_dir(scope, project_root)
         except MemoryScopeError as exc:
             return None, f"Error: {exc}"
         target = (base / raw).resolve()
@@ -251,6 +252,10 @@ def _validate_path(
         # Resolve relative paths against the first user-tier memory_dir.
         # Project-tier roots are absolute-only; mixing them in here would
         # surprise existing callers that pass plain filenames.
+        if not user_bases:
+            from memtomem.memory_scope import EMPTY_MEMORY_DIRS_ERROR
+
+            return None, f"Error: {EMPTY_MEMORY_DIRS_ERROR}"
         target = (user_bases[0] / raw).resolve()
 
     if not any(target.is_relative_to(b) for b in bases):
@@ -446,17 +451,23 @@ async def _mem_add_core(
         # ``mem_add(scope='project_shared')`` would still write to the
         # user-tier path even though the gate accepted the call — the
         # CLI/MCP divergence flagged in PR-D review.
+        from memtomem.errors import ConfigError
         from memtomem.memory_scope import (
             MemoryScopeError,
             is_project_tier_registered,
             project_tier_registration_error,
+            require_user_base,
             resolve_memory_scope_dir,
         )
         from memtomem.server.tools.search import _resolve_project_context_root
 
         if effective_scope == "user":
-            base = mdirs[0] if mdirs else Path(".")
-            base = Path(base).expanduser().resolve()
+            # No silent cwd fallback: an empty ``memory_dirs`` must name
+            # the config field, not write under the server's cwd (#1768).
+            try:
+                base = require_user_base(mdirs)
+            except ConfigError as exc:
+                return (f"Error: {exc}", None)
         else:
             # ADR-0011 PR-D review round 7: prefer the explicit
             # ``project_root_override`` (set by ``mem_consolidate_apply``
@@ -467,9 +478,7 @@ async def _mem_add_core(
             if project_root_override is not None:
                 project_root = project_root_override
             try:
-                base = resolve_memory_scope_dir(
-                    effective_scope, project_root, user_base=Path(mdirs[0])
-                )
+                base = resolve_memory_scope_dir(effective_scope, project_root)
             except MemoryScopeError as exc:
                 return (f"Error: {exc}", None)
             # ADR-0011: refuse if the resolved tier directory is not
@@ -1174,23 +1183,27 @@ async def mem_batch_add(
         # ``_mem_add_core`` so MCP ``mem_batch_add(scope='project_shared')``
         # lands in the project's ``.memtomem/memories/`` directory, not
         # the user-tier path.
+        from memtomem.errors import ConfigError
         from memtomem.memory_scope import (
             MemoryScopeError,
             is_project_tier_registered,
             project_tier_registration_error,
+            require_user_base,
             resolve_memory_scope_dir,
         )
         from memtomem.server.tools.search import _resolve_project_context_root
 
         if effective_scope == "user":
-            base = mdirs[0] if mdirs else Path(".")
-            base = Path(base).expanduser().resolve()
+            # No silent cwd fallback: an empty ``memory_dirs`` must name
+            # the config field, not write under the server's cwd (#1768).
+            try:
+                base = require_user_base(mdirs)
+            except ConfigError as exc:
+                return f"Error: {exc}"
         else:
             project_root = _resolve_project_context_root(app)
             try:
-                base = resolve_memory_scope_dir(
-                    effective_scope, project_root, user_base=Path(mdirs[0])
-                )
+                base = resolve_memory_scope_dir(effective_scope, project_root)
             except MemoryScopeError as exc:
                 return f"Error: {exc}"
             # ADR-0011 PR-D round 6: refuse if the resolved tier dir is

--- a/packages/memtomem/src/memtomem/server/tools/url_index.py
+++ b/packages/memtomem/src/memtomem/server/tools/url_index.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 
+from memtomem.errors import ConfigError
+from memtomem.memory_scope import require_user_base
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
@@ -38,9 +39,10 @@ async def mem_fetch(
         return "Error: URL must start with http:// or https://"
 
     app = await _get_app_initialized(ctx)
-    if not app.config.indexing.memory_dirs:
-        return "Error: no memory directories configured. Run 'mm init' first."
-    memory_dir = Path(app.config.indexing.memory_dirs[0]).expanduser().resolve()
+    try:
+        memory_dir = require_user_base(app.config.indexing.memory_dirs)
+    except ConfigError as exc:
+        return f"Error: {exc}"
     output_dir = memory_dir / "_fetched"
 
     from memtomem.config import classify_scope

--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -263,6 +263,19 @@ def create_app(lifespan=None, mode: WebMode = "prod") -> FastAPI:
         msg = re.sub(r"(?:[A-Za-z]:)?(?:[/\\][\w.\-]+){2,}", "<path>", str(exc))
         return JSONResponse(status_code=400, content={"detail": msg})
 
+    # An unusable-but-loadable configuration (e.g. empty
+    # ``indexing.memory_dirs``, #1768) is an operational conflict, not an
+    # internal defect — surface the field-naming message with 409, matching
+    # ``deps.require_configured``, instead of the opaque generic 500.
+    from memtomem.errors import ConfigError
+
+    @app.exception_handler(ConfigError)
+    async def config_error_handler(request: Request, exc: ConfigError) -> JSONResponse:
+        import re
+
+        msg = re.sub(r"(?:[A-Za-z]:)?(?:[/\\][\w.\-]+){2,}", "<path>", str(exc))
+        return JSONResponse(status_code=409, content={"detail": msg})
+
     @app.exception_handler(KeyError)
     async def key_error_handler(request: Request, exc: KeyError) -> JSONResponse:
         return JSONResponse(status_code=404, content={"detail": "Not found"})

--- a/packages/memtomem/src/memtomem/web/routes/scratch.py
+++ b/packages/memtomem/src/memtomem/web/routes/scratch.py
@@ -105,7 +105,11 @@ async def promote_scratch(
                 status_code=403, detail="Path is outside configured memory directories"
             )
     else:
-        base = bases[0]
+        from memtomem.memory_scope import require_user_base
+
+        # ConfigError → the app-level 409 handler; the "index nothing"
+        # state has no default promotion destination (#1768).
+        base = require_user_base(config.indexing.memory_dirs)
         date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         target = base / f"{date_str}.md"
 

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -1805,26 +1805,22 @@ async def add_memory(
             },
         )
 
-    # Write-surface parity with MCP ``mem_add``: route the default-dated
-    # file to the configured user-tier ``memory_dirs[0]``. Before this
-    # fix the route hardcoded ``~/.memtomem/memories``, ignoring the
-    # user's configured destination and silently diverging from MCP and
-    # CLI which already honor ``memory_dirs[0]``. The historical default
-    # remains as a last-resort fallback when no dirs are configured at
-    # all (``require_configured`` already guards the common case).
-    mdirs = config.indexing.memory_dirs
-    user_base = Path(mdirs[0] if mdirs else "~/.memtomem/memories").expanduser().resolve()
-
     # ADR-0011 §4 PR-F slice 4: resolve the canonical-residency base
     # directory per tier. User tier stays on ``memory_dirs[0]`` for
-    # back-compat. Project tiers route through ``resolve_memory_scope_dir``
-    # against the server's project root so writes land in
-    # ``<proj>/.memtomem/memories[/.local]/`` — the same path the MCP
-    # ``mem_add(scope=...)`` flow uses. Refuses unregistered project-tier
-    # dirs upfront so the row's persisted scope cannot diverge from what
-    # the read surface / watcher can actually see.
+    # write-surface parity with MCP ``mem_add`` and the CLI; an empty
+    # ``memory_dirs`` refuses with ``ConfigError`` → 409 instead of
+    # falling back to the historical ``~/.memtomem/memories`` — the
+    # "index nothing" state must not silently write into a directory the
+    # active config disabled (#1768). Project tiers route through
+    # ``resolve_memory_scope_dir`` against the server's project root so
+    # writes land in ``<proj>/.memtomem/memories[/.local]/`` — the same
+    # path the MCP ``mem_add(scope=...)`` flow uses. Refuses unregistered
+    # project-tier dirs upfront so the row's persisted scope cannot
+    # diverge from what the read surface / watcher can actually see.
     if req.scope == "user":
-        base = user_base
+        from memtomem.memory_scope import require_user_base
+
+        base = require_user_base(config.indexing.memory_dirs)
     else:
         from memtomem.memory_scope import (
             MemoryScopeError,
@@ -1851,7 +1847,7 @@ async def add_memory(
         if project_root is None:
             project_root = Path(server_project_root)
         try:
-            base = resolve_memory_scope_dir(req.scope, project_root, user_base=user_base)
+            base = resolve_memory_scope_dir(req.scope, project_root)
         except MemoryScopeError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
         if not is_project_tier_registered(base, pmdirs):

--- a/packages/memtomem/tests/test_empty_memory_dirs.py
+++ b/packages/memtomem/tests/test_empty_memory_dirs.py
@@ -1,0 +1,231 @@
+"""#1768 — empty ``indexing.memory_dirs`` is a valid "index nothing" state.
+
+Read surfaces degrade gracefully (``mem_context_compose`` answers with no
+pinned blocks); writes that need the user-tier base refuse with a
+``ConfigError`` that names the config field, instead of dying with
+``IndexError: list index out of range`` rendered as an opaque internal
+error — or, worse, silently writing under the server's cwd.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from helpers import StubCtx, isolate_memtomem_env
+from memtomem.server.context import AppContext
+from memtomem.server.tools import memory_crud
+from memtomem.server.tools import pinned as pinned_tools
+
+
+# ---------------------------------------------------------------------------
+# MCP surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mem_context_compose_returns_bundle_not_internal_error(bm25_only_components):
+    """The issue's headline repro: compose must not crash on empty dirs."""
+    comp, _mem_dir = bm25_only_components
+    comp.config.indexing.memory_dirs = []
+    ctx = StubCtx(AppContext.from_components(comp))
+    out = await pinned_tools.mem_context_compose(query=None, ctx=ctx)
+    assert "internal error" not in out
+    assert json.loads(out)["pinned"] == []
+
+
+@pytest.mark.asyncio
+async def test_mem_pinned_set_names_the_config_field(bm25_only_components):
+    comp, _mem_dir = bm25_only_components
+    comp.config.indexing.memory_dirs = []
+    ctx = StubCtx(AppContext.from_components(comp))
+    out = await pinned_tools.mem_pinned_set("block", "harmless content", ctx=ctx)
+    assert out.startswith("Error:")
+    assert "indexing.memory_dirs is empty" in out
+    assert "internal error" not in out
+
+
+@pytest.mark.asyncio
+async def test_mem_add_default_target_errors_instead_of_writing_cwd(
+    bm25_only_components, monkeypatch, tmp_path
+):
+    comp, _mem_dir = bm25_only_components
+    comp.config.indexing.memory_dirs = []
+    ctx = StubCtx(AppContext.from_components(comp))
+    cwd = tmp_path / "server-cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    out = await memory_crud.mem_add(content="a harmless note", ctx=ctx)
+    assert "indexing.memory_dirs is empty" in out
+    assert list(cwd.rglob("*.md")) == []
+
+
+@pytest.mark.asyncio
+async def test_mem_batch_add_default_target_errors_instead_of_writing_cwd(
+    bm25_only_components, monkeypatch, tmp_path
+):
+    comp, _mem_dir = bm25_only_components
+    comp.config.indexing.memory_dirs = []
+    ctx = StubCtx(AppContext.from_components(comp))
+    cwd = tmp_path / "server-cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    out = await memory_crud.mem_batch_add(
+        entries=[{"key": "k", "value": "a harmless note"}], ctx=ctx
+    )
+    assert "indexing.memory_dirs is empty" in out
+    assert list(cwd.rglob("*.md")) == []
+
+
+# ---------------------------------------------------------------------------
+# CLI ``mm mem add`` — user-tier default target
+# ---------------------------------------------------------------------------
+
+
+def test_mm_mem_add_user_scope_refuses_instead_of_legacy_fallback(monkeypatch, tmp_path):
+    """Pre-fix the CLI fell back to the historical ``~/.memtomem/memories``
+    literal, writing into a directory the active config disabled."""
+    from click.testing import CliRunner
+
+    from memtomem.cli.memory import add
+
+    comp = AsyncMock()
+    comp.config.indexing.memory_dirs = []
+    comp.config.indexing.project_memory_dirs = []
+
+    @asynccontextmanager
+    async def fake_components():
+        yield comp
+
+    monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", fake_components)
+    result = CliRunner().invoke(add, ["a harmless note"])
+    assert result.exit_code != 0
+    assert "indexing.memory_dirs is empty" in result.output
+    assert "Traceback" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI ``mm context memory-migrate`` — user-tier resolution
+# ---------------------------------------------------------------------------
+
+
+def test_memory_migrate_touching_user_tier_refuses_on_empty_memory_dirs(monkeypatch, tmp_path):
+    """``--apply`` moves files; an empty ``memory_dirs`` must refuse before
+    resolving the user tier to the historical default directory."""
+    from click.testing import CliRunner
+
+    from memtomem.cli.context_cmd import memory_migrate_cmd
+
+    project_root = tmp_path / "proj"
+    proj_shared = project_root / ".memtomem" / "memories"
+    proj_shared.mkdir(parents=True)
+    (project_root / ".git").mkdir()
+    src = tmp_path / "rule.md"
+    src.write_text("## Rule\n\nharmless body.\n", encoding="utf-8")
+
+    comp = AsyncMock()
+    comp.config.indexing.memory_dirs = []
+    comp.config.indexing.project_memory_dirs = [proj_shared]
+
+    @asynccontextmanager
+    async def fake_components():
+        yield comp
+
+    monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", fake_components)
+    monkeypatch.chdir(project_root)
+    result = CliRunner().invoke(
+        memory_migrate_cmd, [str(src), "--from", "user", "--to", "project_shared"]
+    )
+    assert result.exit_code != 0
+    assert "indexing.memory_dirs is empty" in result.output
+    assert src.exists()  # nothing moved
+
+
+# ---------------------------------------------------------------------------
+# LangGraph store (root=None resolves the user tier)
+# ---------------------------------------------------------------------------
+
+
+def _patch_empty_dirs_config(monkeypatch):
+    import memtomem.config as _cfg
+
+    isolate_memtomem_env(monkeypatch)
+    monkeypatch.setattr(_cfg, "load_config_d", lambda *args, **kwargs: None)
+
+    def _empty_dirs(config):
+        config.indexing.memory_dirs = []
+
+    monkeypatch.setattr(_cfg, "load_config_overrides", _empty_dirs)
+
+
+def test_langgraph_store_default_root_requires_user_memory_dir(monkeypatch):
+    pytest.importorskip("langgraph")
+    from memtomem.config import EmbeddingConfig
+    from memtomem.errors import ConfigError
+    from memtomem.integrations.langgraph_store import MemtomemBaseStore
+
+    _patch_empty_dirs_config(monkeypatch)
+    with pytest.raises(ConfigError, match="indexing.memory_dirs"):
+        MemtomemBaseStore(embedding=EmbeddingConfig(provider="none", dimension=0))
+
+
+def test_langgraph_store_project_tier_ok_with_empty_memory_dirs(monkeypatch, tmp_path):
+    pytest.importorskip("langgraph")
+    from memtomem.config import EmbeddingConfig
+    from memtomem.integrations.langgraph_store import MemtomemBaseStore
+
+    _patch_empty_dirs_config(monkeypatch)
+    store = MemtomemBaseStore(
+        scope="project_local",
+        project_root=tmp_path / "proj",
+        embedding=EmbeddingConfig(provider="none", dimension=0),
+    )
+    try:
+        expected = tmp_path / "proj" / ".memtomem" / "memories.local" / "langgraph-store"
+        assert store.root == expected.resolve()
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# CLI review approve (writes a dated file under the user tier)
+# ---------------------------------------------------------------------------
+
+
+def test_review_approve_empty_memory_dirs_is_clean_cli_error(monkeypatch):
+    from click.testing import CliRunner
+
+    from memtomem.cli.review_cmd import review
+    from memtomem.config import Mem2MemConfig
+
+    config = Mem2MemConfig()
+    config.indexing.memory_dirs = []
+    storage = SimpleNamespace(
+        get_memory_candidate=AsyncMock(
+            return_value={
+                "id": "candidate-1",
+                "status": "pending",
+                "destination": "daily",
+                "kind": "fact",
+                "content": "a harmless durable fact",
+            }
+        ),
+        claim_memory_candidate=AsyncMock(return_value={"id": "candidate-1"}),
+        release_memory_candidate=AsyncMock(),
+    )
+
+    @asynccontextmanager
+    async def fake_components():
+        yield SimpleNamespace(storage=storage, config=config)
+
+    monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", fake_components)
+    result = CliRunner().invoke(review, ["approve", "candidate-1"])
+    assert result.exit_code != 0
+    assert "indexing.memory_dirs is empty" in result.output
+    assert "Traceback" not in result.output
+    # The claim was rolled back, not left dangling.
+    storage.release_memory_candidate.assert_awaited_once()

--- a/packages/memtomem/tests/test_langgraph.py
+++ b/packages/memtomem/tests/test_langgraph.py
@@ -558,7 +558,7 @@ class TestAddPrivacyGate:
 
         result = await store.add("content")
 
-        assert result == {"error": "No memory directories configured. Run 'mm init' first."}
+        assert "indexing.memory_dirs is empty" in result["error"]
         assert len(guard_calls) == 1
         assert append_calls == []
 

--- a/packages/memtomem/tests/test_memory_write_scope.py
+++ b/packages/memtomem/tests/test_memory_write_scope.py
@@ -968,3 +968,20 @@ def test_validate_path_accepts_project_memory_dirs(tmp_path):
     bogus.write_text("x")
     out, err = memory_crud._validate_path(str(bogus), [user_dir], [project_dir])
     assert err is not None
+
+
+def test_validate_path_empty_memory_dirs_no_cwd_fallback(tmp_path):
+    """#1768 — no silent cwd fallback: a relative user-tier path with empty
+    ``memory_dirs`` errors naming the config field; project-tier absolute
+    paths keep validating against ``project_memory_dirs`` alone.
+    """
+    out, err = memory_crud._validate_path("note.md", [], None)
+    assert out is None
+    assert "indexing.memory_dirs is empty" in err
+
+    project_dir = tmp_path / "proj" / ".memtomem" / "memories"
+    project_dir.mkdir(parents=True)
+    team_file = project_dir / "team.md"
+    out, err = memory_crud._validate_path(str(team_file), [], [project_dir])
+    assert err is None
+    assert out == team_file.resolve()

--- a/packages/memtomem/tests/test_pinned_context.py
+++ b/packages/memtomem/tests/test_pinned_context.py
@@ -277,3 +277,51 @@ def test_delete_is_exact_and_confirmed_for_shared(pinned_store):
     pinned_store.set("one", "content")
     assert pinned_store.delete("one") is True
     assert pinned_store.delete("one") is False
+
+
+# ---------------------------------------------------------------------------
+# Empty ``indexing.memory_dirs`` — the "index nothing" state (#1768)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def empty_dirs_config():
+    config = Mem2MemConfig()
+    config.indexing.memory_dirs = []
+    return config
+
+
+def test_empty_memory_dirs_store_constructs_and_reads_gracefully(empty_dirs_config):
+    store = PinnedContextStore(empty_dirs_config)
+    assert store.user_base is None
+    assert store.list() == []
+    assert store.get("anything") is None
+    assert store.search_exclusion_roots() == ()
+
+
+def test_empty_memory_dirs_user_writes_raise_config_error(empty_dirs_config):
+    from memtomem.errors import ConfigError
+
+    store = PinnedContextStore(empty_dirs_config)
+    with pytest.raises(ConfigError, match="indexing.memory_dirs"):
+        store.set("block", "content")
+    with pytest.raises(ConfigError, match="indexing.memory_dirs"):
+        store.delete("block")
+
+
+def test_empty_memory_dirs_project_tier_still_works(empty_dirs_config, tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    store = PinnedContextStore(empty_dirs_config, project_root=project)
+    store.set("team", "team rule", scope="project_shared", confirm_project_shared=True)
+    assert [block.block_id for block in store.list()] == ["team"]
+    assert store.search_exclusion_roots() == (
+        store._base("project_shared").resolve(),
+        store._base("project_local").resolve(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_compose_with_empty_memory_dirs_returns_bundle_without_pinned(empty_dirs_config):
+    bundle = await ContextAssembler(PinnedContextStore(empty_dirs_config)).compose(max_chars=100)
+    assert bundle.pinned == ()

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -4696,3 +4696,54 @@ class TestChunkCrudCrossProcessLock:
         async with async_file_lock(_lock_path_for(target), timeout=5.0):
             resp = await client.post("/api/add", json={"content": "hello", "file": "pinned.md"})
         assert resp.status_code == 503
+
+
+class TestConfigErrorHandler:
+    """#1768 — a loadable-but-unusable configuration surfaces as 409 with a
+    field-naming detail, not the opaque generic 500."""
+
+    async def test_config_error_surfaces_as_409_with_field_name(self, app, client: AsyncClient):
+        from fastapi.routing import APIRoute
+
+        from memtomem.errors import ConfigError
+        from memtomem.memory_scope import EMPTY_MEMORY_DIRS_ERROR
+
+        async def _boom():
+            raise ConfigError(EMPTY_MEMORY_DIRS_ERROR)
+
+        # Insert ahead of the dev-mode SPA catch-all, which would
+        # otherwise shadow any route appended after app creation.
+        app.router.routes.insert(0, APIRoute("/api/__test-config-error", _boom, methods=["GET"]))
+
+        resp = await client.get("/api/__test-config-error")
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "indexing.memory_dirs is empty" in detail
+
+    async def test_api_add_empty_memory_dirs_409_without_legacy_fallback_write(
+        self, app, client: AsyncClient
+    ):
+        """Pre-fix ``/api/add`` substituted ``~/.memtomem/memories`` when
+        ``memory_dirs`` was empty and wrote there (#1768)."""
+        app.state.config.indexing.memory_dirs = []
+        resp = await client.post("/api/add", json={"content": "hello"})
+        assert resp.status_code == 409
+        assert "indexing.memory_dirs is empty" in resp.json()["detail"]
+
+    async def test_scratch_promote_default_target_empty_memory_dirs_409(
+        self, app, client: AsyncClient
+    ):
+        """Pre-fix the default (no ``file``) promotion crashed on ``bases[0]``
+        → generic 500; must be 409 with no write and no promote mark."""
+        app.state.config.indexing.memory_dirs = []
+        app.state.storage.scratch_get = AsyncMock(
+            return_value={"key": "note", "value": "promote me"}
+        )
+        app.state.storage.scratch_promote = AsyncMock()
+
+        with patch("memtomem.tools.memory_writer.append_entry") as appender:
+            resp = await client.post("/api/scratch/note/promote", json={})
+        assert resp.status_code == 409
+        assert "indexing.memory_dirs is empty" in resp.json()["detail"]
+        appender.assert_not_called()
+        app.state.storage.scratch_promote.assert_not_called()


### PR DESCRIPTION
## Summary

`indexing.memory_dirs: []` passes config validation but crashed every path that
reads `memory_dirs[0]` unconditionally — over MCP the client saw only
`Error: internal error (IndexError: list index out of range)` (#1768).

Empty `memory_dirs` stays **valid** — it's a deliberate "index nothing" state
(the issue's own use case: keeping a throwaway server's watcher off live
memory dirs while benchmarking). Instead of rejecting it at validation:

- **Read surfaces degrade gracefully.** `PinnedContextStore` now stores
  `user_base: Path | None`; `list`/`get`/`_read_scope`/`search_exclusion_roots`
  skip the user tier when it's unconfigured, so `mem_context_compose` (the
  issue's verified crash) returns a normal bundle with no pinned blocks.
  Project-tier pinned blocks keep working.
- **Writes that need the user-tier base refuse with a named field.** New
  `memory_scope.require_user_base()` raises
  `ConfigError("indexing.memory_dirs is empty — …")`, used by every user-tier
  write-target resolution: `PinnedContextStore._base` (chokepoint for
  `set`/`delete`), the LangGraph store's default root, `mm review approve`'s
  dated file, and the default scratch-promotion target. Project-tier writes no
  longer evaluate `memory_dirs[0]` at all (it was passed as an unused
  `user_base` argument).
- **Every silent fallback is gone.** `_mem_add_core` / `mem_batch_add` /
  `_validate_path` fell back to `Path(".")` (writes under the server's cwd);
  web `/api/add`, `mm mem add`, and `mm context memory-migrate` fell back to
  the historical `~/.memtomem/memories` literal — the last one can **move**
  files with `--apply`. All now surface the same field-naming error before
  touching the filesystem.
- **Bespoke empty-list messages centralized.** `mem_fetch`, the Notion /
  Obsidian importers, `mm agent share-note`, the LangGraph tool wrapper, and
  the interactive shell now emit the shared `EMPTY_MEMORY_DIRS_ERROR` (each in
  its surface-native shape) instead of five divergent wordings that described
  the state as uninitialized.
- **Every surface renders it cleanly.** MCP already knows `ConfigError`
  (`_KNOWN_EXCEPTIONS`); the CLI routes it through `raise_cli_error` on the
  pinned/review/mem-add write commands (hint reworded — the old one claimed
  the config "failed to load", wrong for a loaded-but-unusable value); the web
  app gains a `ConfigError` handler → **409** with a path-redacted,
  field-naming detail (matching `deps.require_configured`'s convention for
  unusable-config states, vs the opaque generic 500).

## Review

Four `codex` gates. Design gate (report-only, pre-implementation): NEEDS-FIX —
caught the `_mem_add_core`/`mem_batch_add` cwd fallbacks, project-tier writes
needlessly indexing `memory_dirs[0]`, `delete` belonging on the error side (a
mutating op reporting "not found" would be a lie), the 409 convention, and the
stale CLI hint. Diff review round 2: NEEDS-FIX — the three
historical-literal fallbacks (web `/api/add`, `mm mem add`, memory-migrate)
contradicted the new contract, plus message centralization. Round 3:
NEEDS-FIX — default scratch promotion's `bases[0]` (a derived-variable
crash the plain `memory_dirs[0]` grep missed) and the shell messages. Final
convergence re-gate: **SHIP** — repository-wide scan of `memory_dirs[0]` /
`mdirs[0]` / `bases[0]` / `user_bases[0]` shows every remaining access
guarded.

## Testing

- `uv run pytest -m "not ollama"` — full suite.
- New `tests/test_empty_memory_dirs.py`: MCP compose / pinned_set / mem_add /
  mem_batch_add (including "nothing written under cwd" pins), `mm mem add`
  and memory-migrate refusals (no legacy-directory writes/moves, source file
  untouched), LangGraph default-root vs project-tier, `mm review approve`
  clean error with claim rollback.
- Pinned-store unit cases in `test_pinned_context.py` (graceful reads,
  ConfigError writes, project tier, exclusion roots), `_validate_path`
  empty-dirs case in `test_memory_write_scope.py`, and web 409 pins in
  `test_web_routes.py` (handler contract, `/api/add`, scratch promote —
  asserting no write and no promote mark).
- Real-flow smoke against an isolated `HOME` with the issue's exact
  `config.json`: the reported constructor repro passes, `mm pinned compose`
  exits 0 with a normal bundle, `mm pinned set` prints the one-line error +
  hint (no traceback).

Closes #1768

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
