### PR TITLE
fix(chunking): stop counting a phantom heading line for headingless sections

### DIFF
--- a/packages/memtomem/src/memtomem/chunking/markdown.py
+++ b/packages/memtomem/src/memtomem/chunking/markdown.py
@@ -356,12 +356,16 @@ class MarkdownChunker:
                     )
                 )
             else:
-                # Body offset from the heading line: 1 (heading itself) +
+                # Body offset from the section's first line: the heading
+                # itself (when the section has one — headingless sections
+                # start directly at content, so counting a phantom heading
+                # would shift every sub-chunk range one line down, #1807) +
                 # blank lines stripped by .strip() before the blockquote +
                 # blockquote group + trailing blanks. ``_split_section``
                 # uses this to seed its internal line counter so sub-chunk
                 # boundaries map back to real file lines.
-                body_offset = 1 + leading_strip_lines + blockquote_strip_lines
+                heading_line = 1 if section["hierarchy"] else 0
+                body_offset = heading_line + leading_strip_lines + blockquote_strip_lines
                 sub_chunks = self._split_section(text, section, body_offset=body_offset)
                 for sc in sub_chunks:
                     chunks.append(

--- a/packages/memtomem/tests/test_chunking.py
+++ b/packages/memtomem/tests/test_chunking.py
@@ -50,6 +50,33 @@ class TestAdaptiveChunking:
             assert chunk.metadata.end_line == actual_end
             assert 1 <= chunk.metadata.start_line <= chunk.metadata.end_line <= len(source_lines)
 
+    def test_headingless_section_subchunk_lines_not_shifted(self):
+        # Regression for #1807: a headingless section (auto-memory shape —
+        # frontmatter + body, no markdown heading) starts directly at content,
+        # so ``body_offset`` must not count a phantom heading line. Before the
+        # fix every sub-chunk range drifted +1 and the last one pointed past
+        # the end of the file.
+        config = FakeIndexingConfig()
+        config.chunk_overlap_tokens = 0
+        chunker = MarkdownChunker(indexing_config=config)
+        frontmatter = "---\nname: sample\ntype: feedback\n---"
+        body = "\n".join(f"- item {i:02d} " + "w" * 30 for i in range(20))
+        content = f"{frontmatter}\n{body}"
+
+        chunks = chunker.chunk_file(Path("/test.md"), content)
+
+        assert len(chunks) > 1
+        source_lines = content.splitlines()
+        for index, chunk in enumerate(chunks):
+            chunk_lines = chunk.content.splitlines()
+            actual_start = source_lines.index(chunk_lines[0]) + 1
+            actual_end = actual_start + len(chunk_lines) - 1
+
+            assert chunk_lines == source_lines[actual_start - 1 : actual_end]
+            assert chunk.metadata.start_line == (1 if index == 0 else actual_start)
+            assert chunk.metadata.end_line == actual_end
+            assert 1 <= chunk.metadata.start_line <= chunk.metadata.end_line <= len(source_lines)
+
     def test_mid_part_fence_is_kept_atomic(self):
         config = FakeIndexingConfig()
         config.chunk_overlap_tokens = 0


### PR DESCRIPTION
Closes #1807.

`chunk_file` seeded `_split_section`'s line accounting with `body_offset = 1 + ...`, unconditionally counting the section's first line as a consumed heading. Headingless sections (no-heading fallback, pre-heading first section — the exact shape of frontmatter-plus-body memory files) start directly at content, so every sub-chunk `start_line`/`end_line` shifted one line down, the final range pointing past the end of the file. These fields are mutation targets (`mem_edit`/`mem_remove` rewrite the source by exactly this range), so the drift means editing the wrong lines.

The stale `+1` predates #1793 — the old merge loop only used `body_offset` for starts and clamped the last `end_line` to the section end, so it surfaced as a handful of inverted starts. #1793's exact-span accounting (correct in itself) derives both edges from `body_offset`, exposing the shift on whole ranges.

**Fix**: count the heading line only when the section has one (`heading_line = 1 if section["hierarchy"] else 0`). Heading-anchored sections are byte-identical in behavior.

**Verification**
- Real-data smoke over a 375-file memory dir: invalid ranges (inverted or out-of-file) 146 → **0**; chunk count unchanged (1178).
- Regression test uses a headingless frontmatter fixture with exact per-chunk range assertions — fails on `main`, passes here. (Every existing fixture starts with `## ...`, which is why the suite never caught this.)
- Full chunking suite + edit/crud-related tests pass (499); `ruff check` + `format --check` clean.
- Reviewed the `section["hierarchy"]` proxy against all four section-construction paths in `_split_by_headings` (pre-heading, heading-flushed, no-heading fallback, heading-only fallback) — offset `0` is correct for every empty-hierarchy path because none of them strip a heading from `text`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
