### PR TITLE
build(deps): require mcp>=1.28.1 (GHSA-vj7q-gjh5-988w)

### DIFF
--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "mcp[cli]>=1.27.2",
+    "mcp[cli]>=1.28.1",
     "pydantic>=2.10",
     "pydantic-settings>=2.7",
     "sqlite-vec>=0.1.6",

--- a/uv.lock
+++ b/uv.lock
@@ -1062,7 +1062,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.2"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1080,9 +1080,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [package.optional-dependencies]
@@ -1184,7 +1184,7 @@ requires-dist = [
     { name = "langfuse", marker = "extra == 'langfuse'", specifier = ">=4.0" },
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=1.0,<2" },
     { name = "markdown-it-py", specifier = ">=3.0,<5" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.27.2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1" },
     { name = "memtomem", extras = ["onnx", "ollama", "openai", "korean", "code", "web", "langfuse", "langgraph"], marker = "extra == 'all'", editable = "packages/memtomem" },
     { name = "ollama", marker = "extra == 'ollama'", specifier = ">=0.4" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.60" },


### PR DESCRIPTION
## Summary

OSV started flagging `mcp 1.27.2` in `uv.lock` — [GHSA-vj7q-gjh5-988w](https://osv.dev/GHSA-vj7q-gjh5-988w) (High, CVSS 7.6), fixed in 1.28.1. The `python-deps (OSV blocking)` gate now fails every fresh CI run (first seen on #1789, which touches no dependencies; `main`'s last green run predates the advisory).

Bumps the `mcp[cli]` floor to `>=1.28.1` and regenerates `uv.lock` in the same commit.

## Testing

- `uv pip install -e "packages/memtomem[all]"` resolves cleanly to mcp 1.28.1; server module imports.
- `test_meta_tool.py` (tool registry / mem_do dispatch over the MCP SDK) — 27 passed.
- Full `-m "not ollama"` suite riding CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
