### PR TITLE
fix(web): document SnapshotEntryOut as a deliberate allowlist (#1812)

### DIFF
--- a/packages/memtomem/src/memtomem/web/schemas/search_runs.py
+++ b/packages/memtomem/src/memtomem/web/schemas/search_runs.py
@@ -22,9 +22,24 @@ class SearchRunListResponse(BaseModel):
 class SnapshotEntryOut(BaseModel):
     """One snapshotted result row, merged with its current judgment.
 
-    Mirrors the observation snapshot fields (source basename, hash — never
-    content or absolute paths) and stays permissive on optional metadata so
-    older snapshots render too.
+    Mirrors the observation snapshot fields (source basename, hash). Two
+    distinct guarantees, at two layers — don't conflate them:
+
+    * *Which* fields appear is bounded **here**. The field list below is a
+      **deliberate allowlist, not a permissive passthrough**: Pydantic's
+      default ``extra="ignore"`` is load-bearing, so any key the snapshot
+      writer grows later (#1799/#1800 surface) is dropped until it is added
+      here on purpose — the moment to make the privacy call. That stops a
+      future writer regression that adds a stray ``content`` or
+      absolute-path *key* from auto-surfacing. ``test_snapshot_out_is_an_allowlist``
+      pins the drop so it can't happen by accident (#1812).
+    * The *values* of the allowed fields (``source_name`` is a basename,
+      never an absolute path or raw text) are guaranteed **upstream** by the
+      writer's projection — ``search/pipeline.py`` snapshots
+      ``chunk.metadata.source_file.name``, never the full path or content.
+      This model relies on that projection; it does not re-sanitize field
+      contents, so it is not the place to catch a writer that mislabels a
+      value under an already-allowed key.
     """
 
     chunk_id: str

--- a/packages/memtomem/tests/test_web_routes_search_runs.py
+++ b/packages/memtomem/tests/test_web_routes_search_runs.py
@@ -120,6 +120,31 @@ class TestRunDetail:
         assert judged["feedback_updated_at"] == "2026-07-17T00:00:00.000002+00:00"
         assert unjudged["chunk_id"] == "c2" and unjudged["judgment"] is None
 
+    async def test_snapshot_out_is_an_allowlist(self, app, client):
+        # SnapshotEntryOut is a deliberate allowlist, not a passthrough
+        # (#1812): a key the snapshot writer grows later — including a writer
+        # regression that leaked raw content or an absolute path — must be
+        # dropped, never auto-surfaced. This response is the privacy boundary.
+        app.state.storage.get_search_run.return_value = {
+            **RUN_DETAIL,
+            "result_snapshot": [
+                {
+                    **RUN_DETAIL["result_snapshot"][0],
+                    "novelty_score": 0.42,  # benign future field
+                    "content": "raw secret text",  # writer-regression leak
+                    "source_path": "/Users/someone/private/note.md",  # absolute path
+                }
+            ],
+        }
+        resp = await client.get(f"/api/search/runs/{RUN_ID}")
+        assert resp.status_code == 200
+        entry = resp.json()["results"][0]
+        assert "novelty_score" not in entry
+        assert "content" not in entry
+        assert "source_path" not in entry
+        # The declared safe fields still render.
+        assert entry["source_name"] == "note.md" and entry["content_hash"] == "abc"
+
     async def test_unknown_run_maps_to_404(self, app, client):
         app.state.storage.get_search_run.side_effect = KeyError("run_id 'x' not found")
         resp = await client.get("/api/search/runs/x")


### PR DESCRIPTION
Closes #1812. Supersedes #1813 (auto-closed when its base branch `feat/1801-search-feedback` was deleted on the #1810 merge; rebased onto `main`, same commit).

## Problem

`SnapshotEntryOut` (`packages/memtomem/src/memtomem/web/schemas/search_runs.py`) is built via `SnapshotEntryOut(**entry, judgment=..., feedback_updated_at=...)` in `GET /api/search/runs/{run_id}`. Its docstring promised to "mirror the observation snapshot fields" and stay "permissive on optional metadata" — but Pydantic's default `extra="ignore"` made that permissiveness mean *accepted and discarded*, not *passed through*. A field added to the snapshot writer later (#1799/#1800 surface) would land in storage and be silently dropped from the response, with nothing to flag the drift.

## Resolution — closed allowlist, documented as intent

Resolves toward the **closed allowlist**, not verbatim passthrough. The docstring now separates two guarantees at their two layers:

- ***Which* fields appear** is bounded at this response model. Keep the default `extra="ignore"` as load-bearing intent: new snapshot keys are dropped until added to the allowlist on purpose — the moment to make the privacy call. This stops a future writer regression that adds a stray `content` or absolute-path *key* from auto-surfacing. `extra="allow"` would not — and the repo convention reserves it for bodies carried verbatim from another surface (#1692 PR7), which a privacy-scrubbed projection is not.
- **The *values* of allowed fields** (`source_name` = basename, never an absolute path or raw text) are guaranteed **upstream** by the writer's projection (`search/pipeline.py` snapshots `source_file.name`). This model relies on that projection and does not re-sanitize field contents — so the docstring no longer overclaims that the boundary catches a mislabeled value under an already-allowed key. That value-level hardening is tracked separately in #1815.

A test injects a benign future field **plus a `content`/absolute-path leak under unknown keys** and asserts none reach the response while the declared safe fields still render. Mutation-checked: re-introducing `extra="allow"` fails it.

## Review

Codex reviewed across three rounds (extra="allow" → allowlist → docstring precision) and landed on **SHIP**. Follow-up value-sanitization hardening split out to #1815.

Verified on `main`: `pytest test_web_routes_search_runs.py` (16 passed), `ruff check`/`format`, `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
