### PR TITLE
fix(asyncio): share one settlement contract for executor-backed awaits (#1806)

### DIFF
--- a/packages/memtomem/src/memtomem/_settlement.py
+++ b/packages/memtomem/src/memtomem/_settlement.py
@@ -1,0 +1,64 @@
+"""Shared shielded settlement for executor-backed awaits (#1803, #1806).
+
+A worker thread can't be interrupted — cancelling only the awaiting task
+would either drop sync work that is still queued in the executor or leave
+it running while shutdown tears components down under it. The two
+executor-backed settle paths (``server/warmup.py`` model loads and
+``OnnxEmbedder.close`` teardown) await through :func:`settle_shielded`
+so they share one contract instead of drifting apart:
+
+* Every settle-await is shielded — repeated cancellation of the awaiting
+  task can never cancel executor work, queued or running.
+* After the work settles, the *first* caught cancellation is re-raised as
+  the same exception instance, so a ``task.cancel(msg)`` message survives
+  settlement and later cancellations don't overwrite it.
+* Executor-failure precedence is explicit: with no cancellation pending,
+  the failure propagates to the caller unchanged. Once a cancellation has
+  been caught, cancellation wins — the failure is logged (never silently
+  dropped) and the cancellation is re-raised, because shutdown paths rely
+  on observing ``CancelledError`` (e.g. ``AppContext.close`` awaits the
+  cancelled warmup task) and a surprise teardown exception there would
+  masquerade as a crash.
+
+Private module — not part of the public API surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def settle_shielded(future: asyncio.Future, *, what: str) -> None:
+    """Await *future* until it settles, surviving repeated cancellation.
+
+    Returns normally when the future succeeds with no cancellation caught.
+    Re-raises the first caught :class:`asyncio.CancelledError` (message
+    preserved) once the future is done, or the future's own failure when
+    no cancellation was caught. *what* names the work in the log line
+    emitted when cancellation suppresses a failure.
+    """
+    cancelled: asyncio.CancelledError | None = None
+    while True:
+        try:
+            await asyncio.shield(future)
+            break
+        except asyncio.CancelledError as exc:
+            if cancelled is None:
+                cancelled = exc
+            if future.done():
+                break
+        except BaseException:
+            if cancelled is not None:
+                break
+            raise
+    if cancelled is not None:
+        try:
+            future.result()
+        except BaseException:
+            logger.warning(
+                "%s failed while settling a cancellation — cancellation wins", what, exc_info=True
+            )
+        raise cancelled

--- a/packages/memtomem/src/memtomem/embedding/onnx.py
+++ b/packages/memtomem/src/memtomem/embedding/onnx.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import Sequence
 
+from memtomem._settlement import settle_shielded
 from memtomem.config import EmbeddingConfig
 from memtomem.embedding.aliases import resolve_embedder_id
 from memtomem.embedding.fastembed_cache import resolve_fastembed_cache_dir
@@ -450,28 +451,18 @@ class OnnxEmbedder:
     async def close(self) -> None:
         # Teardown runs entirely in ``_close_sync`` on a worker thread, off
         # the event loop, so the blocking ``_load_lock`` acquire / executor
-        # drain never stall the loop. Every await on the teardown future is
-        # ``shield``ed so cancellation of the awaiting task — first or
-        # repeated — can never propagate into the future and cancel a
-        # still-queued ``_close_sync`` before it starts (which would leave
-        # the model and executor alive; an already-running worker can't be
-        # interrupted anyway). On cancellation we keep settling until the
-        # future is done, then propagate. ``server/warmup.py`` uses the same
-        # repeated-shield settlement for model loads; keep both paths aligned
-        # so neither loses queued executor work (#1803).
+        # drain never stall the loop. ``settle_shielded`` owns the settlement
+        # contract, shared with ``server/warmup.py`` so the two paths can't
+        # drift (#1803, #1806): every await on the teardown future is
+        # shielded — cancellation of the awaiting task, first or repeated,
+        # can never cancel a still-queued ``_close_sync`` before it starts
+        # (which would leave the model and executor alive; an already-running
+        # worker can't be interrupted anyway). Once teardown settles, the
+        # first cancellation (message included) is re-raised; a teardown
+        # failure after cancellation is logged instead of displacing it.
         loop = asyncio.get_running_loop()
         future = loop.run_in_executor(None, self._close_sync)
-        cancelled = False
-        while True:
-            try:
-                await asyncio.shield(future)
-                break
-            except asyncio.CancelledError:
-                cancelled = True
-                if future.done():
-                    break
-        if cancelled:
-            raise asyncio.CancelledError
+        await settle_shielded(future, what="ONNX embedder teardown")
 
     def _close_sync(self) -> None:
         # Latch closed and drop the model under ``_load_lock`` — the same lock

--- a/packages/memtomem/src/memtomem/server/warmup.py
+++ b/packages/memtomem/src/memtomem/server/warmup.py
@@ -17,18 +17,20 @@ endpoint and the web hot-reload path already introspect (warmup is
 broader: readiness only inspects onnx/fastembed, warmup also warms the
 ``local`` reranker).
 
-Lazy-import discipline: module level stays stdlib-only so importing
-this from the lifespan's flag gate adds nothing to the flag-off
-handshake path.
+Lazy-import discipline: module level stays stdlib-only (plus the
+itself-stdlib-only ``memtomem._settlement`` helper) so importing this
+from the lifespan's flag gate adds nothing to the flag-off handshake
+path.
 """
 
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+from memtomem._settlement import settle_shielded
 
 if TYPE_CHECKING:
     from memtomem.server.component_factory import Components
@@ -62,28 +64,12 @@ async def _warm_one(
     future = loop.run_in_executor(None, load_model)
     # A worker thread can't be interrupted — cancelling only the awaiting
     # task would leave the load running while shutdown closes components
-    # under it. Every settle-await stays shielded so repeated cancellation
-    # cannot cancel a load that is still queued in the executor. Once the
-    # load settles, preserve cancellation as the caller-visible outcome.
-    cancelled = False
-    while True:
-        try:
-            await asyncio.shield(future)
-            break
-        except asyncio.CancelledError:
-            cancelled = True
-            if future.done():
-                break
-        except BaseException:
-            if cancelled:
-                break
-            raise
-    if cancelled:
-        # Consume a failed/cancelled load in the completion race while
-        # preserving the pre-existing cancellation-wins contract.
-        with contextlib.suppress(BaseException):
-            future.result()
-        raise asyncio.CancelledError
+    # under it. ``settle_shielded`` owns the settlement contract (#1803,
+    # #1806): repeated cancellation never cancels the queued/running load,
+    # the first cancellation (message included) is re-raised once the load
+    # settles, and a load failure after cancellation is logged rather than
+    # displacing the cancellation.
+    await settle_shielded(future, what=f"{component} model load")
     return WarmupOutcome(component, provider, model, "loaded")
 
 

--- a/packages/memtomem/tests/test_embedding_providers.py
+++ b/packages/memtomem/tests/test_embedding_providers.py
@@ -908,8 +908,12 @@ class TestOnnxEmbedder:
         loop = asyncio.get_running_loop()
         blocker_release = threading.Event()
         # Single-worker default executor so _close_sync deterministically
-        # queues behind the blocker instead of starting.
+        # queues behind the blocker instead of starting. Capture the loop's
+        # current default (no public getter) and restore it in the finally so
+        # later run_in_executor(None, ...) callers on shared loops don't
+        # inherit our shut-down pool (#1806).
         small = _TPE(max_workers=1, thread_name_prefix="test-default")
+        prev_executor = getattr(loop, "_default_executor", None)
         loop.set_default_executor(small)
         try:
             blocker = loop.run_in_executor(None, blocker_release.wait, 10)
@@ -932,7 +936,8 @@ class TestOnnxEmbedder:
             assert embedder._model is None
         finally:
             blocker_release.set()
-            small.shutdown(wait=False)
+            loop._default_executor = prev_executor
+            small.shutdown(wait=True)
 
     @pytest.mark.anyio
     async def test_close_double_cancel_still_tears_down(self):
@@ -950,6 +955,7 @@ class TestOnnxEmbedder:
         loop = asyncio.get_running_loop()
         blocker_release = threading.Event()
         small = _TPE(max_workers=1, thread_name_prefix="test-default")
+        prev_executor = getattr(loop, "_default_executor", None)
         loop.set_default_executor(small)
         try:
             blocker = loop.run_in_executor(None, blocker_release.wait, 10)
@@ -974,7 +980,8 @@ class TestOnnxEmbedder:
             assert embedder._model is None
         finally:
             blocker_release.set()
-            small.shutdown(wait=False)
+            loop._default_executor = prev_executor
+            small.shutdown(wait=True)
 
     @staticmethod
     def _blocking_model(stats, stats_lock, entered, release):

--- a/packages/memtomem/tests/test_warmup.py
+++ b/packages/memtomem/tests/test_warmup.py
@@ -260,7 +260,10 @@ class TestShutdownThreadSettlement:
     @pytest.mark.asyncio
     async def test_double_cancel_still_settles_queued_loader(self):
         """#1803: repeated cancellation must not cancel a queued load while
-        ``_warm_one`` is already settling the first cancellation.
+        ``_warm_one`` is already settling the first cancellation. #1806: the
+        *first* cancellation's ``task.cancel(msg)`` message must survive
+        settlement (a later cancel must not overwrite it), and the test must
+        hand the loop back a usable default executor.
         """
         from concurrent.futures import ThreadPoolExecutor
 
@@ -286,23 +289,29 @@ class TestShutdownThreadSettlement:
         small = ThreadPoolExecutor(max_workers=1, thread_name_prefix="test-default")
         blocker = small.submit(occupy_worker)
         assert blocker_started.wait(timeout=5), "default-executor blocker did not start"
+        # ``set_default_executor`` has no public getter or reset, so capture
+        # the loop's current default through the private attribute and put it
+        # back in the ``finally``. Under module-/session-scoped loops a later
+        # ``run_in_executor(None, ...)`` caller must not inherit our shut-down
+        # single-worker pool; restoring ``None`` re-enables lazy creation.
+        prev_executor = getattr(loop, "_default_executor", None)
         loop.set_default_executor(small)
 
         holder = _QueuedLocalModel()
         task = asyncio.create_task(_warm_one("embedder", "onnx", "model", holder))
         try:
             await asyncio.sleep(0)  # submit the model load behind the blocker
-            task.cancel()
+            task.cancel("first shutdown")
             await asyncio.sleep(0)  # enter the first shielded settle iteration
             assert not task.done()
 
-            task.cancel()
+            task.cancel("second shutdown")
             await asyncio.sleep(0)  # deliver the second cancellation mid-settle
             assert not task.done(), "second cancel must not lose the queued load"
             assert load_calls == []
 
             blocker_release.set()
-            with pytest.raises(asyncio.CancelledError):
+            with pytest.raises(asyncio.CancelledError, match="first shutdown"):
                 await task
             blocker.result(timeout=5)
 
@@ -310,7 +319,47 @@ class TestShutdownThreadSettlement:
             assert holder._model is not None
         finally:
             blocker_release.set()
-            small.shutdown(wait=False)
+            loop._default_executor = prev_executor
+            small.shutdown(wait=True)
+
+        # The loop must leave this test with a usable default executor —
+        # recreated lazily by the loop itself now that ours is gone.
+        assert await loop.run_in_executor(None, lambda: "usable") == "usable"
+
+    @pytest.mark.asyncio
+    async def test_loader_failure_after_cancellation_preserves_cancellation(self, caplog):
+        """#1806 precedence policy: once a cancellation has been caught,
+        a loader failure during settlement is logged, not raised — the
+        first cancellation (message included) stays the caller-visible
+        outcome.
+        """
+        from memtomem.server.warmup import _warm_one
+
+        entered = threading.Event()
+        release = threading.Event()
+
+        class _FailingModel:
+            _model: object | None = None
+
+            def _get_model(self) -> object:
+                entered.set()
+                release.wait(timeout=10)
+                raise RuntimeError("load exploded")
+
+        task = asyncio.create_task(_warm_one("embedder", "onnx", "model", _FailingModel()))
+        await asyncio.to_thread(entered.wait, 5)
+        task.cancel("shutdown: app context closing")
+        await asyncio.sleep(0)  # enter the shielded settle iteration
+        release.set()
+
+        with caplog.at_level("WARNING", logger="memtomem._settlement"):
+            with pytest.raises(asyncio.CancelledError, match="shutdown: app context closing"):
+                await task
+
+        assert any(
+            "embedder model load failed while settling a cancellation" in rec.getMessage()
+            for rec in caplog.records
+        ), "suppressed load failure must be logged, never silently dropped"
 
     @pytest.mark.asyncio
     async def test_close_waits_for_inflight_loader_thread(self, isolated_state, monkeypatch):
@@ -349,6 +398,105 @@ class TestShutdownThreadSettlement:
         # thread must have settled — never abandoned mid-load.
         assert settled == [True], "close() returned before the loader thread settled"
         assert task.done()
+
+    @staticmethod
+    def _onnx_embedder():
+        from memtomem.config import EmbeddingConfig
+        from memtomem.embedding.onnx import OnnxEmbedder
+
+        return OnnxEmbedder(EmbeddingConfig(provider="onnx"))
+
+    @pytest.mark.asyncio
+    async def test_close_double_cancel_preserves_first_message(self, monkeypatch):
+        """#1806: ``OnnxEmbedder.close`` shares the warmup settlement
+        contract — repeated cancellation keeps settling, and the first
+        ``task.cancel(msg)`` message is the one re-raised.
+        """
+        from memtomem.embedding.onnx import OnnxEmbedder
+
+        entered = threading.Event()
+        release = threading.Event()
+
+        def blocking_close(self: OnnxEmbedder) -> None:
+            entered.set()
+            release.wait(timeout=10)
+
+        monkeypatch.setattr(OnnxEmbedder, "_close_sync", blocking_close)
+        embedder = self._onnx_embedder()
+        try:
+            task = asyncio.create_task(embedder.close())
+            await asyncio.to_thread(entered.wait, 5)
+            task.cancel("lifespan teardown")
+            await asyncio.sleep(0)  # enter the first shielded settle iteration
+            assert not task.done()
+
+            task.cancel("second teardown")
+            await asyncio.sleep(0)  # deliver the second cancellation mid-settle
+            assert not task.done(), "second cancel must not abandon the teardown"
+
+            release.set()
+            with pytest.raises(asyncio.CancelledError, match="lifespan teardown"):
+                await task
+        finally:
+            release.set()
+            embedder._infer_executor.shutdown(wait=False)
+
+    @pytest.mark.asyncio
+    async def test_close_failure_after_cancellation_preserves_cancellation(
+        self, monkeypatch, caplog
+    ):
+        """#1806 precedence policy, ONNX side: a teardown failure during
+        settlement must not displace the cancellation (it used to win) —
+        it is logged and the cancellation is re-raised.
+        """
+        from memtomem.embedding.onnx import OnnxEmbedder
+
+        entered = threading.Event()
+        release = threading.Event()
+
+        def failing_close(self: OnnxEmbedder) -> None:
+            entered.set()
+            release.wait(timeout=10)
+            raise RuntimeError("teardown exploded")
+
+        monkeypatch.setattr(OnnxEmbedder, "_close_sync", failing_close)
+        embedder = self._onnx_embedder()
+        try:
+            task = asyncio.create_task(embedder.close())
+            await asyncio.to_thread(entered.wait, 5)
+            task.cancel("lifespan teardown")
+            await asyncio.sleep(0)  # enter the shielded settle iteration
+            release.set()
+
+            with caplog.at_level("WARNING", logger="memtomem._settlement"):
+                with pytest.raises(asyncio.CancelledError, match="lifespan teardown"):
+                    await task
+
+            assert any(
+                "ONNX embedder teardown failed while settling a cancellation" in rec.getMessage()
+                for rec in caplog.records
+            ), "suppressed teardown failure must be logged, never silently dropped"
+        finally:
+            release.set()
+            embedder._infer_executor.shutdown(wait=False)
+
+    @pytest.mark.asyncio
+    async def test_close_failure_without_cancellation_propagates(self, monkeypatch):
+        """#1806 precedence policy, other leg: with no cancellation pending,
+        a teardown failure reaches the caller unchanged.
+        """
+        from memtomem.embedding.onnx import OnnxEmbedder
+
+        def failing_close(self: OnnxEmbedder) -> None:
+            raise RuntimeError("teardown exploded")
+
+        monkeypatch.setattr(OnnxEmbedder, "_close_sync", failing_close)
+        embedder = self._onnx_embedder()
+        try:
+            with pytest.raises(RuntimeError, match="teardown exploded"):
+                await embedder.close()
+        finally:
+            embedder._infer_executor.shutdown(wait=False)
 
 
 class TestLoaderConcurrency:


### PR DESCRIPTION
## Summary

Follow-up to #1805 (refs #1803). That fix shielded every settle-await in the warmup loader and `OnnxEmbedder.close()` so repeated cancellation could not cancel queued executor work, but left three consistency gaps between the two hand-rolled copies of the settle loop. This PR extracts the loop into a single private helper and closes all three items of #1806.

### 1. One settlement contract (`memtomem/_settlement.py`)

`settle_shielded(future, what=...)` — private, stdlib-only — now owns the settle loop for both executor-backed paths (`server/warmup.py` model loads, `OnnxEmbedder.close()` teardown), so the two copies can no longer drift. Both call sites document the shared contract instead of re-describing their own loop.

### 2. Cancellation fidelity

The first caught `CancelledError` is re-raised **as the same exception instance** once the executor work settles, so a `task.cancel(msg)` message survives settlement and a second cancellation's message cannot overwrite it. Previously both paths raised a fresh, message-less `CancelledError`.

### 3. Explicit executor-failure precedence

- **No cancellation pending** → the executor failure propagates to the caller unchanged (warmup already did this; ONNX close now has it pinned by a test).
- **After a cancellation was caught** → cancellation wins; the failure is logged at WARNING (never silently dropped, as warmup used to; never displacing the cancellation, as ONNX close used to — race-dependently). Shutdown paths such as `AppContext.close` rely on observing `CancelledError` from the warmup task, so a surprise teardown exception there would masquerade as a crash.

### 4. Test isolation

`test_double_cancel_still_settles_queued_loader` captures the loop's previous default executor, restores it in `finally` (restoring `None` re-enables lazy creation), shuts the temporary pool down with `wait=True`, and proves a subsequent `run_in_executor(None, ...)` still works. The two #1792 close-cancellation tests in `test_embedding_providers.py` used the identical replace-and-abandon pattern and get the same capture-and-restore treatment.

## Tests

- Extended: warmup double-cancel test now also pins first-message preservation and executor restoration.
- New: loader failure after cancellation preserves cancellation (warmup); close double-cancel preserves first message; close failure after cancellation preserves cancellation + logs; close failure without cancellation propagates.
- Full suite: 8914 passed, 11 skipped (`-m "not ollama"`); ruff check + format clean; mypy has no findings in touched files.
- Existing normal-success, normal-failure, single-cancel, and double-cancel tests remain green.

Closes #1806. Refs #1805, #1803, #1792.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>
