### PR TITLE
test(search): pin source_name basename invariant at the snapshot writer (#1815)

### DIFF
--- a/packages/memtomem/tests/test_search_observation.py
+++ b/packages/memtomem/tests/test_search_observation.py
@@ -54,6 +54,38 @@ async def test_ranked_search_persists_durable_secret_free_observation(
     assert "content" not in row["result_snapshot"][0]
 
 
+async def test_snapshot_source_name_is_a_basename_never_a_path(bm25_only_components):
+    """Value-level pin for the snapshot writer's projection (#1815).
+
+    ``SnapshotEntryOut`` deliberately does not re-sanitize field contents
+    (#1813) — the guarantee that ``source_name`` is a bare basename lives
+    at the writer. A writer change that records an absolute or relative
+    path must fail here, not surface through ``GET /api/search/runs``.
+    """
+    components, memory_dir = bm25_only_components
+    nested = memory_dir / "projects" / "alpha"
+    nested.mkdir(parents=True)
+    note = nested / "pinned.md"
+    note.write_text("# Pin\n\nBasename invariant probe content.\n", encoding="utf-8")
+    await components.index_engine.index_file(note)
+
+    results, stats = await components.search_pipeline.search(
+        "basename invariant probe", top_k=5, origin="web"
+    )
+
+    assert results
+    row = (await components.storage.get_query_history(limit=1))[0]
+    assert row["run_id"] == stats.query_run_id
+    assert row["result_snapshot"]
+    for entry in row["result_snapshot"]:
+        source_name = entry["source_name"]
+        assert source_name == note.name
+        # Both separators: catches a path leak regardless of the OS the
+        # writer ran on (POSIX "/" and Windows "\\").
+        assert "/" not in source_name
+        assert "\\" not in source_name
+
+
 async def test_zero_result_ranked_search_still_gets_run_id(bm25_only_components):
     components, memory_dir = bm25_only_components
     await _index_quality_note(components, memory_dir)


### PR DESCRIPTION
## Summary

Option 1 from #1815 — a writer-side pin for the `source_name` basename invariant in search-run snapshots.

#1813 settled `SnapshotEntryOut` as a closed allowlist that deliberately does **not** re-sanitize field contents: the guarantee that `source_name` is a bare basename (never an absolute path or raw text) lives upstream in the snapshot writer's projection (`search/pipeline.py` records `chunk.metadata.source_file.name`). Nothing pinned that value-level invariant — a writer change storing a path under the already-allowed key would surface verbatim through `GET /api/search/runs/{run_id}` with no failing test.

## Change

Test-only. `test_snapshot_source_name_is_a_basename_never_a_path` (in `test_search_observation.py`, next to the existing snapshot contract tests):

- indexes a note in a **nested subdirectory** of the memory dir, so a relative-path regression is distinguishable from the basename;
- runs a ranked search and asserts every snapshot entry's `source_name` equals the bare basename;
- additionally asserts no `/` and no `\` appear, so a path leak is caught regardless of the OS the writer ran on (POSIX + Windows separators — the suite runs on the 3-OS CI matrix).

No read-side re-sanitizing in `SnapshotEntryOut` (explicitly rejected in #1813); option 2 (centralized snapshot sanitizer) stays deferred until another snapshot reader appears.

## Validation

- Mutation check: temporarily changing the writer to `str(result.chunk.metadata.source_file)` makes the new test fail (`AssertionError` on the basename equality); reverting restores green. Mutation application was verified via `git diff` before the failing run.
- `uv run pytest -m "not ollama"` — 8909 passed, 11 skipped.
- `uv run ruff check` + `ruff format --check` over `src`, `tests`, `tools` — clean.

Closes #1815. Refs #1812, #1813.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
