### PR TITLE
feat(search): no-side-effects replay mode on SearchPipeline (#1802)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   Omitted/`true` follows `rerank.enabled`; `true` cannot force-enable
   reranking on a server that has it disabled.
 
+### Changed
+
+- **Historical searches decay to the requested instant** (#1802) — a search
+  with an explicit `as_of_unix` now applies time decay relative to that
+  instant instead of the wall clock, matching how validity filtering already
+  treats `as_of`. Default-path searches (no `as_of`) are unchanged. This makes
+  point-in-time queries reproducible and underpins the Quality Lab's
+  no-side-effects replay mode (new `record=False` on the internal search
+  pipeline), which additionally skips access-counter increments, run
+  observations, and both search caches.
+
 ### Fixed
 
 - **Incremental CRUD re-indexing** (#1788) — `mem_edit`, `mem_delete`, and Web

--- a/packages/memtomem/src/memtomem/search/expansion.py
+++ b/packages/memtomem/src/memtomem/search/expansion.py
@@ -52,6 +52,7 @@ async def expand_query_headings(
     max_terms: int = 3,
     *,
     project_context_root: Path | None = None,
+    exhaustive: bool = False,
 ) -> str:
     """Expand query by appending related heading terms from dense search.
 
@@ -61,6 +62,11 @@ async def expand_query_headings(
     ``SearchPipeline.search`` call. Without it, expansion would
     silently sample only user-tier headings even when the outer
     search is pinned to a project context.
+
+    ``exhaustive`` propagates the caller's deterministic-evaluation mode
+    (#1802) into this leg's own dense probe: heading expansion changes the
+    query text, so a nondeterministic dense cutoff here would perturb the
+    whole downstream ranking during replay.
     """
     try:
         embedding = await embedder.embed_query(query)
@@ -68,6 +74,7 @@ async def expand_query_headings(
             embedding,
             top_k=3,
             project_context_root=project_context_root,
+            exhaustive=exhaustive,
         )
     except Exception:
         logger.warning("Heading expansion failed; returning original query", exc_info=True)

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -760,6 +760,7 @@ class SearchPipeline:
         scope_filter: ScopeFilter | None = None,
         project_context_root: Path | None = None,
         metadata_filter: SearchMetadataFilter | None = None,
+        exhaustive: bool = False,
     ) -> list[SearchResult]:
         """Parallel BM25+dense retrieval restricted to boost_sources.
 
@@ -811,6 +812,7 @@ class SearchPipeline:
                     namespace_filter=None,
                     scope_filter=scope_filter,
                     project_context_root=project_context_root,
+                    exhaustive=exhaustive,
                     **metadata_kwargs,
                 )
             except Exception:
@@ -891,6 +893,7 @@ class SearchPipeline:
         project_context_root: Path | None = None,
         metadata_filter: SearchMetadataFilter | None = None,
         exclude_source_roots: tuple[Path, ...] = (),
+        record: bool = True,
     ) -> tuple[list[SearchResult], RetrievalStats]:
         """Empty-query path (#750): enumerate by filter, skip retrievers.
 
@@ -959,7 +962,12 @@ class SearchPipeline:
         if self._decay_config.enabled and fused:
             from memtomem.search.decay import apply_score_decay
 
-            fused = apply_score_decay(fused, half_life_days=self._decay_config.half_life_days)
+            # Pin decay to the validity instant so replay is time-stable (#1802).
+            fused = apply_score_decay(
+                fused,
+                half_life_days=self._decay_config.half_life_days,
+                now=datetime.fromtimestamp(effective_as_of, tz=UTC),
+            )
 
         if self._access_config.enabled and fused:
             from memtomem.search.access import apply_access_boost
@@ -994,7 +1002,8 @@ class SearchPipeline:
 
         stats.final_total = len(fused)
 
-        if fused:
+        # Skipped under ``record=False`` (#1802) — replay mutates no counters.
+        if fused and record:
 
             async def _increment():
                 await self._storage.increment_access([r.chunk.id for r in fused])
@@ -1025,7 +1034,19 @@ class SearchPipeline:
         exclude_source_roots: tuple[Path, ...] | None = None,
         rerank: bool | None = None,
         origin: str = "internal",
+        record: bool = True,
     ) -> tuple[list[SearchResult], RetrievalStats]:
+        # ``record`` (#1802): the default (True) is today's behavior. False is
+        # the no-side-effects replay/evaluation mode — the call touches no
+        # persistent or cross-call state: it neither reads nor writes the TTL
+        # result cache or the LLM-expansion cache, does not increment access
+        # counters, and does not persist a query-run observation (so
+        # ``stats.query_run_id`` stays None). It also switches the dense legs
+        # to exhaustive KNN so equal-distance boundary rows are selected
+        # deterministically (see ``dense_search(exhaustive=...)``). Pair it
+        # with an explicit ``as_of_unix`` to pin validity + decay to a fixed
+        # instant for byte-reproducible replays.
+        #
         # ``rerank`` (#1766): None = follow server config; False = skip the
         # Stage 3b cross-encoder and collapse the candidate pool to top_k
         # (per-call fast path for latency-bounded callers); True = follow
@@ -1069,6 +1090,7 @@ class SearchPipeline:
                 project_context_root=project_context_root,
                 metadata_filter=metadata_filter,
                 exclude_source_roots=normalized_exclusion_roots,
+                record=record,
             )
 
         original_query = query
@@ -1108,7 +1130,10 @@ class SearchPipeline:
             )
             version_at_start = self._cache_version
             ttl_snapshot = self._cache_ttl
-            if as_of_unix is None and cache_key in self._search_cache:
+            # ``record=False`` (replay) bypasses the TTL result cache in both
+            # directions: it must never be served a cached result nor evict
+            # one, so a concurrent interactive search's cache is untouched.
+            if record and as_of_unix is None and cache_key in self._search_cache:
                 ts, ver, cached_results, cached_stats = self._search_cache[cache_key]
                 if ver == self._cache_version and time.time() - ts < ttl_snapshot:
                     run_stats = dataclass_replace(
@@ -1180,17 +1205,23 @@ class SearchPipeline:
                     # ADR-0011 PR-D round 11: thread the outer search's
                     # project context onto the heading-expansion's dense
                     # probe so it samples from the same scope set the
-                    # primary retrieval is pinned to.
+                    # primary retrieval is pinned to. ``exhaustive`` carries
+                    # replay's deterministic-dense mode into this leg too.
                     query = await expand_query_headings(
                         query,
                         self._storage,
                         self._embedder,
                         max_terms,
                         project_context_root=project_context_root,
+                        exhaustive=not record,
                     )
                 if strategy == "llm":
-                    if query in self._expansion_cache:
-                        query = self._expansion_cache[query]
+                    # Replay (``record=False``) neither reads nor writes the
+                    # expansion cache, so it cannot depend on nor mutate hidden
+                    # prior pipeline state.
+                    cached_expansion = self._expansion_cache.get(query) if record else None
+                    if cached_expansion is not None:
+                        query = cached_expansion
                     elif self._llm_provider is not None:
                         try:
                             original = query
@@ -1199,9 +1230,10 @@ class SearchPipeline:
                                 self._llm_provider,
                                 max_terms,  # type: ignore[arg-type]
                             )
-                            if len(self._expansion_cache) >= _EXPANSION_CACHE_MAX:
-                                self._expansion_cache.clear()
-                            self._expansion_cache[original] = query
+                            if record:
+                                if len(self._expansion_cache) >= _EXPANSION_CACHE_MAX:
+                                    self._expansion_cache.clear()
+                                self._expansion_cache[original] = query
                         except Exception:
                             logger.warning(
                                 "LLM query expansion failed, using original query",
@@ -1235,6 +1267,7 @@ class SearchPipeline:
                         namespace_filter=ns_filter,
                         scope_filter=scope_filter,
                         project_context_root=project_context_root,
+                        exhaustive=not record,
                         **metadata_kwargs,
                     )
                 except Exception as exc:
@@ -1299,6 +1332,7 @@ class SearchPipeline:
                             scope_filter=scope_filter,
                             project_context_root=project_context_root,
                             metadata_filter=metadata_filter,
+                            exhaustive=not record,
                         )
                         rescue_chunk_ids = {r.chunk.id for r in rescue_results}
                 except Exception:
@@ -1439,7 +1473,14 @@ class SearchPipeline:
             if self._decay_config.enabled and fused:
                 from memtomem.search.decay import apply_score_decay
 
-                fused = apply_score_decay(fused, half_life_days=self._decay_config.half_life_days)
+                # Pin decay to the same instant as validity (#1802): otherwise
+                # ``apply_score_decay`` defaults to wall clock and a replay with
+                # an explicit ``as_of_unix`` would still drift with real time.
+                fused = apply_score_decay(
+                    fused,
+                    half_life_days=self._decay_config.half_life_days,
+                    now=datetime.fromtimestamp(effective_as_of, tz=UTC),
+                )
 
             # Stage 5: MMR diversity re-ranking
             if self._mmr_config.enabled and not use_dense:
@@ -1521,8 +1562,11 @@ class SearchPipeline:
 
             stats.final_total = len(fused)
 
-            # Increment access counts for returned results (fire-and-forget)
-            if fused:
+            # Increment access counts for returned results (fire-and-forget).
+            # Skipped under ``record=False`` (#1802): replay must not mutate the
+            # counters that feed the access/importance boosts, or a later
+            # baseline-vs-candidate comparison would drift.
+            if fused and record:
 
                 async def _increment():
                     await self._storage.increment_access([r.chunk.id for r in fused])
@@ -1533,20 +1577,25 @@ class SearchPipeline:
                 t.add_done_callback(self._bg_tasks.discard)
 
             stats.latency_ms = round((time.perf_counter() - started_at) * 1000, 3)
-            stats.query_run_id = await self._record_ranked_search(
-                query=original_query,
-                query_embedding=query_embedding if use_dense else [],
-                results=fused,
-                stats=stats,
-                top_k=top_k,
-                origin=origin,
-                namespace=namespace,
-                scope=scope,
-                source_filter=source_filter,
-                tag_filter=tag_filter,
-                metadata_filter=metadata_filter,
-                as_of_unix=as_of_unix,
-                rrf_weights=effective_weights,
+            # Replay persists no observation, so no run id is minted.
+            stats.query_run_id = (
+                await self._record_ranked_search(
+                    query=original_query,
+                    query_embedding=query_embedding if use_dense else [],
+                    results=fused,
+                    stats=stats,
+                    top_k=top_k,
+                    origin=origin,
+                    namespace=namespace,
+                    scope=scope,
+                    source_filter=source_filter,
+                    tag_filter=tag_filter,
+                    metadata_filter=metadata_filter,
+                    as_of_unix=as_of_unix,
+                    rrf_weights=effective_weights,
+                )
+                if record
+                else None
             )
 
             # Store in TTL cache only if version hasn't changed during search.
@@ -1554,7 +1603,7 @@ class SearchPipeline:
             # historical-query result never overwrites the default-path slot
             # (next default caller would otherwise be served a past-snapshot
             # filtering of the same query).
-            if as_of_unix is None and self._cache_version == version_at_start:
+            if record and as_of_unix is None and self._cache_version == version_at_start:
                 cache_stats = dataclass_replace(
                     stats, query_run_id=None, cache_hit=False, latency_ms=None
                 )

--- a/packages/memtomem/src/memtomem/storage/base.py
+++ b/packages/memtomem/src/memtomem/storage/base.py
@@ -93,6 +93,8 @@ class StorageBackend(Protocol):
         scope_filter: ScopeFilter | None = None,
         project_context_root: Path | None = None,
         metadata_filter: SearchMetadataFilter | None = None,
+        *,
+        exhaustive: bool = False,
     ) -> list[SearchResult]: ...
 
     # Metadata

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -1474,6 +1474,8 @@ class SqliteBackend(
         scope_filter: ScopeFilter | None = None,
         project_context_root: Path | None = None,
         metadata_filter: SearchMetadataFilter | None = None,
+        *,
+        exhaustive: bool = False,
     ) -> list[SearchResult]:
         # bm25-only mode (dimension=0) — no chunks_vec table to query. Return
         # early instead of raising OperationalError that the search pipeline
@@ -1545,11 +1547,24 @@ class SqliteBackend(
         # common case, then jump to "essentially unbounded" before
         # giving up. Stop early when an attempt either returned
         # ``top_k`` rows OR already saw every embedding.
-        attempts = [
-            max(top_k * 5, 100),
-            max(top_k * 50, 1000),
-            total_vec_rows,
-        ]
+        #
+        # ``exhaustive`` (deterministic evaluation mode, #1802): sqlite-vec
+        # 0.1.9 prunes to the inner ``LIMIT`` with an unstable distance-only
+        # sort, so equal-distance rows straddling an adaptive cutoff are
+        # selected nondeterministically — a replay diff cannot tolerate that.
+        # Scanning every embedding once removes the inner cutoff entirely, so
+        # the outer stable ``ORDER BY sub.distance, ..., c.id`` fully
+        # determines selection. Costs one full-table KNN pass; acceptable
+        # because replay runs off the interactive hot path.
+        attempts = (
+            [total_vec_rows or 1]
+            if exhaustive
+            else [
+                max(top_k * 5, 100),
+                max(top_k * 50, 1000),
+                total_vec_rows,
+            ]
+        )
         rows: list = []
         for inner_k in attempts:
             inner_k = max(1, min(inner_k, total_vec_rows or inner_k))

--- a/packages/memtomem/tests/test_dense_exhaustive_replay.py
+++ b/packages/memtomem/tests/test_dense_exhaustive_replay.py
@@ -1,0 +1,93 @@
+"""Deterministic exhaustive dense KNN under replay mode (#1802).
+
+``record=False`` switches every dense leg reachable from ``search()`` — the
+primary retrieval, heading expansion, and session-summary rescue — to an
+exhaustive inner KNN. sqlite-vec 0.1.9 prunes to the adaptive inner ``LIMIT``
+with an unstable distance-only sort, so equal-distance rows straddling that
+cutoff are dropped nondeterministically; scanning every embedding removes the
+cutoff so the outer stable ``ORDER BY ..., c.id`` fully determines selection.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from helpers import make_chunk as _make_chunk
+from memtomem.search.expansion import expand_query_headings
+
+
+class _FakeEmbedder:
+    dimension = 1024
+    model_name = "fake"
+
+    async def embed_query(self, query: str) -> list[float]:
+        return [0.1] * 1024
+
+
+class TestExhaustiveDeterminism:
+    @pytest.mark.asyncio
+    async def test_exhaustive_selects_full_set_deterministically(self, storage):
+        # More tied-distance chunks than the non-exhaustive first cutoff
+        # (max(top_k*5, 100)) so a boundary genuinely exists.
+        vec = [0.2] * 1024
+        chunks = [
+            _make_chunk(f"exhaustive body {i}", source=f"e{i}.md", embedding=vec)
+            for i in range(120)
+        ]
+        await storage.upsert_chunks(chunks)
+
+        results = await storage.dense_search([0.2] * 1024, top_k=5, exhaustive=True)
+        got = [r.chunk.id for r in results]
+
+        # With every row fetched, the outer stable sort returns the 5 lowest ids.
+        expected = sorted((c.id for c in chunks), key=str)[:5]
+        assert got == expected
+
+        # Stable across a repeat call.
+        again = await storage.dense_search([0.2] * 1024, top_k=5, exhaustive=True)
+        assert [r.chunk.id for r in again] == expected
+
+
+class TestExhaustiveThreading:
+    @pytest.mark.asyncio
+    async def test_heading_expansion_threads_exhaustive(self, storage):
+        await storage.upsert_chunks([_make_chunk("body", heading=("Alpha Topic",))])
+        seen: list[bool] = []
+        original = storage.dense_search
+
+        async def _spy(*args, **kwargs):
+            seen.append(kwargs.get("exhaustive", False))
+            return await original(*args, **kwargs)
+
+        storage.dense_search = _spy  # type: ignore[method-assign]
+        await expand_query_headings("query", storage, _FakeEmbedder(), exhaustive=True)
+        assert seen == [True]
+
+    @pytest.mark.asyncio
+    async def test_primary_and_rescue_legs_thread_exhaustive(self, components):
+        storage, pipeline = components.storage, components.search_pipeline
+        pipeline._embedder = _FakeEmbedder()
+
+        await storage.upsert_chunks(
+            [_make_chunk("thread marker body", source=f"t{i}.md") for i in range(3)]
+        )
+
+        seen: list[bool] = []
+        original = storage.dense_search
+
+        async def _spy(*args, **kwargs):
+            seen.append(kwargs.get("exhaustive", False))
+            return await original(*args, **kwargs)
+
+        storage.dense_search = _spy  # type: ignore[method-assign]
+
+        await pipeline.search("thread", record=False)
+        assert seen and all(seen), "every dense leg must run exhaustive under replay"
+
+        seen.clear()
+        await pipeline.search("thread", record=True)
+        if pipeline._bg_tasks:
+            import asyncio
+
+            await asyncio.gather(*list(pipeline._bg_tasks), return_exceptions=True)
+        assert seen and not any(seen), "normal search must not run exhaustive"

--- a/packages/memtomem/tests/test_dense_exhaustive_replay.py
+++ b/packages/memtomem/tests/test_dense_exhaustive_replay.py
@@ -64,7 +64,7 @@ class TestExhaustiveThreading:
         assert seen == [True]
 
     @pytest.mark.asyncio
-    async def test_primary_and_rescue_legs_thread_exhaustive(self, components):
+    async def test_primary_leg_threads_exhaustive(self, components):
         storage, pipeline = components.storage, components.search_pipeline
         pipeline._embedder = _FakeEmbedder()
 
@@ -82,7 +82,7 @@ class TestExhaustiveThreading:
         storage.dense_search = _spy  # type: ignore[method-assign]
 
         await pipeline.search("thread", record=False)
-        assert seen and all(seen), "every dense leg must run exhaustive under replay"
+        assert seen and all(seen), "primary dense leg must run exhaustive under replay"
 
         seen.clear()
         await pipeline.search("thread", record=True)
@@ -91,3 +91,32 @@ class TestExhaustiveThreading:
 
             await asyncio.gather(*list(pipeline._bg_tasks), return_exceptions=True)
         assert seen and not any(seen), "normal search must not run exhaustive"
+
+    @pytest.mark.asyncio
+    async def test_rescue_leg_threads_exhaustive(self, components):
+        # The pipeline's rescue leg only fires with non-empty boost_sources
+        # (from session summaries), which the fixtures don't seed — so exercise
+        # ``_rescue_retrieval`` directly to prove its dense leg threads the flag.
+        storage, pipeline = components.storage, components.search_pipeline
+        chunk = _make_chunk("rescue marker body", source="rescue.md")
+        await storage.upsert_chunks([chunk])
+
+        seen: list[bool] = []
+        original = storage.dense_search
+
+        async def _spy(*args, **kwargs):
+            seen.append(kwargs.get("exhaustive", False))
+            return await original(*args, **kwargs)
+
+        storage.dense_search = _spy  # type: ignore[method-assign]
+
+        await pipeline._rescue_retrieval(
+            "rescue",
+            [0.1] * 1024,
+            top_k=5,
+            boost_sources={str(chunk.metadata.source_file)},
+            use_bm25=False,
+            use_dense=True,
+            exhaustive=True,
+        )
+        assert seen == [True]

--- a/packages/memtomem/tests/test_pipeline_replay_mode.py
+++ b/packages/memtomem/tests/test_pipeline_replay_mode.py
@@ -1,0 +1,113 @@
+"""``record=False`` replay/evaluation mode on ``SearchPipeline.search`` (#1802).
+
+Replay must be a no-side-effects read: no access-counter mutation, no
+query-run observation, and no interaction (read or write) with either the TTL
+result cache or the LLM-expansion cache. It must also pin time decay to the
+supplied ``as_of_unix`` so a delayed replay is byte-stable, and switch the dense
+legs to exhaustive KNN for deterministic boundary selection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from helpers import make_chunk as _make_chunk
+
+
+async def _drain_bg(pipeline):
+    if pipeline._bg_tasks:
+        await asyncio.gather(*list(pipeline._bg_tasks), return_exceptions=True)
+
+
+class TestNoSideEffects:
+    @pytest.mark.asyncio
+    async def test_record_false_touches_no_state(self, bm25_only_components):
+        comp, _ = bm25_only_components
+        storage, pipeline = comp.storage, comp.search_pipeline
+
+        chunks = [_make_chunk("replay marker body", source=f"n{i}.md") for i in range(4)]
+        await storage.upsert_chunks(chunks)
+        ids = [c.id for c in chunks]
+
+        before = await storage.get_access_counts(ids)
+
+        results, stats = await pipeline.search("replay", record=False)
+        await _drain_bg(pipeline)
+
+        assert results, "sanity: BM25 should find the seeded chunks"
+        assert stats.query_run_id is None
+        # No access-counter mutation.
+        assert await storage.get_access_counts(ids) == before
+        # No observation persisted.
+        assert await storage.get_search_runs() == []
+        # Neither cache populated.
+        assert pipeline._search_cache == {}
+        assert pipeline._expansion_cache == {}
+
+    @pytest.mark.asyncio
+    async def test_record_true_still_has_side_effects(self, bm25_only_components):
+        comp, _ = bm25_only_components
+        storage, pipeline = comp.storage, comp.search_pipeline
+
+        chunks = [_make_chunk("record marker body", source=f"r{i}.md") for i in range(4)]
+        await storage.upsert_chunks(chunks)
+        ids = [c.id for c in chunks]
+
+        results, stats = await pipeline.search("record", record=True)
+        await _drain_bg(pipeline)
+
+        assert results
+        assert stats.query_run_id is not None
+        counts = await storage.get_access_counts(ids)
+        assert all(counts.get(str(cid), 0) >= 1 for cid in ids)
+        assert len(await storage.get_search_runs()) == 1
+        assert pipeline._search_cache, "record=True must populate the TTL cache"
+
+
+class TestCacheIsolation:
+    @pytest.mark.asyncio
+    async def test_replay_not_served_from_and_preserves_cache(self, bm25_only_components):
+        comp, _ = bm25_only_components
+        storage, pipeline = comp.storage, comp.search_pipeline
+
+        chunks = [_make_chunk("cache marker body", source=f"c{i}.md") for i in range(4)]
+        await storage.upsert_chunks(chunks)
+
+        # Warm the cache with a normal search.
+        await pipeline.search("cache", record=True)
+        await _drain_bg(pipeline)
+        assert pipeline._search_cache
+        cache_snapshot = dict(pipeline._search_cache)
+
+        # An identical replay within TTL must not be served from the cache
+        # (cache_hit stays False) and must not evict/replace the entry.
+        _, stats = await pipeline.search("cache", record=False)
+        await _drain_bg(pipeline)
+        assert stats.cache_hit is False
+        assert pipeline._search_cache == cache_snapshot
+
+
+class TestDecayPinning:
+    @pytest.mark.asyncio
+    async def test_decay_pinned_to_as_of(self, bm25_only_components):
+        comp, _ = bm25_only_components
+        storage, pipeline = comp.storage, comp.search_pipeline
+        pipeline._decay_config.enabled = True
+
+        await storage.upsert_chunks([_make_chunk("decay marker body", source="d.md")])
+
+        as_of = int(time.time())
+        r1, _ = await pipeline.search("decay", as_of_unix=as_of, record=False)
+        # A second replay pinned to the SAME instant scores identically, even
+        # though wall-clock has advanced between the two calls.
+        r2, _ = await pipeline.search("decay", as_of_unix=as_of, record=False)
+        assert [round(r.score, 9) for r in r1] == [round(r.score, 9) for r in r2]
+
+        # A later ``as_of`` decays the same chunk further — proving decay is
+        # driven by the pinned instant, not ignored.
+        r3, _ = await pipeline.search("decay", as_of_unix=as_of + 400 * 86400, record=False)
+        assert r3
+        assert r3[0].score < r1[0].score

--- a/packages/memtomem/tests/test_pipeline_replay_mode.py
+++ b/packages/memtomem/tests/test_pipeline_replay_mode.py
@@ -92,10 +92,10 @@ class TestCacheIsolation:
 
 class TestDecayPinning:
     @pytest.mark.asyncio
-    async def test_decay_pinned_to_as_of(self, bm25_only_components):
+    async def test_decay_pinned_to_as_of(self, bm25_only_components, monkeypatch):
         comp, _ = bm25_only_components
         storage, pipeline = comp.storage, comp.search_pipeline
-        pipeline._decay_config.enabled = True
+        monkeypatch.setattr(pipeline._decay_config, "enabled", True)
 
         await storage.upsert_chunks([_make_chunk("decay marker body", source="d.md")])
 

--- a/packages/memtomem/tests/test_session_summary_rescue.py
+++ b/packages/memtomem/tests/test_session_summary_rescue.py
@@ -397,7 +397,11 @@ class TestPipelineEndToEndRescue:
             namespace_filter=None,
             scope_filter=None,
             project_context_root=None,
+            **kwargs,
         ):
+            # ``**kwargs`` absorbs keyword-only additions to the real
+            # ``dense_search`` signature (e.g. ``exhaustive`` from the replay
+            # path, #1802) so this double stays call-compatible.
             dense_calls.append(
                 {
                     "project_context_root": project_context_root,


### PR DESCRIPTION
> Stacked on #1817 (base branch `fix/516-search-tiebreak`). The exhaustive-KNN determinism below relies on that PR's outer `c.id` tiebreak. Retarget to `main` once #1817 merges.

## What

Add a keyword-only `record: bool = True` to `SearchPipeline.search`. The default is today's behavior; `record=False` is the no-side-effects replay/evaluation mode the Memory Quality Lab (#1798 → #1802) needs.

## `record=False` contract

A read that touches no persistent or cross-call state:

- neither reads nor writes the TTL **result cache** — a concurrent interactive search's cache is never served to, nor evicted by, a replay;
- neither reads nor writes the LLM **expansion cache**, so replay can't depend on nor mutate hidden prior pipeline state;
- does not **increment access counters** (they feed the access/importance boosts, so mutating them would drift a later baseline-vs-candidate comparison);
- persists **no query-run observation** (`stats.query_run_id` stays `None`).

Threaded through the empty-query filter-only path too, so the flag never lies.

## Two determinism fixes ride along

- **Decay pinning.** `apply_score_decay` defaulted to wall clock at both call sites, so a replay with an explicit `as_of_unix` still drifted with real time (decay ages from `updated_at`). It now receives the effective `as_of` as `now`, so a delayed replay pinned to one instant scores identically.
- **Exhaustive dense KNN.** `record=False` switches **every** dense leg reachable from `search` — primary retrieval, heading expansion, and session-summary rescue — to `dense_search(exhaustive=True)`. sqlite-vec 0.1.9 prunes to the adaptive inner `LIMIT` with an unstable distance-only sort, so equal-distance rows straddling that cutoff are dropped nondeterministically. Scanning every embedding removes the inner cutoff, so the outer stable `ORDER BY sub.distance, …, c.id` (from #1817) fully determines selection. Production keeps the adaptive schedule; the exhaustive pass costs one full-table KNN scan and runs only off the interactive hot path.

## Tests

- `test_pipeline_replay_mode.py` — after `record=False`: access counts unchanged, no observation row, both caches empty; `record=True` still increments + persists + caches; a warm cache entry is neither served to nor mutated by a replay (`cache_hit` stays False); decay pinned to `as_of` is stable across a delayed replay and moves with a later `as_of`.
- `test_dense_exhaustive_replay.py` — with 120 tied-distance chunks (a real boundary past the first adaptive cutoff), exhaustive mode returns the id-sorted top-k deterministically across runs; a spy verifies the `exhaustive` flag threads through the primary leg (via `search`) and is off for normal search, and through heading expansion and the rescue leg (`_rescue_retrieval`) by driving each directly.

`ruff` (src/tests/tools), `mypy` (edited sources), and the search/storage/temporal suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

