### PR TITLE
refactor(quality): promote IR metrics into the package (#1802)

### DIFF
--- a/packages/memtomem/src/memtomem/quality/__init__.py
+++ b/packages/memtomem/src/memtomem/quality/__init__.py
@@ -1,0 +1,6 @@
+"""Memory Quality Lab (#1798): local search-evaluation building blocks.
+
+This package holds the runtime-importable pieces of the Quality Lab —
+starting with pure-function IR metrics (:mod:`memtomem.quality.metrics`).
+Replay, fingerprints, and comparison land in later slices of #1802.
+"""

--- a/packages/memtomem/src/memtomem/quality/metrics.py
+++ b/packages/memtomem/src/memtomem/quality/metrics.py
@@ -10,10 +10,11 @@ The ``retrieved`` argument is an ordered list of IDs from rank 1 downward.
 Identity note (#1802): the Quality Lab keys results by ``content_hash``, and
 several chunks can share one hash, so a ranking may contain duplicate IDs. The
 replay layer deduplicates by identity before calling these functions; as defense
-in depth, ``recall_at_k`` / ``recall_labeled_at_k`` / ``precision_at_k`` count
-*distinct* hits so a duplicated relevant item cannot push a rate above 1.0. For
-rankings of unique IDs (the existing retrieval-regression callers) this is
-identical to the previous occurrence-counting behavior.
+in depth, every metric here — ``recall_at_k``, ``recall_labeled_at_k``,
+``precision_at_k``, ``ndcg_at_k``, ``hit_rate_at_k`` — credits each distinct ID
+at most once within the top-k window, so a duplicated item cannot push a score
+above 1.0. For rankings of unique IDs (the existing retrieval-regression
+callers) this is identical to the previous occurrence-counting behavior.
 """
 
 from __future__ import annotations
@@ -41,7 +42,7 @@ def recall_at_k(retrieved: list[str], relevant: set[str] | frozenset[str], k: in
     """
     if k <= 0 or not relevant:
         return 0.0
-    hits = len(set(retrieved[:k]) & set(relevant))
+    hits = len(set(retrieved[:k]) & relevant)
     return hits / len(relevant)
 
 
@@ -76,11 +77,19 @@ def ndcg_at_k(retrieved: list[str], relevance: Mapping[str, float], k: int) -> f
 
     Missing IDs in ``relevance`` count as zero gain. Returns 0.0 when the ideal
     DCG is zero (no positive-relevance items known at all).
+
+    Each distinct ID is credited once, at its first-occurrence rank within the
+    top-k window — a repeated ID (hash conflation, see module note) neither
+    double-counts nor promotes a rank-(k+1) item, so NDCG stays bounded by 1.0.
     """
     if k <= 0 or not relevance:
         return 0.0
     dcg = 0.0
+    seen: set[str] = set()
     for rank, item in enumerate(retrieved[:k], start=1):
+        if item in seen:
+            continue
+        seen.add(item)
         gain = relevance.get(item, 0.0)
         if gain > 0:
             dcg += gain / math.log2(rank + 1)
@@ -104,7 +113,12 @@ def precision_at_k(
     retrieved — the result is ``None`` (report it as ``incomplete_labels``),
     which an aggregate must exclude rather than average in.
 
-    Counts distinct relevant hits over the distinct considered window.
+    The denominator is the *distinct* window size, not ``k`` and not
+    ``len(window)``: this deviates from textbook P@k in two ways — it shrinks
+    below ``k`` when fewer than ``k`` items are retrieved, and a duplicated
+    non-relevant item raises the score (e.g. ``["a", "b", "b"]`` with ``a``
+    relevant, ``b`` not → 1/2, not 1/3). Both follow from crediting each
+    distinct ID once, consistent with the other metrics here.
     """
     if k <= 0:
         return None
@@ -115,7 +129,7 @@ def precision_at_k(
     considered = set(window)
     if not considered <= labeled:
         return None
-    hits = len(considered & set(relevant))
+    hits = len(considered & relevant)
     return hits / len(considered)
 
 
@@ -123,7 +137,7 @@ def hit_rate_at_k(retrieved: list[str], relevant: set[str] | frozenset[str], k: 
     """1.0 if any relevant item appears in the top-k, else 0.0."""
     if k <= 0 or not relevant:
         return 0.0
-    return 1.0 if set(retrieved[:k]) & set(relevant) else 0.0
+    return 1.0 if set(retrieved[:k]) & relevant else 0.0
 
 
 def mean(values: Iterable[float]) -> float:

--- a/packages/memtomem/src/memtomem/quality/metrics.py
+++ b/packages/memtomem/src/memtomem/quality/metrics.py
@@ -1,0 +1,132 @@
+"""Pure-function IR metrics for retrieval evaluation.
+
+Functions operate on a single query's ranking. Callers aggregate across queries
+(e.g., ``mean(recall_at_k(...) for q in queries)`` for mean recall).
+
+The ``retrieved`` argument is an ordered list of IDs from rank 1 downward.
+``relevant`` is a set of IDs considered relevant for the query. ``relevance``
+(for NDCG) is a dict mapping ID to a non-negative gain — missing IDs count as 0.
+
+Identity note (#1802): the Quality Lab keys results by ``content_hash``, and
+several chunks can share one hash, so a ranking may contain duplicate IDs. The
+replay layer deduplicates by identity before calling these functions; as defense
+in depth, ``recall_at_k`` / ``recall_labeled_at_k`` / ``precision_at_k`` count
+*distinct* hits so a duplicated relevant item cannot push a rate above 1.0. For
+rankings of unique IDs (the existing retrieval-regression callers) this is
+identical to the previous occurrence-counting behavior.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping
+
+__all__ = [
+    "recall_at_k",
+    "recall_labeled_at_k",
+    "reciprocal_rank_at_k",
+    "ndcg_at_k",
+    "precision_at_k",
+    "hit_rate_at_k",
+    "mean",
+]
+
+
+def recall_at_k(retrieved: list[str], relevant: set[str] | frozenset[str], k: int) -> float:
+    """Fraction of relevant items found in the top-k retrieved.
+
+    Returns 0.0 when there are no relevant items (undefined recall → treated as miss
+    so a caller averaging across queries isn't biased by empty-relevance entries).
+    Counts distinct relevant hits, so a duplicated relevant ID cannot exceed 1.0.
+    """
+    if k <= 0 or not relevant:
+        return 0.0
+    hits = len(set(retrieved[:k]) & set(relevant))
+    return hits / len(relevant)
+
+
+def recall_labeled_at_k(retrieved: list[str], relevant: set[str] | frozenset[str], k: int) -> float:
+    """Recall over the *labeled*-relevant set (denominator = labeled relevant).
+
+    Named explicitly to signal this is not true corpus recall: the denominator is
+    only the items a judge marked relevant, not every relevant item in the corpus.
+    Identical computation to :func:`recall_at_k`; the distinct name keeps report
+    fields honest about what the number means.
+    """
+    return recall_at_k(retrieved, relevant, k)
+
+
+def reciprocal_rank_at_k(
+    retrieved: list[str], relevant: set[str] | frozenset[str], k: int
+) -> float:
+    """Reciprocal rank of the first relevant hit within top-k, or 0.0 if none.
+
+    Mean reciprocal rank (MRR) across queries is the ``mean`` of this.
+    """
+    if k <= 0:
+        return 0.0
+    for rank, item in enumerate(retrieved[:k], start=1):
+        if item in relevant:
+            return 1.0 / rank
+    return 0.0
+
+
+def ndcg_at_k(retrieved: list[str], relevance: Mapping[str, float], k: int) -> float:
+    """Normalized DCG@k with the standard ``rel / log2(rank + 1)`` gain.
+
+    Missing IDs in ``relevance`` count as zero gain. Returns 0.0 when the ideal
+    DCG is zero (no positive-relevance items known at all).
+    """
+    if k <= 0 or not relevance:
+        return 0.0
+    dcg = 0.0
+    for rank, item in enumerate(retrieved[:k], start=1):
+        gain = relevance.get(item, 0.0)
+        if gain > 0:
+            dcg += gain / math.log2(rank + 1)
+    ideal_gains = sorted((g for g in relevance.values() if g > 0), reverse=True)[:k]
+    idcg = sum(g / math.log2(rank + 1) for rank, g in enumerate(ideal_gains, start=1))
+    return dcg / idcg if idcg > 0 else 0.0
+
+
+def precision_at_k(
+    retrieved: list[str],
+    relevant: set[str] | frozenset[str],
+    not_relevant: set[str] | frozenset[str],
+    k: int,
+) -> float | None:
+    """Precision@k, or ``None`` when the top-k labels are incomplete.
+
+    Precision needs every retrieved item in the window to carry a judgment:
+    a partially labeled window would silently treat unlabeled items as
+    non-relevant and bias the number downward. When any of the considered items
+    is neither in ``relevant`` nor ``not_relevant`` — or when no items are
+    retrieved — the result is ``None`` (report it as ``incomplete_labels``),
+    which an aggregate must exclude rather than average in.
+
+    Counts distinct relevant hits over the distinct considered window.
+    """
+    if k <= 0:
+        return None
+    window = retrieved[:k]
+    if not window:
+        return None
+    labeled = set(relevant) | set(not_relevant)
+    considered = set(window)
+    if not considered <= labeled:
+        return None
+    hits = len(considered & set(relevant))
+    return hits / len(considered)
+
+
+def hit_rate_at_k(retrieved: list[str], relevant: set[str] | frozenset[str], k: int) -> float:
+    """1.0 if any relevant item appears in the top-k, else 0.0."""
+    if k <= 0 or not relevant:
+        return 0.0
+    return 1.0 if set(retrieved[:k]) & set(relevant) else 0.0
+
+
+def mean(values: Iterable[float]) -> float:
+    """Arithmetic mean, returning 0.0 on empty input (stdlib ``mean`` raises)."""
+    xs = list(values)
+    return sum(xs) / len(xs) if xs else 0.0

--- a/packages/memtomem/tests/ir_metrics.py
+++ b/packages/memtomem/tests/ir_metrics.py
@@ -1,65 +1,30 @@
-"""Pure-function IR metrics for retrieval regression tests.
+"""Re-export shim — canonical IR metrics now live in the package.
 
-Functions operate on a single query's ranking. Callers aggregate across queries
-(e.g., ``statistics.fmean(recall_at_k(...) for q in queries)`` for mean recall).
-
-The ``retrieved`` argument is an ordered list of IDs from rank 1 downward.
-``relevant`` is a set of IDs considered relevant for the query. ``relevance``
-(for NDCG) is a dict mapping ID to a non-negative gain — missing IDs count as 0.
+Historically these pure functions lived here under ``tests/``. They moved to
+:mod:`memtomem.quality.metrics` (#1802) so replay/evaluation code can import
+them at runtime. This shim keeps existing test imports (``from ir_metrics
+import ...``) and the ``tools/retrieval-eval`` file-path loaders working
+unchanged. Import the package module directly in new code.
 """
 
 from __future__ import annotations
 
-import math
-from collections.abc import Iterable, Mapping
+from memtomem.quality.metrics import (
+    hit_rate_at_k,
+    mean,
+    ndcg_at_k,
+    precision_at_k,
+    recall_at_k,
+    recall_labeled_at_k,
+    reciprocal_rank_at_k,
+)
 
-
-def recall_at_k(retrieved: list[str], relevant: set[str] | frozenset[str], k: int) -> float:
-    """Fraction of relevant items found in the top-k retrieved.
-
-    Returns 0.0 when there are no relevant items (undefined recall → treated as miss
-    so a caller averaging across queries isn't biased by empty-relevance entries).
-    """
-    if k <= 0 or not relevant:
-        return 0.0
-    hits = sum(1 for item in retrieved[:k] if item in relevant)
-    return hits / len(relevant)
-
-
-def reciprocal_rank_at_k(
-    retrieved: list[str], relevant: set[str] | frozenset[str], k: int
-) -> float:
-    """Reciprocal rank of the first relevant hit within top-k, or 0.0 if none.
-
-    Mean reciprocal rank (MRR) across queries is ``statistics.fmean`` of this.
-    """
-    if k <= 0:
-        return 0.0
-    for rank, item in enumerate(retrieved[:k], start=1):
-        if item in relevant:
-            return 1.0 / rank
-    return 0.0
-
-
-def ndcg_at_k(retrieved: list[str], relevance: Mapping[str, float], k: int) -> float:
-    """Normalized DCG@k with the standard ``rel / log2(rank + 1)`` gain.
-
-    Missing IDs in ``relevance`` count as zero gain. Returns 0.0 when the ideal
-    DCG is zero (no positive-relevance items known at all).
-    """
-    if k <= 0 or not relevance:
-        return 0.0
-    dcg = 0.0
-    for rank, item in enumerate(retrieved[:k], start=1):
-        gain = relevance.get(item, 0.0)
-        if gain > 0:
-            dcg += gain / math.log2(rank + 1)
-    ideal_gains = sorted((g for g in relevance.values() if g > 0), reverse=True)[:k]
-    idcg = sum(g / math.log2(rank + 1) for rank, g in enumerate(ideal_gains, start=1))
-    return dcg / idcg if idcg > 0 else 0.0
-
-
-def mean(values: Iterable[float]) -> float:
-    """Arithmetic mean, returning 0.0 on empty input (stdlib ``mean`` raises)."""
-    xs = list(values)
-    return sum(xs) / len(xs) if xs else 0.0
+__all__ = [
+    "recall_at_k",
+    "recall_labeled_at_k",
+    "reciprocal_rank_at_k",
+    "ndcg_at_k",
+    "precision_at_k",
+    "hit_rate_at_k",
+    "mean",
+]

--- a/packages/memtomem/tests/test_quality_metrics.py
+++ b/packages/memtomem/tests/test_quality_metrics.py
@@ -1,0 +1,116 @@
+"""Unit tests for the packaged IR metrics (#1802)."""
+
+from __future__ import annotations
+
+import pytest
+
+from memtomem.quality.metrics import (
+    hit_rate_at_k,
+    mean,
+    ndcg_at_k,
+    precision_at_k,
+    recall_at_k,
+    recall_labeled_at_k,
+    reciprocal_rank_at_k,
+)
+
+
+class TestRecall:
+    def test_basic(self):
+        assert recall_at_k(["a", "b", "c"], {"a", "c"}, 3) == 1.0
+        assert recall_at_k(["a", "b", "c"], {"a", "z"}, 3) == 0.5
+
+    def test_empty_relevant_is_zero(self):
+        assert recall_at_k(["a"], set(), 3) == 0.0
+
+    def test_k_zero_is_zero(self):
+        assert recall_at_k(["a"], {"a"}, 0) == 0.0
+
+    def test_duplicate_relevant_hit_bounded_at_one(self):
+        # A ranking that repeats the same relevant id (hash conflation) must
+        # not push recall above 1.0.
+        assert recall_at_k(["a", "a", "a"], {"a"}, 3) == 1.0
+
+    def test_labeled_alias_matches_recall(self):
+        assert recall_labeled_at_k(["a", "b"], {"a"}, 2) == recall_at_k(["a", "b"], {"a"}, 2)
+
+
+class TestReciprocalRank:
+    def test_first_hit_position(self):
+        assert reciprocal_rank_at_k(["x", "a", "b"], {"a"}, 3) == pytest.approx(0.5)
+
+    def test_no_hit_is_zero(self):
+        assert reciprocal_rank_at_k(["x", "y"], {"a"}, 2) == 0.0
+
+    def test_respects_k_window(self):
+        assert reciprocal_rank_at_k(["x", "y", "a"], {"a"}, 2) == 0.0
+
+
+class TestNdcg:
+    def test_perfect_ranking_is_one(self):
+        assert ndcg_at_k(["a", "b"], {"a": 1.0, "b": 1.0}, 2) == pytest.approx(1.0)
+
+    def test_empty_relevance_is_zero(self):
+        assert ndcg_at_k(["a"], {}, 2) == 0.0
+
+
+class TestPrecision:
+    def test_fully_labeled_window(self):
+        assert precision_at_k(["a", "b"], {"a"}, {"b"}, 2) == pytest.approx(0.5)
+
+    def test_none_when_an_item_is_unlabeled(self):
+        # "c" carries no judgment → precision is undefined, not a biased number.
+        assert precision_at_k(["a", "b", "c"], {"a"}, {"b"}, 3) is None
+
+    def test_none_when_no_items_retrieved(self):
+        assert precision_at_k([], {"a"}, set(), 3) is None
+
+    def test_none_when_k_zero(self):
+        assert precision_at_k(["a"], {"a"}, set(), 0) is None
+
+    def test_all_relevant_window(self):
+        assert precision_at_k(["a", "b"], {"a", "b"}, set(), 2) == pytest.approx(1.0)
+
+    def test_duplicate_labeled_hit_bounded(self):
+        assert precision_at_k(["a", "a"], {"a"}, set(), 2) == pytest.approx(1.0)
+
+
+class TestHitRate:
+    def test_hit(self):
+        assert hit_rate_at_k(["x", "a"], {"a"}, 2) == 1.0
+
+    def test_miss(self):
+        assert hit_rate_at_k(["x", "y"], {"a"}, 2) == 0.0
+
+    def test_outside_window_is_miss(self):
+        assert hit_rate_at_k(["x", "y", "a"], {"a"}, 2) == 0.0
+
+
+class TestMean:
+    def test_basic(self):
+        assert mean([1.0, 0.0]) == pytest.approx(0.5)
+
+    def test_empty_is_zero(self):
+        assert mean([]) == 0.0
+
+    def test_aggregate_excludes_none_precision(self):
+        # An aggregate over precision must drop the undefined (None) cases,
+        # not coerce them to 0.0.
+        per_case = [
+            precision_at_k(["a", "b"], {"a"}, {"b"}, 2),  # 0.5
+            precision_at_k(["a", "c"], {"a"}, set(), 2),  # None (c unlabeled)
+            precision_at_k(["a", "b"], {"a", "b"}, set(), 2),  # 1.0
+        ]
+        valid = [p for p in per_case if p is not None]
+        assert len(valid) == 2
+        assert mean(valid) == pytest.approx(0.75)
+
+
+class TestShimParity:
+    def test_shim_reexports_same_callables(self):
+        import ir_metrics
+
+        assert ir_metrics.recall_at_k is recall_at_k
+        assert ir_metrics.reciprocal_rank_at_k is reciprocal_rank_at_k
+        assert ir_metrics.ndcg_at_k is ndcg_at_k
+        assert ir_metrics.mean is mean

--- a/packages/memtomem/tests/test_quality_metrics.py
+++ b/packages/memtomem/tests/test_quality_metrics.py
@@ -53,6 +53,10 @@ class TestNdcg:
     def test_empty_relevance_is_zero(self):
         assert ndcg_at_k(["a"], {}, 2) == 0.0
 
+    def test_duplicate_id_bounded_at_one(self):
+        # A repeated relevant id must not inflate NDCG past 1.0.
+        assert ndcg_at_k(["a", "a"], {"a": 1.0}, 2) == pytest.approx(1.0)
+
 
 class TestPrecision:
     def test_fully_labeled_window(self):
@@ -114,3 +118,6 @@ class TestShimParity:
         assert ir_metrics.reciprocal_rank_at_k is reciprocal_rank_at_k
         assert ir_metrics.ndcg_at_k is ndcg_at_k
         assert ir_metrics.mean is mean
+        assert ir_metrics.precision_at_k is precision_at_k
+        assert ir_metrics.hit_rate_at_k is hit_rate_at_k
+        assert ir_metrics.recall_labeled_at_k is recall_labeled_at_k


### PR DESCRIPTION
## What

Move the four pure IR-metric functions from `tests/ir_metrics.py` into a new runtime-importable module `memtomem.quality.metrics`, and leave `tests/ir_metrics.py` as a re-export shim. Add the metrics the Quality Lab reports need.

## Why

The replay/evaluation work in #1802 (parent #1798) computes hit rate / MRR / precision at runtime, so the metrics can no longer live under `tests/`. The shim keeps every existing consumer working with no change: test imports (`from ir_metrics import ...`) and the `tools/retrieval-eval` file-path loaders both still resolve.

## New metrics

- `hit_rate_at_k` — 1.0 if any relevant item is in the top-k.
- `precision_at_k` — returns `None` unless **every** top-k item carries a judgment, so partial qrels surface as `incomplete_labels` rather than a downward-biased number that an aggregate would silently average in.
- `recall_labeled_at_k` — an explicitly named alias signaling the denominator is the labeled-relevant set, not true corpus recall.

## Duplicate-safety

The Quality Lab keys results by `content_hash`, and several chunks can share one hash, so a ranking may contain duplicate IDs. `recall_at_k` / `recall_labeled_at_k` / `precision_at_k` now count **distinct** hits, so a duplicated relevant item cannot push a rate above 1.0. For the existing unique-id callers this is identical to the prior occurrence-counting behavior.

## Tests

`tests/test_quality_metrics.py` covers precision `None`-on-incomplete-labels, boundary `k`, duplicate-hash bounding at 1.0, an aggregate that excludes `None` precision, and shim parity. Existing `tests/test_ir_metrics.py` continues to pass through the shim; the `tools/retrieval-eval` loader was verified to resolve the shim transparently. `ruff` (src/tests/tools) and `mypy` (quality package) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
