### PR TITLE
fix(search): deterministic id tie-break in BM25/dense legs (#516)

### DIFF
--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -1428,11 +1428,15 @@ class SqliteBackend(
             # importance, validity) activate. Score sits at the
             # trailing position after the chunk columns — see
             # ``_chunks_table_column_count`` consumer below.
+            # Trailing ``c.id`` is the unique final tiebreak (#516): equal
+            # ``fts.rank`` rows within the same scope priority would otherwise
+            # take arbitrary SQLite order, so repeated queries / reopened
+            # connections could reorder them and destabilize replay diffs.
             sql = f"""SELECT c.*, fts.rank
                    FROM chunks_fts fts
                    JOIN chunks c ON c.rowid = fts.rowid
                    WHERE chunks_fts MATCH ? {ns_clause} {scope_clause} {metadata_clause}
-                   ORDER BY fts.rank, {tie_break}
+                   ORDER BY fts.rank, {tie_break}, c.id
                    LIMIT ?"""
 
             # Try AND first (default FTS5 behaviour)
@@ -1522,8 +1526,14 @@ class SqliteBackend(
                    LIMIT ?
                ) sub
                JOIN chunks c ON c.rowid = sub.rowid {ns_clause} {scope_clause} {metadata_clause}
-               ORDER BY sub.distance, {tie_break}
+               ORDER BY sub.distance, {tie_break}, c.id
                LIMIT ?"""
+        # Trailing ``c.id`` gives the outer ordering a unique final tiebreak
+        # (#516). Note this only stabilizes rows the inner KNN actually
+        # returned; sqlite-vec 0.1.9 prunes to the inner ``LIMIT`` with an
+        # unstable distance-only sort, so equal-distance rows straddling that
+        # inner cutoff are a separate concern handled by the exhaustive
+        # evaluation path (see ``dense_search`` replay mode).
 
         # Total embedding rows — the upper bound for a meaningful
         # KNN K. Cheap; sqlite stores chunks_vec row counts in its

--- a/packages/memtomem/tests/test_search_tiebreak.py
+++ b/packages/memtomem/tests/test_search_tiebreak.py
@@ -1,0 +1,75 @@
+"""Deterministic tie-break in the BM25 and dense search legs (#516).
+
+Equal ``fts.rank`` (BM25) or equal ``distance`` (dense) rows within the same
+scope priority previously took arbitrary SQLite order, so repeated queries or
+reopened connections could reorder them — destabilizing replay diffs. Both legs
+now append the unique ``c.id`` as the final ``ORDER BY`` key, so tied rows come
+back in a fixed, id-sorted order.
+"""
+
+import pytest
+
+from helpers import make_chunk as _make_chunk
+from memtomem.storage.sqlite_backend import SqliteBackend
+
+
+def _ids_in_sql_order(chunk_ids):
+    """SQLite orders the TEXT ``id`` column lexicographically; mirror that."""
+    return sorted(chunk_ids, key=str)
+
+
+class TestSearchLegTieBreak:
+    @pytest.mark.asyncio
+    async def test_bm25_tied_rank_orders_by_id(self, storage):
+        # Identical content -> identical BM25 rank; identical scope -> the only
+        # thing left to order by is the trailing ``c.id``.
+        chunks = [_make_chunk("tiebreak marker body", source=f"s{i}.md") for i in range(6)]
+        await storage.upsert_chunks(chunks)
+
+        results = await storage.bm25_search("tiebreak", top_k=6)
+
+        got = [r.chunk.id for r in results]
+        assert got == _ids_in_sql_order(c.id for c in chunks)
+
+    @pytest.mark.asyncio
+    async def test_bm25_tied_rank_stable_across_repeated_queries(self, storage):
+        chunks = [_make_chunk("stable marker body", source=f"s{i}.md") for i in range(6)]
+        await storage.upsert_chunks(chunks)
+
+        first = [r.chunk.id for r in await storage.bm25_search("stable", top_k=6)]
+        second = [r.chunk.id for r in await storage.bm25_search("stable", top_k=6)]
+        assert first == second
+
+    @pytest.mark.asyncio
+    async def test_dense_tied_distance_orders_by_id(self, storage):
+        # Identical embeddings -> identical distance to any query vector.
+        vec = [0.2] * 1024
+        chunks = [_make_chunk("dense tie body", source=f"d{i}.md", embedding=vec) for i in range(6)]
+        await storage.upsert_chunks(chunks)
+
+        results = await storage.dense_search([0.2] * 1024, top_k=6)
+
+        got = [r.chunk.id for r in results]
+        assert got == _ids_in_sql_order(c.id for c in chunks)
+
+    @pytest.mark.asyncio
+    async def test_tied_order_stable_across_connection_reopen(self, storage, components):
+        chunks = [_make_chunk("reopen marker body", source=f"r{i}.md") for i in range(6)]
+        await storage.upsert_chunks(chunks)
+
+        first = [r.chunk.id for r in await storage.bm25_search("reopen", top_k=6)]
+
+        # Reopen a fresh backend against the same DB file: a new connection
+        # pool must not reorder tied rows.
+        cfg = components.config
+        reopened = SqliteBackend(
+            cfg.storage,
+            dimension=cfg.embedding.dimension,
+            strict_dim_check=False,
+        )
+        await reopened.initialize()
+        try:
+            second = [r.chunk.id for r in await reopened.bm25_search("reopen", top_k=6)]
+        finally:
+            await reopened.close()
+        assert first == second


### PR DESCRIPTION
## What

Append the unique `c.id` as the final `ORDER BY` key on both the BM25 and dense search legs so tied rows come back in a fixed, id-sorted order.

## Why

Equal `fts.rank` (BM25) or equal `distance` (dense) rows within the same scope priority took arbitrary SQLite order (#516). Repeated queries or reopened connections could reorder them — harmless for interactive search, but it breaks the byte-deterministic replay diffs the Memory Quality Lab (#1798) needs. This is the first, independently-landable slice of the #1802 replay/eval work.

## Scope note

The dense fix stabilizes only rows the inner KNN actually returned. sqlite-vec 0.1.9 prunes to the inner `LIMIT` inside the vec0 virtual table with an unstable distance-only sort, so equal-distance rows straddling that inner cutoff are a separate concern — handled by the exhaustive-K evaluation path that lands with replay mode. The comment on the dense leg records this.

## Tests

`tests/test_search_tiebreak.py`:
- BM25 tied-rank rows return in id-sorted order.
- Dense tied-distance rows (identical embeddings) return in id-sorted order.
- Order stable across repeated queries.
- Order stable across a fresh backend / connection-pool reopen against the same DB.

`ruff check` + `ruff format --check` (src/tests/tools) and the storage + search suites pass; `mypy` clean on the edited file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Scope note (recall path)

This fixes the tie non-determinism on the **BM25 and dense ranked legs** only. The empty-query filter-only path (`recall_chunks`, `ORDER BY created_at DESC, {scope_sort_priority_case()}`) still lacks a unique final tiebreak, so the original same-second `created_at` flip from #516 remains there. That path is out of scope here — the Quality Lab replay set is keyword-ranked, so this PR unblocks #1802 — and closing it fully can be a separate follow-up. Read this as "deterministic ranked search legs", not "#516 fully closed on every path".

