### PR TITLE
feat(search): persist durable Quality Lab observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   #1781. Both keys are omitted when `retrieved` is empty, so clients should
   gate on the advertised `context_compose` schema version, not key presence.
   Schemas 2 and 3 remain immutable released contracts.
+
+- **Durable local search-run observations (Quality Lab foundation)** — ranked
+  searches now persist a unique `query_run_id`, retrieval profile, latency,
+  cache/degradation state, and a content-free result snapshot in SQLite. MCP
+  structured output and the Web search API expose the ID only after the local
+  commit succeeds; cache hits get distinct IDs, zero-result ranked searches are
+  recorded, filter-only browsing is excluded, and persistence failure never
+  interrupts search. Snapshots omit result content and absolute source paths;
+  existing query-history retention and CLI JSON output remain unchanged.
+  (#1799)
+
 - **Per-call rerank bypass** (#1766) — `mem_search` and `mem_context_compose`
   accept `rerank=false` (CLI: `mm search --no-rerank`, `mm pinned compose
   --no-rerank`) to skip the cross-encoder rerank stage and its candidate-pool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 - **Durable local search-run observations (Quality Lab foundation)** — ranked
   searches now persist a unique `query_run_id`, retrieval profile, latency,
-  cache/degradation state, and a content-free result snapshot in SQLite. MCP
+  cache/degradation state, and a content-minimized result snapshot in SQLite. MCP
   structured output and the Web search API expose the ID only after the local
   commit succeeds; cache hits get distinct IDs, zero-result ranked searches are
   recorded, filter-only browsing is excluded, and persistence failure never

--- a/docs/guides/reference/core-memory-tools.md
+++ b/docs/guides/reference/core-memory-tools.md
@@ -227,6 +227,19 @@ mem_search(query="deploy pipeline", as_of="2025-Q3")    # historical query
 > are no results. `mm search --format json` carries the same values as
 > per-item `score_scale` / `reranker` keys.
 
+> **Quality Lab run ID**: every ranked search persisted by the local SQLite
+> backend receives a durable `query_run_id`. MCP structured output and the Web
+> search API expose it only after the observation commit succeeds, so it can be
+> used to attach later feedback without guessing which invocation produced a
+> result set. Cache hits receive distinct IDs. Filter-only browsing does not
+> create an observation, and an observation write failure never fails search.
+> The local snapshot stores ranks, scores, chunk IDs, content hashes, heading
+> hierarchy, namespaces, languages, and source **basenames**—not result content
+> or absolute paths. Existing query history still records the query text and is
+> pruned by the existing 90-day history policy. `mm search --format json` keeps
+> its current per-result schema; use MCP structured output or the Web API when
+> the run ID is needed.
+
 ### Tuning search weights
 
 Use `bm25_weight` and `dense_weight` to shift between keyword and semantic matching:

--- a/packages/memtomem/src/memtomem/cli/search.py
+++ b/packages/memtomem/src/memtomem/cli/search.py
@@ -134,6 +134,7 @@ async def _search(
             scope=scope,
             project_context_root=project_context_root,
             rerank=rerank,
+            origin="cli",
         )
 
     if not results and fmt in ("table", "plain"):

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -398,8 +398,22 @@ class SearchPipeline:
         Alternate storage backends that only implement legacy query history
         keep the old fire-and-forget behavior and receive no public run ID.
         """
-        saver = getattr(type(self._storage), "save_search_observation", None)
+        # Avoid ``getattr(instance, ...)`` as the capability probe: dynamic
+        # mocks/proxies may fabricate any attribute. A real class method or an
+        # explicitly attached instance method counts as support, and the same
+        # bound callable is then used for dispatch.
+        class_saver = getattr(type(self._storage), "save_search_observation", None)
+        instance_has_saver = "save_search_observation" in vars(self._storage)
+        saver = (
+            getattr(self._storage, "save_search_observation")
+            if class_saver is not None or instance_has_saver
+            else None
+        )
         if saver is None:
+            # Preserve the pre-Quality-Lab contract for alternate backends:
+            # cache hits returned before scheduling legacy history writes.
+            if stats.cache_hit:
+                return None
 
             async def _save_legacy_history() -> None:
                 await self._storage.save_query_history(
@@ -482,7 +496,7 @@ class SearchPipeline:
         ]
         run_id = str(uuid4())
         try:
-            return await getattr(self._storage, "save_search_observation")(
+            return await saver(
                 query,
                 query_embedding,
                 [str(result.chunk.id) for result in results[:top_k]],

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -37,7 +37,10 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
+import json
 import logging
+import time
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from fnmatch import fnmatch
@@ -47,7 +50,7 @@ from typing import TYPE_CHECKING, Literal
 from dataclasses import dataclass
 
 from dataclasses import replace as dataclass_replace
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from memtomem.config import (
     MAX_CONTEXT_WINDOW_CHUNKS,
@@ -316,6 +319,12 @@ class RetrievalStats:
     # logits, Cohere emits [0, 1] relevance), so clients calibrating a
     # threshold need the model, not just the scale family.
     reranker_model: str | None = None
+    # Quality Lab observation envelope. ``query_run_id`` is present only when
+    # the local history commit succeeded; search availability never depends on
+    # observation persistence.
+    query_run_id: str | None = None
+    cache_hit: bool = False
+    latency_ms: float | None = None
 
 
 if TYPE_CHECKING:
@@ -366,6 +375,125 @@ class SearchPipeline:
 
         # LLM query expansion cache (cleared on invalidate_cache)
         self._expansion_cache: dict[str, str] = {}
+
+    async def _record_ranked_search(
+        self,
+        *,
+        query: str,
+        query_embedding: list[float],
+        results: list[SearchResult],
+        stats: RetrievalStats,
+        top_k: int,
+        origin: str,
+        namespace: str | list[str] | None,
+        scope: str | list[str] | None,
+        source_filter: str | None,
+        tag_filter: str | None,
+        metadata_filter: SearchMetadataFilter | None,
+        as_of_unix: int | None,
+        rrf_weights: list[float],
+    ) -> str | None:
+        """Persist a content-minimized ranked-search observation when supported.
+
+        Alternate storage backends that only implement legacy query history
+        keep the old fire-and-forget behavior and receive no public run ID.
+        """
+        saver = getattr(type(self._storage), "save_search_observation", None)
+        if saver is None:
+
+            async def _save_legacy_history() -> None:
+                await self._storage.save_query_history(
+                    query,
+                    query_embedding,
+                    [str(result.chunk.id) for result in results[:top_k]],
+                    [result.score for result in results[:top_k]],
+                )
+
+            task = asyncio.create_task(_save_legacy_history())
+            task.add_done_callback(_bg_task_error_cb)
+            self._bg_tasks.add(task)
+            task.add_done_callback(self._bg_tasks.discard)
+            return None
+
+        normalized_origin = (
+            origin
+            if origin in {"web", "cli", "mcp", "shell", "langgraph", "internal"}
+            else "internal"
+        )
+        if any("\uac00" <= char <= "\ud7a3" for char in query):
+            query_language = "ko"
+        elif any(char.isascii() and char.isalpha() for char in query):
+            query_language = "en"
+        else:
+            query_language = "other"
+
+        profile: dict[str, object] = {
+            "bm25_enabled": self._config.enable_bm25,
+            "dense_enabled": self._config.enable_dense,
+            "bm25_candidates": self._config.bm25_candidates,
+            "dense_candidates": self._config.dense_candidates,
+            "rrf_weights": list(rrf_weights),
+            "embedding_provider": type(self._embedder).__name__,
+            "embedding_model": getattr(self._embedder, "model_name", None),
+            "embedding_dimension": self._embedder.dimension,
+            "rerank_applied": stats.rerank_applied,
+            "reranker": stats.reranker_model,
+        }
+        canonical_profile = json.dumps(
+            profile, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        )
+        observation: dict[str, object] = {
+            "origin": normalized_origin,
+            "purpose": "search",
+            "query_language": query_language,
+            "top_k": top_k,
+            "filters": {
+                "namespace": namespace,
+                "scope": scope,
+                "has_source_filter": source_filter is not None,
+                "has_tag_filter": tag_filter is not None,
+                "has_metadata_filter": metadata_filter is not None,
+                "has_as_of": as_of_unix is not None,
+            },
+            "cache_hit": stats.cache_hit,
+            "latency_ms": stats.latency_ms,
+            "score_scale": stats.score_scale,
+            "reranker": stats.reranker_model,
+            "bm25_candidates": stats.bm25_candidates,
+            "dense_candidates": stats.dense_candidates,
+            "final_total": stats.final_total,
+            "bm25_degraded": stats.bm25_error is not None,
+            "dense_degraded": stats.dense_error is not None,
+            "profile_id": hashlib.sha256(canonical_profile.encode()).hexdigest(),
+            "profile": profile,
+        }
+        result_snapshot = [
+            {
+                "chunk_id": str(result.chunk.id),
+                "rank": result.rank,
+                "score": result.score,
+                "source_name": result.chunk.metadata.source_file.name,
+                "content_hash": result.chunk.content_hash,
+                "heading_hierarchy": list(result.chunk.metadata.heading_hierarchy),
+                "namespace": result.chunk.metadata.namespace,
+                "language": result.chunk.metadata.language,
+            }
+            for result in results[:top_k]
+        ]
+        run_id = str(uuid4())
+        try:
+            return await getattr(self._storage, "save_search_observation")(
+                query,
+                query_embedding,
+                [str(result.chunk.id) for result in results[:top_k]],
+                [result.score for result in results[:top_k]],
+                run_id=run_id,
+                observation=observation,
+                result_snapshot=result_snapshot,
+            )
+        except Exception:
+            logger.debug("search observation persistence failed", exc_info=True)
+            return None
 
     @property
     def rerank_active(self) -> bool:
@@ -882,6 +1010,7 @@ class SearchPipeline:
         created_before: datetime | None = None,
         exclude_source_roots: tuple[Path, ...] | None = None,
         rerank: bool | None = None,
+        origin: str = "internal",
     ) -> tuple[list[SearchResult], RetrievalStats]:
         # ``rerank`` (#1766): None = follow server config; False = skip the
         # Stage 3b cross-encoder and collapse the candidate pool to top_k
@@ -928,8 +1057,10 @@ class SearchPipeline:
                 exclude_source_roots=normalized_exclusion_roots,
             )
 
+        original_query = query
         top_k = self._config.default_top_k if top_k is None else top_k
         effective_weights = rrf_weights or self._config.rrf_weights
+        started_at = time.perf_counter()
 
         # Lease the reranker generation for the whole ranked-search body
         # (#1777): hot reload retires (and eventually closes) these while a
@@ -940,8 +1071,6 @@ class SearchPipeline:
             apply_rerank = reranker is not None and rerank_cfg is not None and rerank is not False
 
             # Check TTL cache for identical queries
-            import time
-
             # ``as_of_unix`` is intentionally excluded from ``cache_key`` and
             # bypasses the cache entirely when explicit. Default-path (None)
             # callers fall through to ``int(time.time())`` below and reuse
@@ -968,7 +1097,28 @@ class SearchPipeline:
             if as_of_unix is None and cache_key in self._search_cache:
                 ts, ver, cached_results, cached_stats = self._search_cache[cache_key]
                 if ver == self._cache_version and time.time() - ts < ttl_snapshot:
-                    return cached_results, cached_stats
+                    run_stats = dataclass_replace(
+                        cached_stats,
+                        query_run_id=None,
+                        cache_hit=True,
+                        latency_ms=round((time.perf_counter() - started_at) * 1000, 3),
+                    )
+                    run_stats.query_run_id = await self._record_ranked_search(
+                        query=original_query,
+                        query_embedding=[],
+                        results=cached_results,
+                        stats=run_stats,
+                        top_k=top_k,
+                        origin=origin,
+                        namespace=namespace,
+                        scope=scope,
+                        source_filter=source_filter,
+                        tag_filter=tag_filter,
+                        metadata_filter=metadata_filter,
+                        as_of_unix=as_of_unix,
+                        rrf_weights=effective_weights,
+                    )
+                    return cached_results, run_stats
                 self._search_cache.pop(cache_key, None)
 
             bm25_k = max(self._config.bm25_candidates, top_k)
@@ -1364,20 +1514,22 @@ class SearchPipeline:
                 self._bg_tasks.add(t)
                 t.add_done_callback(self._bg_tasks.discard)
 
-            # Save to query history (fire-and-forget)
-            async def _save_history():
-                emb = query_embedding if use_dense else []
-                await self._storage.save_query_history(
-                    query,
-                    emb,
-                    [str(r.chunk.id) for r in fused[:top_k]],
-                    [r.score for r in fused[:top_k]],
-                )
-
-            t2 = asyncio.create_task(_save_history())
-            t2.add_done_callback(_bg_task_error_cb)
-            self._bg_tasks.add(t2)
-            t2.add_done_callback(self._bg_tasks.discard)
+            stats.latency_ms = round((time.perf_counter() - started_at) * 1000, 3)
+            stats.query_run_id = await self._record_ranked_search(
+                query=original_query,
+                query_embedding=query_embedding if use_dense else [],
+                results=fused,
+                stats=stats,
+                top_k=top_k,
+                origin=origin,
+                namespace=namespace,
+                scope=scope,
+                source_filter=source_filter,
+                tag_filter=tag_filter,
+                metadata_filter=metadata_filter,
+                as_of_unix=as_of_unix,
+                rrf_weights=effective_weights,
+            )
 
             # Store in TTL cache only if version hasn't changed during search.
             # Skip the write when ``as_of_unix`` was explicit so that a
@@ -1385,7 +1537,15 @@ class SearchPipeline:
             # (next default caller would otherwise be served a past-snapshot
             # filtering of the same query).
             if as_of_unix is None and self._cache_version == version_at_start:
-                self._search_cache[cache_key] = (time.time(), version_at_start, fused, stats)
+                cache_stats = dataclass_replace(
+                    stats, query_run_id=None, cache_hit=False, latency_ms=None
+                )
+                self._search_cache[cache_key] = (
+                    time.time(),
+                    version_at_start,
+                    fused,
+                    cache_stats,
+                )
                 # Evict old entries (keep max 50)
                 if len(self._search_cache) > 50:
                     try:

--- a/packages/memtomem/src/memtomem/server/formatters.py
+++ b/packages/memtomem/src/memtomem/server/formatters.py
@@ -121,6 +121,7 @@ def _format_structured_results(
     hints: list[str] | None = None,
     score_scale: str | None = None,
     reranker: str | None = None,
+    query_run_id: str | None = None,
 ) -> str:
     """JSON structured format for machine consumption.
 
@@ -166,6 +167,8 @@ def _format_structured_results(
         payload["score_scale"] = score_scale
     if reranker is not None:
         payload["reranker"] = reranker
+    if query_run_id is not None:
+        payload["query_run_id"] = query_run_id
     if hints:
         payload["hints"] = list(hints)
     return json.dumps(payload, ensure_ascii=False)

--- a/packages/memtomem/src/memtomem/server/tools/search.py
+++ b/packages/memtomem/src/memtomem/server/tools/search.py
@@ -206,6 +206,7 @@ async def mem_search(
         scope=scope,
         project_context_root=project_context_root,
         rerank=rerank,
+        origin="mcp",
     )
 
     # Build trust-UX hints shared across formats: archive filter count and a
@@ -252,7 +253,9 @@ async def mem_search(
 
         if effective_format == "structured":
             all_hints = hints + empty_hints
-            return _format_structured_results([], hints=all_hints or None)
+            return _format_structured_results(
+                [], hints=all_hints or None, query_run_id=stats.query_run_id
+            )
 
         if (source_filter or tag_filter) and stats.fused_total > 0:
             return (
@@ -281,6 +284,7 @@ async def mem_search(
             hints=hints or None,
             score_scale=stats.score_scale,
             reranker=stats.reranker_model,
+            query_run_id=stats.query_run_id,
         )
     else:
         is_verbose = effective_format == "verbose"

--- a/packages/memtomem/src/memtomem/server/tools/search_history.py
+++ b/packages/memtomem/src/memtomem/server/tools/search_history.py
@@ -32,7 +32,10 @@ async def mem_search_history(
     lines = [f"Search History ({len(rows)} queries):"]
     for r in rows:
         result_count = len(r.get("result_chunk_ids", []))
-        lines.append(f'  [{r["created_at"]}] "{r["query_text"]}" -> {result_count} results')
+        run_suffix = f" run={r['run_id']}" if r.get("run_id") else ""
+        lines.append(
+            f'  [{r["created_at"]}]{run_suffix} "{r["query_text"]}" -> {result_count} results'
+        )
     return "\n".join(lines)
 
 

--- a/packages/memtomem/src/memtomem/storage/mixins/history.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/history.py
@@ -107,7 +107,7 @@ class HistoryMixin:
         if since:
             query += " WHERE created_at >= ?"
             params.append(since)
-        query += " ORDER BY created_at DESC LIMIT ?"
+        query += " ORDER BY created_at DESC, id DESC LIMIT ?"
         params.append(limit)
         rows = db.execute(query, params).fetchall()
         return [

--- a/packages/memtomem/src/memtomem/storage/mixins/history.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/history.py
@@ -40,6 +40,50 @@ class HistoryMixin:
         if self._history_save_count % self._HISTORY_PRUNE_INTERVAL == 0:
             self._prune_old_history()
 
+    async def save_search_observation(
+        self,
+        query_text: str,
+        query_embedding: list[float],
+        result_chunk_ids: list[str],
+        result_scores: list[float],
+        *,
+        run_id: str,
+        observation: dict,
+        result_snapshot: list[dict],
+    ) -> str:
+        """Persist one ranked-search invocation and return its durable run ID.
+
+        This is intentionally separate from ``save_query_history`` so storage
+        backends that only implement the legacy history contract remain usable.
+        The pipeline advertises a run ID only after this local commit succeeds.
+        """
+        db = self._get_db()
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        emb_blob = (
+            struct.pack(f"{len(query_embedding)}f", *query_embedding) if query_embedding else b""
+        )
+        db.execute(
+            """INSERT INTO query_history
+               (query_text, query_embedding, result_chunk_ids, result_scores,
+                run_id, observation_json, result_snapshot_json, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                query_text,
+                emb_blob,
+                json.dumps(result_chunk_ids),
+                json.dumps(result_scores),
+                run_id,
+                json.dumps(observation, ensure_ascii=False, sort_keys=True),
+                json.dumps(result_snapshot, ensure_ascii=False),
+                now,
+            ),
+        )
+        db.commit()
+        self._history_save_count += 1
+        if self._history_save_count % self._HISTORY_PRUNE_INTERVAL == 0:
+            self._prune_old_history()
+        return run_id
+
     def _prune_old_history(self) -> None:
         """Delete query history rows older than _HISTORY_MAX_AGE_DAYS."""
         cutoff = (
@@ -55,7 +99,10 @@ class HistoryMixin:
 
     async def get_query_history(self, limit: int = 20, since: str | None = None) -> list[dict]:
         db = self._get_db()
-        query = "SELECT query_text, result_chunk_ids, result_scores, created_at FROM query_history"
+        query = (
+            "SELECT query_text, result_chunk_ids, result_scores, created_at, "
+            "run_id, observation_json, result_snapshot_json FROM query_history"
+        )
         params: list = []
         if since:
             query += " WHERE created_at >= ?"
@@ -69,6 +116,9 @@ class HistoryMixin:
                 "result_chunk_ids": json.loads(r[1]) if r[1] else [],
                 "result_scores": json.loads(r[2]) if r[2] else [],
                 "created_at": r[3],
+                "run_id": r[4],
+                "observation": json.loads(r[5]) if r[5] else {},
+                "result_snapshot": json.loads(r[6]) if r[6] else [],
             }
             for r in rows
         ]

--- a/packages/memtomem/src/memtomem/storage/sqlite_schema.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_schema.py
@@ -405,10 +405,29 @@ def create_tables(
             query_embedding BLOB NOT NULL,
             result_chunk_ids TEXT NOT NULL,
             result_scores TEXT NOT NULL,
+            run_id TEXT,
+            observation_json TEXT NOT NULL DEFAULT '{}',
+            result_snapshot_json TEXT NOT NULL DEFAULT '[]',
             created_at TEXT NOT NULL
         )
     """)
+    # Additive Quality Lab observation fields. Older 0.3.x binaries safely
+    # ignore these columns, so this does not require a schema-generation bump.
+    for col_sql in (
+        "ALTER TABLE query_history ADD COLUMN run_id TEXT",
+        "ALTER TABLE query_history ADD COLUMN observation_json TEXT NOT NULL DEFAULT '{}'",
+        "ALTER TABLE query_history ADD COLUMN result_snapshot_json TEXT NOT NULL DEFAULT '[]'",
+    ):
+        try:
+            db.execute(col_sql)
+        except sqlite3.OperationalError as e:
+            if "duplicate column" not in str(e).lower():
+                raise
     db.execute("CREATE INDEX IF NOT EXISTS idx_query_history_created ON query_history(created_at)")
+    db.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_query_history_run_id "
+        "ON query_history(run_id) WHERE run_id IS NOT NULL"
+    )
 
     db.execute("""
         CREATE TABLE IF NOT EXISTS namespace_metadata (

--- a/packages/memtomem/src/memtomem/storage/sqlite_schema.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_schema.py
@@ -413,16 +413,21 @@ def create_tables(
     """)
     # Additive Quality Lab observation fields. Older 0.3.x binaries safely
     # ignore these columns, so this does not require a schema-generation bump.
-    for col_sql in (
-        "ALTER TABLE query_history ADD COLUMN run_id TEXT",
-        "ALTER TABLE query_history ADD COLUMN observation_json TEXT NOT NULL DEFAULT '{}'",
-        "ALTER TABLE query_history ADD COLUMN result_snapshot_json TEXT NOT NULL DEFAULT '[]'",
-    ):
-        try:
+    existing_history_columns = {
+        row[1] for row in db.execute("PRAGMA table_info(query_history)").fetchall()
+    }
+    observation_columns = {
+        "run_id": "ALTER TABLE query_history ADD COLUMN run_id TEXT",
+        "observation_json": (
+            "ALTER TABLE query_history ADD COLUMN observation_json TEXT NOT NULL DEFAULT '{}'"
+        ),
+        "result_snapshot_json": (
+            "ALTER TABLE query_history ADD COLUMN result_snapshot_json TEXT NOT NULL DEFAULT '[]'"
+        ),
+    }
+    for column_name, col_sql in observation_columns.items():
+        if column_name not in existing_history_columns:
             db.execute(col_sql)
-        except sqlite3.OperationalError as e:
-            if "duplicate column" not in str(e).lower():
-                raise
     db.execute("CREATE INDEX IF NOT EXISTS idx_query_history_created ON query_history(created_at)")
     db.execute(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_query_history_run_id "

--- a/packages/memtomem/src/memtomem/web/routes/search.py
+++ b/packages/memtomem/src/memtomem/web/routes/search.py
@@ -81,6 +81,7 @@ async def search(
             namespace=namespace,
             context_window=context_window if context_window > 0 else None,
             project_context_root=project_context_root,
+            origin="web",
         )
     except Exception as exc:
         logger.error("Search failed: %s", exc, exc_info=True)
@@ -89,5 +90,6 @@ async def search(
     return SearchResponse(
         results=out,
         total=len(out),
+        query_run_id=rstats.query_run_id,
         retrieval_stats=RetrievalStatsOut(**vars(rstats)),
     )

--- a/packages/memtomem/src/memtomem/web/schemas/core.py
+++ b/packages/memtomem/src/memtomem/web/schemas/core.py
@@ -56,6 +56,9 @@ class RetrievalStatsOut(BaseModel):
     final_total: int = 0
     bm25_error: str | None = None
     dense_error: str | None = None
+    query_run_id: str | None = None
+    cache_hit: bool = False
+    latency_ms: float | None = None
 
 
 class DeleteResponse(BaseModel):

--- a/packages/memtomem/src/memtomem/web/schemas/search.py
+++ b/packages/memtomem/src/memtomem/web/schemas/search.py
@@ -10,6 +10,7 @@ from memtomem.web.schemas.core import SearchResultOut, RetrievalStatsOut
 class SearchResponse(BaseModel):
     results: list[SearchResultOut]
     total: int
+    query_run_id: str | None = None
     retrieval_stats: RetrievalStatsOut | None = None
 
 

--- a/packages/memtomem/tests/test_schema_version_guard.py
+++ b/packages/memtomem/tests/test_schema_version_guard.py
@@ -64,6 +64,39 @@ class TestDowngradeFence:
         finally:
             db.close()
 
+    def test_pre_observation_query_history_gets_additive_columns(self) -> None:
+        """Quality observation fields migrate without replacing legacy rows."""
+        db = _connect_with_vec()
+        try:
+            db.execute(
+                """CREATE TABLE query_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    query_text TEXT NOT NULL,
+                    query_embedding BLOB NOT NULL,
+                    result_chunk_ids TEXT NOT NULL,
+                    result_scores TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                )"""
+            )
+            db.execute(
+                "INSERT INTO query_history "
+                "(query_text, query_embedding, result_chunk_ids, result_scores, created_at) "
+                "VALUES ('legacy', X'', '[]', '[]', '2026-07-17T00:00:00+00:00')"
+            )
+
+            _create_tables(db)
+
+            columns = {row[1] for row in db.execute("PRAGMA table_info(query_history)")}
+            assert {"run_id", "observation_json", "result_snapshot_json"} <= columns
+            row = db.execute(
+                "SELECT query_text, run_id, observation_json, result_snapshot_json "
+                "FROM query_history"
+            ).fetchone()
+            assert row == ("legacy", None, "{}", "[]")
+            assert _stored_version(db) == str(SCHEMA_VERSION)
+        finally:
+            db.close()
+
     def test_pre_versioning_db_passes_and_gets_stamped(self) -> None:
         """Every existing install: meta table exists (legacy embedding keys)
         but has no ``schema_version`` row — must open and get stamped."""

--- a/packages/memtomem/tests/test_search_history.py
+++ b/packages/memtomem/tests/test_search_history.py
@@ -11,6 +11,31 @@ class TestSearchHistory:
         assert len(history) == 1
         assert history[0]["query_text"] == "test query"
         assert len(history[0]["result_chunk_ids"]) == 2
+        assert history[0]["run_id"] is None
+        assert history[0]["observation"] == {}
+        assert history[0]["result_snapshot"] == []
+
+    @pytest.mark.asyncio
+    async def test_save_search_observation_round_trip(self, storage):
+        run_id = "e38ab6c7-4db4-4d68-8dca-93c1da2dcfe6"
+        observation = {"origin": "mcp", "profile_id": "abc123", "cache_hit": False}
+        snapshot = [{"chunk_id": "id1", "rank": 1, "source_name": "note.md"}]
+
+        saved = await storage.save_search_observation(
+            "quality query",
+            [0.1, 0.2],
+            ["id1"],
+            [0.9],
+            run_id=run_id,
+            observation=observation,
+            result_snapshot=snapshot,
+        )
+        history = await storage.get_query_history(limit=1)
+
+        assert saved == run_id
+        assert history[0]["run_id"] == run_id
+        assert history[0]["observation"] == observation
+        assert history[0]["result_snapshot"] == snapshot
 
     @pytest.mark.asyncio
     async def test_empty_history(self, storage):

--- a/packages/memtomem/tests/test_search_history.py
+++ b/packages/memtomem/tests/test_search_history.py
@@ -49,8 +49,9 @@ class TestSearchHistory:
         await storage.save_query_history("query3", [], [], [])
         history = await storage.get_query_history(limit=2)
         assert len(history) == 2
-        # Most recent first
-        assert history[0]["query_text"] == "query3"
+        # Deterministic newest-first order even when second-precision
+        # ``created_at`` values collide.
+        assert [row["query_text"] for row in history] == ["query3", "query2"]
 
     @pytest.mark.asyncio
     async def test_suggest_prefix(self, storage):

--- a/packages/memtomem/tests/test_search_observation.py
+++ b/packages/memtomem/tests/test_search_observation.py
@@ -1,0 +1,128 @@
+"""Quality Lab search-observation contract tests."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+from helpers import StubCtx
+from memtomem.server.context import AppContext
+from memtomem.server.tools.search import mem_search
+
+
+async def _index_quality_note(components, memory_dir):
+    note = memory_dir / "quality.md"
+    note.write_text(
+        "# Retrieval Quality\n\nDurable observation telemetry for local search.\n",
+        encoding="utf-8",
+    )
+    await components.index_engine.index_file(note)
+    return note
+
+
+async def test_ranked_search_persists_durable_secret_free_observation(
+    bm25_only_components,
+):
+    components, memory_dir = bm25_only_components
+    note = await _index_quality_note(components, memory_dir)
+
+    results, stats = await components.search_pipeline.search(
+        "관측 telemetry", top_k=5, origin="web"
+    )
+
+    assert results
+    assert stats.query_run_id is not None
+    UUID(stats.query_run_id)
+    assert stats.cache_hit is False
+    assert stats.latency_ms is not None and stats.latency_ms >= 0
+
+    history = await components.storage.get_query_history(limit=10)
+    assert len(history) == 1
+    row = history[0]
+    assert row["run_id"] == stats.query_run_id
+    assert row["query_text"] == "관측 telemetry"
+    assert row["observation"]["origin"] == "web"
+    assert row["observation"]["query_language"] == "ko"
+    assert len(row["observation"]["profile_id"]) == 64
+    assert row["observation"]["final_total"] == len(results)
+    assert row["result_snapshot"][0]["source_name"] == note.name
+    snapshot_json = json.dumps(row["result_snapshot"], ensure_ascii=False)
+    assert str(memory_dir) not in snapshot_json
+    assert "content" not in row["result_snapshot"][0]
+
+
+async def test_zero_result_ranked_search_still_gets_run_id(bm25_only_components):
+    components, memory_dir = bm25_only_components
+    await _index_quality_note(components, memory_dir)
+
+    results, stats = await components.search_pipeline.search(
+        "term-that-does-not-exist-xyz", origin="mcp"
+    )
+
+    assert results == []
+    assert stats.query_run_id is not None
+    row = (await components.storage.get_query_history(limit=1))[0]
+    assert row["run_id"] == stats.query_run_id
+    assert row["observation"]["origin"] == "mcp"
+    assert row["observation"]["final_total"] == 0
+    assert row["result_snapshot"] == []
+
+
+async def test_cache_hit_records_distinct_durable_run(bm25_only_components):
+    components, memory_dir = bm25_only_components
+    await _index_quality_note(components, memory_dir)
+
+    _, first = await components.search_pipeline.search("telemetry", origin="cli")
+    _, second = await components.search_pipeline.search("telemetry", origin="cli")
+
+    assert first.query_run_id is not None
+    assert second.query_run_id is not None
+    assert first.query_run_id != second.query_run_id
+    assert first.cache_hit is False
+    assert second.cache_hit is True
+    rows = await components.storage.get_query_history(limit=10)
+    assert {row["run_id"] for row in rows} == {first.query_run_id, second.query_run_id}
+    assert {row["observation"]["cache_hit"] for row in rows} == {False, True}
+
+
+async def test_observation_failure_never_fails_search(bm25_only_components, monkeypatch):
+    components, memory_dir = bm25_only_components
+    await _index_quality_note(components, memory_dir)
+    failing_save = AsyncMock(side_effect=RuntimeError("observation DB unavailable"))
+    monkeypatch.setattr(components.storage, "save_search_observation", failing_save)
+
+    results, stats = await components.search_pipeline.search("telemetry", origin="web")
+
+    assert results
+    assert stats.query_run_id is None
+    failing_save.assert_awaited_once()
+
+
+async def test_filter_only_search_is_not_observed(bm25_only_components):
+    components, memory_dir = bm25_only_components
+    note = await _index_quality_note(components, memory_dir)
+
+    results, stats = await components.search_pipeline.search(
+        "", source_filter=note.name, origin="web"
+    )
+
+    assert results
+    assert stats.query_run_id is None
+    assert await components.storage.get_query_history(limit=10) == []
+
+
+async def test_mcp_structured_search_exposes_committed_run_id(bm25_only_components):
+    components, memory_dir = bm25_only_components
+    await _index_quality_note(components, memory_dir)
+    ctx = StubCtx(AppContext.from_components(components))
+
+    output = await mem_search(  # type: ignore[arg-type]
+        query="telemetry", output_format="structured", ctx=ctx
+    )
+
+    payload = json.loads(output)
+    UUID(payload["query_run_id"])
+    row = (await components.storage.get_query_history(limit=1))[0]
+    assert row["run_id"] == payload["query_run_id"]
+    assert row["observation"]["origin"] == "mcp"

--- a/packages/memtomem/tests/test_search_observation.py
+++ b/packages/memtomem/tests/test_search_observation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from unittest.mock import AsyncMock
 from uuid import UUID
@@ -9,6 +10,7 @@ from uuid import UUID
 from helpers import StubCtx
 from memtomem.server.context import AppContext
 from memtomem.server.tools.search import mem_search
+from memtomem.search.pipeline import SearchPipeline
 
 
 async def _index_quality_note(components, memory_dir):
@@ -126,3 +128,64 @@ async def test_mcp_structured_search_exposes_committed_run_id(bm25_only_componen
     row = (await components.storage.get_query_history(limit=1))[0]
     assert row["run_id"] == payload["query_run_id"]
     assert row["observation"]["origin"] == "mcp"
+
+
+async def test_legacy_backend_keeps_fire_and_forget_and_skips_cache_hit_history(
+    bm25_only_components,
+):
+    components, memory_dir = bm25_only_components
+    await _index_quality_note(components, memory_dir)
+
+    class LegacyStorageProxy:
+        def __init__(self, delegate):
+            self._delegate = delegate
+            self.save_query_history = AsyncMock()
+
+        def __getattr__(self, name):
+            return getattr(self._delegate, name)
+
+    legacy_storage = LegacyStorageProxy(components.storage)
+    pipeline = SearchPipeline(
+        storage=legacy_storage,  # type: ignore[arg-type]
+        embedder=components.embedder,
+        config=components.config.search,
+    )
+
+    results, first = await pipeline.search("telemetry", origin="internal")
+    await asyncio.sleep(0)
+    cached_results, second = await pipeline.search("telemetry", origin="internal")
+    await asyncio.sleep(0)
+
+    assert results and cached_results
+    assert first.query_run_id is None
+    assert second.query_run_id is None
+    assert second.cache_hit is True
+    legacy_storage.save_query_history.assert_awaited_once()
+
+
+async def test_explicit_instance_observation_capability_is_used(bm25_only_components):
+    components, memory_dir = bm25_only_components
+    await _index_quality_note(components, memory_dir)
+
+    class InstanceCapabilityProxy:
+        def __init__(self, delegate):
+            self._delegate = delegate
+            self.save_search_observation = AsyncMock(
+                side_effect=lambda *args, **kwargs: kwargs["run_id"]
+            )
+
+        def __getattr__(self, name):
+            return getattr(self._delegate, name)
+
+    proxy = InstanceCapabilityProxy(components.storage)
+    pipeline = SearchPipeline(
+        storage=proxy,  # type: ignore[arg-type]
+        embedder=components.embedder,
+        config=components.config.search,
+    )
+
+    results, stats = await pipeline.search("telemetry", origin="internal")
+
+    assert results
+    assert stats.query_run_id is not None
+    proxy.save_search_observation.assert_awaited_once()

--- a/packages/memtomem/tests/test_server_helpers.py
+++ b/packages/memtomem/tests/test_server_helpers.py
@@ -256,6 +256,13 @@ class TestFormatStructuredResults:
         parsed = json.loads(out)
         assert parsed == {"results": []}
 
+    def test_query_run_id_emitted_top_level(self):
+        import json
+
+        run_id = "e38ab6c7-4db4-4d68-8dca-93c1da2dcfe6"
+        parsed = json.loads(_format_structured_results([], query_run_id=run_id))
+        assert parsed == {"results": [], "query_run_id": run_id}
+
     def test_required_fields(self):
         import json
 

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -935,6 +935,16 @@ class TestSearch:
         assert result["score"] == pytest.approx(0.95)
         assert result["chunk"]["content"] == "test chunk content"
 
+    async def test_search_returns_durable_query_run_id(self, app, client: AsyncClient):
+        run_id = "e38ab6c7-4db4-4d68-8dca-93c1da2dcfe6"
+        app.state.search_pipeline.search.return_value[1].query_run_id = run_id
+
+        resp = await client.get("/api/search", params={"q": "hello world"})
+
+        assert resp.status_code == 200
+        assert resp.json()["query_run_id"] == run_id
+        assert resp.json()["retrieval_stats"]["query_run_id"] == run_id
+
     async def test_search_no_axis_returns_400(self, client: AsyncClient):
         """#750: ``q`` is now optional, but at least one of
         ``q``/``tag_filter``/``source_filter`` must be present — search
@@ -978,6 +988,7 @@ class TestSearch:
         assert kwargs["chunk_types"] == ["markdown_section"]
         assert kwargs["created_from"].tzinfo is not None
         assert kwargs["created_before"] > kwargs["created_from"]
+        assert kwargs["origin"] == "web"
 
     async def test_search_rejects_naive_or_reversed_date_bounds(self, client: AsyncClient):
         naive = await client.get("/api/search", params={"created_from": "2026-07-01T00:00:00"})


### PR DESCRIPTION
## Summary

- persist a durable UUID `query_run_id` for each ranked search invocation after the local SQLite commit succeeds
- store a retrieval profile/fingerprint, latency, cache/degradation state, and a content-minimized result snapshot
- expose committed run IDs through MCP structured output and the Web search API while preserving the existing CLI JSON result shape
- migrate pre-observation `query_history` tables additively without a schema-generation bump
- document the local data shape, privacy boundary, and existing 90-day history retention

## Behavioral boundary

- normal and zero-result ranked searches are observed by the SQLite capability
- SQLite cache hits receive distinct invocation IDs
- filter-only browsing is not observed
- observation persistence failure never fails search and returns no run ID
- snapshots omit result content and absolute source paths; heading hierarchy remains content-derived metadata and existing query history still contains query text
- alternate storage backends keep the legacy fire-and-forget history path, do not advertise a run ID, and preserve the prior behavior of not writing history on cache hits

## Commit-before-advertise performance tradeoff

The SQLite observation INSERT+COMMIT is awaited so a returned run ID always names a durable row. On a local file DB with WAL / `synchronous=NORMAL`, 60 cache-hit invocations measured:

- commit path: p50 `0.057ms`, p95 `0.071ms`
- same path with observation commit replaced by an async no-op: p50 `0.013ms`, p95 `0.014ms`
- observed delta: p50 `0.044ms`, p95 `0.057ms`

This intentionally spends a small amount of cache-hit latency for the durable-ID contract. The synchronous SQLite call still runs on the event-loop thread; if real workloads show materially higher storage latency, a dedicated serialized writer/ack path should be designed rather than moving the thread-affine connection through `to_thread`.

## Validation

- `8838 passed, 11 skipped` — full Python suite before rebasing onto current main
- `481 passed` — search/Web/MCP/schema/Compose boundary suite after rebase
- `606 passed` — post-review search/legacy-backend/schema regression suite
- Ruff and `git diff --check` pass
- mypy adds no errors; existing 18-error gradual baseline remains

Closes #1799
Refs #1798