### PR TITLE
fix(storage): keep feedback reclassification read-only, document replace collapse (#1811)

### DIFF
--- a/packages/memtomem/src/memtomem/storage/mixins/history.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/history.py
@@ -257,9 +257,20 @@ class HistoryMixin:
 
         FK violation → the run was pruned between validation and insert
         (KeyError, same as an unknown run). Unique violation → a concurrent
-        writer landed this (run_id, chunk_id) first: re-read and classify
-        exactly like the existing-row branch (idempotent success or
-        conflict). Anything else stays a StorageError.
+        writer landed this (run_id, chunk_id) first: re-read and classify.
+        Same judgment is an idempotent success; a different judgment is a
+        conflict; anything else stays a StorageError.
+
+        This path is **read-only by design** (#1811). It runs *after*
+        ``db.rollback()``, i.e. outside the ``BEGIN IMMEDIATE`` that
+        serializes the main write, so it must not perform a write here: an
+        unlocked read-modify-write would race a concurrent judgment change
+        or a prune's cascade-delete (a zero-row UPDATE would still report
+        success). A different judgment therefore raises a conflict even when
+        the losing caller passed ``replace=True`` — the caller's replacement
+        intent deliberately collapses to a conflict on this defense-in-depth
+        branch. Recovery is a plain retry through the normal locked path,
+        which then performs the replace correctly.
         """
         message = str(exc).upper()
         if "FOREIGN KEY" in message:
@@ -273,6 +284,8 @@ class HistoryMixin:
             if landed is not None:
                 if landed[0] == judgment:
                     return self._feedback_row(run_id, chunk_id, judgment, landed[1], landed[2])
+                # Different judgment: see docstring — replace intent
+                # collapses to a conflict here rather than an unlocked write.
                 raise FeedbackConflictError(
                     f"feedback for run {run_id!r} chunk {chunk_id!r} is already "
                     f"{landed[0]!r}; pass replace=true to overwrite"

--- a/packages/memtomem/tests/test_search_feedback.py
+++ b/packages/memtomem/tests/test_search_feedback.py
@@ -183,6 +183,29 @@ class TestIntegrityClassification:
                 storage, "UNIQUE constraint failed: search_feedback.run_id", "not_relevant"
             )
 
+    async def test_replace_intent_collapses_to_conflict_and_leaves_row_unchanged(self, storage):
+        """#1811: the reclassification path is read-only by design. Even when
+        the losing caller passed replace=True, a different landed judgment
+        collapses to a conflict here (no unlocked write) — the row is left
+        exactly as the winner wrote it, and recovery is a retry through the
+        normal locked path. The helper is deliberately replace-agnostic, so
+        the collapse holds regardless of the caller's intent."""
+        await _seed_run(storage, RUN_A)
+        winner = await storage.save_search_feedback(RUN_A, "c1", "relevant")
+        with pytest.raises(FeedbackConflictError, match="replace=true"):
+            self._classify(
+                storage, "UNIQUE constraint failed: search_feedback.run_id", "not_relevant"
+            )
+        # No unlocked write happened: the winner's row is untouched.
+        assert _feedback_rows(storage) == [
+            (RUN_A, "c1", "relevant", winner["created_at"], winner["updated_at"])
+        ]
+        # Recovery: a retry through the normal locked path performs the replace.
+        replaced = await storage.save_search_feedback(RUN_A, "c1", "not_relevant", replace=True)
+        assert replaced["replaced"] is True
+        assert replaced["created_at"] == winner["created_at"]
+        assert replaced["updated_at"] > winner["updated_at"]
+
     async def test_unrecognized_integrity_error_stays_storage_error(self, storage):
         with pytest.raises(StorageError, match="feedback write failed"):
             self._classify(


### PR DESCRIPTION
## Problem

Follow-up from the #1810 review (#1801). `HistoryMixin._classify_feedback_integrity_error` re-reads the row a concurrent writer landed after a `UNIQUE` hit and reclassifies it. The issue notes it never received the caller's `replace` flag, so a losing `replace=True` call surfaces a conflict instead of replacing.

## Why the fix is "document the collapse", not "perform the replace"

The helper runs **after `db.rollback()`** — outside the `BEGIN IMMEDIATE` that serializes the main write. Adding an `UPDATE`+`commit` there (the other suggested fix) would introduce an **unlocked read-modify-write**: a concurrent judgment change or a prune's cascade-delete could race the re-read, and a zero-row `UPDATE` would still commit and report `replaced=True` for a row that no longer exists. `BEGIN IMMEDIATE` keeps this branch unreachable in practice, so the right move is to keep it **read-only** and document the contract rather than harden an unreachable write.

## Fix

- Keep the reclassification path replace-agnostic and read-only: same judgment → idempotent success; different judgment → `FeedbackConflictError` (even when the caller passed `replace=True`); FK → `KeyError`; anything else → `StorageError`.
- Document in the helper's docstring that replacement intent **deliberately collapses to a conflict** on this defense-in-depth branch, and that recovery is a plain retry through the normal locked path — which performs the replace correctly.

## Test

`TestIntegrityClassification` gains `test_replace_intent_collapses_to_conflict_and_leaves_row_unchanged`, pinning: the collapse to a conflict, the winner's row left byte-for-byte unchanged (no unlocked write), and a subsequent retry through the locked path replacing correctly (`created_at` pinned, `updated_at` advanced).

Reviewed by Codex (dev-trio), which flagged the unlocked-write race in the initial "perform the replace" approach; this PR takes the read-only/document route it recommended.

Closes #1811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
