### PR TITLE
test(chunking): pin bold-label sub-chunk line ranges

### DIFF
--- a/packages/memtomem/tests/test_chunking.py
+++ b/packages/memtomem/tests/test_chunking.py
@@ -177,6 +177,37 @@ class TestBoldLabelSplit:
         # At least one chunk should open with a bold label
         assert any(c.content.lstrip().startswith("**") for c in chunks)
 
+    def test_bold_label_split_line_ranges_match_source(self):
+        # Regression for #1794: bold-label parts are separated by a single
+        # ``\n`` (not a blank line), so the pre-#1793 ``+2`` per-part line
+        # accounting inflated the counter by a phantom line per entry and the
+        # recorded ranges drifted past — and eventually inverted beyond — the
+        # end of the file. Assert every sub-chunk's recorded range actually
+        # contains its content, the last untested split path with real
+        # multi-line spans.
+        config = FakeIndexingConfig()
+        config.chunk_overlap_tokens = 0
+        chunker = MarkdownChunker(indexing_config=config)
+        body = "\n".join(
+            f"**Label {i:02d}:** entry text with enough words to consume tokens here."
+            for i in range(12)
+        )
+        content = f"## Changelog\n\n{body}"
+
+        chunks = chunker.chunk_file(Path("/test.md"), content)
+
+        assert len(chunks) > 1
+        source_lines = content.splitlines()
+        for index, chunk in enumerate(chunks):
+            chunk_lines = chunk.content.splitlines()
+            actual_start = source_lines.index(chunk_lines[0]) + 1
+            actual_end = actual_start + len(chunk_lines) - 1
+
+            assert chunk_lines == source_lines[actual_start - 1 : actual_end]
+            assert chunk.metadata.start_line == (1 if index == 0 else actual_start)
+            assert chunk.metadata.end_line == actual_end
+            assert 1 <= chunk.metadata.start_line <= chunk.metadata.end_line <= len(source_lines)
+
     def test_single_bold_label_does_not_split(self):
         chunker = MarkdownChunker(indexing_config=FakeIndexingConfig())
         # A single **Note:** inside otherwise prose text — not enough


### PR DESCRIPTION
## Summary

Closes #1794.

Issue #1794 reported that sentence-split (and bold-label) sub-chunks recorded
drifted / inverted `start_line`/`end_line` ranges, caused by
`_split_section`'s `line_offset += part.count("\n") + 2` accounting assuming
every part boundary was a blank line (`\n\n`). That assumption holds for
paragraph splits but not for sentence parts (single space/newline) or
bold-label parts (single `\n`).

**The root cause is already fixed.** PR #1793 (`8a206f65`) replaced the `+2`
accounting with exact character-offset spans (`_locate_text_spans` →
`_TextSpan` → line numbers via `text.count("\n", 0, offset)`), which is
separator-agnostic. The issue's own repro now emits `L1-3 / L3-3 / L3-3`
(no overshoot, no inversion).

What remained was a test gap. `test_chunking.py` already pins range↔content
correspondence for the bullet-list, headingless, sentence, and word paths, but
the **bold-label path** (one of the two single-separator paths the issue names)
had only boundary/content tests — no line-range assertion.

## Change

Test-only. Adds `test_bold_label_split_line_ranges_match_source`, mirroring the
bullet-list regression test: newline-separated `**Label:**` entries oversized
enough to trigger `_split_on_bold_labels`, asserting every sub-chunk's recorded
range actually contains its content, stays in bounds, and is non-inverted.

## Verification

- New test **red on `8a206f65^`** (the pre-#1793 drift: `chunk_lines !=
  source_lines[start-1:end]`), **green on this branch** — proves it pins the
  #1793 fix.
- `pytest packages/memtomem/tests/test_chunking.py` → 14 passed.
- `ruff check` + `ruff format --check` on src/tests/tools → clean.

_Related: #1793, #1785._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
