### PR TITLE
fix(warmup): survive repeated cancellation while settling

### DIFF
--- a/packages/memtomem/src/memtomem/embedding/onnx.py
+++ b/packages/memtomem/src/memtomem/embedding/onnx.py
@@ -280,9 +280,9 @@ class OnnxEmbedder:
         # still-queued ``_close_sync`` before it starts (which would leave
         # the model and executor alive; an already-running worker can't be
         # interrupted anyway). On cancellation we keep settling until the
-        # future is done, then propagate. NOTE: ``server/warmup.py`` uses a
-        # weaker settle (bare ``await future`` after the first cancel) that
-        # a second cancellation can still pierce — don't copy that shape.
+        # future is done, then propagate. ``server/warmup.py`` uses the same
+        # repeated-shield settlement for model loads; keep both paths aligned
+        # so neither loses queued executor work (#1803).
         loop = asyncio.get_running_loop()
         future = loop.run_in_executor(None, self._close_sync)
         cancelled = False

--- a/packages/memtomem/src/memtomem/server/warmup.py
+++ b/packages/memtomem/src/memtomem/server/warmup.py
@@ -60,17 +60,30 @@ async def _warm_one(
         return WarmupOutcome(component, provider, model, "already-loaded")
     loop = asyncio.get_running_loop()
     future = loop.run_in_executor(None, load_model)
-    try:
-        await asyncio.shield(future)
-    except asyncio.CancelledError:
-        # A worker thread can't be interrupted — cancelling only the
-        # awaiting task would leave the load running while shutdown
-        # closes components under it. Wait for the in-flight load to
-        # settle (``close()`` awaits this task after cancelling), then
-        # propagate the cancellation.
+    # A worker thread can't be interrupted — cancelling only the awaiting
+    # task would leave the load running while shutdown closes components
+    # under it. Every settle-await stays shielded so repeated cancellation
+    # cannot cancel a load that is still queued in the executor. Once the
+    # load settles, preserve cancellation as the caller-visible outcome.
+    cancelled = False
+    while True:
+        try:
+            await asyncio.shield(future)
+            break
+        except asyncio.CancelledError:
+            cancelled = True
+            if future.done():
+                break
+        except BaseException:
+            if cancelled:
+                break
+            raise
+    if cancelled:
+        # Consume a failed/cancelled load in the completion race while
+        # preserving the pre-existing cancellation-wins contract.
         with contextlib.suppress(BaseException):
-            await future
-        raise
+            future.result()
+        raise asyncio.CancelledError
     return WarmupOutcome(component, provider, model, "loaded")
 
 

--- a/packages/memtomem/tests/test_warmup.py
+++ b/packages/memtomem/tests/test_warmup.py
@@ -258,6 +258,61 @@ class TestLifespanWarmup:
 
 class TestShutdownThreadSettlement:
     @pytest.mark.asyncio
+    async def test_double_cancel_still_settles_queued_loader(self):
+        """#1803: repeated cancellation must not cancel a queued load while
+        ``_warm_one`` is already settling the first cancellation.
+        """
+        from concurrent.futures import ThreadPoolExecutor
+
+        from memtomem.server.warmup import _warm_one
+
+        blocker_started = threading.Event()
+        blocker_release = threading.Event()
+        load_calls: list[bool] = []
+
+        def occupy_worker() -> None:
+            blocker_started.set()
+            blocker_release.wait(timeout=10)
+
+        class _QueuedLocalModel:
+            _model: object | None = None
+
+            def _get_model(self) -> object:
+                load_calls.append(True)
+                self._model = object()
+                return self._model
+
+        loop = asyncio.get_running_loop()
+        small = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test-default")
+        blocker = small.submit(occupy_worker)
+        assert blocker_started.wait(timeout=5), "default-executor blocker did not start"
+        loop.set_default_executor(small)
+
+        holder = _QueuedLocalModel()
+        task = asyncio.create_task(_warm_one("embedder", "onnx", "model", holder))
+        try:
+            await asyncio.sleep(0)  # submit the model load behind the blocker
+            task.cancel()
+            await asyncio.sleep(0)  # enter the first shielded settle iteration
+            assert not task.done()
+
+            task.cancel()
+            await asyncio.sleep(0)  # deliver the second cancellation mid-settle
+            assert not task.done(), "second cancel must not lose the queued load"
+            assert load_calls == []
+
+            blocker_release.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            blocker.result(timeout=5)
+
+            assert load_calls == [True]
+            assert holder._model is not None
+        finally:
+            blocker_release.set()
+            small.shutdown(wait=False)
+
+    @pytest.mark.asyncio
     async def test_close_waits_for_inflight_loader_thread(self, isolated_state, monkeypatch):
         """Cancelling the warmup task can't interrupt a loader *thread* —
         ``close()`` must wait for it to settle before tearing components


### PR DESCRIPTION
## Summary

- shield every executor-future settle await so repeated task cancellation cannot cancel a queued model load
- preserve cancellation as the caller-visible outcome after the load settles
- add a deterministic single-worker regression for the double-cancel interleaving
- align the ONNX close comment with the now-hardened warmup path

Closes #1803

## Tests

- `uv run pytest packages/memtomem/tests/test_warmup.py -q`
- `uv run pytest packages/memtomem/tests/test_embedding_providers.py -q -k "close_double_cancel_still_tears_down"`
- `uv run ruff check packages/memtomem/src/memtomem/server/warmup.py packages/memtomem/src/memtomem/embedding/onnx.py packages/memtomem/tests/test_warmup.py`
- `uv run ruff format --check packages/memtomem/src/memtomem/server/warmup.py packages/memtomem/src/memtomem/embedding/onnx.py packages/memtomem/tests/test_warmup.py`
- `uv run mypy packages/memtomem/src/memtomem/server/warmup.py packages/memtomem/src/memtomem/embedding/onnx.py`