### PR TITLE
docs(changelog): record the named score scale in structured search output (#1767)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **Named score scale in structured search output** (#1767) — `mem_search`
+  and `mem_agent_search` structured payloads now carry a top-level
+  `score_scale` (`rrf` / `bm25` / `dense` / `none` / `rerank`) plus `reranker`
+  (the rerank model id) so consumers can calibrate a `score` threshold instead
+  of inferring the scale from value ranges; the label is derived from the
+  returned results, so a reranker that silently falls back to fused order stays
+  truthful. `mm search --format json` carries the fields per item (its payload
+  is a bare list). Both omitted when empty; boosts (decay / access / importance,
+  all default-off) multiply on top of the named base scale.
 - **Context Compose schema 4** (#1791) — the composed bundle now names the
   retrieval leg's score scale at the top level (`score_scale`: `rrf` / `bm25`
   / `dense` / `none` / `rerank`, plus `reranker` with the model id when


### PR DESCRIPTION
## Summary

#1781 shipped the top-level `score_scale` / `reranker` fields on `mem_search`
and `mem_agent_search` structured payloads (per-item on `mm search --format
json`), closing #1767, but landed without a `CHANGELOG.md` entry. This
backfills it under `[Unreleased] → Added` so the release notes reflect the
search-output contract change.

Docs-only; verified the wording against the merged behavior (label vocabulary
`rrf`/`bm25`/`dense`/`none`/`rerank`, results-derived rerank label, per-item
CLI JSON, omitted-when-empty rule, boosts multiplying on top of the base
scale).

## Note

The follow-up that mirrors these fields onto `context_compose` (#1791) is in
PR #1796 and carries its own CHANGELOG entry; this PR only fills the gap left
by the original `mem_search` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>