### PR TITLE
feat(compose): name the score scale in the composed bundle (#1791)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **Context Compose schema 4** (#1791) — the composed bundle now names the
+  retrieval leg's score scale at the top level (`score_scale`: `rrf` / `bm25`
+  / `dense` / `none` / `rerank`, plus `reranker` with the model id when
+  reranked), mirroring the fields `mem_search` structured output gained in
+  #1781. Both keys are omitted when `retrieved` is empty, so clients should
+  gate on the advertised `context_compose` schema version, not key presence.
+  Schemas 2 and 3 remain immutable released contracts.
 - **Per-call rerank bypass** (#1766) — `mem_search` and `mem_context_compose`
   accept `rerank=false` (CLI: `mm search --no-rerank`, `mm pinned compose
   --no-rerank`) to skip the cross-encoder rerank stage and its candidate-pool

--- a/docs/guides/pinned-context.md
+++ b/docs/guides/pinned-context.md
@@ -34,6 +34,11 @@ never cut in the middle and omitted ids are returned explicitly.
 `mem_context_compose` schema 2 accepts the same optional `namespace` and
 `context_window` retrieval controls used by search. Schema 3 additionally
 returns adjacent chunks under each retrieved item's optional `context` object.
+Schema 4 additionally names the retrieval leg's score scale at the top level
+of the bundle: `score_scale` (`rrf`, `bm25`, `dense`, `none`, or `rerank` —
+the same labels `mem_search` reports) plus `reranker` with the rerank model id
+when the scale is `rerank`. Both keys are omitted when `retrieved` is empty;
+pinned blocks carry no relevance scale.
 Matched hits retain schema 2 budget priority; de-duplicated adjacent chunks use
 only the remaining composed bundle character budget, selected globally by
 distance with hit rank and before/after as deterministic tie-breakers. Pinned
@@ -46,6 +51,10 @@ Schema 3 is a new capability instead of an in-place schema 2 change because
 schema 2 shipped in memtomem 0.3.9 without adjacent chunks in its response.
 Keeping that released contract immutable lets clients distinguish scoped
 composition from composition that also preserves visible context windows.
+Schema 4 follows the same rule: because `score_scale`/`reranker` are omitted
+for an empty `retrieved` list, a client cannot tell "server too old" from
+"no results" by key presence — the advertised schema version is the
+discovery mechanism.
 
 ## Review-first candidates
 

--- a/docs/guides/reference/operations.md
+++ b/docs/guides/reference/operations.md
@@ -173,7 +173,9 @@ a separate package; it communicates with memtomem core entirely through the MCP
 protocol — no direct code coupling. Enhanced composition is negotiated from
 `mem_do(action="version").capabilities`, not inferred from an installed package
 version: `context_compose` schema 2 enables scoped Pinned Context composition,
-schema 3 additionally preserves adjacent context-window chunks, and
+schema 3 additionally preserves adjacent context-window chunks, schema 4
+additionally names the retrieval leg's score scale (top-level
+`score_scale`/`reranker`, omitted when `retrieved` is empty), and
 `candidate_propose` schema 1 independently enables review-first proposals.
 
 ### How it works

--- a/packages/memtomem/src/memtomem/pinned.py
+++ b/packages/memtomem/src/memtomem/pinned.py
@@ -64,11 +64,12 @@ class ContextBundle:
             "warnings": list(self.warnings),
         }
         # The omission contract is structural: an empty retrieval leg carries
-        # no relevance scale, even if a caller stamped one on the bundle.
+        # no relevance scale, and a reranker id only accompanies the "rerank"
+        # scale — even if a caller stamped inconsistent fields on the bundle.
         if self.retrieved and self.score_scale is not None:
             payload["score_scale"] = self.score_scale
-        if self.retrieved and self.reranker is not None:
-            payload["reranker"] = self.reranker
+            if self.score_scale == "rerank" and self.reranker is not None:
+                payload["reranker"] = self.reranker
         return payload
 
 

--- a/packages/memtomem/src/memtomem/pinned.py
+++ b/packages/memtomem/src/memtomem/pinned.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
@@ -14,6 +14,9 @@ from memtomem.config import Mem2MemConfig, TargetScope
 from memtomem.context._atomic import atomic_write_text
 from memtomem.errors import ConfigError
 from memtomem.memory_scope import EMPTY_MEMORY_DIRS_ERROR, resolve_memory_scope_dir
+
+if TYPE_CHECKING:
+    from memtomem.search.pipeline import ScoreScale
 
 PINNED_BLOCK_MAX_CHARS = 2_000
 PINNED_TOTAL_MAX_CHARS = 6_000
@@ -46,9 +49,11 @@ class ContextBundle:
     used_chars: int
     omitted_block_ids: tuple[str, ...] = ()
     warnings: tuple[str, ...] = ()
+    score_scale: ScoreScale | None = None
+    reranker: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
-        return {
+        payload: dict[str, Any] = {
             "pinned": [block.as_dict() for block in self.pinned],
             "retrieved": list(self.retrieved),
             "max_chars": self.max_chars,
@@ -56,6 +61,11 @@ class ContextBundle:
             "omitted_block_ids": list(self.omitted_block_ids),
             "warnings": list(self.warnings),
         }
+        if self.score_scale is not None:
+            payload["score_scale"] = self.score_scale
+        if self.reranker is not None:
+            payload["reranker"] = self.reranker
+        return payload
 
 
 @dataclass(slots=True)
@@ -285,8 +295,10 @@ class ContextAssembler:
             used += len(block.content)
 
         retrieved: list[dict[str, Any]] = []
+        score_scale: ScoreScale | None = None
+        reranker: str | None = None
         if query and self.search_pipeline is not None and used < max_chars:
-            results, _ = await self.search_pipeline.search(
+            results, stats = await self.search_pipeline.search(
                 query=query,
                 top_k=top_k,
                 namespace=namespace,
@@ -317,6 +329,13 @@ class ContextAssembler:
                 retrieved.append(item)
                 matched.append((result, item))
                 emitted_chunk_ids.add(chunk_id)
+
+            # Scale labels describe the retrieval leg as a whole; budget
+            # truncation can empty `retrieved` even when the pipeline
+            # returned hits, and an empty leg carries no scale to name.
+            if retrieved:
+                score_scale = stats.score_scale
+                reranker = stats.reranker_model
 
             context_windows: list[_ContextWindowSelection] = []
             for result, item in matched:
@@ -384,6 +403,8 @@ class ContextAssembler:
             used_chars=used,
             omitted_block_ids=tuple(omitted),
             warnings=warnings,
+            score_scale=score_scale,
+            reranker=reranker,
         )
 
     @staticmethod

--- a/packages/memtomem/src/memtomem/pinned.py
+++ b/packages/memtomem/src/memtomem/pinned.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import yaml
 
@@ -15,8 +15,10 @@ from memtomem.context._atomic import atomic_write_text
 from memtomem.errors import ConfigError
 from memtomem.memory_scope import EMPTY_MEMORY_DIRS_ERROR, resolve_memory_scope_dir
 
-if TYPE_CHECKING:
-    from memtomem.search.pipeline import ScoreScale
+# Runtime import (not TYPE_CHECKING): the alias must resolve for
+# typing.get_type_hints(ContextBundle) — this is a public payload dataclass
+# and reflection-based consumers may introspect it.
+from memtomem.search.pipeline import ScoreScale
 
 PINNED_BLOCK_MAX_CHARS = 2_000
 PINNED_TOTAL_MAX_CHARS = 6_000
@@ -61,9 +63,11 @@ class ContextBundle:
             "omitted_block_ids": list(self.omitted_block_ids),
             "warnings": list(self.warnings),
         }
-        if self.score_scale is not None:
+        # The omission contract is structural: an empty retrieval leg carries
+        # no relevance scale, even if a caller stamped one on the bundle.
+        if self.retrieved and self.score_scale is not None:
             payload["score_scale"] = self.score_scale
-        if self.reranker is not None:
+        if self.retrieved and self.reranker is not None:
             payload["reranker"] = self.reranker
         return payload
 

--- a/packages/memtomem/src/memtomem/pinned.py
+++ b/packages/memtomem/src/memtomem/pinned.py
@@ -54,6 +54,16 @@ class ContextBundle:
     score_scale: ScoreScale | None = None
     reranker: str | None = None
 
+    def __post_init__(self) -> None:
+        # The scale/model pair invariant (established by RetrievalStats: the
+        # pipeline stamps both together) holds for direct construction too —
+        # an inconsistent pair is a caller bug, rejected loudly rather than
+        # silently normalized at serialization.
+        if self.reranker is not None and self.score_scale != "rerank":
+            raise ValueError("reranker requires score_scale == 'rerank'")
+        if self.score_scale == "rerank" and self.reranker is None:
+            raise ValueError("score_scale == 'rerank' requires a reranker model id")
+
     def as_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
             "pinned": [block.as_dict() for block in self.pinned],
@@ -63,12 +73,11 @@ class ContextBundle:
             "omitted_block_ids": list(self.omitted_block_ids),
             "warnings": list(self.warnings),
         }
-        # The omission contract is structural: an empty retrieval leg carries
-        # no relevance scale, and a reranker id only accompanies the "rerank"
-        # scale — even if a caller stamped inconsistent fields on the bundle.
+        # The empty-retrieved omission is structural: an empty retrieval leg
+        # carries no relevance scale, even if a caller stamped one.
         if self.retrieved and self.score_scale is not None:
             payload["score_scale"] = self.score_scale
-            if self.score_scale == "rerank" and self.reranker is not None:
+            if self.reranker is not None:
                 payload["reranker"] = self.reranker
         return payload
 

--- a/packages/memtomem/src/memtomem/server/tools/pinned.py
+++ b/packages/memtomem/src/memtomem/server/tools/pinned.py
@@ -122,6 +122,11 @@ async def mem_context_compose(
             the cross-encoder rerank stage — the fast path for latency-bounded
             callers. Omitted/``true`` = follow server config (``rerank.enabled``);
             ``true`` cannot enable reranking when the server has it disabled.
+
+    The bundle names the retrieval leg's score scale at the top level
+    (``score_scale``: ``rrf``/``bm25``/``dense``/``none``/``rerank``, plus
+    ``reranker`` with the model ID when reranked); both keys are omitted when
+    ``retrieved`` is empty. Pinned blocks carry no relevance scale.
     """
     app, store = await _store(ctx)
     bundle = await ContextAssembler(store, app.search_pipeline).compose(

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -764,7 +764,7 @@ async def mem_version(
             "version": __version__,
             "capabilities": {
                 "search_formats": ["compact", "verbose", "structured"],
-                "context_compose": {"schema_version": 3},
+                "context_compose": {"schema_version": 4},
                 "candidate_propose": {"schema_version": 1},
                 "runtime_profile": {"schema_version": 1},
             },

--- a/packages/memtomem/tests/test_meta_tool.py
+++ b/packages/memtomem/tests/test_meta_tool.py
@@ -241,7 +241,7 @@ class TestMemVersion:
     async def test_capabilities_stm_bridge(self):
         parsed = json.loads(await mem_version())
         capabilities = parsed["capabilities"]
-        assert capabilities["context_compose"] == {"schema_version": 3}
+        assert capabilities["context_compose"] == {"schema_version": 4}
         assert capabilities["candidate_propose"] == {"schema_version": 1}
         assert "context_compose" in ACTIONS
         assert "candidate_propose" in ACTIONS

--- a/packages/memtomem/tests/test_pinned_context.py
+++ b/packages/memtomem/tests/test_pinned_context.py
@@ -350,6 +350,21 @@ def test_context_bundle_as_dict_enforces_empty_retrieved_omission():
     assert "reranker" not in payload
 
 
+def test_context_bundle_as_dict_ties_reranker_to_rerank_scale():
+    # reranker accompanies the "rerank" scale only; a directly constructed
+    # bundle with an inconsistent pair serializes without the reranker key.
+    retrieved = ({"id": "c1", "content": "x", "source": "m.md", "namespace": "d", "score": 0.5},)
+    inconsistent = ContextBundle((), retrieved, 10, 5, (), (), "rrf", "model-x")
+    payload = inconsistent.as_dict()
+    assert payload["score_scale"] == "rrf"
+    assert "reranker" not in payload
+
+    consistent = ContextBundle((), retrieved, 10, 5, (), (), "rerank", "model-x")
+    payload = consistent.as_dict()
+    assert payload["score_scale"] == "rerank"
+    assert payload["reranker"] == "model-x"
+
+
 def test_context_bundle_annotations_resolve_at_runtime():
     # ScoreScale must be importable at runtime, not TYPE_CHECKING-only —
     # reflection-based consumers introspect this public payload dataclass.

--- a/packages/memtomem/tests/test_pinned_context.py
+++ b/packages/memtomem/tests/test_pinned_context.py
@@ -8,7 +8,8 @@ from types import SimpleNamespace
 import pytest
 
 from memtomem.config import Mem2MemConfig
-from memtomem.pinned import ContextAssembler, PinnedContextStore
+from memtomem.pinned import ContextAssembler, ContextBundle, PinnedContextStore
+from memtomem.search.pipeline import RetrievalStats
 
 
 @pytest.fixture
@@ -88,7 +89,7 @@ async def test_compose_pinned_first_then_retrieval(pinned_store):
             assert kwargs["namespace"] == ["work", "shared"]
             assert kwargs["context_window"] == 2
             assert kwargs["exclude_source_roots"] == pinned_store.search_exclusion_roots()
-            return [result], None
+            return [result], RetrievalStats(score_scale="rrf")
 
     bundle = await ContextAssembler(pinned_store, Pipeline()).compose(
         "deployment", namespace=["work", "shared"], context_window=2
@@ -126,7 +127,7 @@ async def test_compose_schema_three_budgets_neighbors_and_preserves_source_order
 
     class Pipeline:
         async def search(self, **kwargs):
-            return [result], None
+            return [result], RetrievalStats(score_scale="rrf")
 
     bundle = await ContextAssembler(pinned_store, Pipeline()).compose(
         "deployment", max_chars=11, context_window=2
@@ -169,7 +170,7 @@ async def test_compose_schema_three_keeps_hit_when_neighbors_exceed_budget(pinne
 
     class Pipeline:
         async def search(self, **kwargs):
-            return [result], None
+            return [result], RetrievalStats(score_scale="rrf")
 
     bundle = await ContextAssembler(pinned_store, Pipeline()).compose(
         "deployment", max_chars=3, context_window=1
@@ -224,7 +225,7 @@ async def test_compose_schema_three_preserves_hits_and_deduplicates_context(pinn
 
     class Pipeline:
         async def search(self, **kwargs):
-            return results, None
+            return results, RetrievalStats(score_scale="rrf")
 
     bundle = await ContextAssembler(pinned_store, Pipeline()).compose(
         "deployment", max_chars=10, context_window=2
@@ -253,7 +254,7 @@ async def test_mem_context_compose_tool_threads_schema_three_scope(monkeypatch, 
             assert kwargs["namespace"] == "work"
             assert kwargs["context_window"] == 1
             assert kwargs["exclude_source_roots"] == pinned_store.search_exclusion_roots()
-            return [result], None
+            return [result], RetrievalStats(score_scale="rrf")
 
     app = SimpleNamespace(search_pipeline=Pipeline())
 
@@ -271,6 +272,85 @@ async def test_mem_context_compose_tool_threads_schema_three_scope(monkeypatch, 
 
     assert payload["pinned"][0]["content"] == "always visible"
     assert payload["retrieved"][0]["namespace"] == "work"
+    assert payload["score_scale"] == "rrf"
+    assert "reranker" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Top-level score_scale / reranker on the compose bundle (#1791)
+# ---------------------------------------------------------------------------
+
+
+def _retrieval_result(chunk_id: str = "chunk-1", content: str = "retrieved memory"):
+    chunk = SimpleNamespace(
+        id=chunk_id,
+        content=content,
+        metadata=SimpleNamespace(source_file="memory.md", namespace="work"),
+    )
+    return SimpleNamespace(chunk=chunk, score=0.9)
+
+
+def _pipeline(results, stats):
+    class Pipeline:
+        async def search(self, **kwargs):
+            return results, stats
+
+    return Pipeline()
+
+
+@pytest.mark.asyncio
+async def test_compose_names_score_scale_top_level_not_per_item(pinned_store):
+    pinned_store.set("profile", "always visible", priority=1)
+    pipeline = _pipeline([_retrieval_result()], RetrievalStats(score_scale="rrf"))
+    payload = (await ContextAssembler(pinned_store, pipeline).compose("deployment")).as_dict()
+    assert payload["score_scale"] == "rrf"
+    assert "reranker" not in payload
+    assert "score_scale" not in payload["retrieved"][0]
+    assert "score_scale" not in payload["pinned"][0]
+
+
+@pytest.mark.asyncio
+async def test_compose_rerank_scale_carries_reranker_model(pinned_store):
+    stats = RetrievalStats(score_scale="rerank", reranker_model="test-reranker-v1")
+    pipeline = _pipeline([_retrieval_result()], stats)
+    payload = (await ContextAssembler(pinned_store, pipeline).compose("deployment")).as_dict()
+    assert payload["score_scale"] == "rerank"
+    assert payload["reranker"] == "test-reranker-v1"
+
+
+@pytest.mark.asyncio
+async def test_compose_omits_scale_without_query(pinned_store):
+    pinned_store.set("profile", "always visible", priority=1)
+    pipeline = _pipeline([_retrieval_result()], RetrievalStats(score_scale="rrf"))
+    payload = (await ContextAssembler(pinned_store, pipeline).compose()).as_dict()
+    assert "score_scale" not in payload
+    assert "reranker" not in payload
+
+
+@pytest.mark.asyncio
+async def test_compose_omits_scale_when_budget_empties_retrieved(pinned_store):
+    pinned_store.set("profile", "x" * 100, priority=1)
+    stats = RetrievalStats(score_scale="rerank", reranker_model="test-reranker-v1")
+    pipeline = _pipeline([_retrieval_result(content="y" * 500)], stats)
+    payload = (
+        await ContextAssembler(pinned_store, pipeline).compose("deployment", max_chars=120)
+    ).as_dict()
+    assert payload["retrieved"] == []
+    assert "score_scale" not in payload
+    assert "reranker" not in payload
+
+
+def test_context_bundle_positional_construction_predates_scale_fields():
+    # The scale fields sit after every pre-#1791 field, so legacy positional
+    # construction keeps its meaning and the new fields default to omitted.
+    bundle = ContextBundle((), (), 10, 5, ("omitted-id",), ("warned",))
+    assert bundle.omitted_block_ids == ("omitted-id",)
+    assert bundle.warnings == ("warned",)
+    assert bundle.score_scale is None
+    assert bundle.reranker is None
+    payload = bundle.as_dict()
+    assert "score_scale" not in payload
+    assert "reranker" not in payload
 
 
 def test_delete_is_exact_and_confirmed_for_shared(pinned_store):

--- a/packages/memtomem/tests/test_pinned_context.py
+++ b/packages/memtomem/tests/test_pinned_context.py
@@ -350,14 +350,15 @@ def test_context_bundle_as_dict_enforces_empty_retrieved_omission():
     assert "reranker" not in payload
 
 
-def test_context_bundle_as_dict_ties_reranker_to_rerank_scale():
-    # reranker accompanies the "rerank" scale only; a directly constructed
-    # bundle with an inconsistent pair serializes without the reranker key.
+def test_context_bundle_rejects_inconsistent_scale_model_pairs():
+    # The scale/model pair invariant holds at construction: a reranker id
+    # only accompanies the "rerank" scale, and vice versa — inconsistent
+    # direct construction is a caller bug, rejected loudly.
     retrieved = ({"id": "c1", "content": "x", "source": "m.md", "namespace": "d", "score": 0.5},)
-    inconsistent = ContextBundle((), retrieved, 10, 5, (), (), "rrf", "model-x")
-    payload = inconsistent.as_dict()
-    assert payload["score_scale"] == "rrf"
-    assert "reranker" not in payload
+    with pytest.raises(ValueError, match="requires score_scale"):
+        ContextBundle((), retrieved, 10, 5, (), (), "rrf", "model-x")
+    with pytest.raises(ValueError, match="requires a reranker"):
+        ContextBundle((), retrieved, 10, 5, (), (), "rerank", None)
 
     consistent = ContextBundle((), retrieved, 10, 5, (), (), "rerank", "model-x")
     payload = consistent.as_dict()

--- a/packages/memtomem/tests/test_pinned_context.py
+++ b/packages/memtomem/tests/test_pinned_context.py
@@ -340,6 +340,26 @@ async def test_compose_omits_scale_when_budget_empties_retrieved(pinned_store):
     assert "reranker" not in payload
 
 
+def test_context_bundle_as_dict_enforces_empty_retrieved_omission():
+    # The omission contract must hold structurally, not only via compose():
+    # a directly constructed bundle with an empty retrieval leg serializes
+    # without scale keys even when the fields are stamped.
+    bundle = ContextBundle((), (), 10, 5, (), (), "rerank", "model-x")
+    payload = bundle.as_dict()
+    assert "score_scale" not in payload
+    assert "reranker" not in payload
+
+
+def test_context_bundle_annotations_resolve_at_runtime():
+    # ScoreScale must be importable at runtime, not TYPE_CHECKING-only —
+    # reflection-based consumers introspect this public payload dataclass.
+    import typing
+
+    hints = typing.get_type_hints(ContextBundle)
+    assert "score_scale" in hints
+    assert "reranker" in hints
+
+
 def test_context_bundle_positional_construction_predates_scale_fields():
     # The scale fields sit after every pre-#1791 field, so legacy positional
     # construction keeps its meaning and the new fields default to omitted.


### PR DESCRIPTION
## Summary

#1781 added top-level `score_scale` + `reranker` to `mem_search` /
`mem_agent_search` structured payloads (closing #1767), but `context_compose`
— the surface memtomem-stm prefers whenever the negotiated schema is >= 2 —
still emitted bare `score`s. The consumer most likely to be scale-sensitive
was blind on its primary path while the fallback path reported the scale.

Mirror the fields additively on the composed bundle:

- **No new derivation.** Compose already calls the same `SearchPipeline.search()`
  and received the `RetrievalStats` carrying `score_scale` / `reranker_model`
  (all five labels and the results-derived `"rerank"` rule established by
  #1781) — it just discarded the tuple element. Thread it into `ContextBundle`.
- **Top-level placement**, matching the issue: `score_scale` plus `reranker`
  (rerank model id) on the bundle envelope; `retrieved` items and `pinned`
  blocks are untouched — pinned blocks carry no relevance scale.
- **Omission rule**: both keys are omitted when the final post-budget
  `retrieved` list is empty (budget truncation can empty it even when the
  pipeline returned hits; a query-less compose has no retrieval leg at all).
  Enforced structurally in `as_dict()`, not only on the assembler path.
- **Pair invariant at construction**: `ContextBundle.__post_init__` rejects
  inconsistent direct construction loudly in both directions (`reranker`
  without the `"rerank"` scale, `"rerank"` scale without a model id) —
  mirroring the invariant `RetrievalStats` already guarantees on the
  pipeline path.
- **`context_compose` capability bumps to `schema_version: 4`** (schemas 2/3
  stay immutable released contracts). Because the keys are omitted for empty
  results, clients cannot distinguish "server too old" from "no results" by
  key presence — the advertised version is the discovery mechanism, same
  rationale as the 2→3 bump (#1747). Both compose surfaces (MCP
  `mem_context_compose`, `mm pinned compose`) share `ContextBundle.as_dict()`,
  so one emission site covers both.
- `ScoreScale` is imported at runtime (not `TYPE_CHECKING`) so
  `typing.get_type_hints(ContextBundle)` resolves for reflection-based
  consumers; measured cold-import parity with `pinned.py`'s existing deps and
  no cycle, so no new types module.

No ranking or default changes; additive fields only.

## Review

Four `codex` gates. Design gate (report-only, pre-implementation): **SHIP** —
with the field-ordering nit (scale fields appended after every pre-existing
field so legacy positional construction keeps its meaning; regression-tested)
and the docs nit (preserve the schema 2→3 ladder, add 4 as a new rung) folded
in. Diff review round 1: NEEDS-FIX — `TYPE_CHECKING`-only `ScoreScale` broke
`get_type_hints(ContextBundle)`, and `as_dict()` didn't enforce the
empty-retrieved omission on direct construction. Round 2 (full re-gate):
NEEDS-FIX — a stamped `reranker` escaped with non-rerank scales. Round 3
(full re-gate): NEEDS-FIX — the inverse pair (`"rerank"` scale without a
model id) → superseded serialization-side normalization with the
`__post_init__` invariant; a second finding (tolerate `stats=None` via
`getattr`) was **declined**: `SearchPipeline.search()` types the stats as
non-Optional, `(results, None)` was never a valid pipeline contract (only
lazy test doubles, upgraded to real `RetrievalStats` per the design gate).
Round 4 (full re-gate, decline rationale re-examined): **SHIP**, zero
findings — "schema-4 metadata is correctly propagated, validated, documented,
and negotiated; the `stats=None` decline is sound."

## Testing

- `uv run pytest -m "not ollama"` — full suite, 8790 passed (run again after
  the `__post_init__` behavior change).
- New cases in `test_pinned_context.py`: top-level emission (not per-item,
  not on pinned), rerank scale + model id, omission without a query, omission
  when budget truncation empties `retrieved`, structural omission and
  inconsistent-pair rejection on direct construction, runtime-resolvable
  annotations, and legacy positional-construction compatibility. Existing
  compose fakes upgraded from `(results, None)` to real `RetrievalStats`.
- `test_meta_tool.py` capability pin updated to `schema_version: 4`.
- Real-flow smoke on an isolated worktree + isolated `HOME` (fresh index,
  `mm pinned set`, `mm pinned compose`): query compose emits top-level
  `"score_scale": "rrf"` with no per-item/pinned leakage and no stray
  `reranker`; query-less compose omits both keys. Re-run at the final HEAD.

## Follow-up (separate repo, not this PR)

memtomem-stm consumption for its threshold-mismatch diagnostic
(memtomem-stm#727): the design gate enumerated STM's hard-coded schema-3
ceilings to lift when it adopts schema 4 — daemon adapter defaults
(`surfacing/daemon_adapter.py:67`, `:84`), the daemon server clamp
(`daemon/server.py:635`), and `ContextComposeResult` lacking scale fields
(`surfacing/mcp_client.py:89`).

Closes #1791

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
